### PR TITLE
fix: defer tab restore until VFS root is set

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -68,6 +68,13 @@ export default function EditorPage() {
     return _skipAutoRestoreDetected;
   });
 
+  const isElectron = typeof window !== "undefined" && isElectronRenderer();
+
+  // VFS readiness: Web defaults to true (no VFS root validation),
+  // Electron waits for project lifecycle to set VFS root before tab restore.
+  const [vfsReady, setVfsReady] = useState(!isElectron);
+  const handleVfsReady = useCallback(() => setVfsReady(true), []);
+
   const [editorKey, setEditorKey] = useState(0);
   const incrementEditorKey = useCallback(() => {
     setEditorKey(prev => prev + 1);
@@ -103,7 +110,7 @@ export default function EditorPage() {
     onPowerSaveModeChange: handlePowerSaveModeChange,
   });
 
-  const tabManager = useTabManager({ skipAutoRestore, autoSave });
+  const tabManager = useTabManager({ skipAutoRestore, autoSave, vfsReady });
   const {
     content, setContent, currentFile, isDirty, isSaving, lastSavedTime,
     openFile: tabOpenFile, saveFile, saveAsFile,
@@ -134,8 +141,6 @@ export default function EditorPage() {
   const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
   const programmaticScrollRef = useRef(false);
 
-  const isElectron = typeof window !== "undefined" && isElectronRenderer();
-
   // --- Project lifecycle hook ---
   const projectLifecycle = useProjectLifecycle({
     editorMode,
@@ -147,6 +152,7 @@ export default function EditorPage() {
     content,
     skipAutoRestore,
     lastSavedTime,
+    onVfsReady: handleVfsReady,
   });
   const {
     state: {

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -23,9 +23,11 @@ export type { UseTabManagerReturn } from "./types";
 export function useTabManager(options?: {
   skipAutoRestore?: boolean;
   autoSave?: boolean;
+  vfsReady?: boolean;
 }): UseTabManagerReturn {
   const skipAutoRestore = options?.skipAutoRestore ?? false;
   const autoSaveEnabled = options?.autoSave ?? true;
+  const vfsReady = options?.vfsReady;
 
   // --- Core tab state -----------------------------------------------------
 
@@ -114,6 +116,7 @@ export function useTabManager(options?: {
     isProjectRef: tabState.isProjectRef,
     isElectron: tabState.isElectron,
     skipAutoRestore,
+    vfsReady,
   });
 
   // --- Backward compat alias: newFile === newTab --------------------------

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -20,6 +20,8 @@ import {
 export interface UseTabPersistenceParams extends TabManagerCore {
   /** Whether to skip auto-restore on mount. */
   skipAutoRestore: boolean;
+  /** Whether the VFS root has been set (Electron only). Tabs wait for this before reading files. */
+  vfsReady?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +50,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     setActiveTabId,
     isElectron,
     skipAutoRestore,
+    vfsReady,
   } = params;
 
   const [wasAutoRecovered, setWasAutoRecovered] = useState(false);
@@ -184,6 +187,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
 
   useEffect(() => {
     if (!isElectron || skipAutoRestore) return;
+    if (!vfsReady) return;
     if (!window.electronAPI?.vfs?.readFile) return;
 
     const restoreTabs = async () => {
@@ -236,7 +240,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     };
 
     void restoreTabs();
-  }, [isElectron, skipAutoRestore, setTabs, setActiveTabId]);
+  }, [isElectron, skipAutoRestore, vfsReady, setTabs, setActiveTabId]);
 
   return { wasAutoRecovered };
 }


### PR DESCRIPTION
## Summary
- On Electron restart, `useTabPersistence` fired `vfs.readFile()` before `useProjectLifecycle` had set the VFS root, causing `validateVFSPath()` to reject with "ディレクトリが開かれていません" and tabs to be silently lost
- Introduces a `vfsReady` signal: `useProjectLifecycle` calls `onVfsReady` after the VFS root is set (or when no project needs restoring), and `useTabPersistence` waits for this signal before attempting file reads
- Web mode is unaffected (`vfsReady` defaults to `true`)

Fixes #323

## Test plan
- [ ] Launch Electron app with a previously-opened project — tabs should restore correctly
- [ ] Launch with `?welcome` — should skip restore as before
- [ ] Web mode — should work unchanged (vfsReady defaults to true)
- [ ] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed app startup timing in Electron environments to ensure tabs and projects restore correctly from the previous session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->