### PR TITLE
refactor(page): extract keyboard shortcuts and panel state hooks

### DIFF
--- a/lib/editor-page/use-keyboard-shortcuts.ts
+++ b/lib/editor-page/use-keyboard-shortcuts.ts
@@ -1,0 +1,163 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useEffect } from "react";
+
+import type { SupportedFileExtension } from "@/lib/project-types";
+
+interface TabInfo {
+  id: string;
+  file: { name: string; path: string } | null;
+  isDirty: boolean;
+}
+
+interface UseKeyboardShortcutsParams {
+  isElectron: boolean;
+  saveFile: () => Promise<void>;
+  handlePasteAsPlaintext: () => Promise<void>;
+  handleToggleCompactMode: () => void;
+  handleOpenRubyDialog: () => void;
+  handleToggleTcy: () => void;
+  setShowSettingsModal: (value: boolean) => void;
+  setSearchOpenTrigger: Dispatch<SetStateAction<number>>;
+  incrementEditorKey: () => void;
+  // Tab operations
+  nextTab: () => void;
+  prevTab: () => void;
+  newTab: (fileType?: SupportedFileExtension) => void;
+  closeTab: (tabId: string) => void;
+  switchToIndex: (index: number) => void;
+  tabs: TabInfo[];
+  activeTabId: string;
+}
+
+/**
+ * Keyboard shortcut handler for the editor page.
+ *
+ * Handles: save, search, settings, paste-as-plaintext, compact mode,
+ * ruby dialog, tcy toggle, and tab navigation.
+ */
+export function useKeyboardShortcuts({
+  isElectron,
+  saveFile,
+  handlePasteAsPlaintext,
+  handleToggleCompactMode,
+  handleOpenRubyDialog,
+  handleToggleTcy,
+  setShowSettingsModal,
+  setSearchOpenTrigger,
+  incrementEditorKey,
+  nextTab,
+  prevTab,
+  newTab,
+  closeTab,
+  switchToIndex,
+  tabs,
+  activeTabId,
+}: UseKeyboardShortcutsParams): void {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
+      const isMac = nav.userAgentData
+        ? nav.userAgentData.platform === "macOS"
+        : /mac/i.test(navigator.userAgent);
+
+      // Cmd+, (macOS) / Ctrl+, (Windows/Linux): Settings
+      const isSettingsShortcut = isMac
+        ? event.metaKey && event.key === ","
+        : event.ctrlKey && event.key === ",";
+
+      // Cmd+S (macOS) / Ctrl+S (Windows/Linux): Save
+      const isSaveShortcut = isMac
+        ? event.metaKey && event.key === "s"
+        : event.ctrlKey && event.key === "s";
+
+      // Cmd+F (macOS) / Ctrl+F (Windows/Linux): Search
+      const isSearchShortcut = isMac
+        ? event.metaKey && event.key === "f"
+        : event.ctrlKey && event.key === "f";
+
+      // Shift+Cmd+V (macOS) / Shift+Ctrl+V (Windows/Linux): Paste as plaintext
+      const isPasteAsPlaintextShortcut = isMac
+        ? event.shiftKey && event.metaKey && event.key === "v"
+        : event.shiftKey && event.ctrlKey && event.key === "v";
+
+      // Shift+Cmd+M (macOS) / Shift+Ctrl+M (Windows/Linux): Compact mode toggle
+      const isCompactModeShortcut = isMac
+        ? event.shiftKey && event.metaKey && event.key === "m"
+        : event.shiftKey && event.ctrlKey && event.key === "m";
+
+      // Shift+Cmd+R (macOS) / Shift+Ctrl+R (Windows/Linux): Ruby dialog
+      const isRubyShortcut = isMac
+        ? event.shiftKey && event.metaKey && event.key === "r"
+        : event.shiftKey && event.ctrlKey && event.key === "r";
+
+      // Shift+Cmd+T (macOS) / Shift+Ctrl+T (Windows/Linux): Tcy
+      const isTcyShortcut = isMac
+        ? event.shiftKey && event.metaKey && event.key === "t"
+        : event.shiftKey && event.ctrlKey && event.key === "t";
+
+      // Tab shortcuts (Web only; Electron handles Cmd+W/T via menu)
+      const isNextTab = event.ctrlKey && !event.shiftKey && event.key === "Tab";
+      const isPrevTab = event.ctrlKey && event.shiftKey && event.key === "Tab";
+      const isNewTabShortcut = !isElectron && (isMac
+        ? event.metaKey && !event.shiftKey && event.key === "t"
+        : event.ctrlKey && !event.shiftKey && event.key === "t");
+      const isCloseTabShortcut = !isElectron && (isMac
+        ? event.metaKey && event.key === "w"
+        : event.ctrlKey && event.key === "w");
+      const isTabJump = (isMac ? event.metaKey : event.ctrlKey) &&
+        !event.shiftKey && event.key >= "1" && event.key <= "9";
+
+      if (isTcyShortcut) {
+        event.preventDefault();
+        handleToggleTcy();
+      } else if (isRubyShortcut) {
+        event.preventDefault();
+        handleOpenRubyDialog();
+      } else if (isCompactModeShortcut) {
+        event.preventDefault();
+        handleToggleCompactMode();
+      } else if (isSettingsShortcut) {
+        event.preventDefault();
+        setShowSettingsModal(true);
+      } else if (isSaveShortcut) {
+        event.preventDefault();
+        void saveFile();
+      } else if (isSearchShortcut) {
+        event.preventDefault();
+        setSearchOpenTrigger(prev => prev + 1);
+      } else if (isPasteAsPlaintextShortcut) {
+        event.preventDefault();
+        void handlePasteAsPlaintext();
+      } else if (isNextTab) {
+        event.preventDefault();
+        nextTab();
+        incrementEditorKey();
+      } else if (isPrevTab) {
+        event.preventDefault();
+        prevTab();
+        incrementEditorKey();
+      } else if (isNewTabShortcut) {
+        event.preventDefault();
+        newTab();
+        incrementEditorKey();
+      } else if (isCloseTabShortcut) {
+        event.preventDefault();
+        if (tabs.length === 1 && !tabs[0].file && !tabs[0].isDirty) {
+          window.close();
+          return;
+        }
+        closeTab(activeTabId);
+      } else if (isTabJump) {
+        event.preventDefault();
+        const idx = parseInt(event.key, 10) - 1;
+        switchToIndex(idx);
+        incrementEditorKey();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [saveFile, handlePasteAsPlaintext, handleToggleCompactMode, handleOpenRubyDialog, handleToggleTcy, isElectron, nextTab, prevTab, newTab, closeTab, tabs, activeTabId, switchToIndex, setShowSettingsModal, incrementEditorKey, setSearchOpenTrigger]);
+}

--- a/lib/editor-page/use-panel-state.ts
+++ b/lib/editor-page/use-panel-state.ts
@@ -1,0 +1,118 @@
+import type { Dispatch, SetStateAction } from "react";
+import { useCallback, useState } from "react";
+
+import type { ActivityBarView } from "@/components/ActivityBar";
+import type { SettingsCategory } from "@/components/SettingsModal";
+
+export interface PanelState {
+  topView: ActivityBarView;
+  bottomView: ActivityBarView;
+  searchResults: { matches: { from: number; to: number }[]; searchTerm: string } | null;
+  isRightPanelCollapsed: boolean;
+  dictionarySearchTrigger: { term: string; id: number };
+  settingsInitialCategory: SettingsCategory | undefined;
+  switchToCorrectionsTrigger: number;
+  showRubyDialog: boolean;
+  rubySelectedText: string;
+  editorDiff: { snapshotContent: string; currentContent: string; label: string } | null;
+}
+
+export interface PanelHandlers {
+  setTopView: (view: ActivityBarView) => void;
+  setBottomView: (view: ActivityBarView) => void;
+  setIsRightPanelCollapsed: Dispatch<SetStateAction<boolean>>;
+  setSettingsInitialCategory: (category: SettingsCategory | undefined) => void;
+  setShowRubyDialog: (show: boolean) => void;
+  setRubySelectedText: (text: string) => void;
+  setEditorDiff: (diff: { snapshotContent: string; currentContent: string; label: string } | null) => void;
+  handleOpenDictionary: (searchTerm?: string) => void;
+  handleShowAllSearchResults: (matches: { from: number; to: number }[], searchTerm: string) => void;
+  handleCloseSearchResults: () => void;
+  handleOpenLintingSettings: () => void;
+  handleOpenPosHighlightSettings: () => void;
+  triggerSwitchToCorrections: () => void;
+}
+
+interface UsePanelStateParams {
+  setShowSettingsModal: (value: boolean) => void;
+}
+
+/**
+ * Manages sidebar panel state, activity bar views, and panel-related handlers.
+ */
+export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
+  state: PanelState;
+  handlers: PanelHandlers;
+} {
+  const [topView, setTopView] = useState<ActivityBarView>("explorer");
+  const [bottomView, setBottomView] = useState<ActivityBarView>("none");
+  const [searchResults, setSearchResults] = useState<{ matches: { from: number; to: number }[]; searchTerm: string } | null>(null);
+  const [isRightPanelCollapsed, setIsRightPanelCollapsed] = useState(false);
+  const [dictionarySearchTrigger, setDictionarySearchTrigger] = useState<{ term: string; id: number }>({ term: "", id: 0 });
+  const [settingsInitialCategory, setSettingsInitialCategory] = useState<SettingsCategory | undefined>(undefined);
+  const [switchToCorrectionsTrigger, setSwitchToCorrectionsTrigger] = useState(0);
+  const [showRubyDialog, setShowRubyDialog] = useState(false);
+  const [rubySelectedText, setRubySelectedText] = useState("");
+  const [editorDiff, setEditorDiff] = useState<{ snapshotContent: string; currentContent: string; label: string } | null>(null);
+
+  const handleOpenDictionary = useCallback((searchTerm?: string) => {
+    if (searchTerm) {
+      setDictionarySearchTrigger(prev => ({ term: searchTerm, id: prev.id + 1 }));
+    }
+    setTopView("dictionary");
+  }, []);
+
+  const handleShowAllSearchResults = useCallback((matches: { from: number; to: number }[], searchTerm: string) => {
+    setSearchResults({ matches, searchTerm });
+    setTopView("search");
+  }, []);
+
+  const handleCloseSearchResults = useCallback(() => {
+    setSearchResults(null);
+    setTopView("explorer");
+  }, []);
+
+  const handleOpenLintingSettings = useCallback(() => {
+    setSettingsInitialCategory("linting");
+    setShowSettingsModal(true);
+  }, [setShowSettingsModal]);
+
+  const handleOpenPosHighlightSettings = useCallback(() => {
+    setSettingsInitialCategory("pos-highlight");
+    setShowSettingsModal(true);
+  }, [setShowSettingsModal]);
+
+  const triggerSwitchToCorrections = useCallback(() => {
+    setSwitchToCorrectionsTrigger((n) => n + 1);
+  }, []);
+
+  return {
+    state: {
+      topView,
+      bottomView,
+      searchResults,
+      isRightPanelCollapsed,
+      dictionarySearchTrigger,
+      settingsInitialCategory,
+      switchToCorrectionsTrigger,
+      showRubyDialog,
+      rubySelectedText,
+      editorDiff,
+    },
+    handlers: {
+      setTopView,
+      setBottomView,
+      setIsRightPanelCollapsed,
+      setSettingsInitialCategory,
+      setShowRubyDialog,
+      setRubySelectedText,
+      setEditorDiff,
+      handleOpenDictionary,
+      handleShowAllSearchResults,
+      handleCloseSearchResults,
+      handleOpenLintingSettings,
+      handleOpenPosHighlightSettings,
+      triggerSwitchToCorrections,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Extract `useKeyboardShortcuts` hook — all keyboard shortcut logic (Cmd+S, Cmd+F, Cmd+,, Shift+Cmd+V/M/R/T, tab navigation)
- Extract `usePanelState` hook — sidebar panel state, activity bar views, dictionary/search/linting settings handlers
- `page.tsx` reduced from 1223 to 1105 lines

## New Files
- `lib/editor-page/use-keyboard-shortcuts.ts` (163 lines)
- `lib/editor-page/use-panel-state.ts` (113 lines)

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Keyboard shortcuts work as before (save, search, settings, ruby, tcy, compact mode, tabs)
- [ ] Sidebar panel switching works (explorer, files, search, outline, characters, dictionary, word frequency)
- [ ] Right panel collapse/expand works
- [ ] Settings modal opens to correct category from linting/POS highlight links

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured sidebar panel state management and consolidated navigation handlers for improved code organization and consistency
  * Enhanced keyboard shortcut processing system with robust platform-specific support for macOS and other operating systems, ensuring more reliable editor operations, tab navigation, and UI interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->