### PR TITLE
refactor: typed local-preferences facade for localStorage

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -29,6 +29,7 @@ import SelectionCounter from "./SelectionCounter";
 import { searchHighlightPlugin } from "@/lib/search-highlight-plugin";
 import EditorContextMenu, { type ContextMenuAction } from "./EditorContextMenu";
 import { isElectronRenderer } from "@/lib/runtime-env";
+import { localPreferences } from "@/lib/local-preferences";
 import type { RuleRunner, LintIssue } from "@/lib/linting";
 
 interface EditorProps {
@@ -111,7 +112,7 @@ export default function NovelEditor({
   // localStorage から同期的に初期値を読み込む（初回レンダリング前に反映、横→縦のフラッシュ防止）
   const [isVertical, setIsVertical] = useState(() => {
     if (typeof window === "undefined") return false;
-    return localStorage.getItem("illusions-writing-mode") === "vertical";
+    return localPreferences.getWritingMode() === "vertical";
   });
   const [isMounted, setIsMounted] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -128,7 +129,7 @@ export default function NovelEditor({
   // 変更時に縦書き状態を localStorage に保存する
   useEffect(() => {
     if (!isMounted) return;
-    localStorage.setItem('illusions-writing-mode', isVertical ? 'vertical' : 'horizontal');
+    localPreferences.setWritingMode(isVertical ? 'vertical' : 'horizontal');
   }, [isVertical, isMounted]);
 
    // 注意：このエフェクトはもう不要。理由：

--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -32,6 +32,7 @@ import {
   type SystemFontInfo,
 } from "@/lib/fonts";
 import { isElectronRenderer } from "@/lib/runtime-env";
+import { localPreferences } from "@/lib/local-preferences";
 type Tab = "chapters" | "settings" | "style";
 
 const formattingMarkers = ["**", "__", "~~", "*", "_", "`", "["];
@@ -220,16 +221,14 @@ export default function Explorer({
   const [activeTab, setActiveTab] = useState<Tab>("chapters");
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    const savedTab = window.localStorage.getItem("illusions:leftTab");
+    const savedTab = localPreferences.getLeftTab();
     if (savedTab === "chapters" || savedTab === "settings" || savedTab === "style") {
       setActiveTab(savedTab as Tab);
     }
   }, []);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem("illusions:leftTab", activeTab);
+    localPreferences.setLeftTab(activeTab);
   }, [activeTab]);
 
   return (

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -5,34 +5,15 @@ import { Bot, AlertCircle, BarChart3, Edit2, X, History } from "lucide-react";
 import clsx from "clsx";
 import { useEditorMode } from "@/contexts/EditorModeContext";
 import HistoryPanel from "./HistoryPanel";
+import { localPreferences } from "@/lib/local-preferences";
 
 import type { ProjectMode } from "@/lib/project-types";
 import type { LintIssue, Severity } from "@/lib/linting";
 
 type Tab = "ai" | "corrections" | "stats" | "history";
 
-const rightTabStorageKey = "illusions:rightTab";
 const isValidTab = (value: string | null): value is Tab =>
   value === "ai" || value === "corrections" || value === "stats" || value === "history";
-
-const readStoredTab = (): Tab | null => {
-  if (typeof window === "undefined") return null;
-  try {
-    const savedTab = window.localStorage.getItem(rightTabStorageKey);
-    return isValidTab(savedTab) ? savedTab : null;
-  } catch {
-    return null;
-  }
-};
-
-const writeStoredTab = (tab: Tab) => {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(rightTabStorageKey, tab);
-  } catch (error) {
-    console.error("右サイドのタブ状態を保存できませんでした:", error);
-  }
-};
 
 const MDI_EXTENSION = ".mdi";
 
@@ -158,7 +139,8 @@ export default function Inspector({
   }, []);
 
   useEffect(() => {
-    const storedTab = readStoredTab();
+    const raw = localPreferences.getRightTab();
+    const storedTab = isValidTab(raw) ? raw : null;
     if (storedTab) {
       setActiveTab(storedTab);
     }
@@ -168,7 +150,7 @@ export default function Inspector({
 
   useEffect(() => {
     if (!hasLoadedRef.current) return;
-    writeStoredTab(activeTab);
+    localPreferences.setRightTab(activeTab);
   }, [activeTab]);
 
   // プロジェクトモードでない場合に履歴タブが選択されていたらフォールバック

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useState } from "react";
+import { localPreferences } from "@/lib/local-preferences";
 
-type ThemeMode = "light" | "dark" | "auto";
+import type { ThemeMode } from "@/lib/local-preferences";
+
 type Theme = "light" | "dark";
 
 interface ThemeContextType {
@@ -26,7 +28,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     setMounted(true);
     // inline script が設定済みの値と状態を同期する
-    const storedMode = localStorage.getItem("themeMode") as ThemeMode | null;
+    const storedMode = localPreferences.getThemeMode();
     const mode = storedMode || "auto";
     setThemeModeState(mode);
 
@@ -62,7 +64,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
   const setThemeMode = (mode: ThemeMode) => {
     setThemeModeState(mode);
-    localStorage.setItem("themeMode", mode);
+    localPreferences.setThemeMode(mode);
 
     if (mode === "auto") {
       const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;

--- a/lib/local-preferences.ts
+++ b/lib/local-preferences.ts
@@ -1,0 +1,108 @@
+/**
+ * Typed facade for localStorage-based UI preferences.
+ *
+ * These values are read synchronously on mount to prevent visual flash,
+ * which is why they use localStorage instead of the async StorageService.
+ */
+
+const PREFIX = "illusions:" as const
+
+const KEYS = {
+  themeMode: `${PREFIX}theme-mode`,
+  writingMode: `${PREFIX}writing-mode`,
+  leftTab: `${PREFIX}left-tab`,
+  rightTab: `${PREFIX}right-tab`,
+  sidebarTopOrder: `${PREFIX}sidebar-top-order`,
+  sidebarBottomOrder: `${PREFIX}sidebar-bottom-order`,
+} as const
+
+// One-time migration from old keys to new keys
+function migrateOldKeys(): void {
+  if (typeof window === "undefined") return
+  const migrations: [string, string][] = [
+    ["themeMode", KEYS.themeMode],
+    ["illusions-writing-mode", KEYS.writingMode],
+    ["illusions:leftTab", KEYS.leftTab],
+    ["illusions:rightTab", KEYS.rightTab],
+    // These old keys already match the new keys, so no migration needed:
+    // "illusions:sidebar-top-order" === KEYS.sidebarTopOrder
+    // "illusions:sidebar-bottom-order" === KEYS.sidebarBottomOrder
+  ]
+  for (const [oldKey, newKey] of migrations) {
+    if (oldKey === newKey) continue
+    const value = localStorage.getItem(oldKey)
+    if (value !== null && localStorage.getItem(newKey) === null) {
+      localStorage.setItem(newKey, value)
+      localStorage.removeItem(oldKey)
+    }
+  }
+}
+
+// Run migration on first import
+migrateOldKeys()
+
+function get(key: string): string | null {
+  if (typeof window === "undefined") return null
+  return localStorage.getItem(key)
+}
+
+function set(key: string, value: string): void {
+  if (typeof window === "undefined") return
+  localStorage.setItem(key, value)
+}
+
+export type ThemeMode = "light" | "dark" | "auto"
+export type WritingMode = "vertical" | "horizontal"
+
+export const localPreferences = {
+  // --- Theme ---
+  getThemeMode(): ThemeMode | null {
+    return get(KEYS.themeMode) as ThemeMode | null
+  },
+  setThemeMode(mode: ThemeMode): void {
+    set(KEYS.themeMode, mode)
+  },
+
+  // --- Writing mode ---
+  getWritingMode(): WritingMode | null {
+    return get(KEYS.writingMode) as WritingMode | null
+  },
+  setWritingMode(mode: WritingMode): void {
+    set(KEYS.writingMode, mode)
+  },
+
+  // --- Left sidebar tab ---
+  getLeftTab(): string | null {
+    return get(KEYS.leftTab)
+  },
+  setLeftTab(tab: string): void {
+    set(KEYS.leftTab, tab)
+  },
+
+  // --- Right panel tab ---
+  getRightTab(): string | null {
+    return get(KEYS.rightTab)
+  },
+  setRightTab(tab: string): void {
+    set(KEYS.rightTab, tab)
+  },
+
+  // --- Sidebar icon order ---
+  getSidebarTopOrder(): string[] | null {
+    const raw = get(KEYS.sidebarTopOrder)
+    if (!raw) return null
+    try { return JSON.parse(raw) as string[] } catch { return null }
+  },
+  setSidebarTopOrder(ids: string[]): void {
+    set(KEYS.sidebarTopOrder, JSON.stringify(ids))
+  },
+
+  getSidebarBottomOrder(): string[] | null {
+    const raw = get(KEYS.sidebarBottomOrder)
+    if (!raw) return null
+    try { return JSON.parse(raw) as string[] } catch { return null }
+  },
+  setSidebarBottomOrder(ids: string[]): void {
+    set(KEYS.sidebarBottomOrder, JSON.stringify(ids))
+  },
+} as const


### PR DESCRIPTION
## Summary
- Create `lib/local-preferences.ts` — typed facade for synchronous UI preferences
- Migrate 5 components from direct `localStorage` to facade with consistent API
- Normalize key naming (`themeMode` → `illusions:theme-mode`, etc.)
- Add one-time migration from old keys to new keys

### Why not StorageService?
These values need **synchronous reads** on component mount to prevent visual flash (theme, writing mode, tab selections). StorageService uses async APIs (IndexedDB/SQLite) which would cause jank.

### Changes by file
| File | Change |
|------|--------|
| `lib/local-preferences.ts` | NEW — typed localStorage facade |
| `contexts/ThemeContext.tsx` | `themeMode` → `localPreferences.getThemeMode()` |
| `components/Editor.tsx` | `illusions-writing-mode` → `localPreferences.getWritingMode()` |
| `components/Inspector.tsx` | `illusions:rightTab` → `localPreferences.getRightTab()` |
| `components/Explorer.tsx` | `illusions:leftTab` → `localPreferences.getLeftTab()` |
| `components/ActivityBar.tsx` | sidebar order keys → `localPreferences.getSidebar*Order()` |

Closes #196

## Test plan
- [ ] Theme preference persists across page refreshes
- [ ] Writing mode (vertical/horizontal) persists
- [ ] Left sidebar tab selection persists
- [ ] Right panel tab selection persists
- [ ] Sidebar icon order persists after drag
- [ ] Old preferences are migrated on first load
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)