### PR TITLE
feat: add toggle for auto power-save on battery

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -94,7 +94,7 @@ export default function EditorPage() {
     scrollSensitivity, compactMode, showSettingsModal,
     lintingEnabled, lintingRuleConfigs,
     llmEnabled, llmModelId,
-    powerSaveMode,
+    powerSaveMode, autoPowerSaveOnBattery,
   } = settings;
   const {
     handleFontScaleChange, handleLineHeightChange, handleParagraphSpacingChange,
@@ -106,7 +106,7 @@ export default function EditorPage() {
     handleLintingEnabledChange, handleLintingRuleConfigChange,
     handleLintingRuleConfigsBatchChange,
     handleLlmEnabledChange, handleLlmModelIdChange,
-    handlePowerSaveModeChange,
+    handlePowerSaveModeChange, handleAutoPowerSaveOnBatteryChange,
   } = settingsHandlers;
 
   const isElectron = typeof window !== "undefined" && isElectronRenderer();
@@ -114,6 +114,7 @@ export default function EditorPage() {
   // --- Power saving hook ---
   usePowerSaving({
     powerSaveMode,
+    autoPowerSaveOnBattery,
     onPowerSaveModeChange: handlePowerSaveModeChange,
   });
 
@@ -933,6 +934,8 @@ export default function EditorPage() {
           initialCategory={settingsInitialCategory}
           powerSaveMode={powerSaveMode}
           onPowerSaveModeChange={handlePowerSaveModeChange}
+          autoPowerSaveOnBattery={autoPowerSaveOnBattery}
+          onAutoPowerSaveOnBatteryChange={handleAutoPowerSaveOnBatteryChange}
         />
 
         {/* Ruby dialog */}

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -92,6 +92,8 @@ interface SettingsModalProps {
   // Power saving (Electron only)
   powerSaveMode?: boolean;
   onPowerSaveModeChange?: (value: boolean) => void;
+  autoPowerSaveOnBattery?: boolean;
+  onAutoPowerSaveOnBatteryChange?: (value: boolean) => void;
   /** Open modal on a specific tab */
   initialCategory?: SettingsCategory;
 }
@@ -156,6 +158,8 @@ export default function SettingsModal({
   onLlmModelIdChange,
   powerSaveMode,
   onPowerSaveModeChange,
+  autoPowerSaveOnBattery,
+  onAutoPowerSaveOnBatteryChange,
   initialCategory,
 }: SettingsModalProps) {
   const [activeCategory, setActiveCategory] = useState<SettingsCategory>(initialCategory ?? "editor");
@@ -699,8 +703,18 @@ export default function SettingsModal({
                     <span className="text-sm font-medium text-foreground">省電力モードを有効にする</span>
                   </label>
                 </div>
+                <div className="mt-4">
+                  <label className="flex items-center gap-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={autoPowerSaveOnBattery ?? true}
+                      onChange={(e) => onAutoPowerSaveOnBatteryChange?.(e.target.checked)}
+                      className="w-4 h-4 rounded border-border accent-accent"
+                    />
+                    <span className="text-sm font-medium text-foreground">バッテリー駆動時に自動で省電力モードを提案する</span>
+                  </label>
+                </div>
                 <div className="text-xs text-foreground-secondary space-y-1">
-                  <p>• バッテリー駆動中は自動的に省電力モードの使用を提案します</p>
                   <p>• AC電源接続時に自動的に省電力モードを解除します</p>
                   <p>• 省電力モードを解除すると、以前の校正・AI設定が復元されます</p>
                 </div>

--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -26,6 +26,7 @@ export interface EditorSettings {
   llmEnabled: boolean;
   llmModelId: string;
   powerSaveMode: boolean;
+  autoPowerSaveOnBattery: boolean;
 }
 
 export interface EditorSettingsHandlers {
@@ -50,6 +51,7 @@ export interface EditorSettingsHandlers {
   handleLlmEnabledChange: (value: boolean) => void;
   handleLlmModelIdChange: (modelId: string) => void;
   handlePowerSaveModeChange: (enabled: boolean) => void;
+  handleAutoPowerSaveOnBatteryChange: (enabled: boolean) => void;
 }
 
 export interface EditorSettingsSetters {
@@ -98,6 +100,7 @@ export function useEditorSettings(
   const [llmEnabled, setLlmEnabled] = useState(false);
   const [llmModelId, setLlmModelId] = useState("qwen3-1.7b-q8");
   const [powerSaveMode, setPowerSaveMode] = useState(false);
+  const [autoPowerSaveOnBattery, setAutoPowerSaveOnBattery] = useState(true);
 
   // Load persisted settings on mount
   useEffect(() => {
@@ -175,6 +178,7 @@ export function useEditorSettings(
           setLintingRuleConfigs(sanitized);
         }
         if (appState.powerSaveMode !== undefined) setPowerSaveMode(appState.powerSaveMode);
+        if (appState.autoPowerSaveOnBattery !== undefined) setAutoPowerSaveOnBattery(appState.autoPowerSaveOnBattery);
         // Force editor rebuild to apply restored settings (e.g. custom font)
         incrementEditorKey();
       } catch (error) {
@@ -379,6 +383,13 @@ export function useEditorSettings(
     }
   }, [lintingEnabled, lintingRuleConfigs, llmEnabled]);
 
+  const handleAutoPowerSaveOnBatteryChange = useCallback((enabled: boolean) => {
+    setAutoPowerSaveOnBattery(enabled);
+    void persistAppState({ autoPowerSaveOnBattery: enabled }).catch((error) => {
+      console.error("Failed to persist autoPowerSaveOnBattery:", error);
+    });
+  }, []);
+
   return {
     settings: {
       fontScale,
@@ -401,6 +412,7 @@ export function useEditorSettings(
       llmEnabled,
       llmModelId,
       powerSaveMode,
+      autoPowerSaveOnBattery,
     },
     handlers: {
       handleFontScaleChange,
@@ -424,6 +436,7 @@ export function useEditorSettings(
       handleLlmEnabledChange,
       handleLlmModelIdChange,
       handlePowerSaveModeChange,
+      handleAutoPowerSaveOnBatteryChange,
     },
     setters: {
       setLineHeight,

--- a/lib/editor-page/use-power-saving.ts
+++ b/lib/editor-page/use-power-saving.ts
@@ -5,6 +5,7 @@ import { notificationManager } from "@/lib/notification-manager";
 
 interface UsePowerSavingOptions {
   powerSaveMode: boolean;
+  autoPowerSaveOnBattery: boolean;
   onPowerSaveModeChange: (enabled: boolean) => void;
 }
 
@@ -16,11 +17,15 @@ interface UsePowerSavingOptions {
  */
 export function usePowerSaving({
   powerSaveMode,
+  autoPowerSaveOnBattery,
   onPowerSaveModeChange,
 }: UsePowerSavingOptions): void {
   // Use refs to avoid stale closures in the IPC callback
   const powerSaveModeRef = useRef(powerSaveMode);
   powerSaveModeRef.current = powerSaveMode;
+
+  const autoPowerSaveRef = useRef(autoPowerSaveOnBattery);
+  autoPowerSaveRef.current = autoPowerSaveOnBattery;
 
   const onChangeRef = useRef(onPowerSaveModeChange);
   onChangeRef.current = onPowerSaveModeChange;
@@ -31,7 +36,7 @@ export function usePowerSaving({
     if (!api?.power) return;
 
     const cleanup = api.power.onPowerStateChange((state) => {
-      if (state === "battery" && !powerSaveModeRef.current) {
+      if (state === "battery" && !powerSaveModeRef.current && autoPowerSaveRef.current) {
         // Show in-app notification with action buttons
         notificationManager.showMessage(
           "バッテリー駆動を検出しました。省電力モードを有効にしますか？\n校正機能とAI関連機能が一時的に無効になります。",

--- a/lib/storage-types.ts
+++ b/lib/storage-types.ts
@@ -85,6 +85,7 @@ export interface AppState {
 
   // 省電力モード
   powerSaveMode?: boolean;
+  autoPowerSaveOnBattery?: boolean;
   prePowerSaveState?: {
     lintingEnabled: boolean;
     lintingRuleConfigs: Record<string, { enabled: boolean; severity: Severity }>;


### PR DESCRIPTION
## Summary
- Add `autoPowerSaveOnBattery` setting (defaults to `true`, preserving current behavior)
- New toggle in power-save settings: "バッテリー駆動時に自動で省電力モードを提案する"
- When disabled, the battery detection notification is suppressed
- AC reconnection auto-restore still works regardless of this setting

## Changes
- `lib/storage-types.ts`: Add `autoPowerSaveOnBattery` field to `AppState`
- `lib/editor-page/use-editor-settings.ts`: Add state, handler, loading, and return for new setting
- `lib/editor-page/use-power-saving.ts`: Gate battery prompt on `autoPowerSaveOnBattery` ref
- `components/SettingsModal.tsx`: Add props and checkbox toggle in power section
- `app/page.tsx`: Wire new setting and handler through to hooks and modal

## Test plan
- [ ] Default behavior unchanged: on battery, prompt appears
- [ ] Disable toggle → on battery, no prompt appears
- [ ] Re-enable toggle → on battery, prompt appears again
- [ ] Setting persists across app restarts
- [ ] AC reconnection still auto-restores regardless of toggle state

🤖 Generated with [Claude Code](https://claude.com/claude-code)