### PR TITLE
feat: テキストエクスポート（プレーン/ルビ付き）

### DIFF
--- a/lib/export/txt-exporter.ts
+++ b/lib/export/txt-exporter.ts
@@ -1,0 +1,102 @@
+/**
+ * TXT exporter for MDI content
+ *
+ * Converts MDI markdown to plain text with two modes:
+ * - Plain: strips all MDI/markdown markup, no ruby
+ * - With ruby: ruby text placed in fullwidth parentheses（）
+ */
+
+/**
+ * Convert MDI markdown to plain text without ruby annotations.
+ * Strips all MDI syntax and markdown formatting.
+ */
+export function mdiToPlainText(content: string): string {
+  let result = content;
+
+  // Ruby: {base|ruby} → base (discard ruby)
+  result = result.replace(/\{([^|{}]+)\|[^}]+\}/g, "$1");
+
+  // Tate-chu-yoko: ^text^ → text
+  result = result.replace(/\^([^^]+)\^/g, "$1");
+
+  // No-break: [[no-break:text]] → text
+  result = result.replace(/\[\[no-break:([^\]]+)\]\]/g, "$1");
+
+  // Kerning: [[kern:val:text]] → text
+  result = result.replace(/\[\[kern:[^:\]]+:([^\]]+)\]\]/g, "$1");
+
+  // Strip markdown formatting
+  result = stripMarkdown(result);
+
+  return result;
+}
+
+/**
+ * Convert MDI markdown to text with ruby in fullwidth parentheses.
+ * Example: {漢字|かんじ} → 漢字（かんじ）
+ */
+export function mdiToRubyText(content: string): string {
+  let result = content;
+
+  // Ruby: {base|ruby} → base（ruby）
+  // Remove dots in split ruby (e.g. とう.きょう → とうきょう)
+  result = result.replace(
+    /\{([^|{}]+)\|([^}]+)\}/g,
+    (_match, base: string, ruby: string) => {
+      const cleanRuby = ruby.replace(/\./g, "");
+      return `${base}\uFF08${cleanRuby}\uFF09`;
+    },
+  );
+
+  // Tate-chu-yoko: ^text^ → text
+  result = result.replace(/\^([^^]+)\^/g, "$1");
+
+  // No-break: [[no-break:text]] → text
+  result = result.replace(/\[\[no-break:([^\]]+)\]\]/g, "$1");
+
+  // Kerning: [[kern:val:text]] → text
+  result = result.replace(/\[\[kern:[^:\]]+:([^\]]+)\]\]/g, "$1");
+
+  // Strip markdown formatting
+  result = stripMarkdown(result);
+
+  return result;
+}
+
+/**
+ * Strip markdown formatting while preserving text structure.
+ * Handles headings, bold, italic, horizontal rules, etc.
+ */
+function stripMarkdown(text: string): string {
+  const lines = text.split("\n");
+  const result: string[] = [];
+
+  for (const line of lines) {
+    let processed = line;
+
+    // Headings: # Title → Title
+    processed = processed.replace(/^#{1,6}\s+/, "");
+
+    // Horizontal rules: --- / *** / ___ → empty line
+    if (/^(-{3,}|\*{3,}|_{3,})$/.test(processed.trim())) {
+      result.push("");
+      continue;
+    }
+
+    // Bold italic: ***text*** → text
+    processed = processed.replace(/\*\*\*(.+?)\*\*\*/g, "$1");
+
+    // Bold: **text** → text
+    processed = processed.replace(/\*\*(.+?)\*\*/g, "$1");
+
+    // Italic: *text* → text
+    processed = processed.replace(/\*(.+?)\*/g, "$1");
+
+    // Escaped characters: \{ \^ \[ → literal
+    processed = processed.replace(/\\([{^[\]])/g, "$1");
+
+    result.push(processed);
+  }
+
+  return result.join("\n");
+}

--- a/lib/export/types.ts
+++ b/lib/export/types.ts
@@ -15,7 +15,7 @@ export interface ExportOptions {
   includeTableOfContents?: boolean;
 }
 
-export type ExportFormat = "pdf" | "epub" | "docx";
+export type ExportFormat = "pdf" | "epub" | "docx" | "txt" | "txt-ruby";
 
 export interface Chapter {
   title: string;

--- a/lib/menu-definitions.ts
+++ b/lib/menu-definitions.ts
@@ -40,6 +40,9 @@ export const WEB_MENU_STRUCTURE: MenuSection[] = [
       {
         label: 'エクスポート',
         submenu: [
+          { label: 'テキスト（プレーン）としてエクスポート...', action: 'export-txt' },
+          { label: 'テキスト（ルビ付き）としてエクスポート...', action: 'export-txt-ruby' },
+          { type: 'separator' },
           { label: 'PDF としてエクスポート...', action: 'export-pdf' },
           { label: 'EPUB としてエクスポート...', action: 'export-epub' },
           { label: 'DOCX としてエクスポート...', action: 'export-docx' },

--- a/lib/use-web-menu-handlers.ts
+++ b/lib/use-web-menu-handlers.ts
@@ -12,7 +12,7 @@ interface UseWebMenuHandlersProps {
   onOpenRecentProject?: (projectId: string) => void;
   onCloseWindow?: () => void;
   onToggleCompactMode?: () => void;
-  onExport?: (format: 'pdf' | 'epub' | 'docx') => void;
+  onExport?: (format: 'pdf' | 'epub' | 'docx' | 'txt' | 'txt-ruby') => void;
   editorView?: EditorView | null;
   fontScale?: number;
   onFontScaleChange?: (scale: number) => void;
@@ -61,6 +61,12 @@ export function useWebMenuHandlers({
         break;
 
       // Export
+      case 'export-txt':
+        onExport?.('txt');
+        break;
+      case 'export-txt-ruby':
+        onExport?.('txt-ruby');
+        break;
       case 'export-pdf':
         onExport?.('pdf');
         break;


### PR DESCRIPTION
## Summary

- Add TXT export with two modes: plain text (no ruby) and ruby text (fullwidth parentheses)
- New `txt-exporter.ts` handles MDI → plain text conversion
- Works client-side via File System Access API (no Electron IPC needed)
- Accessible from ファイル → エクスポート menu

## Conversion Examples

**MDI source:**
```
{漢字|かんじ}を{覚|おぼ}える。^12^月の話。
```

**Plain export:**
```
漢字を覚える。12月の話。
```

**Ruby export:**
```
漢字（かんじ）を覚（おぼ）える。12月の話。
```

## Files Changed
| File | Change |
|------|--------|
| `lib/export/txt-exporter.ts` | NEW — `mdiToPlainText()` / `mdiToRubyText()` |
| `lib/export/types.ts` | Add `"txt"` / `"txt-ruby"` to `ExportFormat` |
| `lib/export/use-export.ts` | Handle TXT export with save dialog |
| `lib/menu-definitions.ts` | Add TXT menu items |
| `lib/use-web-menu-handlers.ts` | Wire TXT menu actions |

## Test plan

- [ ] ファイル → エクスポート → テキスト（プレーン）→ saves .txt without ruby
- [ ] ファイル → エクスポート → テキスト（ルビ付き）→ saves .txt with ruby in（）
- [ ] Both work in web mode (no Electron required)
- [ ] Cancel save dialog → no error notification
- [ ] Empty document → shows warning notification
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)