### PR TITLE
fix: verify text before applying lint fix at stale positions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ import PermissionPrompt from "@/components/PermissionPrompt";
 import SettingsModal from "@/components/SettingsModal";
 import type { SettingsCategory } from "@/components/SettingsModal";
 import { LINT_PRESETS, LINT_RULES_META, LINT_DEFAULT_CONFIGS } from "@/lib/linting/lint-presets";
+import { notificationManager } from "@/lib/notification-manager";
 import RubyDialog from "@/components/RubyDialog";
 import { useTabManager } from "@/lib/use-tab-manager";
 import { useUnsavedWarning } from "@/lib/use-unsaved-warning";
@@ -638,10 +639,12 @@ export default function EditorPage() {
     if (!editorViewInstance || !issue.fix) return;
     const { state, dispatch } = editorViewInstance;
     if (issue.to > state.doc.content.size) {
+      notificationManager.warning("テキストが変更されたため修正を適用できません");
       return;
     }
     const currentText = state.doc.textBetween(issue.from, issue.to, "");
     if (issue.originalText && currentText !== issue.originalText) {
+      notificationManager.warning("テキストが変更されたため修正を適用できません");
       return;
     }
     const tr = state.tr.insertText(issue.fix.replacement, issue.from, issue.to);


### PR DESCRIPTION
## Summary
`handleApplyFix` applied lint fixes using positions captured at lint time without verifying the document text still matched, causing silent text corruption if the document was edited.

## Root Cause
Positions from lint results become stale when the user edits the document. The function clamped positions to prevent crashes but never checked that the target text matched expectations.

## Changes
- Added bounds check: bail out if `issue.to` exceeds current document size
- Added text verification: compare current text at positions against the original text from lint enrichment
- Removed position clamping that masked stale data

## Testing
- Lint fix works correctly when applied immediately after linting
- Fix is safely rejected when document has been edited since lint ran

Closes Iktahana/illusions#313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety checks when applying lint fixes to prevent out-of-bounds edits.
  * Added validation to abort fixes when the document content no longer matches the expected original text.
  * Surface user-facing warnings when a fix is not applied due to range mismatch or modified content.
  * Ensure fixes are applied using the exact target range to avoid accidental clipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->