### PR TITLE
fix: align TabInfo.file type with MdiFileDescriptor to fix TS2322

### DIFF
--- a/lib/editor-page/use-keyboard-shortcuts.ts
+++ b/lib/editor-page/use-keyboard-shortcuts.ts
@@ -1,11 +1,12 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useEffect } from "react";
 
+import type { MdiFileDescriptor } from "@/lib/mdi-file";
 import type { SupportedFileExtension } from "@/lib/project-types";
 
 interface TabInfo {
   id: string;
-  file: { name: string; path: string } | null;
+  file: MdiFileDescriptor | null;
   isDirty: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Fix TypeScript error `TS2322` at `app/page.tsx` that broke the Desktop Build and Release CI
- The `TabInfo` interface in `use-keyboard-shortcuts.ts` defined `file.path` as `string`, but the actual `MdiFileDescriptor.path` is `string | null`
- Import and use `MdiFileDescriptor` directly instead of the manually-defined inline type

## Test plan
- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Desktop Build and Release CI passes

Closes #380
Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to keyboard shortcuts implementation for enhanced code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->