### PR TITLE
refactor: extract shared useChapters hook — close remaining debt issues

### DIFF
--- a/components/Outline.tsx
+++ b/components/Outline.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { ReactNode, useMemo, useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { RefreshCw } from "lucide-react";
 import clsx from "clsx";
-import { getChaptersFromDOM, parseMarkdownChapters, type Chapter } from "@/lib/utils";
+import type { Chapter } from "@/lib/utils";
+import { useChapters } from "@/lib/editor-page";
 
 interface OutlineProps {
   className?: string;
@@ -17,24 +18,7 @@ export default function Outline({
   onHeadingClick,
 }: OutlineProps): React.ReactElement {
   const [activeHeadingId, setActiveHeadingId] = useState<string | null>(null);
-  const [refreshToken, setRefreshToken] = useState(0);
-
-  // 10秒ごとに自動更新
-  useEffect(() => {
-    const timer = setInterval(() => setRefreshToken((v) => v + 1), 10000);
-    return () => clearInterval(timer);
-  }, []);
-
-  // まずDOMから見出し情報を取得し（より確実）、なければMarkdown解析にフォールバック
-  const headings = useMemo(() => {
-    const domHeadings = getChaptersFromDOM();
-    // DOM側でアンカーIDが取れるなら、それを優先して使う
-    if (domHeadings.length > 0 && domHeadings.some((h) => h.anchorId)) {
-      return domHeadings;
-    }
-    // それ以外はMarkdownを解析して見出し情報を作る
-    return parseMarkdownChapters(content);
-  }, [content, refreshToken]);
+  const { chapters: headings, refresh } = useChapters(content);
 
   // スクロールイベントで現在のセクションを追跡
   useEffect(() => {
@@ -92,7 +76,7 @@ export default function Outline({
           className="p-1 hover:bg-hover rounded transition-colors text-foreground-tertiary hover:text-foreground"
           title="アウトラインを更新"
           aria-label="アウトラインを更新"
-          onClick={() => setRefreshToken((v) => v + 1)}
+          onClick={refresh}
         >
           <RefreshCw className="w-4 h-4" />
         </button>

--- a/components/explorer/ChaptersPanel.tsx
+++ b/components/explorer/ChaptersPanel.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo, useState, useEffect } from "react";
+import { useState } from "react";
 import { RefreshCw } from "lucide-react";
-import { parseMarkdownChapters, getChaptersFromDOM } from "@/lib/utils";
+import { useChapters } from "@/lib/editor-page";
 import { ChapterItem } from "./ChapterItem";
 import { MarkdownSyntaxPanel } from "./MarkdownSyntaxPanel";
 
@@ -14,22 +14,7 @@ interface ChaptersPanelProps {
 
 /** Table of contents panel showing heading-based chapter navigation */
 export function ChaptersPanel({ content, onChapterClick, onInsertText }: ChaptersPanelProps) {
-  const [refreshToken, setRefreshToken] = useState(0);
-
-  // Auto-refresh every 10 seconds
-  useEffect(() => {
-    const timer = setInterval(() => setRefreshToken((v) => v + 1), 10000);
-    return () => clearInterval(timer);
-  }, []);
-
-  // Prefer DOM-based chapters (more reliable), fall back to Markdown parsing
-  const chapters = useMemo(() => {
-    const domChapters = getChaptersFromDOM();
-    if (domChapters.length > 0 && domChapters.some(ch => ch.anchorId)) {
-      return domChapters;
-    }
-    return parseMarkdownChapters(content);
-  }, [content, refreshToken]);
+  const { chapters, refresh } = useChapters(content);
   const [showSyntaxHelp, setShowSyntaxHelp] = useState(false);
 
   return (
@@ -43,7 +28,7 @@ export function ChaptersPanel({ content, onChapterClick, onInsertText }: Chapter
           aria-label="目次を更新"
           onClick={() => {
             setShowSyntaxHelp(false);
-            setRefreshToken((v) => v + 1);
+            refresh();
           }}
         >
           <RefreshCw className="w-4 h-4 text-foreground-secondary" />

--- a/lib/editor-page/index.ts
+++ b/lib/editor-page/index.ts
@@ -2,6 +2,7 @@ export { useTextStatistics } from "./use-text-statistics";
 export { useEditorSettings } from "./use-editor-settings";
 export { useElectronEvents } from "./use-electron-events";
 export { useProjectLifecycle } from "./use-project-lifecycle";
+export { useChapters } from "./use-chapters";
 
 export type { TextStatisticsResult } from "./use-text-statistics";
 export type { EditorSettings, EditorSettingsHandlers, EditorSettingsSetters, UseEditorSettingsResult } from "./use-editor-settings";

--- a/lib/editor-page/use-chapters.ts
+++ b/lib/editor-page/use-chapters.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { useMemo, useState, useEffect, useCallback } from "react";
+import { getChaptersFromDOM, parseMarkdownChapters, type Chapter } from "@/lib/utils";
+
+const AUTO_REFRESH_INTERVAL_MS = 10_000;
+
+interface UseChaptersResult {
+  chapters: Chapter[];
+  refresh: () => void;
+}
+
+/**
+ * Shared hook for chapter detection with auto-refresh.
+ * Prefers DOM-based chapters (more reliable), falls back to Markdown parsing.
+ */
+export function useChapters(content: string): UseChaptersResult {
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  // Auto-refresh every 10 seconds
+  useEffect(() => {
+    const timer = setInterval(
+      () => setRefreshToken((v) => v + 1),
+      AUTO_REFRESH_INTERVAL_MS,
+    );
+    return () => clearInterval(timer);
+  }, []);
+
+  const chapters = useMemo(() => {
+    const domChapters = getChaptersFromDOM();
+    if (domChapters.length > 0 && domChapters.some((ch) => ch.anchorId)) {
+      return domChapters;
+    }
+    return parseMarkdownChapters(content);
+  }, [content, refreshToken]);
+
+  const refresh = useCallback(() => setRefreshToken((v) => v + 1), []);
+
+  return { chapters, refresh };
+}


### PR DESCRIPTION
## Summary
- Extract shared `useChapters()` hook to `lib/editor-page/use-chapters.ts`, consolidating the last remaining DRY violation from #195
- Both `Outline.tsx` and `ChaptersPanel.tsx` now use the shared hook instead of duplicated chapter detection logic

This completes the final remaining item from the two debt issues. All other items were resolved in prior PRs (#222, #223, #228, #272).

## Changes
| File | Action | Purpose |
|------|--------|---------|
| `lib/editor-page/use-chapters.ts` | CREATE | Shared hook: DOM-first chapter detection + Markdown fallback + 10s auto-refresh |
| `lib/editor-page/index.ts` | MODIFY | Add barrel export for `useChapters` |
| `components/Outline.tsx` | MODIFY | Replace inline chapter logic with `useChapters` hook (~20 lines removed) |
| `components/explorer/ChaptersPanel.tsx` | MODIFY | Replace inline chapter logic with `useChapters` hook (~15 lines removed) |

## Test plan
- [ ] Outline panel renders headings correctly
- [ ] Explorer ChaptersPanel renders headings correctly
- [ ] Auto-refresh updates chapters every 10 seconds
- [ ] Manual refresh button works in both panels
- [ ] `npx tsc --noEmit` passes with zero errors

Closes #155
Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized chapter and heading detection into a dedicated hook shared across outline and explorer components for improved code organization and reduced duplication.

* **Minor Changes**
  * Outline component now accepts an optional `content` prop to support the new chapter detection mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->