### PR TITLE
fix: route file-open IPC to focused window (#185)

### DIFF
--- a/main.js
+++ b/main.js
@@ -915,7 +915,9 @@ async function isProjectDirectory(dirPath) {
  * @param {string} filePath - Path to the .mdi file
  */
 async function handleMdiFileOpen(filePath) {
-  if (!mainWindow || !mainWindow.webContents) {
+  // Use focused window when available; fall back to mainWindow (e.g., app in background)
+  const targetWindow = BrowserWindow.getFocusedWindow() || mainWindow
+  if (!targetWindow || !targetWindow.webContents) {
     return false
   }
 
@@ -926,7 +928,7 @@ async function handleMdiFileOpen(filePath) {
     if (isProject) {
       // Open as project with this file as initial file
       log.info('Opening as project:', dirPath, 'Initial file:', path.basename(filePath))
-      mainWindow.webContents.send('open-as-project', {
+      targetWindow.webContents.send('open-as-project', {
         projectPath: dirPath,
         initialFile: path.basename(filePath),
       })
@@ -934,7 +936,7 @@ async function handleMdiFileOpen(filePath) {
       // Open as standalone file
       log.info('Opening as standalone file:', filePath)
       const content = await fs.readFile(filePath, 'utf-8')
-      mainWindow.webContents.send('open-file-from-system', { path: filePath, content })
+      targetWindow.webContents.send('open-file-from-system', { path: filePath, content })
     }
     return true
   } catch (err) {


### PR DESCRIPTION
## Summary
- Fix `handleMdiFileOpen` to send IPC messages to the focused window instead of always targeting `mainWindow`
- Use `BrowserWindow.getFocusedWindow()` with fallback to `mainWindow` for background activation

Closes #185

## Changes
- `handleMdiFileOpen()` in `main.js`: Replace hard-coded `mainWindow` with `const targetWindow = BrowserWindow.getFocusedWindow() || mainWindow`
- Both `open-as-project` and `open-file-from-system` IPC sends now target the correct window

## Test plan
- [ ] Open two windows, focus the second → double-click a `.mdi` file in Finder → file should open in the focused (second) window
- [ ] With no window focused (app in background) → double-click a `.mdi` file → file should open in mainWindow
- [ ] Single-window mode → double-click a `.mdi` file → should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file opening behavior in multi-window scenarios. Files and projects now open in the focused window when available, instead of always opening in the main window. This provides better control over which window receives newly opened files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->