### PR TITLE
fix: create ProseMirror ruby nodes instead of inserting raw MDI text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment } from "@milkdown/prose/model";
 
 import { useTheme } from "@/contexts/ThemeContext";
 import Explorer, { FilesPanel } from "@/components/Explorer";
@@ -323,13 +324,37 @@ export default function EditorPage() {
     setShowRubyDialog(true);
   }, [editorViewInstance, setRubySelectedText, setShowRubyDialog]);
 
-  /** Apply Ruby markup by replacing the editor selection */
+  /** Apply Ruby markup by replacing the editor selection with ProseMirror nodes */
   const handleApplyRuby = useCallback((rubyMarkup: string) => {
     if (!editorViewInstance) return;
     const sel = rubySelectionRef.current;
     if (!sel) return;
     const { state, dispatch } = editorViewInstance;
-    const tr = state.tr.insertText(rubyMarkup, sel.from, sel.to);
+    const rubyNodeType = state.schema.nodes.ruby;
+    if (!rubyNodeType) {
+      // Fallback: insert as plain text if ruby node type is not available
+      const tr = state.tr.insertText(rubyMarkup, sel.from, sel.to);
+      dispatch(tr);
+      rubySelectionRef.current = null;
+      return;
+    }
+    // Parse ruby markup: mixed text and {base|reading} segments
+    const RUBY_RE = /\{([^|]+)\|([^}]+)\}/g;
+    const nodes: import("@milkdown/prose/model").Node[] = [];
+    let lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = RUBY_RE.exec(rubyMarkup)) !== null) {
+      if (m.index > lastIndex) {
+        nodes.push(state.schema.text(rubyMarkup.slice(lastIndex, m.index)));
+      }
+      nodes.push(rubyNodeType.create({ base: m[1], text: m[2] }));
+      lastIndex = m.index + m[0].length;
+    }
+    if (lastIndex < rubyMarkup.length) {
+      nodes.push(state.schema.text(rubyMarkup.slice(lastIndex)));
+    }
+    const fragment = Fragment.from(nodes);
+    const tr = state.tr.replaceWith(sel.from, sel.to, fragment);
     dispatch(tr);
     rubySelectionRef.current = null;
   }, [editorViewInstance]);


### PR DESCRIPTION
## Summary
- Fix `handleApplyRuby` to create proper ProseMirror ruby atom nodes instead of inserting raw MDI syntax (`{base|reading}`) as plain text

## Root Cause
`handleApplyRuby` in `app/page.tsx` used `state.tr.insertText(rubyMarkup, ...)` which inserts the MDI markup string literally into the document. The remark ruby parser only runs during initial markdown→ProseMirror conversion, not on runtime insertions.

## Changes
- Parse the ruby markup string using the same `{base|reading}` regex pattern used by the syntax parser
- Create ProseMirror `ruby` atom nodes (with `base` and `text` attributes) via `state.schema.nodes.ruby.create()`
- Handle mixed content (plain text segments + ruby segments) by building a Fragment
- Added graceful fallback to `insertText()` if the ruby node type is not registered in the schema

## Testing
- Insert ruby via the Ruby Dialog (ルビ設定) → should render as `<ruby><rb>base</rb><rt>reading</rt></ruby>` instead of raw `{base|reading}` text
- Mixed kanji/non-kanji selections should produce correct mix of text + ruby nodes

Closes Iktahana/illusions#427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Ruby text annotation with enhanced parsing support for {base|reading} pattern format
  * Added graceful fallback to plain text insertion when ruby formatting is unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->