### PR TITLE
fix: LLM indicator and model loading for forced validation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -475,6 +475,7 @@ export default function EditorPage() {
     editorViewInstance,
     llmEnabled,
     powerSaveMode,
+    llmModelId,
   );
 
   // --- Ignored corrections hook ---

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -50,6 +50,7 @@ export function useLinting(
   editorViewInstance: EditorView | null,
   llmEnabled: boolean = false,
   powerSaveMode: boolean = false,
+  llmModelId: string = "qwen3-1.7b-q8",
 ): UseLintingResult {
   const ruleRunnerRef = useRef<RuleRunner | null>(null);
   const [lintIssues, setLintIssues] = useState<LintIssue[]>([]);
@@ -134,6 +135,7 @@ export function useLinting(
           nlpClient,
           llmClient: getLlmClient(),
           llmEnabled,
+          llmModelId,
           forceFullScan: true,
           forceLlmValidation: true,
         });
@@ -142,7 +144,7 @@ export function useLinting(
       console.error("[useLinting] Failed to refresh linting:", err);
       setIsLinting(false);
     });
-  }, [editorViewInstance, lintingEnabled, llmEnabled, powerSaveMode]);
+  }, [editorViewInstance, lintingEnabled, llmEnabled, powerSaveMode, llmModelId]);
 
   return {
     ruleRunner,

--- a/lib/hooks/use-llm-status.ts
+++ b/lib/hooks/use-llm-status.ts
@@ -92,8 +92,8 @@ export function useLlmStatus(
     };
   }, []);
 
-  // Inferring overrides ready
-  if (isInferring && baseStatus === "ready") {
+  // Inferring overrides any base status (including "off" during forced validation)
+  if (isInferring) {
     return "inferring";
   }
 

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
@@ -67,6 +67,7 @@ export function updateLintingSettings(
     nlpClient?: INlpClient | null;
     llmClient?: ILlmClient | null;
     llmEnabled?: boolean;
+    llmModelId?: string;
     forceFullScan?: boolean;
     forceLlmValidation?: boolean;
     ignoredCorrections?: IgnoredCorrection[];


### PR DESCRIPTION
## Summary
Fixes two bugs when clicking the refresh button (全文を再検査) with LLM toggle off:

1. **Indicator stayed grey**: `useLlmStatus` only showed "inferring" (green pulse) when `baseStatus === "ready"`. Since `llmEnabled` was off, `baseStatus` was "off" and inference events were ignored. Now shows "inferring" whenever `llm:inference-start` fires, regardless of toggle state.

2. **"Model not loaded" error**: The decoration plugin called `infer()` without first loading the model. Now passes `llmModelId` through the meta chain and calls `loadModel()` before running validation/inference. `loadModel` is a no-op if the model is already loaded.

## Changes
- `lib/hooks/use-llm-status.ts`: Remove `baseStatus === "ready"` guard from inferring check
- `lib/editor-page/use-linting.ts`: Accept and pass `llmModelId` param
- `packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts`: Add `llmModelId` to settings type
- `packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts`: Track `currentLlmModelId`, call `loadModel()` before inference
- `app/page.tsx`: Pass `llmModelId` to `useLinting()`

## Test plan
- [ ] LLM toggle OFF + click refresh → green pulse appears, validation runs without error
- [ ] LLM toggle ON + click refresh → same behavior as before (green pulse, validation + L3)
- [ ] Power-save ON + click refresh → model loads, validation runs, indicator pulses
- [ ] Normal editing with LLM ON → no regression, indicator works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)