### PR TITLE
feat: add toast notifications for power-save mode changes

### DIFF
--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { fetchAppState, persistAppState } from "@/lib/app-state-manager";
 import { DEFAULT_MODEL_ID } from "@/lib/llm-client/model-registry";
 import type { Severity } from "@/lib/linting/types";
+import { notificationManager } from "@/lib/notification-manager";
 
 export interface EditorSettings {
   fontScale: number;
@@ -357,6 +358,7 @@ export function useEditorSettings(
       setPowerSaveMode(true);
       setLintingEnabled(false);
       setLlmEnabled(false);
+      notificationManager.warning("省電力モードが有効になりました。校正精度が低下する場合があります。");
     } else {
       // Restore previous state
       const stored = await fetchAppState();
@@ -376,6 +378,7 @@ export function useEditorSettings(
         await persistAppState({ powerSaveMode: false, prePowerSaveState: null });
       }
       setPowerSaveMode(false);
+      notificationManager.info("省電力モードを解除しました。");
     }
   }, [lintingEnabled, lintingRuleConfigs, llmEnabled]);
 


### PR DESCRIPTION
## Summary
- Show warning toast when power-save mode is enabled: "省電力モードが有効になりました。校正精度が低下する場合があります。"
- Show info toast when power-save mode is disabled: "省電力モードを解除しました。"

## Changes
- `lib/editor-page/use-editor-settings.ts`: Import `notificationManager`, add `.warning()` and `.info()` calls in `handlePowerSaveModeChange`

## Test plan
- [ ] Toggle power-save mode ON → verify warning toast appears in bottom-right
- [ ] Toggle power-save mode OFF → verify info toast appears in bottom-right
- [ ] Verify existing AC power detection notification still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)