### PR TITLE
fix: remove misleading word count for Japanese text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,9 +68,6 @@ function chars(s: string) {
   return s.replace(/\s/g, "").length;
 }
 
-function words(s: string) {
-  return s.split(/\s+/).filter(Boolean).length;
-}
 
 // Module-level flag: persists across React StrictMode/HMR remounts,
 // but resets on page refresh (module re-evaluated).
@@ -851,7 +848,6 @@ export default function EditorPage() {
     setTopView("explorer");
   };
 
-   const wordCount = useMemo(() => words(content), [content]);
    const charCount = useMemo(() => chars(content), [content]);
 
    // 段落数を計算（空行で区切る）
@@ -1770,7 +1766,6 @@ export default function EditorPage() {
           >
           <Inspector
             compactMode={compactMode}
-            wordCount={wordCount}
             charCount={charCount}
             selectedCharCount={selectedCharCount}
             paragraphCount={paragraphCount}

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -51,7 +51,6 @@ function getBaseName(name: string) {
 interface InspectorProps {
   className?: string;
   compactMode?: boolean;
-  wordCount?: number;
   charCount?: number;
   selectedCharCount?: number;
   paragraphCount?: number;
@@ -100,7 +99,6 @@ interface InspectorProps {
 export default function Inspector({
   className,
   compactMode = false,
-  wordCount = 0,
   charCount = 0,
   selectedCharCount = 0,
   paragraphCount = 0,
@@ -435,7 +433,6 @@ export default function Inspector({
          )}
          {activeTab === "stats" && (
            <StatsPanel
-             wordCount={wordCount}
              charCount={charCount}
              selectedCharCount={selectedCharCount}
              paragraphCount={paragraphCount}
@@ -722,7 +719,6 @@ function InfoTooltip({ content, className, children }: { content: string; classN
 }
 
 function StatsPanel({
-  wordCount: _wordCount,
   charCount,
   selectedCharCount,
   paragraphCount,
@@ -732,7 +728,6 @@ function StatsPanel({
   charUsageRates,
   readabilityAnalysis,
 }: {
-  wordCount: number;
   charCount: number;
   selectedCharCount: number;
   paragraphCount: number;


### PR DESCRIPTION
## Summary
- Remove the whitespace-based `words()` function and `wordCount` metric that was meaningless for Japanese text
- A 10,000-character novel with 50 paragraph breaks was reporting ~50 "words" because Japanese doesn't use spaces between words
- Character count (文字数), paragraph count (段落数), and reading time (読了時間) remain as meaningful metrics

Closes #198

## Test plan
- [ ] Word count no longer displayed in statistics panel
- [ ] Character count, paragraph count, manuscript pages, and reading time still work correctly
- [ ] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)