### PR TITLE
docs: update README to reflect recent changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ The proofreading (linting) features in illusions comply with the following offic
 
 - **Token encryption**: OS-level encryption via Electron safeStorage (macOS Keychain / Windows DPAPI)
 - **Context isolation**: Electron preload with secure IPC, sandbox enabled
-- **IPC input validation**: Type and size checks on all renderer-to-main IPC handlers
+- **IPC input validation**: Type and size checks on security-sensitive IPC handlers (VFS, NLP, file operations, context-menu)
 - **Content Security Policy**: CSP headers enforced; `unsafe-eval` disabled in production
 - **Navigation guards**: Blocks unexpected navigation and new-window creation
 - **VFS sandboxing**: File system access restricted to approved project directories


### PR DESCRIPTION
## Summary
- Add IPC input validation to the Security section and Recently Added roadmap
- Update CSP description to note `unsafe-eval` is disabled in production builds

Closes #210

## Test plan
- [ ] README accurately reflects current security features and status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with clarified security policies, including Content Security Policy enforcement details and validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->