### PR TITLE
docs: update README to reflect recent changes (#220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Available for macOS (Intel & Apple Silicon) and Windows
 - **Three-column layout**: Explorer | Editor | Inspector
 - **Activity Bar**: Quick access to Projects, GitHub, Settings
 - **Theme system**: Automatic light/dark mode support
+- **Design system dialogs**: Custom GlassDialog-based alerts and confirmations (no native browser dialogs)
 - **Responsive design**: Optimized for various screen sizes
 
 ### 💾 Storage & Sync
@@ -44,7 +45,7 @@ Available for macOS (Intel & Apple Silicon) and Windows
 - **Crash recovery**: Auto-restore unsaved content
 
 ### 📊 Productivity
-- **Statistics panel**: Character count, word count, manuscript pages (原稿用紙)
+- **Statistics panel**: Character count, paragraph count, manuscript pages (原稿用紙)
 - **Composition settings**: Font, size, line height, spacing
 - **Version history**: Browse and restore previous versions
 - **Diff viewer**: Compare changes between versions
@@ -256,7 +257,9 @@ The proofreading (linting) features in illusions comply with the following offic
 - ✅ Punctuation rules (記号の作法と偶数ルール)
 - ✅ Joyo kanji validation (常用漢字バリデーション)
 - ✅ Number format consistency (数字表記の統一)
-- ✅ Electron security hardening (CSP, navigation guards, safeStorage, IPC input validation)
+- ✅ Electron security hardening (CSP, navigation guards, safeStorage, IPC input validation, save-file path validation)
+- ✅ Design system dialogs replacing native browser alerts/confirms (GlassDialog)
+- ✅ Accurate Japanese text statistics (文字数 character count, misleading word count removed)
 
 ### Planned
 - [ ] Real-time collaboration
@@ -273,6 +276,7 @@ The proofreading (linting) features in illusions comply with the following offic
 - **Token encryption**: OS-level encryption via Electron safeStorage (macOS Keychain / Windows DPAPI)
 - **Context isolation**: Electron preload with secure IPC, sandbox enabled
 - **IPC input validation**: Type and size checks on security-sensitive IPC handlers (VFS, NLP, file operations, context-menu)
+- **Save-file path validation**: Directory traversal prevention, system path denylist, extension allowlist, and dialog-approval enforcement
 - **Content Security Policy**: CSP headers enforced; `unsafe-eval` disabled in production
 - **Navigation guards**: Blocks unexpected navigation and new-window creation
 - **VFS sandboxing**: File system access restricted to approved project directories


### PR DESCRIPTION
## Summary

- Update statistics panel description: replace "word count" with "paragraph count" (word count was removed for Japanese text in #212)
- Add design system dialogs (GlassDialog) to Interface features (#213)
- Add save-file IPC path validation to Security section (#200)
- Update Recently Added roadmap entries for security hardening, dialogs, and statistics

Closes #220

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm no Chinese or Korean text was introduced
- [ ] Check all links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Design system dialogs now replace native browser dialogs for alerts and confirmations.

* **Improvements**
  * Statistics panel now counts paragraphs instead of word count.

* **Documentation**
  * Updated security notes and expanded planned roadmap with save-file path validation and Japanese text statistics improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->