### PR TITLE
feat(linting): wire up linting system to editor and inspector

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,6 +43,7 @@ import { useElectronEvents } from "@/lib/editor-page/use-electron-events";
 import { useProjectLifecycle } from "@/lib/editor-page/use-project-lifecycle";
 import { useLinting } from "@/lib/editor-page/use-linting";
 
+import type { EditorView } from "@milkdown/prose/view";
 import type { LintIssue } from "@/lib/linting/types";
 import type { SupportedFileExtension } from "@/lib/project-types";
 
@@ -118,8 +119,7 @@ export default function EditorPage() {
   const [selectedCharCount, setSelectedCharCount] = useState(0);
   const prevLastSavedTimeRef = useRef<number | null>(null);
   const hasAutoRecoveredRef = useRef(false);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [editorViewInstance, setEditorViewInstance] = useState<any>(null);
+  const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
 
   const isElectron = typeof window !== "undefined" && isElectronRenderer();
 

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import type { EditorView } from "@milkdown/prose/view";
 import { RuleRunner } from "@/lib/linting/rule-runner";
 import type { LintIssue, Severity } from "@/lib/linting/types";
 
@@ -30,8 +31,7 @@ export interface UseLintingResult {
 export function useLinting(
   lintingEnabled: boolean,
   lintingRuleConfigs: Record<string, { enabled: boolean; severity: Severity }>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  editorViewInstance: any,
+  editorViewInstance: EditorView | null,
 ): UseLintingResult {
   const ruleRunnerRef = useRef<RuleRunner | null>(null);
   const [lintIssues, setLintIssues] = useState<LintIssue[]>([]);
@@ -69,8 +69,9 @@ export function useLinting(
   }, [ruleRunner, lintingRuleConfigs]);
 
   const handleLintIssuesUpdated = useCallback((issues: LintIssue[]) => {
+    if (!lintingEnabled) return;
     setLintIssues(issues);
-  }, []);
+  }, [lintingEnabled]);
 
   // Clear issues when linting is disabled
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Create `useLinting` hook that manages `RuleRunner` lifecycle, registers all 11 lint rules, syncs per-rule configs from settings, and provides a refresh mechanism
- Wire linting props through `page.tsx` to `NovelEditor` (ruleRunner + enabled flag), `Inspector` (issues + navigation + fix + refresh), and `SettingsModal` (enable toggle + per-rule config)
- Add `lintingEnabled` / `lintingRuleConfigs` to `AppState` for persistence across sessions
- Add refresh button (RefreshCw icon) to the corrections panel for manual re-linting
- Implement `onNavigateToIssue` (scroll to + select problematic text) and `onApplyFix` (replace text with fix)

## Files Changed
| File | Action | Purpose |
|------|--------|---------|
| `lib/storage-types.ts` | MODIFY | Add `lintingEnabled`, `lintingRuleConfigs` to `AppState` |
| `lib/editor-page/use-editor-settings.ts` | MODIFY | Add linting state, handlers, persistence |
| `lib/editor-page/use-linting.ts` | CREATE | New hook: RuleRunner lifecycle, 11 rules, issues state, refresh |
| `app/page.tsx` | MODIFY | Wire useLinting, pass props to Editor/Inspector/Settings |
| `components/Inspector.tsx` | MODIFY | Add refresh button to CorrectionsPanel |

## Test plan
- [ ] Open the app, type Japanese text with known issues (e.g., `頭痛が痛い`, `私のの本`)
- [ ] Confirm Inspector 校正 tab shows detected issues with correct count
- [ ] Click an issue in Inspector → editor scrolls to and selects the problematic text
- [ ] Click refresh button → issues re-compute
- [ ] Toggle linting on/off in Settings → issues appear/disappear
- [ ] Toggle individual rules in Settings → only enabled rules produce issues
- [ ] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated code linting into the editor with configurable rules.
  * Added linting toggle and per-rule configuration in editor settings (persisted).
  * New lint issue panel with navigation to issues and ability to apply automated fixes.
  * Added a refresh control to update linting results on demand.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->