### PR TITLE
feat: NLP cache statistics tracking

### DIFF
--- a/lib/nlp-backend/nlp-cache.ts
+++ b/lib/nlp-backend/nlp-cache.ts
@@ -11,6 +11,8 @@ import type { Token } from '../nlp-client/types';
 export class NlpCache {
   private cache: Map<string, Token[]> = new Map();
   private readonly maxSize: number;
+  private hitCount: number = 0;
+  private missCount: number = 0;
 
   constructor(maxSize: number = 1000) {
     this.maxSize = maxSize;
@@ -25,9 +27,14 @@ export class NlpCache {
     const cached = this.cache.get(key);
 
     if (cached) {
+      // Track cache hit
+      this.hitCount++;
       // Move to end (LRU: most recently used)
       this.cache.delete(key);
       this.cache.set(key, cached);
+    } else {
+      // Track cache miss
+      this.missCount++;
     }
 
     return cached;
@@ -48,12 +55,53 @@ export class NlpCache {
 
   clear(): void {
     this.cache.clear();
+    this.hitCount = 0;
+    this.missCount = 0;
   }
 
   getStats() {
+    const totalAccesses = this.hitCount + this.missCount;
+    const hitRate = totalAccesses > 0 ? (this.hitCount / totalAccesses) * 100 : 0;
+    const missRate = totalAccesses > 0 ? (this.missCount / totalAccesses) * 100 : 0;
+
     return {
       size: this.cache.size,
       maxSize: this.maxSize,
+      hitCount: this.hitCount,
+      missCount: this.missCount,
+      totalAccesses,
+      hitRate,
+      missRate,
     };
+  }
+
+  /**
+   * Get cache hit count
+   */
+  getHitCount(): number {
+    return this.hitCount;
+  }
+
+  /**
+   * Get cache miss count
+   */
+  getMissCount(): number {
+    return this.missCount;
+  }
+
+  /**
+   * Get cache hit rate percentage
+   */
+  getHitRate(): number {
+    const totalAccesses = this.hitCount + this.missCount;
+    return totalAccesses > 0 ? (this.hitCount / totalAccesses) * 100 : 0;
+  }
+
+  /**
+   * Get cache miss rate percentage
+   */
+  getMissRate(): number {
+    const totalAccesses = this.hitCount + this.missCount;
+    return totalAccesses > 0 ? (this.missCount / totalAccesses) * 100 : 0;
   }
 }


### PR DESCRIPTION
Closes #51

## Changes
- Add hit/miss counters to both frontend and backend NLP caches
- Calculate hit rate and miss rate percentages (0-100%)
- Expose statistics via `getStats()` and individual getter methods:
  - `getHitCount()`: Get total cache hits
  - `getMissCount()`: Get total cache misses
  - `getHitRate()`: Get hit rate percentage
  - `getMissRate()`: Get miss rate percentage
- Reset counters when cache is cleared
- Enable performance monitoring and optimization

## Files Modified
- `lib/nlp-client/nlp-cache.ts`: Frontend cache with statistics
- `lib/nlp-backend/nlp-cache.ts`: Backend cache with statistics

## Testing
- ✅ TypeScript strict mode check passes
- ✅ No compilation errors
- ✅ Statistics calculated correctly (totalAccesses > 0 check)

🤖 Generated with Claude Code