### PR TITLE
fix: sanitizeMdiContent only strips HTML tags, not arbitrary angle brackets

### DIFF
--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -103,7 +103,7 @@ export function sanitizeMdiContent(content: string): string {
   let result = content;
   result = result.replace(/<br\s*\/?>/gi, "\n");
   result = result.replace(/<(\w+)[^>]*>(.*?)<\/\1>/gi, "$2");
-  result = result.replace(/<[^>]+>/g, "");
+  result = result.replace(/<\/?[a-zA-Z][a-zA-Z0-9]*\b[^>]*\/?>/g, "");
   return result;
 }
 


### PR DESCRIPTION
## Summary
The greedy regex `/<[^>]+>/g` in `sanitizeMdiContent()` removed any content between `<` and `>`, causing silent data loss for text containing angle brackets (e.g. `A<B>C` became `AC`).

## Root Cause
The regex was too broad — it matched any angle-bracket-delimited content, not just HTML tags.

## Changes
- Replaced `/<[^>]+>/g` with `/<\/?[a-zA-Z][a-zA-Z0-9]*\b[^>]*\/?>/g` which only matches actual HTML element tags (starting with a letter-based tag name)

## Testing
- Text like `170<180cmの範囲内` is now preserved correctly
- HTML tags like `<div>`, `<span class="x">`, `</p>` are still stripped

Closes Iktahana/illusions#312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTML tag removal in content sanitization to handle tags with attributes more precisely, ensuring more thorough and consistent content cleaning across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->