### PR TITLE
Add notification feedback when lint fixes cannot be applied

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ import PermissionPrompt from "@/components/PermissionPrompt";
 import SettingsModal from "@/components/SettingsModal";
 import type { SettingsCategory } from "@/components/SettingsModal";
 import { LINT_PRESETS, LINT_RULES_META, LINT_DEFAULT_CONFIGS } from "@/lib/linting/lint-presets";
+import { notificationManager } from "@/lib/notification-manager";
 import RubyDialog from "@/components/RubyDialog";
 import { useTabManager } from "@/lib/use-tab-manager";
 import { useUnsavedWarning } from "@/lib/use-unsaved-warning";
@@ -638,10 +639,12 @@ export default function EditorPage() {
     if (!editorViewInstance || !issue.fix) return;
     const { state, dispatch } = editorViewInstance;
     if (issue.to > state.doc.content.size) {
+      notificationManager.warning("テキストが変更されたため修正を適用できません");
       return;
     }
     const currentText = state.doc.textBetween(issue.from, issue.to, "");
     if (issue.originalText && currentText !== issue.originalText) {
+      notificationManager.warning("テキストが変更されたため修正を適用できません");
       return;
     }
     const tr = state.tr.insertText(issue.fix.replacement, issue.from, issue.to);


### PR DESCRIPTION
## Summary
Added user-facing notifications to inform users when lint fixes cannot be applied due to text changes in the document.

## Key Changes
- Imported `notificationManager` from the notification manager library
- Added warning notifications in two validation scenarios within the fix application logic:
  - When the target text range exceeds the document size
  - When the current text differs from the original text that the fix was generated for

## Implementation Details
These notifications provide better UX by explicitly communicating why a fix operation failed, rather than silently returning without feedback. This helps users understand that their document has been modified since the lint issues were detected, and they may need to re-run linting to get updated fixes.

https://claude.ai/code/session_015B6pQkWe8E6gwV4RqxV7Ym