### PR TITLE
fix: defer tab restoration until VFS root is initialized

### DIFF
--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -23,9 +23,12 @@ export type { UseTabManagerReturn } from "./types";
 export function useTabManager(options?: {
   skipAutoRestore?: boolean;
   autoSave?: boolean;
+  /** Whether VFS root has been initialized. Tab restore waits for this in Electron. */
+  vfsReady?: boolean;
 }): UseTabManagerReturn {
   const skipAutoRestore = options?.skipAutoRestore ?? false;
   const autoSaveEnabled = options?.autoSave ?? true;
+  const vfsReady = options?.vfsReady ?? true;
 
   // --- Core tab state -----------------------------------------------------
 
@@ -114,6 +117,7 @@ export function useTabManager(options?: {
     isProjectRef: tabState.isProjectRef,
     isElectron: tabState.isElectron,
     skipAutoRestore,
+    vfsReady,
   });
 
   // --- Backward compat alias: newFile === newTab --------------------------


### PR DESCRIPTION
## Summary
- Fix race condition where tab restore fires `vfs:read-file` IPC calls before the VFS root directory is registered in the main process, causing all tab reads to silently fail with "ディレクトリが開かれていません"
- Add a `vfsReady` signal that flows from the project lifecycle to the tab persistence hook, deferring tab restoration until the VFS root is available
- In Web mode, `vfsReady` defaults to `true` since there is no root validation requirement

Closes #323

## Test plan
- [ ] Verify that on Electron startup with a previously opened project, tabs are restored correctly (file contents visible, no console errors about "ディレクトリが開かれていません")
- [ ] Verify that on fresh start (no recent projects), the editor loads normally without blocking
- [ ] Verify that Web mode is unaffected (vfsReady defaults to true)
- [ ] Verify `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)