### PR TITLE
fix: add text verification to handleApplyFix before applying lint fix

### DIFF
--- a/lib/linting/types.ts
+++ b/lib/linting/types.ts
@@ -24,6 +24,8 @@ export interface LintIssue {
   to: number;
   /** Reference to official standard */
   reference?: LintReference;
+  /** Original text at [from, to] when the issue was detected, used to verify before applying a fix */
+  originalText?: string;
   /** Optional fix suggestion */
   fix?: {
     label: string;

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -501,7 +501,7 @@ export function createLintingPlugin(
               allDecorations.push(
                 Decoration.inline(from, to, {
                   class: severityToClass(issue.severity),
-                  'data-lint-issue': JSON.stringify({ ...issue, from, to }),
+                  'data-lint-issue': JSON.stringify({ ...issue, from, to, originalText: issueText }),
                 })
               );
 
@@ -510,6 +510,7 @@ export function createLintingPlugin(
                 ...issue,
                 from,
                 to,
+                originalText: issueText,
               });
             }
           }
@@ -646,11 +647,11 @@ export function createLintingPlugin(
             allDecorations.push(
               Decoration.inline(from, to, {
                 class: severityToClass(issue.severity),
-                'data-lint-issue': JSON.stringify({ ...issue, from, to }),
+                'data-lint-issue': JSON.stringify({ ...issue, from, to, originalText: issueText }),
               })
             );
 
-            allIssues.push({ ...issue, from, to });
+            allIssues.push({ ...issue, from, to, originalText: issueText });
           }
 
           // L3 issues from LLM cache (already have absolute positions)
@@ -667,14 +668,15 @@ export function createLintingPlugin(
                     isIssueIgnored(issue, l3IssueText, paragraph.text, currentIgnoredCorrections)) {
                   continue;
                 }
+                const issueWithOriginal = { ...issue, originalText: l3IssueText };
                 allDecorations.push(
                   Decoration.inline(issue.from, issue.to, {
                     class: severityToClass(issue.severity),
-                    'data-lint-issue': JSON.stringify(issue),
+                    'data-lint-issue': JSON.stringify(issueWithOriginal),
                   })
                 );
 
-                allIssues.push(issue);
+                allIssues.push(issueWithOriginal);
               }
             }
           }


### PR DESCRIPTION
## Summary

- Add text verification in `handleApplyFix` to prevent applying lint fixes at stale positions after document edits
- Store original text (`originalText`) in `LintIssue` when issues are created with absolute positions in the decoration plugin
- Show a Japanese warning notification when the text at the target range no longer matches, prompting the user to re-run linting

Closes #313

## Changes

| File | Change |
|------|--------|
| `lib/linting/types.ts` | Add optional `originalText` field to `LintIssue` interface |
| `packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts` | Populate `originalText` when building issues with absolute positions (L1/L2 per-paragraph, L1/L2 document-level, L3 LLM) |
| `app/page.tsx` | Add text verification before applying fix; show warning notification on mismatch |

## Test plan

- [ ] Open a document with lint issues that have auto-fix suggestions
- [ ] Apply a fix without editing the document -- fix should apply normally
- [ ] Trigger linting, then edit the document text at a lint issue location, then try to apply the fix -- a warning notification should appear in Japanese saying the text has changed
- [ ] After the warning, re-run linting and verify fixes can be applied again on the updated positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added text verification before applying lint fixes. If the original text has been modified since the issue was detected, a warning notification is displayed and the fix is aborted, preventing unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->