### PR TITLE
feat(linting): add 公用文モード preset

### DIFF
--- a/lib/linting/lint-presets.ts
+++ b/lib/linting/lint-presets.ts
@@ -125,4 +125,20 @@ export const LINT_PRESETS: Record<string, LintPreset> = {
       "correlative-expression": { enabled: true, severity: "warning" },
     },
   },
+  official: {
+    nameJa: "公用文モード",
+    configs: {
+      "punctuation-rules": { enabled: true, severity: "error" },
+      "number-format": { enabled: true, severity: "error" },
+      "joyo-kanji": { enabled: true, severity: "warning" },
+      "era-year-validator": { enabled: true, severity: "error" },
+      "particle-no-repetition": { enabled: true, severity: "warning" },
+      "conjugation-errors": { enabled: true, severity: "error" },
+      "redundant-expression": { enabled: true, severity: "error" },
+      "verbose-expression": { enabled: true, severity: "warning" },
+      "sentence-ending-repetition": { enabled: true, severity: "info" },
+      "notation-consistency": { enabled: true, severity: "error" },
+      "correlative-expression": { enabled: true, severity: "error" },
+    },
+  },
 };


### PR DESCRIPTION
## Summary
- Add `official` (公用文モード) lint preset for government/official document writing
- Strict error-level enforcement on punctuation, number format, era dates, conjugation, redundancy, notation consistency, and correlative expressions
- Dropdown now shows 5 presets: 寛容/標準/厳格/小説/公用文

## Test plan
- [ ] Preset dropdown shows 5 options
- [ ] Selecting 公用文モード applies the expected severity levels
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)