### PR TITLE
ci: skip desktop build for www-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
       - dev
     tags:
       - "v*"
+    paths-ignore:
+      - 'www/**'
+      - '.github/workflows/deploy-www.yml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `paths-ignore` for `www/**` and `.github/workflows/deploy-www.yml` to `build.yml`
- Pushes that only touch the website no longer trigger the full Electron desktop build pipeline

This saves CI minutes and avoids unnecessary macOS/Windows builds when only the static site is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build workflow to skip unnecessary runs when changes occur in the documentation directory or deployment configuration files, improving CI/CD pipeline efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->