### PR TITLE
fix(linting): enable skipDialogue by default in 8 lint rules

### DIFF
--- a/lib/linting/rules/conjugation-errors.ts
+++ b/lib/linting/rules/conjugation-errors.ts
@@ -151,6 +151,7 @@ export class ConjugationErrorRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
   };
 
   lint(text: string, config: LintRuleConfig): LintIssue[] {

--- a/lib/linting/rules/era-year-validator.ts
+++ b/lib/linting/rules/era-year-validator.ts
@@ -84,6 +84,7 @@ export class EraYearValidatorRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
   };
 
   lint(text: string, config: LintRuleConfig): LintIssue[] {

--- a/lib/linting/rules/joyo-kanji.ts
+++ b/lib/linting/rules/joyo-kanji.ts
@@ -126,6 +126,7 @@ export class JoyoKanjiRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "info",
+    skipDialogue: true,
     options: { allowJinmeiyo: true } satisfies JoyoKanjiOptions,
   };
 

--- a/lib/linting/rules/notation-consistency.ts
+++ b/lib/linting/rules/notation-consistency.ts
@@ -47,6 +47,7 @@ export class NotationConsistencyRule extends AbstractDocumentLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
   };
 
   lintDocument(

--- a/lib/linting/rules/number-format.ts
+++ b/lib/linting/rules/number-format.ts
@@ -271,6 +271,7 @@ export class NumberFormatRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
     options: {
       isVertical: false,
     },

--- a/lib/linting/rules/particle-no-repetition.ts
+++ b/lib/linting/rules/particle-no-repetition.ts
@@ -102,6 +102,7 @@ export class ParticleNoRepetitionRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "info",
+    skipDialogue: true,
     options: {
       threshold: 4,
     },

--- a/lib/linting/rules/redundant-expression.ts
+++ b/lib/linting/rules/redundant-expression.ts
@@ -172,6 +172,7 @@ export class RedundantExpressionRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
   };
 
   lint(text: string, config: LintRuleConfig): LintIssue[] {

--- a/lib/linting/rules/verbose-expression.ts
+++ b/lib/linting/rules/verbose-expression.ts
@@ -82,6 +82,7 @@ export class VerboseExpressionRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "info",
+    skipDialogue: true,
   };
 
   lint(text: string, config: LintRuleConfig): LintIssue[] {


### PR DESCRIPTION
## Summary

- Add `skipDialogue: true` to `defaultConfig` in 8 lint rules that already supported dialogue masking but had the flag missing
- Fixes 8 failing tests in `lib/linting/rules/__tests__/` that expected dialogue content inside 「」/『』 to be excluded from lint results

## Affected Rules

| Rule | File |
|------|------|
| conjugation-errors | `lib/linting/rules/conjugation-errors.ts` |
| era-year-validator | `lib/linting/rules/era-year-validator.ts` |
| joyo-kanji | `lib/linting/rules/joyo-kanji.ts` |
| notation-consistency | `lib/linting/rules/notation-consistency.ts` |
| number-format | `lib/linting/rules/number-format.ts` |
| particle-no-repetition | `lib/linting/rules/particle-no-repetition.ts` |
| redundant-expression | `lib/linting/rules/redundant-expression.ts` |
| verbose-expression | `lib/linting/rules/verbose-expression.ts` |

## Root Cause

Each rule called `maskDialogue()` only when `config.skipDialogue` was truthy, but `defaultConfig` lacked `skipDialogue: true`. Tests using `rule.defaultConfig` therefore never triggered masking, causing lint issues to be reported for text inside dialogue brackets.

## Test plan

- [x] All 8 previously-failing dialogue masking tests now pass
- [x] All 224 tests pass (`npx vitest run lib/linting`)
- [x] `npx tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Linting analysis now skips dialogue content by default across all text-checking rules, allowing focused checks on narrative text. Settings can be overridden per-rule if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->