### PR TITLE
fix: prevent sanitizeMdiContent from stripping angle bracket content

### DIFF
--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -96,14 +96,136 @@ export function inferFileType(fileName: string): SupportedFileExtension {
 }
 
 /**
+ * Known HTML tag names that may be injected by the editor (ProseMirror/Milkdown)
+ * and should be stripped when saving to .mdi format.
+ *
+ * Only properly paired tags (e.g. `<div>...</div>`) and void elements
+ * (e.g. `<img>`, `<hr>`) are removed. Orphaned non-void tags like a bare
+ * `<B>` are left intact so that arbitrary angle-bracket content
+ * (e.g. math expressions `A<B>C`) is not silently destroyed.
+ */
+const PAIRED_HTML_TAGS = [
+  "a",
+  "abbr",
+  "article",
+  "aside",
+  "b",
+  "blockquote",
+  "body",
+  "caption",
+  "cite",
+  "code",
+  "colgroup",
+  "dd",
+  "del",
+  "details",
+  "dfn",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "figcaption",
+  "figure",
+  "footer",
+  "h[1-6]",
+  "head",
+  "header",
+  "html",
+  "i",
+  "iframe",
+  "ins",
+  "kbd",
+  "label",
+  "li",
+  "main",
+  "mark",
+  "nav",
+  "noscript",
+  "ol",
+  "p",
+  "picture",
+  "pre",
+  "q",
+  "rp",
+  "rt",
+  "ruby",
+  "s",
+  "samp",
+  "script",
+  "section",
+  "select",
+  "small",
+  "span",
+  "strong",
+  "style",
+  "sub",
+  "summary",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "template",
+  "textarea",
+  "tfoot",
+  "th",
+  "thead",
+  "time",
+  "title",
+  "tr",
+  "u",
+  "ul",
+  "var",
+  "video",
+] as const;
+
+/**
+ * Void HTML elements that are self-closing and cannot have content.
+ * These are safe to strip even when not paired, since tag names like
+ * `img`, `hr`, `wbr` etc. are unambiguous and won't collide with
+ * user-authored angle-bracket content.
+ */
+const VOID_HTML_TAGS = [
+  "area",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "source",
+  "track",
+  "wbr",
+] as const;
+
+/** Regex matching void HTML elements (opening or self-closing form). */
+const VOID_TAG_PATTERN = new RegExp(
+  `<(${VOID_HTML_TAGS.join("|")})(\\s[^>]*)?\\/?>`,
+  "gi",
+);
+
+/**
  * Sanitize MDI content before saving.
- * Converts/removes HTML tags that should not appear in .mdi files.
+ * Strips known HTML tags that should not appear in .mdi files,
+ * while preserving arbitrary angle-bracket content (e.g. `A<B>C`).
  */
 export function sanitizeMdiContent(content: string): string {
   let result = content;
+  // Step 1: Convert <br> tags to newlines
   result = result.replace(/<br\s*\/?>/gi, "\n");
-  result = result.replace(/<(\w+)[^>]*>(.*?)<\/\1>/gi, "$2");
-  result = result.replace(/<[^>]+>/g, "");
+  // Step 2: Remove properly paired known HTML tags, keeping inner content.
+  // Only matched pairs (e.g. <div>...</div>) are stripped; an orphaned
+  // `<B>` without a closing `</B>` is left untouched.
+  result = result.replace(
+    new RegExp(
+      `<(${PAIRED_HTML_TAGS.join("|")})(\\s[^>]*)?>([\\s\\S]*?)<\\/\\1>`,
+      "gi",
+    ),
+    "$3",
+  );
+  // Step 3: Remove void HTML elements (img, hr, etc.) which are always
+  // self-closing and cannot be confused with user content.
+  result = result.replace(VOID_TAG_PATTERN, "");
   return result;
 }
 


### PR DESCRIPTION
## Summary
- Fix greedy regex in `sanitizeMdiContent()` that silently deleted content between angle brackets (e.g. `A<B>C` became `AC`)
- Replace catch-all `<[^>]+>` regex with a whitelist-based approach that only strips known HTML tags
- Properly paired HTML tags (e.g. `<div>...</div>`) are stripped while preserving inner content; void elements (`<img>`, `<hr>`, etc.) are stripped independently; orphaned angle-bracket content is now preserved

Closes #312

## Test plan
- [ ] Verify that saving a document containing `A<B>C` preserves the content (previously `B` was silently deleted)
- [ ] Verify that saving a document with editor-injected HTML (e.g. pasted rich text producing `<div>`, `<span>`) still strips those tags correctly
- [ ] Verify that `<br>` tags are still converted to newlines
- [ ] Verify that void elements like `<img src="...">` are still removed
- [ ] Run `npx tsc --noEmit` — passes with zero errors

Generated with [Claude Code](https://claude.com/claude-code)