### PR TITLE
fix: remove vitest/globals from tsconfig types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["@serwist/next/typings", "vitest/globals"],
+    "types": ["@serwist/next/typings"],
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Summary
- Remove `vitest/globals` from `tsconfig.json` `types` array to fix `TS2688: Cannot find type definition file for 'vitest/globals'`
- Test files already import from `vitest` directly, so the global type injection is unnecessary

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] `npm run dev` starts without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript build configuration for improved type checking consistency.

---

**Note:** This release contains primarily internal development improvements with no direct impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->