### PR TITLE
feat(correction): Phase B — unified CorrectionConfig + ConfigChangeReason (#448)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -512,10 +512,11 @@ export default function EditorPage() {
 
     import("@/packages/milkdown-plugin-japanese-novel/linting-plugin").then(
       ({ updateLintingSettings }) => {
-        updateLintingSettings(editorViewInstance, {
-          ignoredCorrections,
-          forceFullScan: true,
-        });
+        updateLintingSettings(
+          editorViewInstance,
+          { ignoredCorrections },
+          "ignored-correction",
+        );
       },
     ).catch((err) => {
       console.error("[page] Failed to sync ignored corrections:", err);

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -689,10 +689,14 @@ function MilkdownEditor({
     if (!editorViewInstance) return;
 
     import('@/packages/milkdown-plugin-japanese-novel/linting-plugin').then(({ updateLintingSettings }) => {
-      updateLintingSettings(editorViewInstance, {
-        enabled: lintingEnabled,
-        ruleRunner: lintingRuleRunner,
-      });
+      updateLintingSettings(
+        editorViewInstance,
+        {
+          enabled: lintingEnabled,
+          ruleRunner: lintingRuleRunner,
+        },
+        "rule-config-change",
+      );
     }).catch(err => {
       console.error('[Editor] Failed to update linting settings:', err);
     });

--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from "react";
 import { fetchAppState, persistAppState } from "@/lib/app-state-manager";
 import { DEFAULT_MODEL_ID } from "@/lib/llm-client/model-registry";
 import type { Severity } from "@/lib/linting/types";
+import type { CorrectionConfig } from "@/lib/linting/correction-config";
+import { DEFAULT_CORRECTION_CONFIG } from "@/lib/linting/correction-config";
 
 export interface EditorSettings {
   fontScale: number;
@@ -26,6 +28,8 @@ export interface EditorSettings {
   llmEnabled: boolean;
   llmModelId: string;
   powerSaveMode: boolean;
+  /** Unified correction config derived from individual linting fields */
+  correctionConfig: CorrectionConfig;
 }
 
 export interface EditorSettingsHandlers {
@@ -401,6 +405,16 @@ export function useEditorSettings(
       llmEnabled,
       llmModelId,
       powerSaveMode,
+      correctionConfig: {
+        ...DEFAULT_CORRECTION_CONFIG,
+        enabled: lintingEnabled,
+        ruleOverrides: lintingRuleConfigs,
+        llm: {
+          ...DEFAULT_CORRECTION_CONFIG.llm,
+          modelId: llmModelId,
+          validationEnabled: llmEnabled,
+        },
+      },
     },
     handlers: {
       handleFontScaleChange,

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -132,13 +132,16 @@ export function useLinting(
             ? getLlmClient()
             : null;
 
-        updateLintingSettings(editorViewInstance, {
-          ruleRunner: ruleRunnerRef.current,
-          nlpClient,
-          llmClient,
-          llmEnabled,
-          forceFullScan: true,
-        });
+        updateLintingSettings(
+          editorViewInstance,
+          {
+            ruleRunner: ruleRunnerRef.current,
+            nlpClient,
+            llmClient,
+            llmEnabled,
+          },
+          "manual-refresh",
+        );
       },
     ).catch((err) => {
       console.error("[useLinting] Failed to refresh linting:", err);

--- a/lib/linting/correction-config.ts
+++ b/lib/linting/correction-config.ts
@@ -1,0 +1,65 @@
+/**
+ * CorrectionConfig - Single source of truth for all correction settings.
+ * 校正設定の統一インターフェース定義。
+ */
+
+import type { LintRuleConfig } from "./types";
+import type { IgnoredCorrection } from "@/lib/project-types";
+
+/**
+ * Identifies what triggered a config change, enabling smart cache invalidation
+ * in the decoration plugin.
+ */
+export type ConfigChangeReason =
+  | "text-edit"            // re-run affected paragraphs only
+  | "rule-config-change"   // clear issue cache, full re-run
+  | "mode-change"          // clear all caches, full re-run
+  | "guideline-change"     // clear issue + validation cache
+  | "model-change"         // clear validation cache only
+  | "ignored-correction"   // rebuild decorations only (no re-run)
+  | "manual-refresh";      // clear all caches, force re-run
+
+/** Correction mode identifiers */
+export type CorrectionModeId = "novel" | "official" | "blog" | "academic" | "sns";
+
+/** Guideline identifiers */
+export type GuidelineId =
+  | "joyo-kanji-2010"
+  | "okurigana-1973"
+  | "gairai-1991"
+  | "gendai-kanazukai-1986"
+  | "koyo-bun-2022"
+  | "jis-x-4051"
+  | "kisha-handbook-14"
+  | "jtf-style-3"
+  | "jtca-style-3"
+  | "editors-rulebook"
+  | "novel-manuscript";
+
+/** Single source of truth for all correction settings */
+export interface CorrectionConfig {
+  enabled: boolean;
+  mode: CorrectionModeId;
+  guidelines: GuidelineId[];
+  ruleOverrides: Record<string, Partial<LintRuleConfig>>;
+  llm: {
+    modelId: string;
+    cooldownMs: number;
+    validationEnabled: boolean;
+  };
+  ignoredCorrections: IgnoredCorrection[];
+}
+
+/** Default CorrectionConfig values */
+export const DEFAULT_CORRECTION_CONFIG: CorrectionConfig = {
+  enabled: true,
+  mode: "novel",
+  guidelines: ["joyo-kanji-2010", "novel-manuscript"],
+  ruleOverrides: {},
+  llm: {
+    modelId: "",
+    cooldownMs: 60_000,
+    validationEnabled: true,
+  },
+  ignoredCorrections: [],
+};

--- a/lib/linting/index.ts
+++ b/lib/linting/index.ts
@@ -20,3 +20,11 @@ export {
   AbstractMorphologicalDocumentLintRule,
 } from "./base-rule";
 export { RuleRunner } from "./rule-runner";
+
+export type {
+  ConfigChangeReason,
+  CorrectionModeId,
+  GuidelineId,
+  CorrectionConfig,
+} from "./correction-config";
+export { DEFAULT_CORRECTION_CONFIG } from "./correction-config";

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
@@ -9,6 +9,8 @@ import type { RuleRunner, LintIssue } from '@/lib/linting';
 import type { INlpClient } from '@/lib/nlp-client/types';
 import type { ILlmClient } from '@/lib/llm-client/types';
 import type { IgnoredCorrection } from '@/lib/project-types';
+import type { ConfigChangeReason } from '@/lib/linting/correction-config';
+import type { LintingSettingsUpdate } from './types';
 import { createLintingPlugin, lintingKey } from './decoration-plugin';
 
 // Export the plugin key for external use
@@ -58,19 +60,18 @@ export function linting(options: LintingOptions = {}) {
  *
  * @param view EditorView instance
  * @param settings Settings to update
+ * @param reason Optional reason for the change, enabling smart cache invalidation
  */
 export function updateLintingSettings(
   view: EditorView,
-  settings: {
-    enabled?: boolean;
-    ruleRunner?: RuleRunner | null;
-    nlpClient?: INlpClient | null;
-    llmClient?: ILlmClient | null;
-    llmEnabled?: boolean;
-    forceFullScan?: boolean;
-    ignoredCorrections?: IgnoredCorrection[];
-  }
+  settings: LintingSettingsUpdate,
+  reason?: ConfigChangeReason
 ): void {
-  const tr = view.state.tr.setMeta(lintingKey, settings);
+  const meta: LintingSettingsUpdate = { ...settings };
+  // If a reason is provided as a separate argument, it takes precedence
+  if (reason !== undefined) {
+    meta.changeReason = reason;
+  }
+  const tr = view.state.tr.setMeta(lintingKey, meta);
   view.dispatch(tr);
 }

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
@@ -9,6 +9,9 @@ import type { RuleRunner } from '@/lib/linting';
 import type { INlpClient } from '@/lib/nlp-client/types';
 import type { ILlmClient } from '@/lib/llm-client/types';
 import type { IgnoredCorrection } from '@/lib/project-types';
+import type { ConfigChangeReason } from '@/lib/linting/correction-config';
+
+export type { ConfigChangeReason };
 
 /**
  * Options for the linting ProseMirror plugin
@@ -30,4 +33,21 @@ export interface LintingPluginOptions {
 export interface LintingPluginState {
   decorations: DecorationSet;
   enabled: boolean;
+}
+
+/**
+ * Settings that can be passed to updateLintingSettings().
+ * The optional changeReason enables smart cache invalidation.
+ */
+export interface LintingSettingsUpdate {
+  enabled?: boolean;
+  ruleRunner?: RuleRunner | null;
+  nlpClient?: INlpClient | null;
+  llmClient?: ILlmClient | null;
+  llmEnabled?: boolean;
+  /** @deprecated Use changeReason instead */
+  forceFullScan?: boolean;
+  ignoredCorrections?: IgnoredCorrection[];
+  /** Identifies the trigger for this change, enabling precise cache invalidation */
+  changeReason?: ConfigChangeReason;
 }


### PR DESCRIPTION
## Summary

- Define `CorrectionConfig` as single source of truth for all correction settings
- Add `ConfigChangeReason` type for precise, semantic cache invalidation (replaces `forceFullScan: boolean`)
- `ignored-correction` fast path: skips rule re-run, only rebuilds decorations

## Changes

- `lib/linting/correction-config.ts` — NEW: CorrectionConfig, ConfigChangeReason, GuidelineId, CorrectionModeId
- `lib/linting/index.ts` — MODIFY: exports new types
- `lib/editor-page/use-editor-settings.ts` — MODIFY: adds derived `correctionConfig` field
- `lib/editor-page/use-linting.ts` — MODIFY: passes `"manual-refresh"` reason to updateLintingSettings
- `packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts` — MODIFY: LintingSettingsUpdate with changeReason
- `packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts` — MODIFY: updateLintingSettings accepts optional reason
- `packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts` — MODIFY: ConfigChangeReason switch
- `app/page.tsx` — MODIFY: ignoredCorrections uses "ignored-correction" reason
- `components/Editor.tsx` — MODIFY: lintingEnabled changes use "rule-config-change" reason

## Verification

- `npx tsc --noEmit` ✅ zero errors

Part of #433
Closes #448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced multiple correction modes (novel, official, blog, academic, SNS) for specialized writing contexts
  - Added comprehensive guideline support for customizable writing standards and rule configurations
  - Enhanced correction settings with improved LLM integration and validation options

* **Improvements**
  - Optimized linting system performance through smarter cache invalidation based on change triggers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->