### PR TITLE
chore: remove unused 'inspector' type

### DIFF
--- a/components/ActivityBar.tsx
+++ b/components/ActivityBar.tsx
@@ -30,7 +30,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-export type ActivityBarView = "files" | "explorer" | "inspector" | "settings" | "search" | "outline" | "wordfreq" | "characters" | "dictionary" | "none";
+export type ActivityBarView = "files" | "explorer" | "settings" | "search" | "outline" | "wordfreq" | "characters" | "dictionary" | "none";
 
 interface ActivityBarItem {
   id: ActivityBarView;


### PR DESCRIPTION
Closes #47

## Changes
- Remove `'inspector'` from `ActivityBarView` type
- Aligns type definition with actual implementation

## Testing
- ✅ TypeScript check passes

🤖 Generated with Claude Code