### PR TITLE
feat(correction): correction system v2 — merge main into beta (#433)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Available for macOS (Intel & Apple Silicon) and Windows
 
 ### 📊 Productivity
 - **Statistics panel**: Character count, paragraph count, manuscript pages (原稿用紙)
+- **Export to PDF/EPUB/DOCX**: Export your work to standard publishing formats
 - **Composition settings**: Font, size, line height, spacing
 - **Version history**: Browse and restore previous versions
 - **Diff viewer**: Compare changes between versions
@@ -257,6 +258,7 @@ The proofreading (linting) features in illusions comply with the following offic
 - ✅ Landing page with SEO optimization
 
 ### Recently Added
+- ✅ Export to PDF/EPUB/DOCX — export novels to standard publishing formats
 - ✅ Local LLM engine for AI proofreading (ローカルLLMによるAI校正)
 - ✅ Correction ignore feature — dismiss individual lint warnings
 - ✅ Dialogue-aware linting — skip dialogue content with per-rule toggle
@@ -272,7 +274,6 @@ The proofreading (linting) features in illusions comply with the following offic
 ### Planned
 - [ ] Real-time collaboration
 - [ ] Advanced AI grammar and style checking (local LLM integration in progress)
-- [ ] Export to PDF/EPUB
 - [ ] Custom themes and fonts
 - [ ] Plugin system
 - [ ] Mobile app (iOS/Android)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -515,10 +515,11 @@ export default function EditorPage() {
 
     import("@/packages/milkdown-plugin-japanese-novel/linting-plugin").then(
       ({ updateLintingSettings }) => {
-        updateLintingSettings(editorViewInstance, {
-          ignoredCorrections,
-          forceFullScan: true,
-        });
+        updateLintingSettings(
+          editorViewInstance,
+          { ignoredCorrections },
+          "ignored-correction",
+        );
       },
     ).catch((err) => {
       console.error("[page] Failed to sync ignored corrections:", err);

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -727,10 +727,14 @@ function MilkdownEditor({
     if (!editorViewInstance) return;
 
     import('@/packages/milkdown-plugin-japanese-novel/linting-plugin').then(({ updateLintingSettings }) => {
-      updateLintingSettings(editorViewInstance, {
-        enabled: lintingEnabled,
-        ruleRunner: lintingRuleRunner,
-      });
+      updateLintingSettings(
+        editorViewInstance,
+        {
+          enabled: lintingEnabled,
+          ruleRunner: lintingRuleRunner,
+        },
+        "rule-config-change",
+      );
     }).catch(err => {
       console.error('[Editor] Failed to update linting settings:', err);
     });

--- a/components/GuidelineList.tsx
+++ b/components/GuidelineList.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { ChevronUp, ChevronDown } from "lucide-react";
+import clsx from "clsx";
+
+import type { GuidelineId } from "@/lib/linting/correction-config";
+import type { GuidelineLicense } from "@/lib/linting/guidelines";
+import { GUIDELINES } from "@/lib/linting/guidelines";
+
+/** All known guideline IDs in their canonical display order. */
+const ALL_GUIDELINE_IDS: GuidelineId[] = [
+  "novel-manuscript",
+  "joyo-kanji-2010",
+  "okurigana-1973",
+  "gendai-kanazukai-1986",
+  "gairai-1991",
+  "koyo-bun-2022",
+  "jis-x-4051",
+  "kisha-handbook-14",
+  "jtf-style-3",
+  "jtca-style-3",
+  "editors-rulebook",
+];
+
+interface GuidelineListProps {
+  /** Ordered list of enabled guideline IDs (highest priority first). */
+  guidelines: GuidelineId[];
+  /** Called with the updated ordered list when the user changes priority or toggles a guideline. */
+  onChange: (guidelines: GuidelineId[]) => void;
+}
+
+/**
+ * Display label for a guideline license.
+ */
+function LicenseBadge({ license }: { license: GuidelineLicense }) {
+  const styles: Record<GuidelineLicense, string> = {
+    Public: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
+    Paid: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+    "CC BY 4.0": "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  };
+  const labels: Record<GuidelineLicense, string> = {
+    Public: "公開",
+    Paid: "有償",
+    "CC BY 4.0": "CC BY 4.0",
+  };
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium flex-shrink-0",
+        styles[license],
+      )}
+    >
+      {labels[license]}
+    </span>
+  );
+}
+
+/**
+ * GuidelineList — shows all available guidelines as an ordered priority list.
+ *
+ * Guidelines present in `guidelines` prop are considered enabled (and ordered
+ * by their position in that array, highest priority first). Guidelines absent
+ * from the array are shown as disabled at the bottom.
+ *
+ * Reordering uses up/down arrow buttons (no external DnD dependency required).
+ */
+export default function GuidelineList({ guidelines, onChange }: GuidelineListProps) {
+  const enabledSet = new Set(guidelines);
+
+  /**
+   * Build the full display order:
+   * 1. Enabled guidelines in their current priority order.
+   * 2. Disabled guidelines in canonical order (appended at the end).
+   */
+  const displayOrder: GuidelineId[] = [
+    ...guidelines,
+    ...ALL_GUIDELINE_IDS.filter((id) => !enabledSet.has(id)),
+  ];
+
+  const handleToggle = (id: GuidelineId) => {
+    if (enabledSet.has(id)) {
+      // Disable: remove from the enabled list
+      onChange(guidelines.filter((g) => g !== id));
+    } else {
+      // Enable: append to the end of the enabled list
+      onChange([...guidelines, id]);
+    }
+  };
+
+  const handleMoveUp = (id: GuidelineId) => {
+    const idx = guidelines.indexOf(id);
+    if (idx <= 0) return;
+    const next = [...guidelines];
+    [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
+    onChange(next);
+  };
+
+  const handleMoveDown = (id: GuidelineId) => {
+    const idx = guidelines.indexOf(id);
+    if (idx < 0 || idx >= guidelines.length - 1) return;
+    const next = [...guidelines];
+    [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
+    onChange(next);
+  };
+
+  return (
+    <div className="divide-y divide-border border border-border rounded-lg overflow-hidden">
+      {displayOrder.map((id, displayIdx) => {
+        const meta = GUIDELINES[id];
+        const isEnabled = enabledSet.has(id);
+        const enabledIdx = guidelines.indexOf(id);
+        const isFirst = enabledIdx === 0;
+        const isLast = enabledIdx === guidelines.length - 1;
+
+        return (
+          <div
+            key={id}
+            className={clsx(
+              "flex items-center gap-2 px-3 py-2 transition-colors",
+              isEnabled ? "bg-background" : "bg-background-tertiary/40 opacity-60",
+              displayIdx === 0 && "rounded-t-lg",
+            )}
+          >
+            {/* Priority reorder buttons (only for enabled guidelines) */}
+            <div className="flex flex-col gap-0.5 flex-shrink-0">
+              <button
+                onClick={() => handleMoveUp(id)}
+                disabled={!isEnabled || isFirst}
+                className={clsx(
+                  "p-0.5 rounded transition-colors",
+                  isEnabled && !isFirst
+                    ? "text-foreground-secondary hover:text-foreground hover:bg-hover"
+                    : "text-foreground-muted cursor-not-allowed",
+                )}
+                aria-label="優先度を上げる"
+              >
+                <ChevronUp className="w-3 h-3" />
+              </button>
+              <button
+                onClick={() => handleMoveDown(id)}
+                disabled={!isEnabled || isLast}
+                className={clsx(
+                  "p-0.5 rounded transition-colors",
+                  isEnabled && !isLast
+                    ? "text-foreground-secondary hover:text-foreground hover:bg-hover"
+                    : "text-foreground-muted cursor-not-allowed",
+                )}
+                aria-label="優先度を下げる"
+              >
+                <ChevronDown className="w-3 h-3" />
+              </button>
+            </div>
+
+            {/* Priority rank badge */}
+            <span
+              className={clsx(
+                "text-[10px] font-mono w-4 text-center flex-shrink-0",
+                isEnabled ? "text-foreground-tertiary" : "text-foreground-muted",
+              )}
+            >
+              {isEnabled ? String(enabledIdx + 1) : "—"}
+            </span>
+
+            {/* Guideline info */}
+            <div className="flex-1 min-w-0">
+              <span
+                className={clsx(
+                  "text-sm block truncate",
+                  isEnabled ? "text-foreground" : "text-foreground-tertiary",
+                )}
+              >
+                {meta.nameJa}
+              </span>
+              <span className="text-[10px] text-foreground-tertiary block truncate">
+                {meta.publisherJa}
+                {meta.year !== null ? `　${meta.year}` : ""}
+              </span>
+            </div>
+
+            {/* License badge */}
+            <LicenseBadge license={meta.license} />
+
+            {/* Enable/disable toggle */}
+            <button
+              onClick={() => handleToggle(id)}
+              className={clsx(
+                "relative inline-flex h-5 w-9 items-center rounded-full transition-colors flex-shrink-0",
+                isEnabled ? "bg-accent" : "bg-foreground-muted",
+              )}
+              aria-label={isEnabled ? "ガイドラインを無効にする" : "ガイドラインを有効にする"}
+            >
+              <span
+                className={clsx(
+                  "inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform shadow-sm",
+                  isEnabled ? "translate-x-5" : "translate-x-0.5",
+                )}
+              />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -5,6 +5,8 @@ import { fetchAppState, persistAppState } from "@/lib/app-state-manager";
 import { DEFAULT_MODEL_ID } from "@/lib/llm-client/model-registry";
 import type { Severity } from "@/lib/linting/types";
 import { notificationManager } from "@/lib/notification-manager";
+import type { CorrectionConfig } from "@/lib/linting/correction-config";
+import { DEFAULT_CORRECTION_CONFIG } from "@/lib/linting/correction-config";
 
 export interface EditorSettings {
   fontScale: number;
@@ -28,6 +30,8 @@ export interface EditorSettings {
   llmModelId: string;
   powerSaveMode: boolean;
   autoPowerSaveOnBattery: boolean;
+  /** Unified correction config derived from individual linting fields */
+  correctionConfig: CorrectionConfig;
 }
 
 export interface EditorSettingsHandlers {
@@ -416,6 +420,16 @@ export function useEditorSettings(
       llmModelId,
       powerSaveMode,
       autoPowerSaveOnBattery,
+      correctionConfig: {
+        ...DEFAULT_CORRECTION_CONFIG,
+        enabled: lintingEnabled,
+        ruleOverrides: lintingRuleConfigs,
+        llm: {
+          ...DEFAULT_CORRECTION_CONFIG.llm,
+          modelId: llmModelId,
+          validationEnabled: llmEnabled,
+        },
+      },
     },
     handlers: {
       handleFontScaleChange,

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -32,6 +32,49 @@ import { CounterWordMismatchRule } from "@/lib/linting/rules/counter-word-mismat
 import { AdverbFormConsistencyRule } from "@/lib/linting/rules/adverb-form-consistency";
 import { HomophoneDetectionRule } from "@/lib/linting/rules/homophone-detection";
 
+// New rules from official Japanese language standards (#438)
+import { MixedWidthSpacingRule } from "@/lib/linting/rules/mixed-width-spacing-rule";
+import { BracketSpacingRule } from "@/lib/linting/rules/bracket-spacing-rule";
+import { KatakanaWidthRule } from "@/lib/linting/rules/katakana-width-rule";
+import { KatakanaChouonRule } from "@/lib/linting/rules/katakana-chouon-rule";
+import { JapanesePunctuationWidthRule } from "@/lib/linting/rules/japanese-punctuation-width-rule";
+import { HeadingPeriodRule } from "@/lib/linting/rules/heading-period-rule";
+import { AlphanumericHalfWidthRule } from "@/lib/linting/rules/alphanumeric-half-width-rule";
+import { ListFormattingConsistencyRule } from "@/lib/linting/rules/list-formatting-consistency-rule";
+import { NakaguroUsageRule } from "@/lib/linting/rules/nakaguro-usage-rule";
+import { WaveDashUnificationRule } from "@/lib/linting/rules/wave-dash-unification-rule";
+import { IterationMarkRule } from "@/lib/linting/rules/iteration-mark-rule";
+import { BracketPeriodPlacementRule } from "@/lib/linting/rules/bracket-period-placement-rule";
+import { LargeNumberCommaRule } from "@/lib/linting/rules/large-number-comma-rule";
+import { ParagraphIndentationRule } from "@/lib/linting/rules/paragraph-indentation-rule";
+import { CounterCharacterRule } from "@/lib/linting/rules/counter-character-rule";
+import { VuKatakanaRule } from "@/lib/linting/rules/vu-katakana-rule";
+import { GairaiKanaTableRule } from "@/lib/linting/rules/gairai-kana-table-rule";
+import { JiZuKanaRule } from "@/lib/linting/rules/ji-zu-kana-rule";
+import { HistoricalKanaDetection } from "@/lib/linting/rules/historical-kana-detection";
+import { LongVowelKanaRule } from "@/lib/linting/rules/long-vowel-kana-rule";
+import { VerbOkuriganaStrictRule } from "@/lib/linting/rules/verb-okurigana-strict-rule";
+import { FixedOkuriganaNounRule } from "@/lib/linting/rules/fixed-okurigana-noun-rule";
+import { FormalNounOpeningRule } from "@/lib/linting/rules/formal-noun-opening-rule";
+import { AuxiliaryVerbOpeningRule } from "@/lib/linting/rules/auxiliary-verb-opening-rule";
+import { ConjunctionOpeningRule } from "@/lib/linting/rules/conjunction-opening-rule";
+import { ParticleSuffixModifierOpeningRule } from "@/lib/linting/rules/particle-suffix-modifier-opening-rule";
+import { CompoundNounOkuriganaOmissionRule } from "@/lib/linting/rules/compound-noun-okurigana-omission-rule";
+import { PrefixScriptMatchingRule } from "@/lib/linting/rules/prefix-script-matching-rule";
+import { PronounKanjiRule } from "@/lib/linting/rules/pronoun-kanji-rule";
+import { DoubleNegativeRule } from "@/lib/linting/rules/double-negative-rule";
+import { ParticleKaraYoriRule } from "@/lib/linting/rules/particle-kara-yori-rule";
+import { ConjunctiveGaOveruseRule } from "@/lib/linting/rules/conjunctive-ga-overuse-rule";
+import { SuruBekiConjugationRule } from "@/lib/linting/rules/suru-beki-conjugation-rule";
+import { ConjunctionHierarchyRule } from "@/lib/linting/rules/conjunction-hierarchy-rule";
+import { ConsecutiveParticleRule } from "@/lib/linting/rules/consecutive-particle-rule";
+import { TautologyRedundancyRule } from "@/lib/linting/rules/tautology-redundancy-rule";
+import { OfficialStyleCopulaRule } from "@/lib/linting/rules/official-style-copula-rule";
+import { LiteraryStyleExclusionRule } from "@/lib/linting/rules/literary-style-exclusion-rule";
+import { ExcessiveHonorificRule } from "@/lib/linting/rules/excessive-honorific-rule";
+import { ModifierLengthOrderRule } from "@/lib/linting/rules/modifier-length-order-rule";
+import { KanjiVerbOneCharDo } from "@/lib/linting/rules/kanji-verb-one-char-do";
+
 export interface UseLintingResult {
   ruleRunner: RuleRunner;
   lintIssues: LintIssue[];
@@ -85,6 +128,51 @@ export function useLinting(
     // L3 rules (LLM-based)
     runner.registerRule(new HomophoneDetectionRule());
 
+    // New rules from official Japanese language standards (#438)
+    // Notation (約物・表記) — JTF / 公用文 / 外来語の表記 / 現代仮名遣い
+    runner.registerRule(new MixedWidthSpacingRule());
+    runner.registerRule(new BracketSpacingRule());
+    runner.registerRule(new KatakanaWidthRule());
+    runner.registerRule(new KatakanaChouonRule());
+    runner.registerRule(new JapanesePunctuationWidthRule());
+    runner.registerRule(new HeadingPeriodRule());
+    runner.registerRule(new AlphanumericHalfWidthRule());
+    runner.registerRule(new ListFormattingConsistencyRule());
+    runner.registerRule(new NakaguroUsageRule());
+    runner.registerRule(new WaveDashUnificationRule());
+    runner.registerRule(new IterationMarkRule());
+    runner.registerRule(new BracketPeriodPlacementRule());
+    runner.registerRule(new LargeNumberCommaRule());
+    runner.registerRule(new ParagraphIndentationRule());
+    runner.registerRule(new CounterCharacterRule());
+    runner.registerRule(new VuKatakanaRule());
+    runner.registerRule(new GairaiKanaTableRule());
+    runner.registerRule(new JiZuKanaRule());
+    runner.registerRule(new HistoricalKanaDetection());
+    runner.registerRule(new LongVowelKanaRule());
+    // Kanji / grammar / style — 送り仮名の付け方 / 漢字使用等 / 公用文作成の考え方
+    runner.registerRule(new VerbOkuriganaStrictRule());
+    runner.registerRule(new FixedOkuriganaNounRule());
+    runner.registerRule(new FormalNounOpeningRule());
+    runner.registerRule(new AuxiliaryVerbOpeningRule());
+    runner.registerRule(new ConjunctionOpeningRule());
+    runner.registerRule(new ParticleSuffixModifierOpeningRule());
+    runner.registerRule(new CompoundNounOkuriganaOmissionRule());
+    runner.registerRule(new PrefixScriptMatchingRule());
+    runner.registerRule(new PronounKanjiRule());
+    runner.registerRule(new DoubleNegativeRule());
+    runner.registerRule(new ParticleKaraYoriRule());
+    runner.registerRule(new ConjunctiveGaOveruseRule());
+    runner.registerRule(new SuruBekiConjugationRule());
+    runner.registerRule(new ConjunctionHierarchyRule());
+    runner.registerRule(new ConsecutiveParticleRule());
+    runner.registerRule(new TautologyRedundancyRule());
+    runner.registerRule(new OfficialStyleCopulaRule());
+    runner.registerRule(new LiteraryStyleExclusionRule());
+    runner.registerRule(new ExcessiveHonorificRule());
+    runner.registerRule(new ModifierLengthOrderRule());
+    runner.registerRule(new KanjiVerbOneCharDo());
+
     ruleRunnerRef.current = runner;
   }
 
@@ -130,21 +218,27 @@ export function useLinting(
           ? getNlpClient()
           : null;
 
-        updateLintingSettings(editorViewInstance, {
-          ruleRunner: ruleRunnerRef.current,
-          nlpClient,
-          llmClient: getLlmClient(),
-          llmEnabled,
-          llmModelId,
-          forceFullScan: true,
-          forceLlmValidation: true,
-        });
+        const llmClient: ILlmClient | null =
+          llmEnabled && ruleRunnerRef.current?.hasLlmRules()
+            ? getLlmClient()
+            : null;
+
+        updateLintingSettings(
+          editorViewInstance,
+          {
+            ruleRunner: ruleRunnerRef.current,
+            nlpClient,
+            llmClient,
+            llmEnabled,
+          },
+          "manual-refresh",
+        );
       },
     ).catch((err) => {
       console.error("[useLinting] Failed to refresh linting:", err);
       setIsLinting(false);
     });
-  }, [editorViewInstance, lintingEnabled, llmEnabled, powerSaveMode, llmModelId]);
+  }, [editorViewInstance, lintingEnabled, llmEnabled]);
 
   return {
     ruleRunner,

--- a/lib/editor-page/use-power-saving.ts
+++ b/lib/editor-page/use-power-saving.ts
@@ -11,8 +11,8 @@ interface UsePowerSavingOptions {
 
 /**
  * Listens for Electron powerMonitor events and manages power saving mode.
- * - On battery (>1min debounced): shows in-app notification with action buttons
- * - On AC (>1min debounced): auto-disables power saving mode with info notification
+ * - On battery: shows in-app notification with action buttons
+ * - On AC: auto-disables power saving mode with info notification
  * - No-op on web platform
  */
 export function usePowerSaving({

--- a/lib/linting/correction-config.ts
+++ b/lib/linting/correction-config.ts
@@ -1,0 +1,65 @@
+/**
+ * CorrectionConfig - Single source of truth for all correction settings.
+ * 校正設定の統一インターフェース定義。
+ */
+
+import type { LintRuleConfig } from "./types";
+import type { IgnoredCorrection } from "@/lib/project-types";
+
+/**
+ * Identifies what triggered a config change, enabling smart cache invalidation
+ * in the decoration plugin.
+ */
+export type ConfigChangeReason =
+  | "text-edit"            // re-run affected paragraphs only
+  | "rule-config-change"   // clear issue cache, full re-run
+  | "mode-change"          // clear all caches, full re-run
+  | "guideline-change"     // clear issue + validation cache
+  | "model-change"         // clear validation cache only
+  | "ignored-correction"   // rebuild decorations only (no re-run)
+  | "manual-refresh";      // clear all caches, force re-run
+
+/** Correction mode identifiers */
+export type CorrectionModeId = "novel" | "official" | "blog" | "academic" | "sns";
+
+/** Guideline identifiers */
+export type GuidelineId =
+  | "joyo-kanji-2010"
+  | "okurigana-1973"
+  | "gairai-1991"
+  | "gendai-kanazukai-1986"
+  | "koyo-bun-2022"
+  | "jis-x-4051"
+  | "kisha-handbook-14"
+  | "jtf-style-3"
+  | "jtca-style-3"
+  | "editors-rulebook"
+  | "novel-manuscript";
+
+/** Single source of truth for all correction settings */
+export interface CorrectionConfig {
+  enabled: boolean;
+  mode: CorrectionModeId;
+  guidelines: GuidelineId[];
+  ruleOverrides: Record<string, Partial<LintRuleConfig>>;
+  llm: {
+    modelId: string;
+    cooldownMs: number;
+    validationEnabled: boolean;
+  };
+  ignoredCorrections: IgnoredCorrection[];
+}
+
+/** Default CorrectionConfig values */
+export const DEFAULT_CORRECTION_CONFIG: CorrectionConfig = {
+  enabled: true,
+  mode: "novel",
+  guidelines: ["joyo-kanji-2010", "novel-manuscript"],
+  ruleOverrides: {},
+  llm: {
+    modelId: "",
+    cooldownMs: 60_000,
+    validationEnabled: true,
+  },
+  ignoredCorrections: [],
+};

--- a/lib/linting/correction-modes.ts
+++ b/lib/linting/correction-modes.ts
@@ -1,0 +1,106 @@
+/**
+ * Correction mode presets.
+ * 校正モードのプリセット定義。
+ */
+
+import type { CorrectionModeId, GuidelineId } from "./correction-config";
+import type { LintRuleConfig } from "./types";
+
+export interface CorrectionMode {
+  id: CorrectionModeId;
+  nameJa: string;
+  toneJa: string;
+  descriptionJa: string;
+  defaultGuidelines: GuidelineId[];
+  ruleOverrides: Record<string, Partial<LintRuleConfig>>;
+  llmPromptStyleJa: string;
+}
+
+export const CORRECTION_MODES: Record<CorrectionModeId, CorrectionMode> = {
+  novel: {
+    id: "novel",
+    nameJa: "小説",
+    toneJa: "感性・具象・張力",
+    descriptionJa: "小説・フィクション向けの校正モード。文体の個性を尊重します。",
+    defaultGuidelines: ["novel-manuscript", "joyo-kanji-2010", "jis-x-4051"],
+    ruleOverrides: {
+      "desu-masu-consistency": { enabled: false },
+    },
+    llmPromptStyleJa:
+      "小説の文体として自然な表現かどうかを判断してください。文学的な表現や倒置法は許容します。",
+  },
+  official: {
+    id: "official",
+    nameJa: "公用文",
+    toneJa: "厳粛・対等・標準化",
+    descriptionJa:
+      "官公庁・公的機関の文書向けモード。内閣告示の各種基準に準拠します。",
+    defaultGuidelines: [
+      "koyo-bun-2022",
+      "joyo-kanji-2010",
+      "okurigana-1973",
+      "gairai-1991",
+    ],
+    ruleOverrides: {
+      "taigen-dome-overuse": { enabled: false },
+    },
+    llmPromptStyleJa:
+      "公用文として適切な表現かどうかを判断してください。擬声語・個人的感情・倒置文は不適切とします。",
+  },
+  blog: {
+    id: "blog",
+    nameJa: "ブログ",
+    toneJa: "親切・共有感・半正式",
+    descriptionJa: "ウェブ記事・ブログ向けモード。読みやすさを重視します。",
+    defaultGuidelines: ["jtf-style-3", "joyo-kanji-2010"],
+    ruleOverrides: {
+      "sentence-length": { enabled: true },
+    },
+    llmPromptStyleJa:
+      "ウェブ記事として読みやすく親しみやすい表現かどうかを判断してください。過度な堅苦しさや難解な語彙は避けてください。",
+  },
+  academic: {
+    id: "academic",
+    nameJa: "学術",
+    toneJa: "冷静・客観・構造化",
+    descriptionJa:
+      "論文・学術文書向けモード。客観性と構造的な記述を重視します。",
+    defaultGuidelines: ["joyo-kanji-2010", "okurigana-1973", "jis-x-4051"],
+    ruleOverrides: {
+      "taigen-dome-overuse": { enabled: true, severity: "warning" },
+    },
+    llmPromptStyleJa:
+      "学術論文として適切な客観的表現かどうかを判断してください。「私は」などの主観表現や修辞的隠喩は不適切とします。",
+  },
+  sns: {
+    id: "sns",
+    nameJa: "SNS",
+    toneJa: "簡潔・インパクト",
+    descriptionJa: "SNS・短文投稿向けモード。最も寛容な設定です。",
+    defaultGuidelines: ["joyo-kanji-2010"],
+    ruleOverrides: {
+      "sentence-length": { enabled: false },
+      "taigen-dome-overuse": { enabled: false },
+      "conjunction-overuse": { enabled: false },
+    },
+    llmPromptStyleJa: "SNSの短文として自然かどうかを判断してください。",
+  },
+};
+
+/**
+ * Retrieve a correction mode by ID.
+ * @param id CorrectionModeId to look up
+ * @returns The CorrectionMode definition
+ */
+export function getCorrectionMode(id: CorrectionModeId): CorrectionMode {
+  return CORRECTION_MODES[id];
+}
+
+/** Ordered list of all available correction mode IDs. */
+export const CORRECTION_MODE_IDS: CorrectionModeId[] = [
+  "novel",
+  "official",
+  "blog",
+  "academic",
+  "sns",
+];

--- a/lib/linting/guidelines.ts
+++ b/lib/linting/guidelines.ts
@@ -1,0 +1,117 @@
+/**
+ * Guideline metadata catalog.
+ * 校正ガイドラインのメタデータカタログ。
+ */
+
+import type { GuidelineId } from "./correction-config";
+
+export type GuidelineLicense = "Public" | "Paid" | "CC BY 4.0";
+
+export interface Guideline {
+  id: GuidelineId;
+  nameJa: string;
+  publisherJa: string;
+  year: number | null;
+  license: GuidelineLicense;
+  descriptionJa: string;
+}
+
+export const GUIDELINES: Record<GuidelineId, Guideline> = {
+  "joyo-kanji-2010": {
+    id: "joyo-kanji-2010",
+    nameJa: "常用漢字表",
+    publisherJa: "内閣告示",
+    year: 2010,
+    license: "Public",
+    descriptionJa: "日常的な文書に用いる漢字の標準表",
+  },
+  "okurigana-1973": {
+    id: "okurigana-1973",
+    nameJa: "送り仮名の付け方",
+    publisherJa: "内閣告示",
+    year: 1973,
+    license: "Public",
+    descriptionJa: "送り仮名の付け方に関する内閣告示",
+  },
+  "gairai-1991": {
+    id: "gairai-1991",
+    nameJa: "外来語の表記",
+    publisherJa: "内閣告示",
+    year: 1991,
+    license: "Public",
+    descriptionJa: "外来語・外国語の日本語表記基準",
+  },
+  "gendai-kanazukai-1986": {
+    id: "gendai-kanazukai-1986",
+    nameJa: "現代仮名遣い",
+    publisherJa: "内閣告示",
+    year: 1986,
+    license: "Public",
+    descriptionJa: "現代語の仮名遣いに関する基準",
+  },
+  "koyo-bun-2022": {
+    id: "koyo-bun-2022",
+    nameJa: "公用文作成の考え方",
+    publisherJa: "文化審議会",
+    year: 2022,
+    license: "Public",
+    descriptionJa: "官公庁の公文書作成に関する指針",
+  },
+  "jis-x-4051": {
+    id: "jis-x-4051",
+    nameJa: "JIS X 4051 日本語組版",
+    publisherJa: "JSA",
+    year: 2004,
+    license: "Paid",
+    descriptionJa: "日本語文書の組版に関するJIS規格",
+  },
+  "kisha-handbook-14": {
+    id: "kisha-handbook-14",
+    nameJa: "記者ハンドブック 第14版",
+    publisherJa: "共同通信社",
+    year: 2022,
+    license: "Paid",
+    descriptionJa: "新聞・報道向けの表記統一基準",
+  },
+  "jtf-style-3": {
+    id: "jtf-style-3",
+    nameJa: "JTF日本語標準スタイルガイド",
+    publisherJa: "日本翻訳連盟",
+    year: 2019,
+    license: "CC BY 4.0",
+    descriptionJa: "翻訳・ローカライズ向けの日本語スタイルガイド",
+  },
+  "jtca-style-3": {
+    id: "jtca-style-3",
+    nameJa: "日本語スタイルガイド 第3版",
+    publisherJa: "JTCA",
+    year: 2016,
+    license: "Paid",
+    descriptionJa: "テクニカルコミュニケーション向けスタイルガイド",
+  },
+  "editors-rulebook": {
+    id: "editors-rulebook",
+    nameJa: "日本語表記ルールブック 第2版",
+    publisherJa: "日本エディタースクール",
+    year: 2012,
+    license: "Paid",
+    descriptionJa: "編集・出版向けの日本語表記ルール集",
+  },
+  "novel-manuscript": {
+    id: "novel-manuscript",
+    nameJa: "小説原稿作法",
+    publisherJa: "慣習ベース",
+    year: null,
+    license: "Public",
+    descriptionJa: "小説・フィクション向けの慣用的な原稿作法",
+  },
+};
+
+/**
+ * Retrieve a guideline by ID.
+ * @param id GuidelineId to look up
+ * @returns The Guideline metadata record
+ */
+export function getGuideline(id: GuidelineId): Guideline {
+  return GUIDELINES[id];
+}

--- a/lib/linting/index.ts
+++ b/lib/linting/index.ts
@@ -1,4 +1,5 @@
 export type {
+  CorrectionEngine,
   Severity,
   LintIssue,
   LintRule,
@@ -20,3 +21,33 @@ export {
   AbstractMorphologicalDocumentLintRule,
 } from "./base-rule";
 export { RuleRunner } from "./rule-runner";
+export type { LlmState, LlmControllerOptions } from "./llm-controller";
+export { LlmController } from "./llm-controller";
+
+export type {
+  ConfigChangeReason,
+  CorrectionModeId,
+  GuidelineId,
+  CorrectionConfig,
+} from "./correction-config";
+export { DEFAULT_CORRECTION_CONFIG } from "./correction-config";
+
+export type { Guideline, GuidelineLicense } from "./guidelines";
+export { GUIDELINES, getGuideline } from "./guidelines";
+export type { CorrectionMode } from "./correction-modes";
+export {
+  CORRECTION_MODES,
+  getCorrectionMode,
+  CORRECTION_MODE_IDS,
+} from "./correction-modes";
+export { getPresetForMode } from "./lint-presets";
+
+// Phase D exports — unified CorrectionRule interface
+export type {
+  AnalysisContext,
+  CorrectionCandidate,
+  CorrectionRule,
+} from "./types";
+export { AbstractCorrectionRule } from "./base-rule";
+export { CorrectionRuleRunner } from "./rule-runner";
+export { LlmValidator } from "./llm-validator";

--- a/lib/linting/lint-presets.ts
+++ b/lib/linting/lint-presets.ts
@@ -232,3 +232,33 @@ export const LINT_PRESETS: Record<string, LintPreset> = {
     },
   },
 };
+
+// ---------------------------------------------------------------------------
+// Mode-based preset generation
+// ---------------------------------------------------------------------------
+
+import type { CorrectionModeId } from "./correction-config";
+import { CORRECTION_MODES } from "./correction-modes";
+
+/**
+ * Generate a LintPreset from a correction mode by merging the mode's
+ * ruleOverrides on top of the standard (default) preset configs.
+ *
+ * @param modeId - The correction mode to generate a preset for
+ * @returns A LintPreset with the mode's overrides applied
+ */
+export function getPresetForMode(modeId: CorrectionModeId): LintPreset {
+  const mode = CORRECTION_MODES[modeId];
+  const base = { ...LINT_DEFAULT_CONFIGS };
+
+  const merged: Record<string, LintRulePresetConfig> = { ...base };
+  for (const [ruleId, override] of Object.entries(mode.ruleOverrides)) {
+    const existing = merged[ruleId] ?? { enabled: true, severity: "warning" as const };
+    merged[ruleId] = { ...existing, ...override } as LintRulePresetConfig;
+  }
+
+  return {
+    nameJa: mode.nameJa,
+    configs: merged,
+  };
+}

--- a/lib/linting/llm-controller.ts
+++ b/lib/linting/llm-controller.ts
@@ -1,0 +1,188 @@
+import type { ILlmClient } from "@/lib/llm-client/types";
+
+/**
+ * LLM lifecycle states.
+ *
+ * State machine:
+ *   IDLE → LOADING → READY → ACTIVE → COOLING → UNLOADING → IDLE
+ */
+export type LlmState =
+  | "IDLE"
+  | "LOADING"
+  | "READY"
+  | "ACTIVE"
+  | "COOLING"
+  | "UNLOADING";
+
+/** Options accepted by LlmController constructor */
+export interface LlmControllerOptions {
+  /** Milliseconds to wait after last task finishes before unloading. Default: 60_000 */
+  cooldownMs?: number;
+}
+
+/**
+ * Minimal async mutex to prevent concurrent loadModel() calls.
+ * async-mutex is not bundled with this project, so we use a simple
+ * Promise-chain implementation instead.
+ */
+class SimpleMutex {
+  private _queue: Promise<void> = Promise.resolve();
+
+  /**
+   * Acquire the mutex.
+   * Returns a release function that must be called when the critical section ends.
+   */
+  async acquire(): Promise<() => void> {
+    let release!: () => void;
+    const next = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    // Chain onto the existing queue so callers are serialized
+    const previous = this._queue;
+    this._queue = previous.then(() => next);
+
+    // Wait for all previous holders to release
+    await previous;
+
+    return release;
+  }
+}
+
+/**
+ * Manages the LLM model lifecycle with auto start/stop for power efficiency.
+ *
+ * State machine:
+ *   IDLE → LOADING → READY → ACTIVE → COOLING → UNLOADING → IDLE
+ *
+ * Power efficiency is achieved by automatically unloading the model after a
+ * configurable cooldown period (default 60 s) once all tasks complete.
+ * This replaces the old battery-detection approach in use-power-saving.ts.
+ */
+export class LlmController {
+  private readonly _client: ILlmClient;
+  private readonly _modelId: string;
+  private readonly _cooldownMs: number;
+  private readonly _mutex: SimpleMutex = new SimpleMutex();
+
+  private _state: LlmState = "IDLE";
+  private _cooldownTimer: ReturnType<typeof setTimeout> | null = null;
+  private _listeners: Set<(state: LlmState) => void> = new Set();
+
+  constructor(
+    client: ILlmClient,
+    modelId: string,
+    options: LlmControllerOptions = {},
+  ) {
+    this._client = client;
+    this._modelId = modelId;
+    this._cooldownMs = options.cooldownMs ?? 60_000;
+  }
+
+  // --------------------------------------------------------------------------
+  // Public API
+  // --------------------------------------------------------------------------
+
+  /** Returns the current lifecycle state. */
+  getState(): LlmState {
+    return this._state;
+  }
+
+  /**
+   * Subscribe to state changes.
+   * @returns Unsubscribe function — call it to stop receiving events.
+   */
+  onStateChange(cb: (state: LlmState) => void): () => void {
+    this._listeners.add(cb);
+    return () => {
+      this._listeners.delete(cb);
+    };
+  }
+
+  /**
+   * Request a validation task.
+   *
+   * - If the model is not loaded, it is loaded first (LOADING → READY).
+   * - The state transitions to ACTIVE while the task runs.
+   * - After the task completes, a cooldown timer starts.
+   * - When the timer fires (and no other task has started), the model is
+   *   unloaded (UNLOADING → IDLE).
+   *
+   * Concurrent calls are serialized via a mutex so that the model is only
+   * loaded once even when multiple requests arrive simultaneously.
+   */
+  async requestValidation(task: () => Promise<void>): Promise<void> {
+    // Cancel any pending cooldown — we're active again
+    this._cancelCooldown();
+
+    // Serialize model loading to prevent race conditions (fixes #424)
+    const release = await this._mutex.acquire();
+    try {
+      if (this._state === "IDLE" || this._state === "UNLOADING") {
+        await this._load();
+      }
+    } finally {
+      release();
+    }
+
+    // Run the task in ACTIVE state
+    this._setState("ACTIVE");
+    try {
+      await task();
+    } finally {
+      // Start cooldown regardless of whether the task succeeded or failed
+      this._startCooldown();
+    }
+  }
+
+  /**
+   * Immediately unload the model from memory.
+   * Safe to call from any state; no-op when already IDLE.
+   */
+  async unload(): Promise<void> {
+    this._cancelCooldown();
+
+    if (this._state === "IDLE") return;
+
+    await this._unload();
+  }
+
+  // --------------------------------------------------------------------------
+  // Private helpers
+  // --------------------------------------------------------------------------
+
+  private async _load(): Promise<void> {
+    this._setState("LOADING");
+    await this._client.loadModel(this._modelId);
+    this._setState("READY");
+  }
+
+  private async _unload(): Promise<void> {
+    this._setState("UNLOADING");
+    await this._client.unloadModel();
+    this._setState("IDLE");
+  }
+
+  private _startCooldown(): void {
+    this._setState("COOLING");
+    this._cooldownTimer = setTimeout(() => {
+      this._cooldownTimer = null;
+      // Only unload if we're still cooling (not interrupted by a new task)
+      if (this._state === "COOLING") {
+        void this._unload();
+      }
+    }, this._cooldownMs);
+  }
+
+  private _cancelCooldown(): void {
+    if (this._cooldownTimer !== null) {
+      clearTimeout(this._cooldownTimer);
+      this._cooldownTimer = null;
+    }
+  }
+
+  private _setState(state: LlmState): void {
+    this._state = state;
+    this._listeners.forEach((cb) => cb(state));
+  }
+}

--- a/lib/linting/llm-validator.ts
+++ b/lib/linting/llm-validator.ts
@@ -1,0 +1,104 @@
+import type { CorrectionCandidate } from "./types";
+import type { ILlmClient } from "@/lib/llm-client/types";
+
+/**
+ * LlmValidator — batch-validates CorrectionCandidates using an LLM.
+ *
+ * Candidates with skipValidation=true are passed through without calling the LLM.
+ * Candidates that need validation are checked against the LLM to filter
+ * false positives before they are shown to the user.
+ */
+export class LlmValidator {
+  constructor(private readonly llmClient: ILlmClient) {}
+
+  /**
+   * Validate a batch of candidates.
+   * Returns only candidates that pass validation (or are marked skipValidation).
+   *
+   * @param candidates - Candidates to validate
+   * @param signal - Optional AbortSignal for cancellation
+   */
+  async validate(
+    candidates: CorrectionCandidate[],
+    signal?: AbortSignal,
+  ): Promise<CorrectionCandidate[]> {
+    const toValidate = candidates.filter((c) => !c.skipValidation);
+    const skipValidation = candidates.filter((c) => c.skipValidation);
+
+    if (toValidate.length === 0) return candidates;
+
+    // Validate candidates that require LLM review
+    const validated: CorrectionCandidate[] = [];
+    for (const candidate of toValidate) {
+      if (signal?.aborted) break;
+      const isValid = await this.validateOne(candidate, signal);
+      if (isValid) validated.push(candidate);
+    }
+
+    return [...skipValidation, ...validated];
+  }
+
+  /**
+   * Validate a single candidate using the LLM.
+   * Returns true if the candidate should be kept, false if it should be discarded.
+   * On error, defaults to keeping the candidate (fail-open).
+   */
+  private async validateOne(
+    candidate: CorrectionCandidate,
+    signal?: AbortSignal,
+  ): Promise<boolean> {
+    if (!this.llmClient.isAvailable()) return true;
+
+    try {
+      const isLoaded = await this.llmClient.isModelLoaded();
+      if (!isLoaded) return true;
+
+      const prompt = this.buildValidationPrompt(candidate);
+      const result = await this.llmClient.infer(prompt, {
+        signal,
+        maxTokens: 64,
+      });
+
+      return this.parseValidationResponse(result.text);
+    } catch {
+      // On any error (including AbortError), keep the candidate
+      return true;
+    }
+  }
+
+  /**
+   * Build a compact validation prompt for a single candidate.
+   */
+  private buildValidationPrompt(candidate: CorrectionCandidate): string {
+    const hint = candidate.ruleId
+      ? `ルールID: ${candidate.ruleId}`
+      : "";
+    const validationHint = "";
+
+    return `/no_think
+日本語校正の専門家として、以下の指摘が正しいか判定してください。
+
+## 文脈
+${candidate.context}
+
+## 指摘
+- 対象文字位置: ${candidate.from}–${candidate.to}
+- 問題: ${candidate.messageJa}
+${hint}
+${validationHint}
+
+## 指示
+この指摘は正しいですか？「YES」か「NO」のみ回答してください。`;
+  }
+
+  /**
+   * Parse a YES/NO validation response.
+   * Defaults to true (keep) if the response is ambiguous.
+   */
+  private parseValidationResponse(responseText: string): boolean {
+    const normalized = responseText.trim().toUpperCase();
+    if (normalized.startsWith("NO")) return false;
+    // Default to keeping the candidate for any other response
+    return true;
+  }
+}

--- a/lib/linting/rule-runner.ts
+++ b/lib/linting/rule-runner.ts
@@ -1,7 +1,15 @@
 import type { ILlmClient } from "@/lib/llm-client/types";
 import type { Token } from "@/lib/nlp-client/types";
 
-import type { LintRule, LintRuleConfig, LintIssue } from "./types";
+import type {
+  CorrectionEngine,
+  LintRule,
+  LintRuleConfig,
+  LintIssue,
+  AnalysisContext,
+  CorrectionCandidate,
+  CorrectionRule,
+} from "./types";
 import {
   isDocumentLintRule,
   isLlmLintRule,
@@ -190,6 +198,21 @@ export class RuleRunner {
   }
 
   /**
+   * Returns all rules for the given engine type.
+   * Engine field acts as implementation metadata, not architectural boundary.
+   */
+  getRulesByEngine(engine: CorrectionEngine): LintRule[] {
+    return Array.from(this.rules.values()).filter(r => r.engine === engine);
+  }
+
+  /**
+   * Checks whether any enabled rules use the given engine.
+   */
+  hasRulesForEngine(engine: CorrectionEngine): boolean {
+    return Array.from(this.rules.values()).some(r => this.configs.get(r.id)?.enabled !== false && r.engine === engine);
+  }
+
+  /**
    * Run all enabled L3 (LLM) rules on the given sentences.
    * Returns aggregated issues from all L3 rules.
    */
@@ -223,5 +246,87 @@ export class RuleRunner {
     }
 
     return allIssues.sort((a, b) => a.from - b.from);
+  }
+}
+
+// ============================================================================
+// CorrectionRuleRunner (Phase D)
+// ============================================================================
+
+/**
+ * Unified rule runner for the new CorrectionRule interface.
+ * Provides a single code path — no L1/L2/L3 branching.
+ *
+ * Run in parallel with the legacy RuleRunner during migration;
+ * once all rules are migrated, RuleRunner can be removed.
+ */
+export class CorrectionRuleRunner {
+  private rules = new Map<string, CorrectionRule>();
+  private configs = new Map<string, LintRuleConfig>();
+
+  /** Register a rule. Uses the rule's defaultConfig if none has been set yet. */
+  register(rule: CorrectionRule): void {
+    this.rules.set(rule.id, rule);
+    if (!this.configs.has(rule.id)) {
+      this.configs.set(rule.id, { ...rule.defaultConfig });
+    }
+  }
+
+  /** Partially override the config for a specific rule. */
+  setConfig(ruleId: string, config: Partial<LintRuleConfig>): void {
+    const existing = this.configs.get(ruleId) ?? { enabled: true, severity: "warning" as const };
+    this.configs.set(ruleId, { ...existing, ...config });
+  }
+
+  /** Get the current merged config for a rule. */
+  getConfig(ruleId: string): LintRuleConfig {
+    return this.configs.get(ruleId) ?? { enabled: true, severity: "warning" as const };
+  }
+
+  /** Run all enabled paragraph-scope rules against the given context. */
+  analyzeParagraph(context: AnalysisContext): CorrectionCandidate[] {
+    const results: CorrectionCandidate[] = [];
+    for (const rule of this.rules.values()) {
+      const config = this.getConfig(rule.id);
+      if (!config.enabled) continue;
+      if (rule.scope !== "paragraph") continue;
+      // Skip morphological rules when no tokens are available
+      if (rule.engine === "morphological" && !context.tokens) continue;
+      try {
+        results.push(...rule.analyze(context, config));
+      } catch (e) {
+        console.error(`[CorrectionRuleRunner] Rule "${rule.id}" error:`, e);
+      }
+    }
+    return results;
+  }
+
+  /** Run all enabled document-scope rules against the given context. */
+  analyzeDocument(context: AnalysisContext): CorrectionCandidate[] {
+    const results: CorrectionCandidate[] = [];
+    for (const rule of this.rules.values()) {
+      const config = this.getConfig(rule.id);
+      if (!config.enabled) continue;
+      if (rule.scope !== "document") continue;
+      if (rule.engine === "morphological" && !context.tokens) continue;
+      try {
+        results.push(...rule.analyze(context, config));
+      } catch (e) {
+        console.error(`[CorrectionRuleRunner] Rule "${rule.id}" error:`, e);
+      }
+    }
+    return results;
+  }
+
+  /** Return all registered rules. */
+  getRegisteredRules(): CorrectionRule[] {
+    return Array.from(this.rules.values());
+  }
+
+  /** Return only enabled rules. */
+  getEnabledRules(): CorrectionRule[] {
+    return Array.from(this.rules.values()).filter(
+      (rule) => this.getConfig(rule.id).enabled,
+    );
   }
 }

--- a/lib/linting/rules/adverb-form-consistency.ts
+++ b/lib/linting/rules/adverb-form-consistency.ts
@@ -5,7 +5,7 @@ import {
   type AdverbVariantGroup,
 } from "../data/adverb-variants";
 import { isInDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -88,6 +88,7 @@ function getMajorityForm(
  */
 export class AdverbFormConsistencyRule extends AbstractMorphologicalDocumentLintRule {
   readonly id = "adverb-form-consistency";
+  override engine: CorrectionEngine = "morphological";
   readonly name = "Adverb Form Consistency";
   readonly nameJa = "副詞の漢字・ひらがな統一";
   readonly description =

--- a/lib/linting/rules/alphanumeric-half-width-rule.ts
+++ b/lib/linting/rules/alphanumeric-half-width-rule.ts
@@ -1,0 +1,94 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for alphanumeric half-width rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "2.2.3",
+};
+
+/**
+ * Convert a full-width ASCII character (U+FF01–U+FF5E) to its
+ * half-width equivalent (U+0021–U+007E).
+ */
+function fullWidthToHalf(ch: string): string {
+  const code = ch.codePointAt(0);
+  if (code === undefined) return ch;
+  if (code >= 0xFF01 && code <= 0xFF5E) {
+    return String.fromCodePoint(code - 0xFEE0);
+  }
+  return ch;
+}
+
+/** Matches full-width digits (０–９) */
+const FULL_WIDTH_DIGITS = /[\uFF10-\uFF19]/g;
+/** Matches full-width uppercase letters (Ａ–Ｚ) */
+const FULL_WIDTH_UPPER = /[\uFF21-\uFF3A]/g;
+/** Matches full-width lowercase letters (ａ–ｚ) */
+const FULL_WIDTH_LOWER = /[\uFF41-\uFF5A]/g;
+
+/**
+ * AlphanumericHalfWidthRule -- L1 regex-based rule.
+ *
+ * Detects full-width digits and Latin letters (Ａ–Ｚ, ａ–ｚ, ０–９)
+ * and suggests converting them to their half-width equivalents.
+ * Per JTF 2.2.3, Arabic numerals and alphabets should always be
+ * written in half-width form in Japanese text.
+ */
+export class AlphanumericHalfWidthRule extends AbstractLintRule {
+  readonly id = "alphanumeric-half-width";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Use half-width alphanumeric characters";
+  readonly nameJa = "算用数字・アルファベットの半角統一";
+  readonly description =
+    "Detects full-width digits and alphabets that should be half-width";
+  readonly descriptionJa =
+    "全角の数字・アルファベットを検出します。半角で記述してください";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+    skipDialogue: true,
+  };
+
+  private static readonly PATTERNS: ReadonlyArray<RegExp> = [
+    FULL_WIDTH_DIGITS,
+    FULL_WIDTH_UPPER,
+    FULL_WIDTH_LOWER,
+  ];
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const pattern of AlphanumericHalfWidthRule.PATTERNS) {
+      // Clone regex to reset lastIndex
+      const re = new RegExp(pattern.source, "g");
+      for (const match of text.matchAll(re)) {
+        if (match.index === undefined) continue;
+
+        const fullChar = match[0];
+        const halfChar = fullWidthToHalf(fullChar);
+
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Use half-width "${halfChar}" instead of full-width "${fullChar}" (JTF 2.2.3)`,
+          messageJa: `JTF 2.2.3に基づき、全角「${fullChar}」は半角「${halfChar}」で記述してください`,
+          from: match.index,
+          to: match.index + 1,
+          originalText: fullChar,
+          reference: JTF_REF,
+          fix: {
+            label: `Replace with half-width "${halfChar}"`,
+            labelJa: `半角「${halfChar}」に変換`,
+            replacement: halfChar,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/auxiliary-verb-opening-rule.ts
+++ b/lib/linting/rules/auxiliary-verb-opening-rule.ts
@@ -1,0 +1,130 @@
+import type { Token } from "@/lib/nlp-client/types";
+import { AbstractMorphologicalLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KANJI_REF: LintReference = {
+  standard: "公用文における漢字使用等について（内閣訓令、2010）",
+};
+
+/**
+ * Auxiliary verbs and adjectives (補助動詞・補助形容詞) that should be written
+ * in hiragana when used in grammatical (non-lexical) contexts.
+ *
+ * Key: kanji surface form
+ * Value: hiragana replacement
+ */
+const AUXILIARY_VERB_MAP: ReadonlyMap<string, string> = new Map([
+  // 補助動詞
+  ["居る", "いる"],
+  ["居ます", "います"],
+  ["居た", "いた"],
+  ["置く", "おく"],
+  ["置き", "おき"],
+  ["置いて", "おいて"],
+  ["仕舞う", "しまう"],
+  ["仕舞い", "しまい"],
+  ["仕舞って", "しまって"],
+  ["見る", "みる"],
+  ["見て", "みて"],
+  ["見た", "みた"],
+  ["来る", "くる"],
+  ["来て", "きて"],
+  ["来た", "きた"],
+  ["行く", "いく"],
+  ["行って", "いって"],
+  ["頂く", "いただく"],
+  ["頂き", "いただき"],
+  ["頂いて", "いただいて"],
+  ["下さい", "ください"],
+  ["下さる", "くださる"],
+  ["下さって", "くださって"],
+  ["上げる", "あげる"],
+  ["上げて", "あげて"],
+  ["貰う", "もらう"],
+  ["貰って", "もらって"],
+]);
+
+/**
+ * Check if a kanji string contains at least one kanji character.
+ */
+function containsKanji(str: string): boolean {
+  return /[\u4e00-\u9fff]/.test(str);
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Auxiliary Verb Opening Rule (L2)
+ *
+ * Auxiliary verbs and adjectives (補助動詞・補助形容詞) used after the te-form
+ * of verbs should be written in hiragana in official documents.
+ * e.g., 〜て「居る」→「いる」, 〜て「置く」→「おく」, 「下さい」→「ください」
+ *
+ * Detection uses morphological analysis: tokens classified as 動詞・非自立
+ * with a kanji surface form matching known auxiliary verbs.
+ *
+ * Reference: 公用文における漢字使用等について（内閣訓令、2010）
+ */
+export class AuxiliaryVerbOpeningRule extends AbstractMorphologicalLintRule {
+  readonly id = "auxiliary-verb-opening";
+  override engine: CorrectionEngine = "morphological";
+  readonly name = "Auxiliary Verb in Hiragana";
+  readonly nameJa = "補助動詞・補助形容詞のひらがな表記";
+  readonly description = "Auxiliary verbs used after te-form should be written in hiragana";
+  readonly descriptionJa = "補助動詞・補助形容詞（いる・おく・しまう・みる・いただく・ください等）はひらがなで書きます（公用文における漢字使用等について）";
+  readonly level = "L2" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lintWithTokens(
+    _text: string,
+    tokens: ReadonlyArray<Token>,
+    config: LintRuleConfig,
+  ): LintIssue[] {
+    const issues: LintIssue[] = [];
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+
+      // Auxiliary verbs: 動詞・非自立 containing kanji
+      const isAuxVerb =
+        token.pos === "動詞" && token.pos_detail_1 === "非自立";
+
+      // Also check for 下さい which may tokenize differently
+      const isMiscAux =
+        (token.pos === "動詞" || token.pos === "助動詞") &&
+        containsKanji(token.surface);
+
+      if (!isAuxVerb && !isMiscAux) continue;
+
+      const hiragana = AUXILIARY_VERB_MAP.get(token.surface);
+      if (!hiragana) continue;
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Auxiliary verb "${token.surface}" should be written in hiragana as "${hiragana}"`,
+        messageJa: `補助動詞「${token.surface}」はひらがなで「${hiragana}」と書きます（公用文における漢字使用等について）`,
+        from: token.start,
+        to: token.end,
+        originalText: token.surface,
+        reference: KANJI_REF,
+        fix: {
+          label: `Replace with "${hiragana}"`,
+          labelJa: `「${hiragana}」に置換`,
+          replacement: hiragana,
+        },
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/bracket-period-placement-rule.ts
+++ b/lib/linting/rules/bracket-period-placement-rule.ts
@@ -1,0 +1,82 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for bracket period placement rule */
+const KOYO_REF: LintReference = {
+  standard: "文化庁「公用文作成の考え方」(2022)",
+  section: "3.4",
+};
+
+/**
+ * Matches a Japanese period (。) immediately followed by a closing bracket.
+ * This is the incorrect pattern: the period should come AFTER the bracket.
+ *
+ * Pattern examples:
+ * - 誤: 本文（注記。）  →  正: 本文（注記）。
+ * - 誤: 本文（注記。）  →  正: 本文（注記）。
+ */
+const PERIOD_BEFORE_CLOSE_BRACKET = /。[）〕\]]/g;
+
+/**
+ * BracketPeriodPlacementRule -- L1 regex-based rule.
+ *
+ * Detects cases where a Japanese period (。) appears immediately before
+ * a closing bracket. Per 公用文作成の考え方 §3.4, when a sentence ends
+ * with a parenthetical annotation, the period should be placed AFTER
+ * the closing bracket, not inside it.
+ *
+ * Correct:   本文（注記）。
+ * Incorrect: 本文（注記。）
+ */
+export class BracketPeriodPlacementRule extends AbstractLintRule {
+  readonly id = "bracket-period-placement";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Period placement relative to closing bracket";
+  readonly nameJa = "文末の注釈括弧と句点の位置関係";
+  readonly description =
+    "Detects periods inside closing parentheses — period should follow the bracket";
+  readonly descriptionJa =
+    "括弧の閉じる前に句点がある場合を検出します。句点は括弧の外側に置いてください";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const match of text.matchAll(PERIOD_BEFORE_CLOSE_BRACKET)) {
+      if (match.index === undefined) continue;
+
+      const closeBracket = match[0][1];
+      // The period is at match.index
+      const periodPos = match.index;
+      const closeBracketPos = match.index + 1;
+
+      // Suggest: remove period from before bracket, add after bracket
+      const corrected = closeBracket + "。";
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Period before closing bracket "${closeBracket}" — move period after the bracket (公用文作成の考え方 §3.4)`,
+        messageJa: `公用文作成の考え方に基づき、句点（。）は括弧「${closeBracket}」の外側に置いてください`,
+        from: periodPos,
+        to: closeBracketPos + 1,
+        originalText: match[0],
+        reference: KOYO_REF,
+        fix: {
+          label: `Move period after bracket: "${corrected}"`,
+          labelJa: `「${corrected}」（括弧の外に句点）に修正`,
+          replacement: corrected,
+        },
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/bracket-spacing-rule.ts
+++ b/lib/linting/rules/bracket-spacing-rule.ts
@@ -1,0 +1,96 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for bracket spacing rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "2.1.7",
+};
+
+/**
+ * BracketSpacingRule -- L1 regex-based rule.
+ *
+ * Detects half-width spaces immediately inside or outside of
+ * Japanese bracket characters. Per JTF 2.1.7, no space should
+ * be placed adjacent to bracket characters.
+ *
+ * Examples:
+ * - 誤: （ テキスト ）  →  正: （テキスト）
+ * - 誤: 「 テキスト 」  →  正: 「テキスト」
+ */
+export class BracketSpacingRule extends AbstractLintRule {
+  readonly id = "bracket-spacing";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "No space inside brackets";
+  readonly nameJa = "括弧類と隣接する文字間のスペース禁止";
+  readonly description =
+    "Detects spaces immediately inside Japanese bracket characters";
+  readonly descriptionJa =
+    "日本語括弧類の直内側にあるスペースを検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+    skipDialogue: true,
+  };
+
+  /** Opening brackets — space after opening bracket is wrong */
+  private static readonly OPEN_BRACKETS = /[（「『【〔〈《【〘〚]\s/g;
+  /** Closing brackets — space before closing bracket is wrong */
+  private static readonly CLOSE_BRACKETS = /\s[）」』】〕〉》】〙〛]/g;
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    // Space after opening bracket
+    for (const match of text.matchAll(BracketSpacingRule.OPEN_BRACKETS)) {
+      if (match.index === undefined) continue;
+      const spacePos = match.index + 1;
+      const bracket = match[0][0];
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Remove space after opening bracket "${bracket}" (JTF 2.1.7)`,
+        messageJa: `JTF 2.1.7に基づき、括弧「${bracket}」の直後にスペースを入れないでください`,
+        from: spacePos,
+        to: spacePos + 1,
+        originalText: " ",
+        reference: JTF_REF,
+        fix: {
+          label: "Remove space",
+          labelJa: "スペースを削除",
+          replacement: "",
+        },
+      });
+    }
+
+    // Space before closing bracket
+    for (const match of text.matchAll(BracketSpacingRule.CLOSE_BRACKETS)) {
+      if (match.index === undefined) continue;
+      const spacePos = match.index;
+      const bracket = match[0][1];
+      const alreadyFlagged = issues.some((i) => i.from === spacePos);
+      if (!alreadyFlagged) {
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Remove space before closing bracket "${bracket}" (JTF 2.1.7)`,
+          messageJa: `JTF 2.1.7に基づき、括弧「${bracket}」の直前にスペースを入れないでください`,
+          from: spacePos,
+          to: spacePos + 1,
+          originalText: " ",
+          reference: JTF_REF,
+          fix: {
+            label: "Remove space",
+            labelJa: "スペースを削除",
+            replacement: "",
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/comma-frequency.ts
+++ b/lib/linting/rules/comma-frequency.ts
@@ -1,7 +1,7 @@
 import { AbstractLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
 import { splitIntoSentences } from "../helpers/sentence-splitter";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -31,6 +31,7 @@ const STYLE_GUIDE_REF: LintReference = {
  */
 export class CommaFrequencyRule extends AbstractLintRule {
   readonly id = "comma-frequency";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Comma Frequency";
   readonly nameJa = "読点の頻度チェック";
   readonly description = "Flags sentences with too many or too few commas";

--- a/lib/linting/rules/compound-noun-okurigana-omission-rule.ts
+++ b/lib/linting/rules/compound-noun-okurigana-omission-rule.ts
@@ -1,0 +1,107 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KANJI_REF: LintReference = {
+  standard: "公用文における漢字使用等について（内閣訓令、2010）",
+};
+
+/**
+ * Compound nouns where okurigana of the latter element should be omitted
+ * in official writing.
+ * verbose: the form with okurigana retained
+ * official: the form used in official documents
+ */
+const COMPOUND_OKURIGANA_OMIT: ReadonlyArray<{ verbose: string; official: string }> = [
+  { verbose: "書き留め", official: "書留" },
+  { verbose: "書きとめ", official: "書留" },
+  { verbose: "貸し付け", official: "貸付" },
+  { verbose: "振り込み", official: "振込" },
+  { verbose: "割り増し", official: "割増" },
+  { verbose: "引き渡し", official: "引渡" },
+  { verbose: "引き受け", official: "引受" },
+  { verbose: "払い込み", official: "払込" },
+  { verbose: "払い出し", official: "払出" },
+  { verbose: "繰り越し", official: "繰越" },
+  { verbose: "繰り入れ", official: "繰入" },
+  { verbose: "差し引き", official: "差引" },
+  { verbose: "見積もり", official: "見積" },
+  { verbose: "組み合わせ", official: "組合" },
+  { verbose: "割り引き", official: "割引" },
+  { verbose: "申し込み", official: "申込" },
+  { verbose: "受け付け", official: "受付" },
+  { verbose: "売り上げ", official: "売上" },
+  { verbose: "積み立て", official: "積立" },
+];
+
+/**
+ * Find all non-overlapping occurrences of a literal string in text.
+ */
+function findAllOccurrences(text: string, needle: string): number[] {
+  const indices: number[] = [];
+  let pos = 0;
+  while (pos <= text.length - needle.length) {
+    const idx = text.indexOf(needle, pos);
+    if (idx === -1) break;
+    indices.push(idx);
+    pos = idx + needle.length;
+  }
+  return indices;
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compound Noun Okurigana Omission Rule (L1)
+ *
+ * In official writing, compound nouns omit the okurigana of the latter element.
+ * e.g., 「書き留め」→「書留」, 「振り込み」→「振込」
+ *
+ * Reference: 公用文における漢字使用等について（内閣訓令、2010）
+ */
+export class CompoundNounOkuriganaOmissionRule extends AbstractLintRule {
+  readonly id = "compound-noun-okurigana-omission";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Compound Noun Okurigana Omission";
+  readonly nameJa = "複合名詞の送り仮名省略";
+  readonly description = "Compound nouns should omit okurigana in official documents";
+  readonly descriptionJa = "公用文では複合名詞の後半要素の送り仮名を省略します（公用文における漢字使用等について）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { verbose, official } of COMPOUND_OKURIGANA_OMIT) {
+      for (const from of findAllOccurrences(text, verbose)) {
+        const to = from + verbose.length;
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Compound noun "${verbose}" should be written as "${official}" in official documents`,
+          messageJa: `公用文では「${verbose}」の送り仮名を省略し「${official}」と書きます（公用文における漢字使用等について）`,
+          from,
+          to,
+          originalText: verbose,
+          reference: KANJI_REF,
+          fix: {
+            label: `Replace with "${official}"`,
+            labelJa: `「${official}」に置換`,
+            replacement: official,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/conjugation-errors.ts
+++ b/lib/linting/rules/conjugation-errors.ts
@@ -1,6 +1,6 @@
 import { AbstractLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference, Severity } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference, Severity , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -141,6 +141,7 @@ function findAllOccurrences(text: string, needle: string): number[] {
  */
 export class ConjugationErrorRule extends AbstractLintRule {
   readonly id = "conjugation-errors";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Conjugation error detection";
   readonly nameJa = "活用の誤り検出";
   readonly description =
@@ -150,6 +151,7 @@ export class ConjugationErrorRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
   };
 
   lint(text: string, config: LintRuleConfig): LintIssue[] {

--- a/lib/linting/rules/conjunction-hierarchy-rule.ts
+++ b/lib/linting/rules/conjunction-hierarchy-rule.ts
@@ -1,0 +1,105 @@
+import { AbstractLintRule } from "../base-rule";
+import { splitIntoSentences } from "../helpers/sentence-splitter";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Conjunction hierarchy rule for 並列 (parallel) and 選択 (alternative) conjunctions.
+ *
+ * Hierarchy in legal/official Japanese:
+ * - Parallel (and): 「及び」(simpler) < 「並びに」(higher-level)
+ * - Alternative (or): 「又は」(simpler) < 「若しくは」(higher-level)
+ *
+ * When both levels appear in the same sentence, it indicates complex nesting
+ * that requires careful review to ensure correct hierarchy is applied.
+ */
+const HIERARCHY_CHECKS: ReadonlyArray<{
+  lower: string;
+  higher: string;
+  type: string;
+  note: string;
+}> = [
+  {
+    lower: "及び",
+    higher: "並びに",
+    type: "parallel",
+    note: "「及び」と「並びに」が同一文に共存しています。並列の階層構造を確認してください。「及び」が小項目、「並びに」が大項目の並列に使います",
+  },
+  {
+    lower: "又は",
+    higher: "若しくは",
+    type: "alternative",
+    note: "「又は」と「若しくは」が同一文に共存しています。選択の階層構造を確認してください。「若しくは」が小項目、「又は」が大項目の選択に使います",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Conjunction Hierarchy Rule (L1 heuristic)
+ *
+ * In legal and official Japanese, parallel and alternative conjunctions
+ * follow a strict hierarchy:
+ * - Parallel: 「及び」(lower level) + 「並びに」(higher level)
+ * - Alternative: 「若しくは」(lower level) + 「又は」(higher level)
+ *
+ * When both levels appear in the same sentence, the hierarchy must be
+ * applied correctly. This rule flags such co-occurrences for manual review.
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class ConjunctionHierarchyRule extends AbstractLintRule {
+  readonly id = "conjunction-hierarchy";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Conjunction Hierarchy";
+  readonly nameJa = "並列・選択の接続詞の階層ルール";
+  readonly description = "Check correct hierarchy of 及び/並びに and 又は/若しくは in the same sentence";
+  readonly descriptionJa = "「及び」「並びに」「又は」「若しくは」の階層的な使い分けを確認します（公用文作成の考え方）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    const sentences = splitIntoSentences(text);
+
+    for (const sentence of sentences) {
+      const sentenceText = text.slice(sentence.from, sentence.to);
+
+      for (const { lower, higher, note } of HIERARCHY_CHECKS) {
+        if (sentenceText.includes(lower) && sentenceText.includes(higher)) {
+          // Flag at the position of the higher-level conjunction
+          const higherIdx = sentenceText.indexOf(higher);
+          const from = sentence.from + higherIdx;
+          const to = from + higher.length;
+
+          issues.push({
+            ruleId: this.id,
+            severity: config.severity,
+            message: `Both "${lower}" and "${higher}" appear in the same sentence. Check conjunction hierarchy.`,
+            messageJa: note,
+            from,
+            to,
+            originalText: higher,
+            reference: KOYO_REF,
+          });
+        }
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/conjunction-opening-rule.ts
+++ b/lib/linting/rules/conjunction-opening-rule.ts
@@ -1,0 +1,94 @@
+import type { Token } from "@/lib/nlp-client/types";
+import { AbstractMorphologicalLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KANJI_REF: LintReference = {
+  standard: "公用文における漢字使用等について（内閣訓令、2010）",
+};
+
+/**
+ * Conjunctions that should be written in hiragana in official documents.
+ * Key: kanji surface form
+ * Value: hiragana replacement
+ *
+ * Note: 「又は」「及び」「並びに」「若しくは」are special legal terms
+ * kept in kanji for precision in legal/official contexts.
+ * Non-legal conjunctions like 「但し」「尚」should be hiragana.
+ */
+const CONJUNCTION_HIRAGANA_MAP: ReadonlyMap<string, string> = new Map([
+  ["但し", "ただし"],
+  ["尚", "なお"],
+  ["且つ", "かつ"],
+  ["即ち", "すなわち"],
+  ["従って", "したがって"],
+  ["因って", "よって"],
+  ["故に", "ゆえに"],
+  ["乃至", "ないし"],
+]);
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Conjunction Opening Rule (L2)
+ *
+ * Certain conjunctions should be written in hiragana in official documents
+ * per 公用文における漢字使用等について.
+ * e.g., 「但し」→「ただし」, 「尚」→「なお」, 「且つ」→「かつ」
+ *
+ * Note: Legal conjunctions 「又は」「及び」「並びに」「若しくは」
+ * remain in kanji as established terminology.
+ *
+ * Reference: 公用文における漢字使用等について（内閣訓令、2010）
+ */
+export class ConjunctionOpeningRule extends AbstractMorphologicalLintRule {
+  readonly id = "conjunction-opening";
+  override engine: CorrectionEngine = "morphological";
+  readonly name = "Conjunction in Hiragana";
+  readonly nameJa = "接続詞のひらがな表記";
+  readonly description = "Certain conjunctions should be written in hiragana in official writing";
+  readonly descriptionJa = "「ただし」「なお」「かつ」「すなわち」「したがって」等の接続詞はひらがなで書きます（公用文における漢字使用等について）";
+  readonly level = "L2" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lintWithTokens(
+    _text: string,
+    tokens: ReadonlyArray<Token>,
+    config: LintRuleConfig,
+  ): LintIssue[] {
+    const issues: LintIssue[] = [];
+
+    for (const token of tokens) {
+      if (token.pos !== "接続詞") continue;
+
+      const hiragana = CONJUNCTION_HIRAGANA_MAP.get(token.surface);
+      if (!hiragana) continue;
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Conjunction "${token.surface}" should be written in hiragana as "${hiragana}"`,
+        messageJa: `接続詞「${token.surface}」はひらがなで「${hiragana}」と書きます（公用文における漢字使用等について）`,
+        from: token.start,
+        to: token.end,
+        originalText: token.surface,
+        reference: KANJI_REF,
+        fix: {
+          label: `Replace with "${hiragana}"`,
+          labelJa: `「${hiragana}」に置換`,
+          replacement: hiragana,
+        },
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/conjunction-overuse.ts
+++ b/lib/linting/rules/conjunction-overuse.ts
@@ -3,7 +3,7 @@ import { AbstractMorphologicalLintRule } from "../base-rule";
 import { isInDialogue } from "../helpers/dialogue-mask";
 import type { SentenceSpan } from "../helpers/sentence-splitter";
 import { splitIntoSentences } from "../helpers/sentence-splitter";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -32,6 +32,7 @@ const STYLE_GUIDE_REF: LintReference = {
  */
 export class ConjunctionOveruseRule extends AbstractMorphologicalLintRule {
   readonly id = "conjunction-overuse";
+  override engine: CorrectionEngine = "morphological";
   readonly name = "Conjunction Overuse";
   readonly nameJa = "接続詞の多用検出";
   readonly description =

--- a/lib/linting/rules/conjunctive-ga-overuse-rule.ts
+++ b/lib/linting/rules/conjunctive-ga-overuse-rule.ts
@@ -1,0 +1,103 @@
+import type { Token } from "@/lib/nlp-client/types";
+import { AbstractMorphologicalDocumentLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/** Maximum number of conjunctive が per paragraph before flagging */
+const MAX_CONJUNCTIVE_GA_PER_PARAGRAPH = 2;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Count connective 「が」tokens in a token array.
+ * Connective が is classified as 助詞・接続助詞.
+ */
+function countConnectiveGa(tokens: ReadonlyArray<Token>): Array<{ start: number; end: number }> {
+  return tokens
+    .filter(
+      (t) =>
+        t.pos === "助詞" &&
+        t.pos_detail_1 === "接続助詞" &&
+        t.surface === "が",
+    )
+    .map((t) => ({ start: t.start, end: t.end }));
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Conjunctive Ga Overuse Rule (L2, document-level)
+ *
+ * The conjunctive particle 「が」connecting clauses is often overused in
+ * Japanese writing, creating long, rambling sentences. Official writing
+ * guidelines recommend limiting its use to at most 2 times per paragraph.
+ *
+ * Detection uses morphological analysis to identify tokens classified as
+ * 助詞・接続助詞 with surface form 「が」.
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class ConjunctiveGaOveruseRule extends AbstractMorphologicalDocumentLintRule {
+  readonly id = "conjunctive-ga-overuse";
+  override engine: CorrectionEngine = "morphological";
+  readonly name = "Conjunctive が Overuse";
+  readonly nameJa = "接続助詞「が」の多用禁止";
+  readonly description = "Limit the use of conjunctive が to avoid long, convoluted sentences";
+  readonly descriptionJa = "接続助詞「が」の多用を避け、文を分けてください（公用文作成の考え方）";
+  readonly level = "L2" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lintDocumentWithTokens(
+    paragraphs: ReadonlyArray<{
+      text: string;
+      index: number;
+      tokens: ReadonlyArray<Token>;
+    }>,
+    config: LintRuleConfig,
+  ): Array<{ paragraphIndex: number; issues: LintIssue[] }> {
+    const results: Array<{ paragraphIndex: number; issues: LintIssue[] }> = [];
+
+    for (const paragraph of paragraphs) {
+      const gaOccurrences = countConnectiveGa(paragraph.tokens);
+
+      if (gaOccurrences.length <= MAX_CONJUNCTIVE_GA_PER_PARAGRAPH) continue;
+
+      const issues: LintIssue[] = [];
+
+      // Flag from the third occurrence onward
+      for (let i = MAX_CONJUNCTIVE_GA_PER_PARAGRAPH; i < gaOccurrences.length; i++) {
+        const occ = gaOccurrences[i];
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Conjunctive "が" appears ${gaOccurrences.length} times in this paragraph (max ${MAX_CONJUNCTIVE_GA_PER_PARAGRAPH}). Consider splitting the sentence.`,
+          messageJa: `この段落で接続助詞「が」が${gaOccurrences.length}回使われています（推奨は${MAX_CONJUNCTIVE_GA_PER_PARAGRAPH}回以内）。文を分割することを検討してください（公用文作成の考え方）`,
+          from: occ.start,
+          to: occ.end,
+          originalText: "が",
+          reference: KOYO_REF,
+        });
+      }
+
+      if (issues.length > 0) {
+        results.push({ paragraphIndex: paragraph.index, issues });
+      }
+    }
+
+    return results;
+  }
+}

--- a/lib/linting/rules/consecutive-particle-rule.ts
+++ b/lib/linting/rules/consecutive-particle-rule.ts
@@ -1,0 +1,83 @@
+import type { Token } from "@/lib/nlp-client/types";
+import { AbstractMorphologicalLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Particles that should not appear consecutively (same particle repeated).
+ * Consecutive identical particles usually indicate a structural error.
+ */
+const MONITORED_PARTICLES = new Set(["は", "が", "を", "に", "で", "て", "も", "へ", "から", "より"]);
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Consecutive Particle Rule (L2)
+ *
+ * Consecutive use of the same particle (e.g., 「〜のの」「〜がが」)
+ * is a grammatical error or structural problem in Japanese.
+ * This rule detects consecutive identical particles within a token sequence.
+ *
+ * Detection strategy:
+ * - Scan morphological tokens for consecutive 助詞 tokens with the same surface
+ * - Flag as an error if the same meaningful particle appears twice in a row
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class ConsecutiveParticleRule extends AbstractMorphologicalLintRule {
+  readonly id = "consecutive-particle";
+  override engine: CorrectionEngine = "morphological";
+  readonly name = "Consecutive Particle";
+  readonly nameJa = "同一助詞の連続使用制限";
+  readonly description = "The same particle should not appear consecutively";
+  readonly descriptionJa = "同一の助詞を連続して使うと読みにくくなります。文の構造を見直してください（公用文作成の考え方）";
+  readonly level = "L2" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lintWithTokens(
+    _text: string,
+    tokens: ReadonlyArray<Token>,
+    config: LintRuleConfig,
+  ): LintIssue[] {
+    const issues: LintIssue[] = [];
+
+    for (let i = 1; i < tokens.length; i++) {
+      const prev = tokens[i - 1];
+      const curr = tokens[i];
+
+      // Both tokens must be particles (助詞)
+      if (prev.pos !== "助詞" || curr.pos !== "助詞") continue;
+
+      // Same surface form
+      if (prev.surface !== curr.surface) continue;
+
+      // Only flag monitored particles to avoid false positives
+      if (!MONITORED_PARTICLES.has(curr.surface)) continue;
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Consecutive identical particle "${curr.surface}${curr.surface}" detected. Restructure the sentence.`,
+        messageJa: `助詞「${curr.surface}」が連続しています（「${prev.surface}${curr.surface}」）。文の構造を見直してください（公用文作成の考え方）`,
+        from: prev.start,
+        to: curr.end,
+        originalText: prev.surface + curr.surface,
+        reference: KOYO_REF,
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/correlative-expression.ts
+++ b/lib/linting/rules/correlative-expression.ts
@@ -2,7 +2,7 @@ import { AbstractLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
 import type { SentenceSpan } from "../helpers/sentence-splitter";
 import { splitIntoSentences } from "../helpers/sentence-splitter";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -398,6 +398,7 @@ function findAllOccurrences(text: string, needle: string): number[] {
  */
 export class CorrelativeExpressionRule extends AbstractLintRule {
   readonly id = "correlative-expression";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Correlative expression consistency";
   readonly nameJa = "呼応表現の整合性";
   readonly description =

--- a/lib/linting/rules/counter-character-rule.ts
+++ b/lib/linting/rules/counter-character-rule.ts
@@ -1,0 +1,104 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for counter character rule */
+const KOYO_REF: LintReference = {
+  standard: "文化庁「公用文作成の考え方」(2022)",
+};
+
+/**
+ * Patterns for incorrect counter usage.
+ * ヵ (U+30F5) and ヶ (U+30F6) used as counters should be か or 箇.
+ */
+const COUNTER_PATTERNS: ReadonlyArray<{
+  pattern: RegExp;
+  replacement: string;
+  example: string;
+}> = [
+  {
+    pattern: /(\d+|[一二三四五六七八九十百千万]+)[ヵヶケ]所/g,
+    replacement: "か所",
+    example: "3ヵ所 → 3か所",
+  },
+  {
+    pattern: /(\d+|[一二三四五六七八九十百千万]+)[ヵヶケ]月/g,
+    replacement: "か月",
+    example: "6ヶ月 → 6か月",
+  },
+  {
+    pattern: /(\d+|[一二三四五六七八九十百千万]+)[ヵヶケ]年/g,
+    replacement: "か年",
+    example: "3ケ年 → 3か年",
+  },
+  {
+    pattern: /(\d+|[一二三四五六七八九十百千万]+)[ヵヶケ]国/g,
+    replacement: "か国",
+    example: "5ヶ国 → 5か国",
+  },
+];
+
+/**
+ * CounterCharacterRule -- L1 regex-based rule.
+ *
+ * Detects incorrect use of ヵ (U+30F5), ヶ (U+30F6), or ケ as
+ * counter suffixes. Per 公用文作成の考え方, the counter particle
+ * should be written as か (hiragana), not as katakana variants.
+ *
+ * Examples:
+ * - 誤: 3ヵ所  →  正: 3か所
+ * - 誤: 6ヶ月  →  正: 6か月
+ * - 誤: 3ケ年  →  正: 3か年
+ */
+export class CounterCharacterRule extends AbstractLintRule {
+  readonly id = "counter-character";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Use hiragana か for counters";
+  readonly nameJa = "助数詞「か」のひらがな表記";
+  readonly description =
+    "Detects katakana ヵ/ヶ/ケ used as counter particles (should be hiragana か)";
+  readonly descriptionJa =
+    "助数詞に片仮名「ヵ」「ヶ」「ケ」を使っている場合を検出します。平仮名「か」で表記してください";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, replacement, example } of COUNTER_PATTERNS) {
+      const re = new RegExp(pattern.source, "g");
+      for (const match of text.matchAll(re)) {
+        if (match.index === undefined) continue;
+
+        const matchedText = match[0];
+        const numPart = match[1]; // captured number/kanji
+        const wrongCounter = matchedText.slice(numPart.length, numPart.length + 1);
+        const suffix = matchedText.slice(numPart.length + 1);
+        const fixedText = numPart + replacement.slice(0, 1) + suffix;
+
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Use hiragana か for counter (e.g., ${example}) (公用文作成の考え方)`,
+          messageJa: `公用文作成の考え方に基づき、助数詞「${wrongCounter}」はひらがな「か」で表記してください（例：${example}）`,
+          from: match.index,
+          to: match.index + matchedText.length,
+          originalText: matchedText,
+          reference: KOYO_REF,
+          fix: {
+            label: `Replace with "${fixedText}"`,
+            labelJa: `「${fixedText}」に変換`,
+            replacement: fixedText,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/counter-word-mismatch.ts
+++ b/lib/linting/rules/counter-word-mismatch.ts
@@ -2,7 +2,7 @@ import type { Token } from "@/lib/nlp-client/types";
 import { AbstractMorphologicalLintRule } from "../base-rule";
 import { COUNTER_MISMATCHES } from "../data/counter-words";
 import { isInDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -126,6 +126,7 @@ function findNearbyNoun(
  */
 export class CounterWordMismatchRule extends AbstractMorphologicalLintRule {
   readonly id = "counter-word-mismatch";
+  override engine: CorrectionEngine = "morphological";
   readonly name = "Counter Word Mismatch";
   readonly nameJa = "助数詞の誤用検出";
   readonly description = "Validates number + counter word combinations";

--- a/lib/linting/rules/dash-format.ts
+++ b/lib/linting/rules/dash-format.ts
@@ -1,5 +1,5 @@
 import { AbstractLintRule } from "../base-rule";
-import type { LintIssue, LintRuleConfig, LintReference, Severity } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference, Severity , CorrectionEngine} from "../types";
 
 /** JIS X 4051:2004 reference for dash formatting rules */
 const JIS_REF: LintReference = {
@@ -26,6 +26,7 @@ const PAIRED_DASH = `${HORIZONTAL_BAR}${HORIZONTAL_BAR}`; // ――
  */
 export class DashFormatRule extends AbstractLintRule {
   readonly id = "dash-format";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Dash Format";
   readonly nameJa = "ダッシュの用法";
   readonly description =

--- a/lib/linting/rules/desu-masu-consistency.ts
+++ b/lib/linting/rules/desu-masu-consistency.ts
@@ -2,7 +2,7 @@ import type { Token } from "@/lib/nlp-client/types";
 import { AbstractMorphologicalDocumentLintRule } from "../base-rule";
 import { isInDialogue } from "../helpers/dialogue-mask";
 import { splitIntoSentences } from "../helpers/sentence-splitter";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -179,6 +179,7 @@ function classifySentenceStyle(
  */
 export class DesuMasuConsistencyRule extends AbstractMorphologicalDocumentLintRule {
   readonly id = "desu-masu-consistency";
+  override engine: CorrectionEngine = "morphological";
   readonly name = "Desu/Masu Consistency";
   readonly nameJa = "敬体・常体の混在検出";
   readonly description =

--- a/lib/linting/rules/dialogue-punctuation.ts
+++ b/lib/linting/rules/dialogue-punctuation.ts
@@ -1,5 +1,5 @@
 import { AbstractLintRule } from "../base-rule";
-import type { LintIssue, LintRuleConfig, LintReference, Severity } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference, Severity , CorrectionEngine} from "../types";
 
 /** JIS X 4051:2004 reference for dialogue bracket rules */
 const JIS_REF: LintReference = {
@@ -16,6 +16,7 @@ const JIS_REF: LintReference = {
  */
 export class DialoguePunctuationRule extends AbstractLintRule {
   readonly id = "dialogue-punctuation";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Dialogue Punctuation";
   readonly nameJa = "台詞の約物チェック";
   readonly description = "Detects formatting errors in dialogue brackets";

--- a/lib/linting/rules/double-negative-rule.ts
+++ b/lib/linting/rules/double-negative-rule.ts
@@ -1,0 +1,109 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Double negative patterns to detect.
+ * These constructions create ambiguity and should be rewritten affirmatively.
+ */
+const DOUBLE_NEGATIVE_PATTERNS: ReadonlyArray<{
+  pattern: RegExp;
+  note: string;
+}> = [
+  {
+    pattern: /[なに][いく]ではな[いく]/g,
+    note: "二重否定。肯定的な表現に言い換えてください",
+  },
+  {
+    pattern: /ないではない/g,
+    note: "二重否定「ないではない」。「ある」などに言い換えてください",
+  },
+  {
+    pattern: /ないことはない/g,
+    note: "二重否定「ないことはない」。直接肯定で表現してください",
+  },
+  {
+    pattern: /なくはない/g,
+    note: "二重否定「なくはない」。「ある」などに言い換えてください",
+  },
+  {
+    pattern: /ないわけではない/g,
+    note: "二重否定「ないわけではない」。「ある」に言い換えてください",
+  },
+  {
+    pattern: /ないとも言えない/g,
+    note: "二重否定「ないとも言えない」。直接的な表現を使ってください",
+  },
+  {
+    pattern: /ないとは言えない/g,
+    note: "二重否定「ないとは言えない」。直接的な表現を使ってください",
+  },
+  {
+    pattern: /ないとは限らない/g,
+    note: "二重否定「ないとは限らない」。直接的な表現を使ってください",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Double Negative Rule (L1)
+ *
+ * Double negatives (二重否定) in Japanese create ambiguity and are prohibited
+ * in official writing per 公用文作成の考え方.
+ * e.g., 「ないではない」「ないことはない」「なくはない」
+ *
+ * These constructions should be rephrased as direct affirmatives.
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class DoubleNegativeRule extends AbstractLintRule {
+  readonly id = "double-negative";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Double Negative";
+  readonly nameJa = "二重否定の禁止";
+  readonly description = "Double negatives create ambiguity and should be avoided in official writing";
+  readonly descriptionJa = "二重否定（ないではない・ないことはない等）は公用文では原則として使いません（公用文作成の考え方）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, note } of DOUBLE_NEGATIVE_PATTERNS) {
+      // Reset regex state
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+
+      while ((match = pattern.exec(text)) !== null) {
+        const from = match.index;
+        const to = from + match[0].length;
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Double negative detected: "${match[0]}". ${note}`,
+          messageJa: `二重否定が検出されました：「${match[0]}」。${note}`,
+          from,
+          to,
+          originalText: match[0],
+          reference: KOYO_REF,
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/era-year-validator.ts
+++ b/lib/linting/rules/era-year-validator.ts
@@ -1,6 +1,6 @@
 import { AbstractLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -74,6 +74,7 @@ const ERA_WESTERN_PATTERN =
  */
 export class EraYearValidatorRule extends AbstractLintRule {
   readonly id = "era-year-validator";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Era/Western year consistency";
   readonly nameJa = "元号・西暦の一致チェック";
   readonly description =
@@ -83,6 +84,7 @@ export class EraYearValidatorRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
   };
 
   lint(text: string, config: LintRuleConfig): LintIssue[] {

--- a/lib/linting/rules/excessive-honorific-rule.ts
+++ b/lib/linting/rules/excessive-honorific-rule.ts
@@ -1,0 +1,131 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Excessive or double honorific (過剰な敬語・二重敬語) patterns.
+ * These expressions are overly polite or grammatically redundant.
+ */
+const EXCESSIVE_HONORIFIC_PATTERNS: ReadonlyArray<{
+  pattern: string;
+  correct: string;
+  note: string;
+}> = [
+  {
+    pattern: "おっしゃられ",
+    correct: "おっしゃ",
+    note: "「おっしゃる」はすでに尊敬語。「られる」を重ねると二重敬語になります",
+  },
+  {
+    pattern: "拝見させていただ",
+    correct: "拝見し",
+    note: "「拝見する」はすでに謙譲語。「させていただく」を重ねると過剰です",
+  },
+  {
+    pattern: "お召し上がりになられ",
+    correct: "召し上がり",
+    note: "「召し上がる」はすでに尊敬語。「お〜になられる」を重ねると二重敬語になります",
+  },
+  {
+    pattern: "いただけましたでしょうか",
+    correct: "いただけますか",
+    note: "「〜ましたでしょうか」は過剰な丁寧表現です",
+  },
+  {
+    pattern: "させていただきます",
+    correct: "します",
+    note: "「させていただく」の多用は過剰な丁寧表現になります（文脈により許容）",
+  },
+  {
+    pattern: "ご覧になられ",
+    correct: "ご覧になり",
+    note: "「ご覧になる」はすでに尊敬語。「られる」を重ねると二重敬語になります",
+  },
+  {
+    pattern: "おられます",
+    correct: "いらっしゃいます",
+    note: "「おられる」は誤った尊敬語。「いらっしゃる」が正しい尊敬語です",
+  },
+  {
+    pattern: "いただけたでしょうか",
+    correct: "いただけましたか",
+    note: "「〜いただけたでしょうか」は過剰な丁寧表現です",
+  },
+  {
+    pattern: "ご確認のほどよろしくお願い申し上げます",
+    correct: "ご確認をお願いします",
+    note: "重複した丁寧表現です。より簡潔に表現してください",
+  },
+];
+
+/**
+ * Find all non-overlapping occurrences of a literal string in text.
+ */
+function findAllOccurrences(text: string, needle: string): number[] {
+  const indices: number[] = [];
+  let pos = 0;
+  while (pos <= text.length - needle.length) {
+    const idx = text.indexOf(needle, pos);
+    if (idx === -1) break;
+    indices.push(idx);
+    pos = idx + needle.length;
+  }
+  return indices;
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Excessive Honorific Rule (L1)
+ *
+ * Detects excessive or double honorific expressions (過剰な敬語・二重敬語).
+ * Double keigo occurs when two honorific elements are stacked unnecessarily,
+ * e.g., 「おっしゃられる」(おっしゃる + られる) or 「拝見させていただく」.
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class ExcessiveHonorificRule extends AbstractLintRule {
+  readonly id = "excessive-honorific";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Excessive Honorific Expression";
+  readonly nameJa = "過剰な敬語表現の禁止";
+  readonly description = "Detect double keigo and excessively polite expressions";
+  readonly descriptionJa = "二重敬語や過剰な丁寧表現（おっしゃられる・拝見させていただく等）を検出します（公用文作成の考え方）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, correct, note } of EXCESSIVE_HONORIFIC_PATTERNS) {
+      for (const from of findAllOccurrences(text, pattern)) {
+        const to = from + pattern.length;
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Excessive honorific: "${pattern}". ${note} Consider: "${correct}..."`,
+          messageJa: `過剰な敬語表現：「${pattern}」。${note}「${correct}」を検討してください`,
+          from,
+          to,
+          originalText: pattern,
+          reference: KOYO_REF,
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/fixed-okurigana-noun-rule.ts
+++ b/lib/linting/rules/fixed-okurigana-noun-rule.ts
@@ -1,0 +1,107 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const OKURIGANA_REF: LintReference = {
+  standard: "送り仮名の付け方（内閣告示、1973）",
+};
+
+/**
+ * Nouns where okurigana should be omitted in official writing (公用文).
+ * These are established by 送り仮名の付け方 §許容.
+ */
+const OMIT_OKURIGANA: ReadonlyArray<{ verbose: string; official: string }> = [
+  { verbose: "手続き", official: "手続" },
+  { verbose: "問合わせ", official: "問合せ" },
+  { verbose: "取扱い", official: "取扱" },
+  { verbose: "申込み", official: "申込" },
+  { verbose: "受付け", official: "受付" },
+  { verbose: "売上げ", official: "売上" },
+  { verbose: "積立て", official: "積立" },
+  { verbose: "繰越し", official: "繰越" },
+  { verbose: "貸出し", official: "貸出" },
+  { verbose: "払出し", official: "払出" },
+  { verbose: "払込み", official: "払込" },
+  { verbose: "振出し", official: "振出" },
+  { verbose: "引受け", official: "引受" },
+  { verbose: "引渡し", official: "引渡" },
+  { verbose: "見積り", official: "見積" },
+  { verbose: "割引き", official: "割引" },
+  { verbose: "貸付け", official: "貸付" },
+  { verbose: "繰入れ", official: "繰入" },
+  { verbose: "差引き", official: "差引" },
+  { verbose: "組合せ", official: "組合" },
+];
+
+/**
+ * Find all non-overlapping occurrences of a literal string in text.
+ */
+function findAllOccurrences(text: string, needle: string): number[] {
+  const indices: number[] = [];
+  let pos = 0;
+  while (pos <= text.length - needle.length) {
+    const idx = text.indexOf(needle, pos);
+    if (idx === -1) break;
+    indices.push(idx);
+    pos = idx + needle.length;
+  }
+  return indices;
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed Okurigana Noun Rule (L1)
+ *
+ * In official writing (公用文), certain compound nouns have their okurigana
+ * omitted by convention per 送り仮名の付け方 §許容.
+ * e.g., 手続き → 手続, 取扱い → 取扱
+ *
+ * Reference: 送り仮名の付け方（内閣告示、1973）
+ */
+export class FixedOkuriganaNounRule extends AbstractLintRule {
+  readonly id = "fixed-okurigana-noun";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Fixed Okurigana Noun";
+  readonly nameJa = "慣用固定名詞の送り仮名省略";
+  readonly description = "Detect noun okurigana that should be omitted in official writing";
+  readonly descriptionJa = "公用文では慣用が固定した名詞の送り仮名を省略します（送り仮名の付け方 §許容）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { verbose, official } of OMIT_OKURIGANA) {
+      for (const from of findAllOccurrences(text, verbose)) {
+        const to = from + verbose.length;
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `"${verbose}" should be written as "${official}" in official documents (okurigana omission)`,
+          messageJa: `公用文では「${verbose}」の送り仮名を省略し「${official}」と書きます（送り仮名の付け方 §許容）`,
+          from,
+          to,
+          originalText: verbose,
+          reference: OKURIGANA_REF,
+          fix: {
+            label: `Replace with "${official}"`,
+            labelJa: `「${official}」に置換`,
+            replacement: official,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/formal-noun-opening-rule.ts
+++ b/lib/linting/rules/formal-noun-opening-rule.ts
@@ -1,0 +1,96 @@
+import type { Token } from "@/lib/nlp-client/types";
+import { AbstractMorphologicalLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KANJI_REF: LintReference = {
+  standard: "公用文における漢字使用等について（内閣訓令、2010）",
+};
+
+/**
+ * Formal nouns (形式名詞) that should be written in hiragana in official documents.
+ * Key: kanji surface form
+ * Value: hiragana replacement
+ */
+const FORMAL_NOUN_MAP: ReadonlyMap<string, string> = new Map([
+  ["事", "こと"],
+  ["物", "もの"],
+  ["時", "とき"],
+  ["所", "ところ"],
+  ["訳", "わけ"],
+  ["為", "ため"],
+  ["通り", "とおり"],
+  ["方", "ほう"],
+  ["上", "うえ"],
+  ["中", "なか"],
+  ["間", "あいだ"],
+  ["内", "うち"],
+]);
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Formal Noun Opening Rule (L2)
+ *
+ * Formal nouns (形式名詞) should be written in hiragana in official documents.
+ * These nouns lose their concrete meaning when used grammatically,
+ * e.g., 「わかった事」→「わかったこと」, 「する為」→「するため」
+ *
+ * Detection uses morphological analysis: tokens classified as 名詞・非自立
+ * with a kanji surface form that matches known formal nouns.
+ *
+ * Reference: 公用文における漢字使用等について（内閣訓令、2010）
+ */
+export class FormalNounOpeningRule extends AbstractMorphologicalLintRule {
+  readonly id = "formal-noun-opening";
+  override engine: CorrectionEngine = "morphological";
+  readonly name = "Formal Noun in Hiragana";
+  readonly nameJa = "形式名詞のひらがな表記";
+  readonly description = "Formal nouns (形式名詞) should be written in hiragana";
+  readonly descriptionJa = "形式名詞（こと・もの・とき・ところ・わけ・ため等）はひらがなで書きます（公用文における漢字使用等について）";
+  readonly level = "L2" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lintWithTokens(
+    _text: string,
+    tokens: ReadonlyArray<Token>,
+    config: LintRuleConfig,
+  ): LintIssue[] {
+    const issues: LintIssue[] = [];
+
+    for (const token of tokens) {
+      // Match tokens classified as 名詞・非自立 (non-independent noun = formal noun)
+      if (token.pos !== "名詞") continue;
+      if (token.pos_detail_1 !== "非自立") continue;
+
+      const hiragana = FORMAL_NOUN_MAP.get(token.surface);
+      if (!hiragana) continue;
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Formal noun "${token.surface}" should be written in hiragana as "${hiragana}"`,
+        messageJa: `形式名詞「${token.surface}」はひらがなで「${hiragana}」と書きます（公用文における漢字使用等について）`,
+        from: token.start,
+        to: token.end,
+        originalText: token.surface,
+        reference: KANJI_REF,
+        fix: {
+          label: `Replace with "${hiragana}"`,
+          labelJa: `「${hiragana}」に置換`,
+          replacement: hiragana,
+        },
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/gairai-kana-table-rule.ts
+++ b/lib/linting/rules/gairai-kana-table-rule.ts
@@ -1,0 +1,97 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for gairai kana table rule */
+const GAIRAI_REF: LintReference = {
+  standard: "文化庁「外来語の表記」(1991, 内閣告示第二号)",
+};
+
+/**
+ * Second-table (第2表) extended kana combinations.
+ * These are allowed in general usage but should be avoided in formal/public documents
+ * where first-table (第1表) standard kana is preferred.
+ *
+ * Each entry provides the extended form and the preferred standard form.
+ */
+const SECOND_TABLE_KANA: ReadonlyArray<{
+  pattern: RegExp;
+  extended: string;
+  preferred: string;
+}> = [
+  { pattern: /ティ/g, extended: "ティ", preferred: "チ" },
+  { pattern: /ディ/g, extended: "ディ", preferred: "ジ" },
+  { pattern: /デュ/g, extended: "デュ", preferred: "ジュ" },
+  { pattern: /ファ/g, extended: "ファ", preferred: "ハ" },
+  { pattern: /フィ/g, extended: "フィ", preferred: "ヒ" },
+  { pattern: /フェ/g, extended: "フェ", preferred: "ヘ" },
+  { pattern: /フォ/g, extended: "フォ", preferred: "ホ" },
+  { pattern: /ウィ/g, extended: "ウィ", preferred: "ウイ" },
+  { pattern: /ウェ/g, extended: "ウェ", preferred: "ウエ" },
+  { pattern: /ウォ/g, extended: "ウォ", preferred: "ウオ" },
+  { pattern: /チェ/g, extended: "チェ", preferred: "チエ" },
+  { pattern: /トゥ/g, extended: "トゥ", preferred: "トウ" },
+  { pattern: /ドゥ/g, extended: "ドゥ", preferred: "ドウ" },
+  { pattern: /イェ/g, extended: "イェ", preferred: "イエ" },
+];
+
+/**
+ * GairaiKanaTableRule -- L1 regex-based rule.
+ *
+ * Detects use of extended (第2表) katakana combinations in text that
+ * should use standard (第1表) representations. Per 文化庁「外来語の表記」,
+ * formal and public documents should prefer the first-table standard kana
+ * over the extended second-table forms.
+ *
+ * Examples:
+ * - ティ → チ (party: パーティ → パーチ)
+ * - ファ → ハ (file: ファイル → ハイル)
+ * Note: Suggestions are approximate; the user should verify the correct
+ * standard form for the specific loanword.
+ */
+export class GairaiKanaTableRule extends AbstractLintRule {
+  readonly id = "gairai-kana-table";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Use first-table kana for loanwords";
+  readonly nameJa = "外来語仮名の第1表・第2表準拠";
+  readonly description =
+    "Detects second-table extended kana combinations in formal text";
+  readonly descriptionJa =
+    "公用文・学術文書では外来語表記の第2表（拡張仮名）の使用を避け、第1表の表記を推奨します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, extended, preferred } of SECOND_TABLE_KANA) {
+      const re = new RegExp(pattern.source, "g");
+      for (const match of text.matchAll(re)) {
+        if (match.index === undefined) continue;
+
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Extended kana "${extended}" (第2表) should be "${preferred}" (第1表) in formal text (外来語の表記)`,
+          messageJa: `外来語の表記に基づき、公用文では第2表の「${extended}」より第1表の「${preferred}」が推奨されます`,
+          from: match.index,
+          to: match.index + extended.length,
+          originalText: extended,
+          reference: GAIRAI_REF,
+          fix: {
+            label: `Replace with first-table form "${preferred}"`,
+            labelJa: `第1表の形「${preferred}」に変換`,
+            replacement: preferred,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/heading-period-rule.ts
+++ b/lib/linting/rules/heading-period-rule.ts
@@ -1,0 +1,73 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for heading period rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "2.1.2",
+};
+
+/** Maximum character length to consider a text as a potential heading */
+const MAX_HEADING_LENGTH = 20;
+
+/**
+ * HeadingPeriodRule -- L1 regex-based rule.
+ *
+ * Detects short text lines (≤ 20 characters) that end with a Japanese
+ * period (。). Per JTF 2.1.2, headings should not end with a period.
+ *
+ * A "heading" is heuristically identified as a short text segment
+ * (≤ 20 characters) that ends with 。.
+ */
+export class HeadingPeriodRule extends AbstractLintRule {
+  readonly id = "heading-period";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "No period at end of heading";
+  readonly nameJa = "見出し末尾の句点禁止";
+  readonly description =
+    "Detects short headings that incorrectly end with a Japanese period (。)";
+  readonly descriptionJa =
+    "句点（。）で終わっている短い見出しを検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    // Only consider short texts as potential headings
+    const trimmed = text.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_HEADING_LENGTH) return [];
+
+    // Must end with 。
+    if (!trimmed.endsWith("。")) return [];
+
+    // Ignore texts that look like full sentences (contain sentence-internal periods)
+    const internalPeriods = (trimmed.slice(0, -1).match(/。/g) ?? []).length;
+    if (internalPeriods > 0) return [];
+
+    const periodPos = text.lastIndexOf("。");
+    if (periodPos === -1) return [];
+
+    return [
+      {
+        ruleId: this.id,
+        severity: config.severity,
+        message: "Headings should not end with a period (JTF 2.1.2)",
+        messageJa: "JTF 2.1.2に基づき、見出しの末尾に句点（。）は使用しないでください",
+        from: periodPos,
+        to: periodPos + 1,
+        originalText: "。",
+        reference: JTF_REF,
+        fix: {
+          label: "Remove trailing period",
+          labelJa: "末尾の句点を削除",
+          replacement: "",
+        },
+      },
+    ];
+  }
+}

--- a/lib/linting/rules/historical-kana-detection.ts
+++ b/lib/linting/rules/historical-kana-detection.ts
@@ -1,0 +1,101 @@
+import { AbstractDocumentLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for historical kana detection */
+const KANA_REF: LintReference = {
+  standard: "文化庁「現代仮名遣い」(1986, 内閣告示第一号)",
+};
+
+/**
+ * Historical kana characters that are no longer used in modern Japanese.
+ * These are remnants of historical kana spelling (歴史的仮名遣い).
+ */
+const HISTORICAL_KANA: ReadonlyArray<{
+  char: string;
+  modern: string;
+  nameJa: string;
+}> = [
+  { char: "\u3090", modern: "い", nameJa: "ゐ（ゐ）" },  // ゐ
+  { char: "\u3091", modern: "え", nameJa: "ゑ（ゑ）" },  // ゑ
+  { char: "\u30F0", modern: "イ", nameJa: "ヰ（ヰ）" },  // ヰ
+  { char: "\u30F1", modern: "エ", nameJa: "ヱ（ヱ）" },  // ヱ
+];
+
+/**
+ * HistoricalKanaDetection -- L1 document-level rule.
+ *
+ * Detects historical kana characters (歴史的仮名遣い) that are no longer
+ * used in modern Japanese: ゐ (U+3090), ゑ (U+3091), ヰ (U+30F0), ヱ (U+30F1).
+ * Per 文化庁「現代仮名遣い」, these characters should be replaced with their
+ * modern equivalents except in quotations of classical texts.
+ *
+ * Historical characters and their modern equivalents:
+ * - ゐ → い
+ * - ゑ → え
+ * - ヰ → イ
+ * - ヱ → エ
+ */
+export class HistoricalKanaDetection extends AbstractDocumentLintRule {
+  readonly id = "historical-kana-detection";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Detect historical kana characters";
+  readonly nameJa = "歴史的仮名遣いの検出";
+  readonly description =
+    "Detects historical kana (ゐ, ゑ, ヰ, ヱ) that should use modern equivalents";
+  readonly descriptionJa =
+    "現代では使用されない歴史的仮名遣い（ゐ・ゑ・ヰ・ヱ）を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lintDocument(
+    paragraphs: ReadonlyArray<{ text: string; index: number }>,
+    config: LintRuleConfig,
+  ): Array<{ paragraphIndex: number; issues: LintIssue[] }> {
+    if (!config.enabled || paragraphs.length === 0) return [];
+
+    const results: Array<{ paragraphIndex: number; issues: LintIssue[] }> = [];
+
+    for (const para of paragraphs) {
+      const issues = this.checkParagraph(para.text, config);
+      if (issues.length > 0) {
+        results.push({ paragraphIndex: para.index, issues });
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Check a single paragraph for historical kana characters.
+   */
+  private checkParagraph(text: string, config: LintRuleConfig): LintIssue[] {
+    const issues: LintIssue[] = [];
+
+    for (const { char, modern, nameJa } of HISTORICAL_KANA) {
+      for (let i = 0; i < text.length; i++) {
+        if (text[i] !== char) continue;
+
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Historical kana "${char}" (${nameJa}) should be replaced with "${modern}" in modern Japanese (現代仮名遣い)`,
+          messageJa: `現代仮名遣いに基づき、歴史的仮名遣い「${char}」（${nameJa}）は現代表記「${modern}」に改めてください（古典文の引用を除く）`,
+          from: i,
+          to: i + 1,
+          originalText: char,
+          reference: KANA_REF,
+          fix: {
+            label: `Replace with "${modern}"`,
+            labelJa: `「${modern}」に変換`,
+            replacement: modern,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/homophone-detection.ts
+++ b/lib/linting/rules/homophone-detection.ts
@@ -1,10 +1,11 @@
 import type { ILlmClient } from "@/lib/llm-client/types";
 
 import { AbstractLlmLintRule } from "../base-rule";
-import type { LintIssue, LintRuleConfig } from "../types";
+import type { LintIssue, LintRuleConfig , CorrectionEngine} from "../types";
 
 export class HomophoneDetectionRule extends AbstractLlmLintRule {
   readonly id = "homophone-detection";
+  override engine: CorrectionEngine = "llm";
   readonly name = "Homophone Detection";
   readonly nameJa = "同音異義語の検出";
   readonly description =

--- a/lib/linting/rules/iteration-mark-rule.ts
+++ b/lib/linting/rules/iteration-mark-rule.ts
@@ -1,0 +1,72 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for iteration mark rule */
+const KOYO_REF: LintReference = {
+  standard: "文化庁「公用文作成の考え方」(2022)",
+};
+
+/** Hiragana range: ぁ–ん (U+3041–U+3093) */
+const HIRAGANA_RANGE = /[\u3041-\u3093]/;
+/** Katakana range: ァ–ン (U+30A1–U+30F3) */
+const KATAKANA_RANGE = /[\u30A1-\u30F3]/;
+
+/**
+ * Matches 々 (U+3005) preceded by hiragana or katakana — invalid usage.
+ */
+const INVALID_ITERATION_MARK = /[\u3041-\u3093\u30A1-\u30F3]々/g;
+
+/**
+ * IterationMarkRule -- L1 regex-based rule.
+ *
+ * Detects invalid use of the kanji repetition mark 々 (U+3005) when
+ * preceded by hiragana or katakana characters. The 々 mark is valid
+ * only when repeating a kanji character (e.g., 山々, 人々).
+ *
+ * Reference: 公用文作成の考え方
+ */
+export class IterationMarkRule extends AbstractLintRule {
+  readonly id = "iteration-mark";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Correct use of kanji iteration mark (々)";
+  readonly nameJa = "繰り返し符号「々」の制限";
+  readonly description =
+    "Detects 々 used after hiragana or katakana (invalid usage)";
+  readonly descriptionJa =
+    "平仮名・片仮名の後に「々」が使われている無効な用法を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const match of text.matchAll(INVALID_ITERATION_MARK)) {
+      if (match.index === undefined) continue;
+
+      const precedingChar = match[0][0];
+      const charType = HIRAGANA_RANGE.test(precedingChar) ? "平仮名" : "片仮名";
+
+      // Position of 々 is one character after the preceding char
+      const iterPos = match.index + 1;
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `"々" should only follow kanji characters, not ${charType === "平仮名" ? "hiragana" : "katakana"} (公用文作成の考え方)`,
+        messageJa: `公用文作成の考え方に基づき、繰り返し符号「々」は漢字の後にのみ使用できます。${charType}「${precedingChar}」の後には使用しないでください`,
+        from: iterPos,
+        to: iterPos + 1,
+        originalText: "々",
+        reference: KOYO_REF,
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/japanese-punctuation-width-rule.ts
+++ b/lib/linting/rules/japanese-punctuation-width-rule.ts
@@ -1,0 +1,83 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for Japanese punctuation width rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "2.1.1",
+};
+
+/** CJK / full-width character range (used for context detection) */
+const CJK_RANGE = /[\u3000-\u9FFF\uFF00-\uFFEF]/;
+
+/**
+ * Map from half-width punctuation to full-width equivalents
+ * for use in Japanese text context.
+ */
+const HALF_TO_FULL_PUNCT: ReadonlyMap<string, string> = new Map([
+  ["!", "！"],
+  ["?", "？"],
+]);
+
+/**
+ * JapanesePunctuationWidthRule -- L1 regex-based rule.
+ *
+ * Detects half-width exclamation marks (!) and question marks (?)
+ * when they appear directly adjacent to Japanese (CJK) characters.
+ * Per JTF 2.1.1, punctuation in Japanese text should use full-width
+ * characters (！, ？).
+ */
+export class JapanesePunctuationWidthRule extends AbstractLintRule {
+  readonly id = "japanese-punctuation-width";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Use full-width punctuation in Japanese text";
+  readonly nameJa = "和文中の句読点・記号の全角統一";
+  readonly description =
+    "Detects half-width ! and ? adjacent to Japanese characters";
+  readonly descriptionJa =
+    "日本語文字に隣接する半角の感嘆符・疑問符を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (let i = 0; i < text.length; i++) {
+      const ch = text[i];
+      const fullWidth = HALF_TO_FULL_PUNCT.get(ch);
+      if (fullWidth === undefined) continue;
+
+      // Check if preceded or followed by a CJK character
+      const prevChar = i > 0 ? text[i - 1] : "";
+      const nextChar = i < text.length - 1 ? text[i + 1] : "";
+      const adjacentToJapanese =
+        CJK_RANGE.test(prevChar) || CJK_RANGE.test(nextChar);
+
+      if (!adjacentToJapanese) continue;
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Use full-width "${fullWidth}" instead of half-width "${ch}" in Japanese text (JTF 2.1.1)`,
+        messageJa: `JTF 2.1.1に基づき、日本語文中では半角「${ch}」ではなく全角「${fullWidth}」を使用してください`,
+        from: i,
+        to: i + 1,
+        originalText: ch,
+        reference: JTF_REF,
+        fix: {
+          label: `Replace with full-width "${fullWidth}"`,
+          labelJa: `全角「${fullWidth}」に変換`,
+          replacement: fullWidth,
+        },
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/ji-zu-kana-rule.ts
+++ b/lib/linting/rules/ji-zu-kana-rule.ts
@@ -1,0 +1,106 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for ji/zu kana rule */
+const KANA_REF: LintReference = {
+  standard: "文化庁「現代仮名遣い」(1986, 内閣告示第一号)",
+};
+
+/**
+ * Common misspellings where ず/づ or じ/ぢ are confused.
+ * Each entry specifies the incorrect pattern and its correction.
+ *
+ * These are cases where the standard modern kana usage (現代仮名遣い)
+ * requires づ but writers mistakenly use ず, or vice versa.
+ */
+const JI_ZU_ERRORS: ReadonlyArray<{
+  pattern: RegExp;
+  correct: string;
+  description: string;
+}> = [
+  // 続く — correct: つづく, common error: つずく
+  { pattern: /つずく/g, correct: "つづく", description: "続く" },
+  // 基づく — correct: もとづく, common error: もとずく
+  { pattern: /もとずく/g, correct: "もとづく", description: "基づく" },
+  // 気づく — correct: きづく, common error: きずく
+  { pattern: /きずく/g, correct: "きづく", description: "気づく" },
+  // 近づく — correct: ちかづく, common error: ちかずく
+  { pattern: /ちかずく/g, correct: "ちかづく", description: "近づく" },
+  // 続ける — correct: つづける, common error: つずける
+  { pattern: /つずける/g, correct: "つづける", description: "続ける" },
+  // 片付く — correct: かたづく, common error: かたずく
+  { pattern: /かたずく/g, correct: "かたづく", description: "片付く" },
+  // 傷つく — correct: きずつく, common error: きづつく
+  // (きずつく IS correct — 傷 = きず, so skip this one)
+  // 落ち着く — correct: おちつく (no づ involved, skip)
+  // 育つ — correct: そだつ (no confusion)
+  // 見つかる — correct: みつかる (no confusion)
+  // 手続き — correct: てつづき, common error: てつずき
+  { pattern: /てつずき/g, correct: "てつづき", description: "手続き" },
+  // 落ち着く — no confusion
+  // 縮む — correct: ちぢむ, common error: ちずむ
+  { pattern: /ちずむ/g, correct: "ちぢむ", description: "縮む" },
+  // 縮める — correct: ちぢめる, common error: ちずめる
+  { pattern: /ちずめる/g, correct: "ちぢめる", description: "縮める" },
+];
+
+/**
+ * JiZuKanaRule -- L1 regex-based rule.
+ *
+ * Detects common misspellings where づ/ぢ and ず/じ are confused.
+ * Per 文化庁「現代仮名遣い」, the general rule is:
+ * - Use じ and ず as the standard forms
+ * - Use ぢ and づ only for rendaku (連濁) and specific traditional words
+ *
+ * This rule checks for well-known cases where writers mistakenly
+ * use ず where づ is required (after rendaku or in compound words).
+ */
+export class JiZuKanaRule extends AbstractLintRule {
+  readonly id = "ji-zu-kana";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Correct ji/zu kana usage (じ/ぢ・ず/づ)";
+  readonly nameJa = "じ/ぢ・ず/づの使い分け";
+  readonly description =
+    "Detects common misspellings involving じ/ぢ and ず/づ confusion";
+  readonly descriptionJa =
+    "現代仮名遣いに基づき、じ/ぢ・ず/づの誤った使い方を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, correct, description } of JI_ZU_ERRORS) {
+      const re = new RegExp(pattern.source, "g");
+      for (const match of text.matchAll(re)) {
+        if (match.index === undefined) continue;
+
+        const wrongForm = match[0];
+
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Incorrect kana: "${wrongForm}" should be "${correct}" (${description}) — 現代仮名遣い`,
+          messageJa: `現代仮名遣いに基づき、「${wrongForm}」は「${correct}」（${description}）と表記してください`,
+          from: match.index,
+          to: match.index + wrongForm.length,
+          originalText: wrongForm,
+          reference: KANA_REF,
+          fix: {
+            label: `Replace with "${correct}"`,
+            labelJa: `「${correct}」に修正`,
+            replacement: correct,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/joyo-kanji.ts
+++ b/lib/linting/rules/joyo-kanji.ts
@@ -2,7 +2,7 @@ import { AbstractLintRule } from "../base-rule";
 import { JINMEIYO_KANJI_SET } from "../data/jinmeiyo-kanji";
 import { JOYO_KANJI_SET } from "../data/joyo-kanji";
 import { maskDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -117,6 +117,7 @@ const CJK_KANJI_REGEX = /[\u4e00-\u9fff\u3400-\u4dbf\u{20000}-\u{2a6df}]/gu;
  */
 export class JoyoKanjiRule extends AbstractLintRule {
   readonly id = "joyo-kanji";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Joyo kanji validation";
   readonly nameJa = "常用漢字バリデーション";
   readonly description = "Detect kanji outside the official Joyo kanji set";
@@ -125,6 +126,7 @@ export class JoyoKanjiRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "info",
+    skipDialogue: true,
     options: { allowJinmeiyo: true } satisfies JoyoKanjiOptions,
   };
 

--- a/lib/linting/rules/kanji-verb-one-char-do.ts
+++ b/lib/linting/rules/kanji-verb-one-char-do.ts
@@ -1,0 +1,146 @@
+import type { Token } from "@/lib/nlp-client/types";
+import { AbstractMorphologicalLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Single-kanji + する compound verbs where a more descriptive
+ * two-kanji + する form exists and is preferred in official writing.
+ *
+ * form: the single-kanji+する form
+ * preferred: the preferred, more descriptive form(s)
+ * note: explanation
+ */
+const SINGLE_KANJI_SURU: ReadonlyArray<{
+  form: string;
+  preferred: string;
+  note: string;
+}> = [
+  {
+    form: "処する",
+    preferred: "処置する・処理する",
+    note: "「処する」より具体的な「処置する」「処理する」が明確です",
+  },
+  {
+    form: "発する",
+    preferred: "発信する・発表する・発令する",
+    note: "「発する」より「発信する」「発表する」等が意味を明確に伝えます",
+  },
+  {
+    form: "論する",
+    preferred: "論じる・論述する",
+    note: "「論する」は文語的。「論じる」または「論述する」が適切です",
+  },
+  {
+    form: "称する",
+    preferred: "称号を与える・呼称する",
+    note: "「称する」より具体的な表現を使ってください",
+  },
+  {
+    form: "接する",
+    preferred: "接触する・対応する",
+    note: "「接する」より具体的な「接触する」「対応する」が明確です（文脈による）",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Kanji Verb One Char Do Rule (L2)
+ *
+ * Certain single-kanji + する compound verbs (漢字1字＋する) are vague
+ * and can be replaced with more descriptive two-kanji + する forms
+ * in official writing.
+ * e.g., 「処する」→「処置する」, 「発する」→「発信する」
+ *
+ * Detection uses morphological analysis to find サ変 (suru-verb) tokens
+ * whose basic form matches the dictionary of vague single-kanji+する verbs.
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class KanjiVerbOneCharDo extends AbstractMorphologicalLintRule {
+  readonly id = "kanji-verb-one-char-do";
+  override engine: CorrectionEngine = "morphological";
+  readonly name = "Single-Kanji + する Verb Paraphrase";
+  readonly nameJa = "「漢字1字＋する」型の動詞の言い換え";
+  readonly description = "Replace vague single-kanji+する verbs with more descriptive forms";
+  readonly descriptionJa = "「処する」「発する」等の「漢字1字＋する」型動詞をより具体的な表現に言い換えます（公用文作成の考え方）";
+  readonly level = "L2" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "info",
+  };
+
+  lintWithTokens(
+    _text: string,
+    tokens: ReadonlyArray<Token>,
+    config: LintRuleConfig,
+  ): LintIssue[] {
+    const issues: LintIssue[] = [];
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+
+      // Look for サ変接続 nouns followed by する
+      // or direct サ変動詞 tokens with matching basic_form
+      if (token.pos === "動詞") {
+        const basicForm = token.basic_form ?? token.surface;
+        const guidance = SINGLE_KANJI_SURU.find((g) => g.form === basicForm);
+
+        if (!guidance) continue;
+
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `"${guidance.form}" is vague. Consider: "${guidance.preferred}"`,
+          messageJa: `「${guidance.form}」の意味が曖昧な場合があります。${guidance.note}（候補：「${guidance.preferred}」）`,
+          from: token.start,
+          to: token.end,
+          originalText: token.surface,
+          reference: KOYO_REF,
+        });
+        continue;
+      }
+
+      // Also check for [名詞・サ変接続] + [する] pattern
+      if (
+        token.pos === "名詞" &&
+        token.pos_detail_1 === "サ変接続" &&
+        i + 1 < tokens.length
+      ) {
+        const nextToken = tokens[i + 1];
+        if (
+          nextToken.pos === "動詞" &&
+          (nextToken.basic_form === "する" || nextToken.surface === "する")
+        ) {
+          const compound = token.surface + "する";
+          const guidance = SINGLE_KANJI_SURU.find((g) => g.form === compound);
+
+          if (!guidance) continue;
+
+          issues.push({
+            ruleId: this.id,
+            severity: config.severity,
+            message: `"${guidance.form}" is vague. Consider: "${guidance.preferred}"`,
+            messageJa: `「${guidance.form}」の意味が曖昧な場合があります。${guidance.note}（候補：「${guidance.preferred}」）`,
+            from: token.start,
+            to: nextToken.end,
+            originalText: compound,
+            reference: KOYO_REF,
+          });
+        }
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/katakana-chouon-rule.ts
+++ b/lib/linting/rules/katakana-chouon-rule.ts
@@ -1,0 +1,105 @@
+import type { Token } from "@/lib/nlp-client/types";
+import { AbstractMorphologicalLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for katakana long vowel rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "2.2.2",
+};
+
+/**
+ * Patterns where repeated vowels in katakana should use ー (long vowel mark).
+ * These patterns detect repeated vowel sequences that are commonly mistaken
+ * for valid katakana but should use the long vowel mark instead.
+ */
+const VOWEL_REPETITION_PATTERNS: ReadonlyArray<{
+  pattern: RegExp;
+  replacement: string;
+  description: string;
+}> = [
+  { pattern: /アア/g, replacement: "アー", description: "アア→アー" },
+  { pattern: /イイ/g, replacement: "イー", description: "イイ→イー" },
+  { pattern: /ウウ/g, replacement: "ウー", description: "ウウ→ウー" },
+  { pattern: /エエ/g, replacement: "エー", description: "エエ→エー" },
+  { pattern: /オオ/g, replacement: "オー", description: "オオ→オー" },
+  { pattern: /ラア/g, replacement: "ラー", description: "ラア→ラー" },
+  { pattern: /リイ/g, replacement: "リー", description: "リイ→リー" },
+  { pattern: /ルウ/g, replacement: "ルー", description: "ルウ→ルー" },
+  { pattern: /レエ/g, replacement: "レー", description: "レエ→レー" },
+  { pattern: /ロオ/g, replacement: "ロー", description: "ロオ→ロー" },
+];
+
+/**
+ * KatakanaChouonRule -- L2 morphological rule (paragraph-level).
+ *
+ * Detects katakana words containing repeated vowel sequences that should
+ * use the long vowel mark (ー) instead. Per JTF 2.2.2, katakana loanwords
+ * should use ー for long vowel sounds rather than repeating the vowel.
+ *
+ * This rule uses morphological analysis to identify katakana tokens,
+ * then checks those tokens for vowel repetition patterns.
+ */
+export class KatakanaChouonRule extends AbstractMorphologicalLintRule {
+  readonly id = "katakana-chouon";
+  override engine: CorrectionEngine = "morphological";
+  readonly name = "Use long vowel mark in katakana";
+  readonly nameJa = "カタカナ語の長音省略禁止";
+  readonly description =
+    "Detects katakana words using repeated vowels instead of the long vowel mark (ー)";
+  readonly descriptionJa =
+    "長音記号「ー」の代わりに母音を繰り返しているカタカナ語を検出します";
+  readonly level = "L2" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  /** Matches a string that is entirely or mostly katakana */
+  private static readonly KATAKANA_PATTERN = /^[\u30A0-\u30FFー]+$/;
+
+  lintWithTokens(
+    text: string,
+    tokens: ReadonlyArray<Token>,
+    config: LintRuleConfig,
+  ): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const token of tokens) {
+      // Only examine tokens whose surface form is katakana
+      if (!KatakanaChouonRule.KATAKANA_PATTERN.test(token.surface)) continue;
+
+      for (const { pattern, replacement, description } of VOWEL_REPETITION_PATTERNS) {
+        // Reset lastIndex for the reused regex
+        pattern.lastIndex = 0;
+        for (const match of token.surface.matchAll(pattern)) {
+          if (match.index === undefined) continue;
+
+          const from = token.start + match.index;
+          const to = from + match[0].length;
+
+          issues.push({
+            ruleId: this.id,
+            severity: config.severity,
+            message: `Use long vowel mark (ー) instead of repeated vowel: ${description} (JTF 2.2.2)`,
+            messageJa: `JTF 2.2.2に基づき、母音の繰り返し「${match[0]}」は長音記号「${replacement}」で表記してください`,
+            from,
+            to,
+            originalText: match[0],
+            reference: JTF_REF,
+            fix: {
+              label: `Replace with "${replacement}"`,
+              labelJa: `「${replacement}」に変換`,
+              replacement,
+            },
+          });
+        }
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/katakana-width-rule.ts
+++ b/lib/linting/rules/katakana-width-rule.ts
@@ -1,0 +1,88 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for katakana width rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "2.2.1",
+};
+
+/**
+ * Mapping from half-width katakana (U+FF66–U+FF9F) to full-width katakana.
+ */
+const HALF_TO_FULL: ReadonlyMap<string, string> = new Map([
+  ["ｦ", "ヲ"], ["ｧ", "ァ"], ["ｨ", "ィ"], ["ｩ", "ゥ"], ["ｪ", "ェ"],
+  ["ｫ", "ォ"], ["ｬ", "ャ"], ["ｭ", "ュ"], ["ｮ", "ョ"], ["ｯ", "ッ"],
+  ["ｰ", "ー"], ["ｱ", "ア"], ["ｲ", "イ"], ["ｳ", "ウ"], ["ｴ", "エ"],
+  ["ｵ", "オ"], ["ｶ", "カ"], ["ｷ", "キ"], ["ｸ", "ク"], ["ｹ", "ケ"],
+  ["ｺ", "コ"], ["ｻ", "サ"], ["ｼ", "シ"], ["ｽ", "ス"], ["ｾ", "セ"],
+  ["ｿ", "ソ"], ["ﾀ", "タ"], ["ﾁ", "チ"], ["ﾂ", "ツ"], ["ﾃ", "テ"],
+  ["ﾄ", "ト"], ["ﾅ", "ナ"], ["ﾆ", "ニ"], ["ﾇ", "ヌ"], ["ﾈ", "ネ"],
+  ["ﾉ", "ノ"], ["ﾊ", "ハ"], ["ﾋ", "ヒ"], ["ﾌ", "フ"], ["ﾍ", "ヘ"],
+  ["ﾎ", "ホ"], ["ﾏ", "マ"], ["ﾐ", "ミ"], ["ﾑ", "ム"], ["ﾒ", "メ"],
+  ["ﾓ", "モ"], ["ﾔ", "ヤ"], ["ﾕ", "ユ"], ["ﾖ", "ヨ"], ["ﾗ", "ラ"],
+  ["ﾘ", "リ"], ["ﾙ", "ル"], ["ﾚ", "レ"], ["ﾛ", "ロ"], ["ﾜ", "ワ"],
+  ["ﾝ", "ン"], ["ﾞ", "゛"], ["ﾟ", "゜"],
+]);
+
+/** Matches any single half-width katakana character */
+const HALF_KANA_PATTERN = /[\uFF66-\uFF9F]/g;
+
+/**
+ * KatakanaWidthRule -- L1 regex-based rule.
+ *
+ * Detects half-width katakana characters (U+FF66–U+FF9F) and suggests
+ * converting them to their full-width equivalents. Per JTF 2.2.1,
+ * katakana characters should always be written in full-width form.
+ */
+export class KatakanaWidthRule extends AbstractLintRule {
+  readonly id = "katakana-width";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Use full-width katakana";
+  readonly nameJa = "カタカナの全角統一";
+  readonly description =
+    "Detects half-width katakana characters that should be full-width";
+  readonly descriptionJa =
+    "半角カタカナを検出します。カタカナは全角で記述してください";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const match of text.matchAll(HALF_KANA_PATTERN)) {
+      if (match.index === undefined) continue;
+
+      const halfChar = match[0];
+      const fullChar = HALF_TO_FULL.get(halfChar);
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Half-width katakana "${halfChar}" should be full-width (JTF 2.2.1)`,
+        messageJa: `JTF 2.2.1に基づき、半角カタカナ「${halfChar}」は全角で記述してください`,
+        from: match.index,
+        to: match.index + 1,
+        originalText: halfChar,
+        reference: JTF_REF,
+        ...(fullChar !== undefined
+          ? {
+              fix: {
+                label: `Replace with full-width "${fullChar}"`,
+                labelJa: `全角「${fullChar}」に変換`,
+                replacement: fullChar,
+              },
+            }
+          : {}),
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/large-number-comma-rule.ts
+++ b/lib/linting/rules/large-number-comma-rule.ts
@@ -1,0 +1,80 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for large number comma rule */
+const KOYO_REF: LintReference = {
+  standard: "文化庁「公用文作成の考え方」(2022)",
+};
+
+/**
+ * Matches 4 or more consecutive ASCII digits not already separated by commas.
+ * We use a word boundary approach: digits must not be immediately preceded
+ * by a comma or digit (to avoid matching already-formatted numbers).
+ */
+const LARGE_NUMBER_PATTERN = /(?<![,\d])\d{4,}(?![,\d])/g;
+
+/**
+ * Format a number string by inserting commas every 3 digits from the right.
+ */
+function formatWithCommas(numStr: string): string {
+  return numStr.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+/**
+ * LargeNumberCommaRule -- L1 regex-based rule.
+ *
+ * Detects sequences of 4 or more consecutive digits that lack comma
+ * separators (e.g., 10000 should be 10,000). Per 公用文作成の考え方,
+ * large numbers should use comma separators for readability.
+ */
+export class LargeNumberCommaRule extends AbstractLintRule {
+  readonly id = "large-number-comma";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Use commas in large numbers";
+  readonly nameJa = "大きな数字の桁区切り";
+  readonly description =
+    "Detects numbers with 4+ digits that lack comma thousand-separators";
+  readonly descriptionJa =
+    "4桁以上の数字に桁区切りのカンマがない場合を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const match of text.matchAll(LARGE_NUMBER_PATTERN)) {
+      if (match.index === undefined) continue;
+
+      const numStr = match[0];
+      const formatted = formatWithCommas(numStr);
+
+      // Skip if formatting produces no change (already has commas — shouldn't happen
+      // given the pattern, but as a safety check)
+      if (formatted === numStr) continue;
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Large number "${numStr}" should use comma separators: "${formatted}" (公用文作成の考え方)`,
+        messageJa: `公用文作成の考え方に基づき、大きな数字「${numStr}」には桁区切りのカンマを入れてください（例：${formatted}）`,
+        from: match.index,
+        to: match.index + numStr.length,
+        originalText: numStr,
+        reference: KOYO_REF,
+        fix: {
+          label: `Add comma separators: "${formatted}"`,
+          labelJa: `「${formatted}」に変換`,
+          replacement: formatted,
+        },
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/list-formatting-consistency-rule.ts
+++ b/lib/linting/rules/list-formatting-consistency-rule.ts
@@ -1,0 +1,122 @@
+import { AbstractDocumentLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for list formatting consistency rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "3.1.1",
+};
+
+/** Bullet prefixes that indicate a list item */
+const LIST_ITEM_PREFIX = /^[・○●◎◯▶▷►→\-\*]\s*/;
+/** Numbered list prefix */
+const NUMBERED_ITEM_PREFIX = /^[0-9０-９]+[.．、。）)]\s*/;
+
+/** Maximum character length for a text to be considered a list item */
+const MAX_LIST_ITEM_LENGTH = 60;
+
+/**
+ * Determine if a text line looks like a list item.
+ */
+function isListItem(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_LIST_ITEM_LENGTH) return false;
+  return LIST_ITEM_PREFIX.test(trimmed) || NUMBERED_ITEM_PREFIX.test(trimmed);
+}
+
+/**
+ * ListFormattingConsistencyRule -- L1 document-level rule.
+ *
+ * Detects inconsistent use of trailing 。 (period) within a run of
+ * list items. Per JTF 3.1.1, all items in a list should either all
+ * end with 。 or all omit the trailing period.
+ *
+ * Detection strategy:
+ * 1. Find runs of ≥ 3 consecutive paragraphs that look like list items.
+ * 2. Within each run, check whether some items end with 。 and others do not.
+ * 3. Flag the minority style items.
+ */
+export class ListFormattingConsistencyRule extends AbstractDocumentLintRule {
+  readonly id = "list-formatting-consistency";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Consistent list item punctuation";
+  readonly nameJa = "箇条書きの文体・句点の統一";
+  readonly description =
+    "Detects inconsistent trailing period usage within list items";
+  readonly descriptionJa =
+    "箇条書き内で句点（。）の有無が混在している場合を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  lintDocument(
+    paragraphs: ReadonlyArray<{ text: string; index: number }>,
+    config: LintRuleConfig,
+  ): Array<{ paragraphIndex: number; issues: LintIssue[] }> {
+    if (!config.enabled || paragraphs.length === 0) return [];
+
+    const results: Array<{ paragraphIndex: number; issues: LintIssue[] }> = [];
+
+    // Find consecutive runs of list items
+    let runStart = -1;
+    const runs: Array<Array<{ text: string; index: number }>> = [];
+
+    for (let i = 0; i <= paragraphs.length; i++) {
+      const para = paragraphs[i];
+      const isItem = para !== undefined && isListItem(para.text);
+
+      if (isItem && runStart === -1) {
+        runStart = i;
+      } else if (!isItem && runStart !== -1) {
+        const run = paragraphs.slice(runStart, i);
+        if (run.length >= 3) {
+          runs.push(Array.from(run));
+        }
+        runStart = -1;
+      }
+    }
+
+    // Check each run for consistency
+    for (const run of runs) {
+      const withPeriod = run.filter((p) => p.text.trim().endsWith("。"));
+      const withoutPeriod = run.filter((p) => !p.text.trim().endsWith("。"));
+
+      if (withPeriod.length === 0 || withoutPeriod.length === 0) continue;
+
+      // Flag minority
+      const minority =
+        withPeriod.length <= withoutPeriod.length ? withPeriod : withoutPeriod;
+      const hasMinorityPeriod = withPeriod.length <= withoutPeriod.length;
+
+      for (const item of minority) {
+        const trimmed = item.text.trim();
+        const from = item.text.lastIndexOf(trimmed.slice(-1));
+        const to = from + 1;
+
+        results.push({
+          paragraphIndex: item.index,
+          issues: [
+            {
+              ruleId: this.id,
+              severity: config.severity,
+              message: hasMinorityPeriod
+                ? "List item ends with 。 but most items do not — remove for consistency (JTF 3.1.1)"
+                : "List item lacks trailing 。 but most items have one — add for consistency (JTF 3.1.1)",
+              messageJa: hasMinorityPeriod
+                ? "JTF 3.1.1に基づき、他の箇条書き項目と統一するため末尾の句点（。）を削除してください"
+                : "JTF 3.1.1に基づき、他の箇条書き項目と統一するため末尾に句点（。）を追加してください",
+              from,
+              to,
+              reference: JTF_REF,
+            },
+          ],
+        });
+      }
+    }
+
+    return results;
+  }
+}

--- a/lib/linting/rules/literary-style-exclusion-rule.ts
+++ b/lib/linting/rules/literary-style-exclusion-rule.ts
@@ -1,0 +1,147 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Literary/classical Japanese (文語調) patterns to avoid in modern official writing.
+ * These are archaic endings and expressions that should be replaced
+ * with modern equivalents.
+ */
+const LITERARY_PATTERNS: ReadonlyArray<{
+  pattern: RegExp;
+  example: string;
+  modern: string;
+  note: string;
+}> = [
+  {
+    pattern: /せり[。、\s]/g,
+    example: "〜せり",
+    modern: "〜した",
+    note: "文語の完了形「〜せり」は現代語に言い換えてください",
+  },
+  {
+    pattern: /なり[。、\s]/g,
+    example: "〜なり",
+    modern: "〜である",
+    note: "文語の断定「〜なり」は「〜である」に言い換えてください",
+  },
+  {
+    pattern: /たり[。、\s]/g,
+    example: "〜たり",
+    modern: "〜た",
+    note: "文語の完了「〜たり」は「〜た」に言い換えてください",
+  },
+  {
+    pattern: /べし[。、\s]/g,
+    example: "〜べし",
+    modern: "〜すべきである",
+    note: "文語の推量・義務「〜べし」は「〜すべきである」に言い換えてください",
+  },
+  {
+    pattern: /にて[、。\s]/g,
+    example: "〜にて",
+    modern: "〜で",
+    note: "文語の場所・手段「〜にて」は「〜で」に言い換えてください",
+  },
+  {
+    pattern: /のみ[。、\s]/g,
+    example: "〜のみ",
+    modern: "〜だけ",
+    note: "「のみ」は文語的。「だけ」を使うことが多い（文脈によっては許容）",
+  },
+  {
+    pattern: /なれども/g,
+    example: "〜なれども",
+    modern: "〜であるが",
+    note: "文語の逆接「〜なれども」は「〜であるが」に言い換えてください",
+  },
+  {
+    pattern: /いわんや/g,
+    example: "いわんや",
+    modern: "まして",
+    note: "文語の強調「いわんや」は「まして」に言い換えてください",
+  },
+  {
+    pattern: /しかるに/g,
+    example: "しかるに",
+    modern: "しかし",
+    note: "文語の逆接「しかるに」は「しかし」に言い換えてください",
+  },
+  {
+    pattern: /しかれども/g,
+    example: "しかれども",
+    modern: "しかしながら",
+    note: "文語の逆接「しかれども」は「しかしながら」に言い換えてください",
+  },
+  {
+    pattern: /〜ごとく/g,
+    example: "〜ごとく",
+    modern: "〜のように",
+    note: "文語の比況「〜ごとく」は「〜のように」に言い換えてください",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Literary Style Exclusion Rule (L1)
+ *
+ * Classical Japanese (文語調) expressions should be avoided in modern
+ * official writing. This rule detects archaic endings and forms
+ * that should be replaced with contemporary equivalents.
+ *
+ * e.g., 「〜せり」→「〜した」, 「〜なり」→「〜である」, 「〜べし」→「〜すべきである」
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class LiteraryStyleExclusionRule extends AbstractLintRule {
+  readonly id = "literary-style-exclusion";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Literary Style Exclusion";
+  readonly nameJa = "文語調表現の排除";
+  readonly description = "Detect and flag archaic literary Japanese expressions in modern official writing";
+  readonly descriptionJa = "「〜せり」「〜なり」「〜べし」「〜にて」等の文語調表現を検出します（公用文作成の考え方）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, example, modern, note } of LITERARY_PATTERNS) {
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+
+      while ((match = pattern.exec(text)) !== null) {
+        const from = match.index;
+        // Point to the literary ending, not the trailing punctuation
+        const to = from + match[0].trimEnd().length;
+
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Literary expression "${example}" detected. Consider modern form: "${modern}"`,
+          messageJa: `文語調表現「${example}」が検出されました。${note}（現代語：「${modern}」）`,
+          from,
+          to,
+          originalText: match[0].trimEnd(),
+          reference: KOYO_REF,
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/long-vowel-kana-rule.ts
+++ b/lib/linting/rules/long-vowel-kana-rule.ts
@@ -1,0 +1,116 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for long vowel kana rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+};
+
+const KANA_REF: LintReference = {
+  standard: "文化庁「現代仮名遣い」(1986, 内閣告示第一号)",
+};
+
+/**
+ * Patterns where katakana words incorrectly use a vowel character
+ * instead of the long vowel mark (ー) to represent a long vowel sound.
+ *
+ * Strategy: detect katakana sequences ending in a vowel (ア/イ/ウ/エ/オ)
+ * where the preceding character is a non-matching vowel or consonant+vowel
+ * combination that typically uses ー in standard orthography.
+ *
+ * Common problematic patterns — these are known loanword misspellings:
+ */
+const LONG_VOWEL_ERRORS: ReadonlyArray<{
+  pattern: RegExp;
+  correct: string;
+  description: string;
+}> = [
+  // エラア → エラー (error)
+  { pattern: /エラア(?![ァ-ン])/g, correct: "エラー", description: "error" },
+  // コンピュータア → コンピューター (computer)
+  { pattern: /コンピュータア/g, correct: "コンピューター", description: "computer" },
+  // プリンタア → プリンター (printer)
+  { pattern: /プリンタア/g, correct: "プリンター", description: "printer" },
+  // スキャナア → スキャナー (scanner)
+  { pattern: /スキャナア/g, correct: "スキャナー", description: "scanner" },
+  // モニタア → モニター (monitor)
+  { pattern: /モニタア/g, correct: "モニター", description: "monitor" },
+  // サーバア → サーバー (server)
+  { pattern: /サーバア/g, correct: "サーバー", description: "server" },
+  // フォルダア → フォルダー (folder)
+  { pattern: /フォルダア/g, correct: "フォルダー", description: "folder" },
+  // カーソルウ → (not common, skip)
+  // コーヒイ → コーヒー (coffee)
+  { pattern: /コーヒイ/g, correct: "コーヒー", description: "coffee" },
+  // タクシイ → タクシー (taxi)
+  { pattern: /タクシイ/g, correct: "タクシー", description: "taxi" },
+  // パーティイ → パーティー (party)
+  { pattern: /パーティイ/g, correct: "パーティー", description: "party" },
+  // ストーリイ → ストーリー (story)
+  { pattern: /ストーリイ/g, correct: "ストーリー", description: "story" },
+  // ボディイ → ボディー (body)
+  { pattern: /ボディイ/g, correct: "ボディー", description: "body" },
+  // アイデアア → アイデア (idea — ends in ア naturally, so skip; アイデアア is double)
+];
+
+/**
+ * LongVowelKanaRule -- L1 regex-based rule.
+ *
+ * Detects katakana loanwords that use repeated vowels instead of the
+ * long vowel mark (ー) to represent a long vowel sound. Per JTF and
+ * 現代仮名遣い, katakana loanwords should use ー for long vowels.
+ *
+ * Examples:
+ * - 誤: エラア   → 正: エラー
+ * - 誤: コーヒイ → 正: コーヒー
+ * - 誤: タクシイ → 正: タクシー
+ */
+export class LongVowelKanaRule extends AbstractLintRule {
+  readonly id = "long-vowel-kana";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Use long vowel mark (ー) in katakana loanwords";
+  readonly nameJa = "長音の仮名表記";
+  readonly description =
+    "Detects katakana words using repeated vowels instead of the long vowel mark (ー)";
+  readonly descriptionJa =
+    "カタカナ語で長音記号「ー」の代わりに母音を繰り返している場合を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, correct, description } of LONG_VOWEL_ERRORS) {
+      const re = new RegExp(pattern.source, "g");
+      for (const match of text.matchAll(re)) {
+        if (match.index === undefined) continue;
+
+        const wrongForm = match[0];
+
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Use long vowel mark: "${wrongForm}" → "${correct}" (${description}) — JTF/現代仮名遣い`,
+          messageJa: `JTF・現代仮名遣いに基づき、「${wrongForm}」は長音記号を使って「${correct}」と表記してください（${description}）`,
+          from: match.index,
+          to: match.index + wrongForm.length,
+          originalText: wrongForm,
+          reference: JTF_REF,
+          fix: {
+            label: `Replace with "${correct}"`,
+            labelJa: `「${correct}」に修正`,
+            replacement: correct,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/mixed-width-spacing-rule.ts
+++ b/lib/linting/rules/mixed-width-spacing-rule.ts
@@ -1,0 +1,90 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for mixed-width spacing rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "2.1.6",
+};
+
+/**
+ * MixedWidthSpacingRule -- L1 regex-based rule.
+ *
+ * Detects half-width spaces inserted between Japanese (CJK) characters
+ * and ASCII/Latin characters. Per JTF 2.1.6, no space should be placed
+ * between Japanese text and ASCII text.
+ */
+export class MixedWidthSpacingRule extends AbstractLintRule {
+  readonly id = "mixed-width-spacing";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "No space between Japanese and ASCII";
+  readonly nameJa = "和欧文字間のスペース禁止";
+  readonly description =
+    "Detects half-width spaces between Japanese characters and ASCII characters";
+  readonly descriptionJa =
+    "日本語文字とASCII文字の間にある半角スペースを検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+    skipDialogue: true,
+  };
+
+  /** Regex: CJK/full-width char followed by space then ASCII, or vice versa */
+  private static readonly CJK_TO_ASCII = /[\u3000-\u9FFF\uFF00-\uFFEF] [\u0021-\u007E]/g;
+  private static readonly ASCII_TO_CJK = /[\u0021-\u007E] [\u3000-\u9FFF\uFF00-\uFFEF]/g;
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    // CJK + space + ASCII
+    for (const match of text.matchAll(MixedWidthSpacingRule.CJK_TO_ASCII)) {
+      if (match.index === undefined) continue;
+      const spacePos = match.index + 1;
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: "Do not insert a space between Japanese and ASCII characters (JTF 2.1.6)",
+        messageJa: "JTF 2.1.6に基づき、和文とASCII文字の間にスペースを入れないでください",
+        from: spacePos,
+        to: spacePos + 1,
+        originalText: " ",
+        reference: JTF_REF,
+        fix: {
+          label: "Remove space",
+          labelJa: "スペースを削除",
+          replacement: "",
+        },
+      });
+    }
+
+    // ASCII + space + CJK
+    for (const match of text.matchAll(MixedWidthSpacingRule.ASCII_TO_CJK)) {
+      if (match.index === undefined) continue;
+      const spacePos = match.index + 1;
+      // Avoid duplicate if already flagged by the previous pattern
+      const alreadyFlagged = issues.some((i) => i.from === spacePos);
+      if (!alreadyFlagged) {
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: "Do not insert a space between ASCII and Japanese characters (JTF 2.1.6)",
+          messageJa: "JTF 2.1.6に基づき、ASCII文字と和文の間にスペースを入れないでください",
+          from: spacePos,
+          to: spacePos + 1,
+          originalText: " ",
+          reference: JTF_REF,
+          fix: {
+            label: "Remove space",
+            labelJa: "スペースを削除",
+            replacement: "",
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/modifier-length-order-rule.ts
+++ b/lib/linting/rules/modifier-length-order-rule.ts
@@ -1,0 +1,93 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Minimum character length of a pre-noun modifier (before の or 名詞)
+ * to be considered "long" and worth flagging.
+ */
+const LONG_MODIFIER_THRESHOLD = 15;
+
+/**
+ * Pattern to detect a long pre-noun modifier followed by の + noun.
+ * This matches a sequence of 15+ characters followed by の.
+ *
+ * Captures: (.{15,}?)の([^\s。、]{1,8})
+ * - Group 1: the long modifier
+ * - Group 2: the modified noun (short, up to 8 chars)
+ */
+const LONG_MODIFIER_PATTERN = new RegExp(
+  `([^。、\\s]{${LONG_MODIFIER_THRESHOLD},}?)の([^\\s。、]{1,8})`,
+  "g",
+);
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Modifier Length Order Rule (L1 heuristic)
+ *
+ * In Japanese, long pre-noun modifiers (長い修飾節) that precede the noun
+ * can impede readability. 公用文作成の考え方 recommends that:
+ * - Long modifiers should be placed before the noun (standard Japanese)
+ * - But very long modifier chains (15+ chars before の) may indicate
+ *   the sentence should be restructured for clarity
+ *
+ * This rule flags long pre-noun modifier chains for manual review.
+ * The heuristic detects sequences of 15+ non-punctuation characters
+ * followed by の + a short noun.
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class ModifierLengthOrderRule extends AbstractLintRule {
+  readonly id = "modifier-length-order";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Long Modifier Placement";
+  readonly nameJa = "長い修飾節の先行配置";
+  readonly description = "Long pre-noun modifiers (15+ chars) may indicate a sentence that needs restructuring";
+  readonly descriptionJa = "15文字以上の長い修飾節が「の」の前に置かれています。文を分割または再構成することを検討してください（公用文作成の考え方）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "info",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    LONG_MODIFIER_PATTERN.lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = LONG_MODIFIER_PATTERN.exec(text)) !== null) {
+      const modifier = match[1];
+      const modifiedNoun = match[2];
+      const from = match.index;
+      const to = from + match[0].length;
+
+      // Skip if the match is too short (re-check threshold)
+      if (modifier.length < LONG_MODIFIER_THRESHOLD) continue;
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Long pre-noun modifier (${modifier.length} chars) before "の${modifiedNoun}". Consider restructuring the sentence.`,
+        messageJa: `「の${modifiedNoun}」の前に${modifier.length}文字の長い修飾節があります。文を分割または再構成することを検討してください（公用文作成の考え方）`,
+        from,
+        to,
+        originalText: match[0],
+        reference: KOYO_REF,
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/nakaguro-usage-rule.ts
+++ b/lib/linting/rules/nakaguro-usage-rule.ts
@@ -1,0 +1,99 @@
+import { AbstractDocumentLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for nakaguro usage rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "2.1.5",
+};
+
+/**
+ * Heuristic: ・ used as a bullet (line starts with ・ possibly after whitespace)
+ */
+const BULLET_PATTERN = /^[　\s]*・/;
+
+/**
+ * Heuristic: ・ used as a separator between words (e.g., 山田・田中, ア・イ・ウ)
+ * Looks for ・ surrounded by non-space characters (not at line start).
+ */
+const SEPARATOR_PATTERN = /\S・\S/;
+
+/**
+ * NakaguroUsageRule -- L1 document-level rule.
+ *
+ * Detects mixed usage of 中黒（・）as both a bullet marker and
+ * as a word separator within the same document. Per JTF 2.1.5,
+ * ・ should be used consistently for one purpose throughout.
+ *
+ * When mixed usage is detected, the minority usage is flagged.
+ */
+export class NakaguroUsageRule extends AbstractDocumentLintRule {
+  readonly id = "nakaguro-usage";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Consistent nakaguro usage";
+  readonly nameJa = "中黒（・）の用法統一";
+  readonly description =
+    "Detects mixed usage of ・ as both bullet marker and word separator";
+  readonly descriptionJa =
+    "中黒（・）が箇条書きと区切り符号の両方に使われている場合を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lintDocument(
+    paragraphs: ReadonlyArray<{ text: string; index: number }>,
+    config: LintRuleConfig,
+  ): Array<{ paragraphIndex: number; issues: LintIssue[] }> {
+    if (!config.enabled || paragraphs.length === 0) return [];
+
+    const bulletParas: Array<{ text: string; index: number }> = [];
+    const separatorParas: Array<{ text: string; index: number }> = [];
+
+    for (const para of paragraphs) {
+      const hasBullet = BULLET_PATTERN.test(para.text);
+      const hasSeparator = SEPARATOR_PATTERN.test(para.text);
+
+      if (hasBullet) bulletParas.push(para);
+      else if (hasSeparator) separatorParas.push(para);
+    }
+
+    // Only flag if both usages exist
+    if (bulletParas.length === 0 || separatorParas.length === 0) return [];
+
+    // Flag minority usage
+    const minority =
+      bulletParas.length <= separatorParas.length ? bulletParas : separatorParas;
+    const minorityIsBullet = bulletParas.length <= separatorParas.length;
+
+    const results: Array<{ paragraphIndex: number; issues: LintIssue[] }> = [];
+
+    for (const para of minority) {
+      // Find the position of ・ in this paragraph
+      const pos = para.text.indexOf("・");
+      if (pos === -1) continue;
+
+      results.push({
+        paragraphIndex: para.index,
+        issues: [
+          {
+            ruleId: this.id,
+            severity: config.severity,
+            message: minorityIsBullet
+              ? "・ is used as a bullet here, but mostly as a separator elsewhere — unify usage (JTF 2.1.5)"
+              : "・ is used as a separator here, but mostly as a bullet elsewhere — unify usage (JTF 2.1.5)",
+            messageJa: minorityIsBullet
+              ? "JTF 2.1.5に基づき、文書内で中黒（・）が箇条書きと区切り符号に混用されています。用法を統一してください"
+              : "JTF 2.1.5に基づき、文書内で中黒（・）が区切り符号と箇条書きに混用されています。用法を統一してください",
+            from: pos,
+            to: pos + 1,
+            reference: JTF_REF,
+          },
+        ],
+      });
+    }
+
+    return results;
+  }
+}

--- a/lib/linting/rules/notation-consistency.ts
+++ b/lib/linting/rules/notation-consistency.ts
@@ -1,6 +1,6 @@
 import { AbstractDocumentLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 import {
   VARIANT_GROUPS,
   VARIANT_CATEGORY_LABELS,
@@ -38,6 +38,7 @@ interface VariantLocation {
  */
 export class NotationConsistencyRule extends AbstractDocumentLintRule {
   readonly id = "notation-consistency";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Notation consistency";
   readonly nameJa = "表記ゆれの検出";
   readonly description = "Detect inconsistent notation variants across the document";
@@ -46,6 +47,7 @@ export class NotationConsistencyRule extends AbstractDocumentLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
   };
 
   lintDocument(

--- a/lib/linting/rules/number-format.ts
+++ b/lib/linting/rules/number-format.ts
@@ -1,6 +1,6 @@
 import { AbstractLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -262,6 +262,7 @@ function isKanjiException(
  */
 export class NumberFormatRule extends AbstractLintRule {
   readonly id = "number-format";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Number format consistency";
   readonly nameJa = "数字表記の統一";
   readonly description = "Check for mixed Arabic/Kanji numeral usage";
@@ -270,6 +271,7 @@ export class NumberFormatRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
     options: {
       isVertical: false,
     },

--- a/lib/linting/rules/official-style-copula-rule.ts
+++ b/lib/linting/rules/official-style-copula-rule.ts
@@ -1,0 +1,209 @@
+import type { Token } from "@/lib/nlp-client/types";
+import { AbstractMorphologicalDocumentLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * In official and academic plain-style (常体) writing, sentence-ending 「だ」
+ * and 「だった」are discouraged. 「である」and「であった」are preferred.
+ *
+ * This rule detects 助動詞 tokens with basic_form=「だ」at sentence endings.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a token sequence ends with sentence-final 「だ」or「だった」.
+ * Returns the problematic token range if found.
+ */
+function findSentenceFinalDa(
+  tokens: ReadonlyArray<Token>,
+): { start: number; end: number; surface: string } | null {
+  // Scan from the end backwards
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const token = tokens[i];
+
+    // Skip punctuation
+    if (token.pos === "記号") continue;
+
+    // Look for 助動詞 with basic_form = "だ"
+    if (token.pos === "助動詞" && token.basic_form === "だ") {
+      // Make sure it's not part of だろう / だって etc.
+      const surface = token.surface;
+      if (surface === "だ" || surface === "だっ") {
+        // Check next non-punctuation token
+        let nextSurface = "";
+        for (let j = i + 1; j < tokens.length; j++) {
+          if (tokens[j].pos !== "記号") {
+            nextSurface = tokens[j].surface;
+            break;
+          }
+        }
+        // If 「だっ」, the next should be 「た」
+        if (surface === "だっ" && nextSurface === "た") {
+          return { start: token.start, end: tokens[i + 1]?.end ?? token.end, surface: "だった" };
+        }
+        if (surface === "だ") {
+          return { start: token.start, end: token.end, surface: "だ" };
+        }
+      }
+      break;
+    }
+
+    // Stop at content words
+    if (
+      token.pos === "動詞" ||
+      token.pos === "形容詞" ||
+      token.pos === "名詞"
+    ) {
+      break;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if a document uses predominantly 「である」style.
+ * Detects sentences ending in である/であった.
+ */
+function countDeAruStyle(tokens: ReadonlyArray<Token>): number {
+  let count = 0;
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    const prev = tokens[i - 1];
+    if (
+      token.basic_form === "ある" &&
+      prev.pos === "助動詞" &&
+      prev.surface === "で"
+    ) {
+      count++;
+    }
+  }
+  return count;
+}
+
+/**
+ * Count sentence-final 「だ」occurrences.
+ */
+function countSentenceFinalDa(tokens: ReadonlyArray<Token>): number {
+  let count = 0;
+  for (const token of tokens) {
+    if (token.pos === "助動詞" && token.basic_form === "だ" && token.surface === "だ") {
+      count++;
+    }
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Official Style Copula Rule (L2, document-level)
+ *
+ * In official and academic writing using plain style (常体),
+ * sentence-ending 「だ」and「だった」are discouraged.
+ * 「である」and「であった」are the preferred forms.
+ *
+ * Detection strategy:
+ * 1. Check document for である style usage (indicates official/academic context)
+ * 2. Flag sentence-final 「だ」that appear in documents predominantly using 「である」
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class OfficialStyleCopulaRule extends AbstractMorphologicalDocumentLintRule {
+  readonly id = "official-style-copula";
+  override engine: CorrectionEngine = "morphological";
+  readonly name = "Official Style Copula (だ → である)";
+  readonly nameJa = "常体における「だ・だった」の禁止";
+  readonly description = "In official plain style, use である/であった instead of だ/だった";
+  readonly descriptionJa = "公用文・学術文の常体では「だ・だった」を避け「である・であった」を使います（公用文作成の考え方）";
+  readonly level = "L2" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+  };
+
+  lintDocumentWithTokens(
+    paragraphs: ReadonlyArray<{
+      text: string;
+      index: number;
+      tokens: ReadonlyArray<Token>;
+    }>,
+    config: LintRuleConfig,
+  ): Array<{ paragraphIndex: number; issues: LintIssue[] }> {
+    if (paragraphs.length === 0) return [];
+
+    // Step 1: Determine if the document uses である style
+    const allTokens = paragraphs.flatMap((p) => p.tokens);
+    const deAruCount = countDeAruStyle(allTokens);
+    const daCount = countSentenceFinalDa(allTokens);
+
+    // Only flag in documents that predominantly use である (deAru > da)
+    // or in documents with any である usage (official context indicator)
+    if (deAruCount === 0 && daCount === 0) return [];
+
+    // If mostly だ style, likely a casual text — don't flag
+    if (daCount > 0 && deAruCount === 0) return [];
+
+    const results: Array<{ paragraphIndex: number; issues: LintIssue[] }> = [];
+
+    // Step 2: Flag sentence-final 「だ」in each paragraph
+    for (const paragraph of paragraphs) {
+      const issues: LintIssue[] = [];
+      const paraTokens = paragraph.tokens;
+
+      // Find sentence boundaries by looking for 記号 (。！？)
+      let sentenceStart = 0;
+
+      for (let i = 0; i < paraTokens.length; i++) {
+        const token = paraTokens[i];
+        const isSentenceEnd =
+          token.pos === "記号" &&
+          (token.surface === "。" || token.surface === "！" || token.surface === "？");
+
+        if (isSentenceEnd || i === paraTokens.length - 1) {
+          const sentenceTokens = paraTokens.slice(sentenceStart, i + 1);
+          const found = findSentenceFinalDa(sentenceTokens);
+
+          if (found !== null) {
+            issues.push({
+              ruleId: this.id,
+              severity: config.severity,
+              message: `Sentence-final "${found.surface}" detected. Use "である" or "であった" in official plain style`,
+              messageJa: `文末の「${found.surface}」が検出されました。公用文の常体では「${found.surface === "だった" ? "であった" : "である"}」を使ってください（公用文作成の考え方）`,
+              from: found.start,
+              to: found.end,
+              originalText: found.surface,
+              reference: KOYO_REF,
+              fix: {
+                label: `Replace with "${found.surface === "だった" ? "であった" : "である"}"`,
+                labelJa: `「${found.surface === "だった" ? "であった" : "である"}」に置換`,
+                replacement: found.surface === "だった" ? "であった" : "である",
+              },
+            });
+          }
+
+          sentenceStart = i + 1;
+        }
+      }
+
+      if (issues.length > 0) {
+        results.push({ paragraphIndex: paragraph.index, issues });
+      }
+    }
+
+    return results;
+  }
+}

--- a/lib/linting/rules/paragraph-indentation-rule.ts
+++ b/lib/linting/rules/paragraph-indentation-rule.ts
@@ -1,0 +1,108 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for paragraph indentation rule */
+const KOYO_REF: LintReference = {
+  standard: "文化庁「公用文作成の考え方」(2022)",
+};
+
+/** Hiragana range start character */
+const HIRAGANA_START = "\u3041"; // ぁ
+/** Hiragana range end character */
+const HIRAGANA_END = "\u3093"; // ん
+
+/** Katakana range start character */
+const KATAKANA_START = "\u30A1"; // ァ
+/** Katakana range end character */
+const KATAKANA_END = "\u30F3"; // ン
+
+/** Kanji range start */
+const KANJI_START = "\u4E00";
+/** Kanji range end */
+const KANJI_END = "\u9FFF";
+
+/**
+ * Determine if a character is a Japanese content character
+ * (hiragana, katakana, or kanji).
+ */
+function isJapaneseContentChar(ch: string): boolean {
+  return (
+    (ch >= HIRAGANA_START && ch <= HIRAGANA_END) ||
+    (ch >= KATAKANA_START && ch <= KATAKANA_END) ||
+    (ch >= KANJI_START && ch <= KANJI_END)
+  );
+}
+
+/**
+ * ParagraphIndentationRule -- L1 regex-based rule.
+ *
+ * Detects paragraph text that begins directly with a Japanese character
+ * without a leading ideographic space (　U+3000) or half-width space.
+ * Per 公用文作成の考え方, paragraph openings should be indented by one
+ * character (1字下げ).
+ *
+ * Note: This rule only flags text that starts with Japanese content
+ * characters directly, to avoid false positives on headings, list items,
+ * or non-body text.
+ */
+export class ParagraphIndentationRule extends AbstractLintRule {
+  readonly id = "paragraph-indentation";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Paragraph indentation (1 character)";
+  readonly nameJa = "段落行頭の1字下げ";
+  readonly description =
+    "Detects paragraphs that start with a Japanese character without leading indentation";
+  readonly descriptionJa =
+    "日本語文字で始まる段落に行頭の1字下げがない場合を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const firstChar = text[0];
+    if (firstChar === undefined) return [];
+
+    // Already indented with ideographic space or regular space
+    if (firstChar === "\u3000" || firstChar === " " || firstChar === "\t") return [];
+
+    // Only flag if the paragraph starts with a Japanese content character
+    if (!isJapaneseContentChar(firstChar)) return [];
+
+    // Skip very short texts (headings, labels) — only flag text that looks like body copy
+    // Require at least 10 characters to avoid flagging headings
+    if (text.length < 10) return [];
+
+    // Skip list items (text starting with ・, 「, or common list markers)
+    if (
+      firstChar === "・" ||
+      firstChar === "「" ||
+      firstChar === "『" ||
+      firstChar === "【" ||
+      firstChar === "（"
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        ruleId: this.id,
+        severity: config.severity,
+        message: "Paragraph should start with one-character indentation (公用文作成の考え方)",
+        messageJa: "公用文作成の考え方に基づき、段落の行頭は1字下げ（全角スペース）にしてください",
+        from: 0,
+        to: 1,
+        reference: KOYO_REF,
+        fix: {
+          label: "Add ideographic space indent",
+          labelJa: "行頭に全角スペースを追加",
+          replacement: "\u3000" + firstChar,
+        },
+      },
+    ];
+  }
+}

--- a/lib/linting/rules/particle-kara-yori-rule.ts
+++ b/lib/linting/rules/particle-kara-yori-rule.ts
@@ -1,0 +1,120 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Patterns indicating 「より」used as a source/starting-point marker
+ * (= 「から」) rather than as a comparative marker.
+ *
+ * Heuristic: 「より」preceded by a place or time noun followed by
+ * a movement/origin verb suggests misuse as 「から」.
+ *
+ * Flag patterns:
+ * - 「〜よりも」when not comparing two items explicitly
+ * - 「〜より参りました」「〜より届いた」— origin/source usage
+ * - Sentence-initial 「より〜」(formal but potentially ambiguous)
+ */
+const YORI_MISUSE_PATTERNS: ReadonlyArray<{
+  pattern: RegExp;
+  note: string;
+}> = [
+  {
+    pattern: /より参り/g,
+    note: "「より参り」は「から参り」（起点）の意味で使われています。起点を示す場合は「から」を使ってください",
+  },
+  {
+    pattern: /より届い/g,
+    note: "「より届い」は「から届い」（起点）の意味で使われています。起点を示す場合は「から」を使ってください",
+  },
+  {
+    pattern: /より送付/g,
+    note: "「より送付」は「から送付」（起点）の意味の可能性があります。起点を示す場合は「から」を使ってください",
+  },
+  {
+    pattern: /より発送/g,
+    note: "「より発送」は「から発送」（起点）の意味の可能性があります。起点を示す場合は「から」を使ってください",
+  },
+  {
+    pattern: /より着信/g,
+    note: "「より着信」は「から着信」（起点）の意味で使われています。「から」を使ってください",
+  },
+  {
+    pattern: /より来た/g,
+    note: "「より来た」は「から来た」（起点）の意味で使われています。「から」を使ってください",
+  },
+  {
+    pattern: /より受信/g,
+    note: "「より受信」は「から受信」（起点）の意味で使われています。「から」を使ってください",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Particle Kara/Yori Rule (L1)
+ *
+ * 「より」is primarily a comparative particle meaning "than/more than".
+ * Using it to indicate a source or starting point (= 「から」) is a misuse
+ * common in formal writing but discouraged in modern 公用文.
+ * e.g., 「東京より参りました」→「東京から参りました」
+ *
+ * This rule uses heuristic regex patterns to detect likely misuse.
+ * For ambiguous cases, manual review is recommended.
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class ParticleKaraYoriRule extends AbstractLintRule {
+  readonly id = "particle-kara-yori";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Misuse of より as Starting-Point Particle";
+  readonly nameJa = "起点を示す「より」の誤用";
+  readonly description = "「より」should not be used as a starting-point marker; use 「から」instead";
+  readonly descriptionJa = "起点・出所を表す場合は「より」でなく「から」を使います（公用文作成の考え方）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, note } of YORI_MISUSE_PATTERNS) {
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+
+      while ((match = pattern.exec(text)) !== null) {
+        const from = match.index;
+        const to = from + match[0].length;
+        const replacement = match[0].replace("より", "から");
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Possible misuse of "より" as starting-point marker. ${note}`,
+          messageJa: note,
+          from,
+          to,
+          originalText: match[0],
+          reference: KOYO_REF,
+          fix: {
+            label: `Replace "より" with "から"`,
+            labelJa: `「より」を「から」に置換`,
+            replacement,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/particle-no-repetition.ts
+++ b/lib/linting/rules/particle-no-repetition.ts
@@ -1,7 +1,7 @@
 import { AbstractLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
 import { splitIntoSentences } from "../helpers/sentence-splitter";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -92,6 +92,7 @@ function countParticleNo(sentence: string): number {
  */
 export class ParticleNoRepetitionRule extends AbstractLintRule {
   readonly id = "particle-no-repetition";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Excessive particle の usage";
   readonly nameJa = "助詞「の」の連続使用";
   readonly description =
@@ -101,6 +102,7 @@ export class ParticleNoRepetitionRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "info",
+    skipDialogue: true,
     options: {
       threshold: 4,
     },

--- a/lib/linting/rules/particle-suffix-modifier-opening-rule.ts
+++ b/lib/linting/rules/particle-suffix-modifier-opening-rule.ts
@@ -1,0 +1,106 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KANJI_REF: LintReference = {
+  standard: "公用文における漢字使用等について（内閣訓令、2010）",
+};
+
+/**
+ * Particles, suffixes, and pre-noun modifiers (副助詞・接尾語・連体詞)
+ * that should be written in hiragana in official documents.
+ * Key: kanji surface form
+ * Value: hiragana replacement
+ */
+const PARTICLE_SUFFIX_HIRAGANA: ReadonlyArray<{ kanji: string; hiragana: string }> = [
+  { kanji: "程", hiragana: "ほど" },
+  { kanji: "位", hiragana: "くらい" },
+  { kanji: "迄", hiragana: "まで" },
+  { kanji: "共", hiragana: "とも" },
+  { kanji: "等", hiragana: "など" },
+  { kanji: "頃", hiragana: "ごろ" },
+  { kanji: "毎", hiragana: "ごと" },
+  { kanji: "共々", hiragana: "ともども" },
+  { kanji: "此", hiragana: "この" },
+  { kanji: "其", hiragana: "その" },
+  { kanji: "彼の", hiragana: "あの" },
+  { kanji: "何れ", hiragana: "いずれ" },
+];
+
+/**
+ * Build a regex pattern that matches the kanji form only when used
+ * as a standalone particle (surrounded by non-kanji context).
+ */
+function buildParticlePattern(kanji: string): RegExp {
+  // Escape regex special chars
+  const escaped = kanji.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Match the kanji when not part of a larger kanji compound
+  return new RegExp(`(?<=[^\\u4e00-\\u9fff\\w]|^)${escaped}(?=[^\\u4e00-\\u9fff\\w]|$)`, "g");
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Particle Suffix Modifier Opening Rule (L1)
+ *
+ * Particles, suffixes, and pre-noun modifiers (副助詞・接尾語・連体詞)
+ * should be written in hiragana in official documents.
+ * e.g., 「程」→「ほど」, 「等」→「など」, 「頃」→「ごろ」
+ *
+ * This rule uses regex with context-awareness to avoid flagging
+ * kanji that are part of compound words.
+ *
+ * Reference: 公用文における漢字使用等について（内閣訓令、2010）
+ */
+export class ParticleSuffixModifierOpeningRule extends AbstractLintRule {
+  readonly id = "particle-suffix-modifier-opening";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Particle/Suffix in Hiragana";
+  readonly nameJa = "副助詞・接尾語・連体詞のひらがな表記";
+  readonly description = "Particles, suffixes, and pre-noun modifiers should be hiragana";
+  readonly descriptionJa = "「ほど」「くらい」「まで」「など」「ごろ」等の副助詞・接尾語・連体詞はひらがなで書きます（公用文における漢字使用等について）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { kanji, hiragana } of PARTICLE_SUFFIX_HIRAGANA) {
+      const pattern = buildParticlePattern(kanji);
+      let match: RegExpExecArray | null;
+
+      // Reset lastIndex
+      pattern.lastIndex = 0;
+      while ((match = pattern.exec(text)) !== null) {
+        const from = match.index;
+        const to = from + kanji.length;
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `"${kanji}" (particle/suffix) should be written in hiragana as "${hiragana}"`,
+          messageJa: `「${kanji}」はひらがなで「${hiragana}」と書きます（公用文における漢字使用等について）`,
+          from,
+          to,
+          originalText: kanji,
+          reference: KANJI_REF,
+          fix: {
+            label: `Replace with "${hiragana}"`,
+            labelJa: `「${hiragana}」に置換`,
+            replacement: hiragana,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/passive-overuse.ts
+++ b/lib/linting/rules/passive-overuse.ts
@@ -3,7 +3,7 @@ import { AbstractMorphologicalLintRule } from "../base-rule";
 import { isInDialogue } from "../helpers/dialogue-mask";
 import type { SentenceSpan } from "../helpers/sentence-splitter";
 import { splitIntoSentences } from "../helpers/sentence-splitter";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -77,6 +77,7 @@ function hasPassiveVoice(sentenceTokens: ReadonlyArray<Token>): boolean {
  */
 export class PassiveOveruseRule extends AbstractMorphologicalLintRule {
   readonly id = "passive-overuse";
+  override engine: CorrectionEngine = "morphological";
   readonly name = "Passive Overuse";
   readonly nameJa = "受動態の多用検出";
   readonly description = "Flags consecutive passive-voice sentences";

--- a/lib/linting/rules/prefix-script-matching-rule.ts
+++ b/lib/linting/rules/prefix-script-matching-rule.ts
@@ -1,0 +1,112 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KANJI_REF: LintReference = {
+  standard: "公用文における漢字使用等について（内閣訓令、2010）",
+};
+
+/**
+ * Known mismatches of お/ご prefix with word type.
+ * Rule: 和語 → お〜, 漢語 → ご〜
+ *
+ * wrong: incorrect prefix + word combination
+ * correct: correct prefix + word combination
+ * note: explanation of the mismatch
+ */
+const PREFIX_MISMATCH_PAIRS: ReadonlyArray<{
+  wrong: string;
+  correct: string;
+  note: string;
+}> = [
+  // ご+和語 (should be お+和語)
+  { wrong: "ご心配", correct: "お心配", note: "「心配」は和語的使用のためお〜が適切" },
+  { wrong: "ご手紙", correct: "お手紙", note: "「手紙」は和語のためお〜が適切" },
+  { wrong: "ご祝儀", correct: "ご祝儀", note: "「祝儀」は漢語のためご〜が適切（正しい）" },
+  // お+漢語 (should be ご+漢語)
+  { wrong: "お利用", correct: "ご利用", note: "「利用」は漢語のためご〜が適切" },
+  { wrong: "お案内", correct: "ご案内", note: "「案内」は漢語のためご〜が適切" },
+  { wrong: "お連絡", correct: "ご連絡", note: "「連絡」は漢語のためご〜が適切" },
+  { wrong: "お確認", correct: "ご確認", note: "「確認」は漢語のためご〜が適切" },
+  { wrong: "お報告", correct: "ご報告", note: "「報告」は漢語のためご〜が適切" },
+  { wrong: "お説明", correct: "ご説明", note: "「説明」は漢語のためご〜が適切" },
+  { wrong: "お参加", correct: "ご参加", note: "「参加」は漢語のためご〜が適切" },
+  { wrong: "お協力", correct: "ご協力", note: "「協力」は漢語のためご〜が適切" },
+  { wrong: "お質問", correct: "ご質問", note: "「質問」は漢語のためご〜が適切" },
+  { wrong: "お返信", correct: "ご返信", note: "「返信」は漢語のためご〜が適切" },
+].filter((pair) => pair.wrong !== pair.correct);
+
+/**
+ * Find all non-overlapping occurrences of a literal string in text.
+ */
+function findAllOccurrences(text: string, needle: string): number[] {
+  const indices: number[] = [];
+  let pos = 0;
+  while (pos <= text.length - needle.length) {
+    const idx = text.indexOf(needle, pos);
+    if (idx === -1) break;
+    indices.push(idx);
+    pos = idx + needle.length;
+  }
+  return indices;
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Prefix Script Matching Rule (L1)
+ *
+ * The honorific prefixes 「お」and「ご」follow a script-matching rule:
+ * - Yamato words (和語): お〜 (e.g., お手紙, お願い)
+ * - Sino-Japanese words (漢語): ご〜 (e.g., ご利用, ご確認)
+ *
+ * This rule flags known mismatches from a dictionary.
+ *
+ * Reference: 公用文における漢字使用等について（内閣訓令、2010）
+ */
+export class PrefixScriptMatchingRule extends AbstractLintRule {
+  readonly id = "prefix-script-matching";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Honorific Prefix Script Matching (お/ご)";
+  readonly nameJa = "接頭語「御・ご・お」の使い分け";
+  readonly description = "Yamato words take お〜, Sino-Japanese words take ご〜";
+  readonly descriptionJa = "和語にはお〜、漢語にはご〜を付けます（公用文における漢字使用等について）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { wrong, correct, note } of PREFIX_MISMATCH_PAIRS) {
+      for (const from of findAllOccurrences(text, wrong)) {
+        const to = from + wrong.length;
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `"${wrong}" uses incorrect honorific prefix. Consider "${correct}". (${note})`,
+          messageJa: `「${wrong}」の接頭語が不適切です。「${correct}」を検討してください。（${note}）`,
+          from,
+          to,
+          originalText: wrong,
+          reference: KANJI_REF,
+          fix: {
+            label: `Replace with "${correct}"`,
+            labelJa: `「${correct}」に置換`,
+            replacement: correct,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/pronoun-kanji-rule.ts
+++ b/lib/linting/rules/pronoun-kanji-rule.ts
@@ -1,0 +1,118 @@
+import type { Token } from "@/lib/nlp-client/types";
+import { AbstractMorphologicalLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KANJI_REF: LintReference = {
+  standard: "公用文における漢字使用等について（内閣訓令、2010）",
+};
+
+/**
+ * Pronouns that should use specific forms in official writing.
+ * wrong: non-standard form
+ * correct: recommended form in official contexts
+ * note: explanation
+ */
+const PRONOUN_GUIDANCE: ReadonlyArray<{
+  surface: string;
+  correct: string;
+  note: string;
+}> = [
+  {
+    surface: "我々",
+    correct: "私たち",
+    note: "公用文では「私たち」または「われわれ」が適切",
+  },
+  {
+    surface: "吾々",
+    correct: "私たち",
+    note: "公用文では「私たち」が適切",
+  },
+  {
+    surface: "吾輩",
+    correct: "私",
+    note: "文語的表現。公用文では「私」を使用",
+  },
+  {
+    surface: "余",
+    correct: "私",
+    note: "文語的一人称。公用文では「私」を使用",
+  },
+  {
+    surface: "拙者",
+    correct: "私",
+    note: "古語的一人称。公用文では「私」を使用",
+  },
+  {
+    surface: "誰",
+    correct: "だれ",
+    note: "公用文では「だれ」とひらがなで書くことが多い",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Pronoun Kanji Rule (L2)
+ *
+ * Certain pronouns should use specific forms in official writing.
+ * e.g., 「我々」→「私たち」, 「誰」→「だれ」in formal contexts.
+ *
+ * Detection uses morphological analysis to identify pronoun tokens
+ * (名詞・代名詞・一般) with non-standard surface forms.
+ *
+ * Reference: 公用文における漢字使用等について（内閣訓令、2010）
+ */
+export class PronounKanjiRule extends AbstractMorphologicalLintRule {
+  readonly id = "pronoun-kanji";
+  override engine: CorrectionEngine = "morphological";
+  readonly name = "Pronoun Kanji Form";
+  readonly nameJa = "代名詞の漢字表記統一";
+  readonly description = "Pronouns should use recommended forms in official writing";
+  readonly descriptionJa = "公用文では代名詞の表記を統一します（「我々」→「私たち」等）（公用文における漢字使用等について）";
+  readonly level = "L2" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lintWithTokens(
+    _text: string,
+    tokens: ReadonlyArray<Token>,
+    config: LintRuleConfig,
+  ): LintIssue[] {
+    const issues: LintIssue[] = [];
+
+    for (const token of tokens) {
+      // Match pronoun tokens: 名詞・代名詞・一般
+      if (token.pos !== "名詞") continue;
+      if (token.pos_detail_1 !== "代名詞") continue;
+
+      const guidance = PRONOUN_GUIDANCE.find((g) => g.surface === token.surface);
+      if (!guidance) continue;
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Pronoun "${token.surface}" — consider "${guidance.correct}". ${guidance.note}`,
+        messageJa: `代名詞「${token.surface}」について：${guidance.note}。「${guidance.correct}」を検討してください`,
+        from: token.start,
+        to: token.end,
+        originalText: token.surface,
+        reference: KANJI_REF,
+        fix: {
+          label: `Replace with "${guidance.correct}"`,
+          labelJa: `「${guidance.correct}」に置換`,
+          replacement: guidance.correct,
+        },
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/punctuation-rules.ts
+++ b/lib/linting/rules/punctuation-rules.ts
@@ -1,5 +1,5 @@
 import { AbstractLintRule } from "../base-rule";
-import type { LintIssue, LintRuleConfig, LintReference, Severity } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference, Severity , CorrectionEngine} from "../types";
 
 /** JIS X 4051:2004 reference for punctuation rules */
 const JIS_REF: LintReference = {
@@ -65,6 +65,7 @@ const WIDTH_VARIANTS: readonly WidthVariant[] = [
  */
 export class PunctuationRule extends AbstractLintRule {
   readonly id = "punctuation-rules";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Punctuation conventions";
   readonly nameJa = "記号の作法";
   readonly description =

--- a/lib/linting/rules/redundant-expression.ts
+++ b/lib/linting/rules/redundant-expression.ts
@@ -1,6 +1,6 @@
 import { AbstractLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 /** Reference for redundant expression detection */
 const STYLE_GUIDE_REF: LintReference = {
@@ -162,6 +162,7 @@ const REDUNDANT_EXPRESSIONS: ReadonlyArray<RedundantEntry> = [
  */
 export class RedundantExpressionRule extends AbstractLintRule {
   readonly id = "redundant-expression";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Redundant expression detection";
   readonly nameJa = "二重表現の検出";
   readonly description =
@@ -171,6 +172,7 @@ export class RedundantExpressionRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "warning",
+    skipDialogue: true,
   };
 
   lint(text: string, config: LintRuleConfig): LintIssue[] {

--- a/lib/linting/rules/sentence-ending-repetition.ts
+++ b/lib/linting/rules/sentence-ending-repetition.ts
@@ -1,6 +1,6 @@
 import { AbstractLintRule } from "../base-rule";
 import { isInDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -103,6 +103,7 @@ function extractSentences(text: string): SentenceInfo[] {
  */
 export class SentenceEndingRepetitionRule extends AbstractLintRule {
   readonly id = "sentence-ending-repetition";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Sentence ending repetition";
   readonly nameJa = "文末表現の重複";
   readonly description =

--- a/lib/linting/rules/sentence-length.ts
+++ b/lib/linting/rules/sentence-length.ts
@@ -1,7 +1,7 @@
 import { AbstractLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
 import { splitIntoSentences } from "../helpers/sentence-splitter";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -32,6 +32,7 @@ const STYLE_GUIDE_REF: LintReference = {
  */
 export class SentenceLengthRule extends AbstractLintRule {
   readonly id = "sentence-length";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Sentence Length";
   readonly nameJa = "長文の検出";
   readonly description =

--- a/lib/linting/rules/suru-beki-conjugation-rule.ts
+++ b/lib/linting/rules/suru-beki-conjugation-rule.ts
@@ -1,0 +1,101 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Invalid conjugation forms of サ変動詞 (suru-verbs) + 「べき」.
+ *
+ * Standard forms: 「すべき」or「するべき」
+ * Invalid forms: conjugations other than 連体形 (する) before べき
+ *
+ * Detect: [しさせ]べき — these are incorrect conjugations.
+ */
+const SURU_BEKI_INVALID_PATTERNS: ReadonlyArray<{
+  pattern: RegExp;
+  wrong: string;
+  correct: string;
+}> = [
+  {
+    pattern: /しべき/g,
+    wrong: "しべき",
+    correct: "するべき（すべき）",
+  },
+  {
+    pattern: /させべき/g,
+    wrong: "させべき",
+    correct: "するべき（すべき）",
+  },
+  {
+    // Incorrect polite form + べき
+    pattern: /しますべき/g,
+    wrong: "しますべき",
+    correct: "するべき",
+  },
+  {
+    // Negative form + べき (occasional hypercorrection)
+    pattern: /せざるべき/g,
+    wrong: "せざるべき",
+    correct: "すべきでない",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Suru-beki Conjugation Rule (L1)
+ *
+ * サ変動詞 (suru-verbs) combined with 「べき」must use the 連体形 (する),
+ * yielding either 「すべき」or 「するべき」.
+ * Invalid forms like 「しべき」(using 連用形) are grammatical errors.
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class SuruBekiConjugationRule extends AbstractLintRule {
+  readonly id = "suru-beki-conjugation";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Suru-verb + べき Conjugation";
+  readonly nameJa = "サ変動詞＋「べき」の活用統一";
+  readonly description = "サ変動詞 before べき must use 連体形: すべき or するべき";
+  readonly descriptionJa = "サ変動詞＋「べき」は「すべき」または「するべき」が正しい活用です（公用文作成の考え方）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, wrong, correct } of SURU_BEKI_INVALID_PATTERNS) {
+      pattern.lastIndex = 0;
+      let match: RegExpExecArray | null;
+
+      while ((match = pattern.exec(text)) !== null) {
+        const from = match.index;
+        const to = from + match[0].length;
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `"${wrong}" is an incorrect conjugation. Use "${correct}" instead`,
+          messageJa: `「${wrong}」は誤った活用形です。「${correct}」を使ってください（公用文作成の考え方）`,
+          from,
+          to,
+          originalText: match[0],
+          reference: KOYO_REF,
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/taigen-dome-overuse.ts
+++ b/lib/linting/rules/taigen-dome-overuse.ts
@@ -3,7 +3,7 @@ import { AbstractMorphologicalLintRule } from "../base-rule";
 import { isInDialogue } from "../helpers/dialogue-mask";
 import type { SentenceSpan } from "../helpers/sentence-splitter";
 import { splitIntoSentences } from "../helpers/sentence-splitter";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -55,6 +55,7 @@ function isTaigenDome(
  */
 export class TaigenDomeOveruseRule extends AbstractMorphologicalLintRule {
   readonly id = "taigen-dome-overuse";
+  override engine: CorrectionEngine = "morphological";
   readonly name = "Taigen-dome Overuse";
   readonly nameJa = "体言止めの多用検出";
   readonly description = "Flags consecutive sentences ending with nouns";

--- a/lib/linting/rules/tautology-redundancy-rule.ts
+++ b/lib/linting/rules/tautology-redundancy-rule.ts
@@ -1,0 +1,181 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const KOYO_REF: LintReference = {
+  standard: "公用文作成の考え方（文化審議会、2022）",
+};
+
+/**
+ * Common tautologies (重言・重複表現) in Japanese.
+ * These expressions contain redundant meaning.
+ */
+const TAUTOLOGIES: ReadonlyArray<{
+  pattern: string;
+  correct: string;
+  note: string;
+}> = [
+  {
+    pattern: "まず最初に",
+    correct: "まず",
+    note: "「まず」と「最初に」は同じ意味の重複です",
+  },
+  {
+    pattern: "一番最初",
+    correct: "最初",
+    note: "「一番」と「最初」は同じ意味の重複です",
+  },
+  {
+    pattern: "一番最後",
+    correct: "最後",
+    note: "「一番」と「最後」は同じ意味の重複です",
+  },
+  {
+    pattern: "後で後悔",
+    correct: "後悔",
+    note: "「後悔」には「後で」の意味が含まれています",
+  },
+  {
+    pattern: "頭痛が痛い",
+    correct: "頭が痛い",
+    note: "「頭痛」には「痛い」の意味が含まれています",
+  },
+  {
+    pattern: "馬から落馬",
+    correct: "落馬",
+    note: "「落馬」には「馬から落ちる」の意味が含まれています",
+  },
+  {
+    pattern: "犯罪を犯す",
+    correct: "犯罪を行う",
+    note: "「犯す」と「犯罪」は同じ語源の重複です",
+  },
+  {
+    pattern: "被害を被る",
+    correct: "被害を受ける",
+    note: "「被る」と「被害」は同じ語源の重複です",
+  },
+  {
+    pattern: "違和感を感じる",
+    correct: "違和感がある",
+    note: "「感じる」と「違和感」は同じ語源の重複です",
+  },
+  {
+    pattern: "過半数を超える",
+    correct: "過半数に達する",
+    note: "「過半数」には「半分を超える」の意味が含まれています",
+  },
+  {
+    pattern: "必ず必要",
+    correct: "必要",
+    note: "「必ず」と「必要」は同じ意味の重複です",
+  },
+  {
+    pattern: "各々それぞれ",
+    correct: "それぞれ",
+    note: "「各々」と「それぞれ」は同じ意味の重複です",
+  },
+  {
+    pattern: "引き続き継続",
+    correct: "継続",
+    note: "「引き続き」と「継続」は同じ意味の重複です",
+  },
+  {
+    pattern: "お体の具合はいかがでしょうか",
+    correct: "お体の具合はいかがですか",
+    note: "「具合」と「いかが」を組み合わせると冗長になります（過剰な丁寧表現）",
+  },
+  {
+    pattern: "最後の結末",
+    correct: "結末",
+    note: "「最後」と「結末」は同じ意味の重複です",
+  },
+  {
+    pattern: "返事を返す",
+    correct: "返事をする",
+    note: "「返事」と「返す」は同じ語源の重複です",
+  },
+  {
+    pattern: "はっきりと明確に",
+    correct: "明確に",
+    note: "「はっきり」と「明確」は同じ意味の重複です",
+  },
+  {
+    pattern: "予め予約",
+    correct: "予約",
+    note: "「予約」には「予め」の意味が含まれています",
+  },
+];
+
+/**
+ * Find all non-overlapping occurrences of a literal string in text.
+ */
+function findAllOccurrences(text: string, needle: string): number[] {
+  const indices: number[] = [];
+  let pos = 0;
+  while (pos <= text.length - needle.length) {
+    const idx = text.indexOf(needle, pos);
+    if (idx === -1) break;
+    indices.push(idx);
+    pos = idx + needle.length;
+  }
+  return indices;
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Tautology Redundancy Rule (L1)
+ *
+ * Detects common tautologies (重言・重複表現) where the same meaning is
+ * expressed twice in the same phrase.
+ * e.g., 「まず最初に」→「まず」, 「頭痛が痛い」→「頭が痛い」
+ *
+ * Reference: 公用文作成の考え方（文化審議会、2022）
+ */
+export class TautologyRedundancyRule extends AbstractLintRule {
+  readonly id = "tautology-redundancy";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Tautology / Redundant Expression";
+  readonly nameJa = "重複表現（重言）の禁止";
+  readonly description = "Detect tautological expressions where the same meaning is stated twice";
+  readonly descriptionJa = "「まず最初に」「頭痛が痛い」等の重複表現（重言）を検出します（公用文作成の考え方）";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { pattern, correct, note } of TAUTOLOGIES) {
+      for (const from of findAllOccurrences(text, pattern)) {
+        const to = from + pattern.length;
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Tautology detected: "${pattern}". ${note} Consider: "${correct}"`,
+          messageJa: `重複表現（重言）：「${pattern}」。${note}「${correct}」への修正を検討してください`,
+          from,
+          to,
+          originalText: pattern,
+          reference: KOYO_REF,
+          fix: {
+            label: `Replace with "${correct}"`,
+            labelJa: `「${correct}」に置換`,
+            replacement: correct,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/verb-okurigana-strict-rule.ts
+++ b/lib/linting/rules/verb-okurigana-strict-rule.ts
@@ -1,0 +1,102 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const OKURIGANA_REF: LintReference = {
+  standard: "送り仮名の付け方（内閣告示、1973）",
+};
+
+/**
+ * Dictionary of common verb okurigana errors.
+ * wrong: the incorrect surface form
+ * correct: the standard form per 送り仮名の付け方 本則
+ */
+const VERB_OKURIGANA_ERRORS: ReadonlyArray<{ wrong: string; correct: string }> = [
+  { wrong: "動す", correct: "動かす" },
+  { wrong: "著す", correct: "著わす" },
+  { wrong: "表す", correct: "表わす" },
+  { wrong: "現す", correct: "現わす" },
+  { wrong: "行う", correct: "行う" }, // placeholder — actually standard, skip
+  { wrong: "断る", correct: "断る" }, // placeholder, skip
+  { wrong: "承る", correct: "承る" }, // placeholder, skip
+  // Actual errors below
+  { wrong: "浮ぶ", correct: "浮かぶ" },
+  { wrong: "生れる", correct: "生まれる" },
+  { wrong: "押える", correct: "押さえる" },
+  { wrong: "起る", correct: "起こる" },
+  { wrong: "収る", correct: "収まる" },
+  { wrong: "縮る", correct: "縮まる" },
+  { wrong: "従う", correct: "従う" }, // standard — skip
+].filter((pair) => pair.wrong !== pair.correct);
+
+/**
+ * Find all non-overlapping occurrences of a literal string in text.
+ */
+function findAllOccurrences(text: string, needle: string): number[] {
+  const indices: number[] = [];
+  let pos = 0;
+  while (pos <= text.length - needle.length) {
+    const idx = text.indexOf(needle, pos);
+    if (idx === -1) break;
+    indices.push(idx);
+    pos = idx + needle.length;
+  }
+  return indices;
+}
+
+// ---------------------------------------------------------------------------
+// Rule implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Verb Okurigana Strict Rule (L1)
+ *
+ * Detects common verb okurigana errors based on 送り仮名の付け方 本則.
+ * Flags forms that omit required okurigana from verbs.
+ *
+ * Reference: 送り仮名の付け方（内閣告示、1973）
+ */
+export class VerbOkuriganaStrictRule extends AbstractLintRule {
+  readonly id = "verb-okurigana-strict";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Verb Okurigana (Strict)";
+  readonly nameJa = "動詞の送り仮名「本則」";
+  readonly description = "Detect verb okurigana errors per 送り仮名の付け方 本則";
+  readonly descriptionJa = "送り仮名の付け方（内閣告示、1973）の本則に基づき、動詞の送り仮名の誤りを検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!text) return [];
+    const issues: LintIssue[] = [];
+
+    for (const { wrong, correct } of VERB_OKURIGANA_ERRORS) {
+      for (const from of findAllOccurrences(text, wrong)) {
+        const to = from + wrong.length;
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `"${wrong}" is an incorrect okurigana form. Standard form: "${correct}"`,
+          messageJa: `「${wrong}」は送り仮名の誤りです。正しくは「${correct}」です（送り仮名の付け方 本則）`,
+          from,
+          to,
+          originalText: wrong,
+          reference: OKURIGANA_REF,
+          fix: {
+            label: `Replace with "${correct}"`,
+            labelJa: `「${correct}」に置換`,
+            replacement: correct,
+          },
+        });
+      }
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/verbose-expression.ts
+++ b/lib/linting/rules/verbose-expression.ts
@@ -1,6 +1,6 @@
 import { AbstractLintRule } from "../base-rule";
 import { maskDialogue } from "../helpers/dialogue-mask";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 /** Reference for verbose expression checks */
 const STYLE_GUIDE_REF: LintReference = {
@@ -73,6 +73,7 @@ const VERBOSE_PATTERNS: ReadonlyArray<VerbosePattern> = [
  */
 export class VerboseExpressionRule extends AbstractLintRule {
   readonly id = "verbose-expression";
+  override engine: CorrectionEngine = "regex";
   readonly name = "Verbose expression simplification";
   readonly nameJa = "冗長表現の簡略化";
   readonly description = "Detect verbose expressions and suggest concise alternatives";
@@ -81,6 +82,7 @@ export class VerboseExpressionRule extends AbstractLintRule {
   readonly defaultConfig: LintRuleConfig = {
     enabled: true,
     severity: "info",
+    skipDialogue: true,
   };
 
   lint(text: string, config: LintRuleConfig): LintIssue[] {

--- a/lib/linting/rules/vu-katakana-rule.ts
+++ b/lib/linting/rules/vu-katakana-rule.ts
@@ -1,0 +1,88 @@
+import { AbstractLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** Reference for vu-katakana rule */
+const GAIRAI_REF: LintReference = {
+  standard: "文化庁「外来語の表記」(1991, 内閣告示第二号)",
+};
+
+/** Matches the katakana character ヴ (U+30F4) and its combinations */
+const VU_PATTERN = /ヴ[ァィゥェォ]?/g;
+
+/**
+ * Standard substitutions for ヴ combinations.
+ * These represent the preferred forms in public documents.
+ */
+const VU_SUBSTITUTIONS: ReadonlyMap<string, string> = new Map([
+  ["ヴァ", "バ"],
+  ["ヴィ", "ビ"],
+  ["ヴ", "ブ"],
+  ["ヴェ", "ベ"],
+  ["ヴォ", "ボ"],
+]);
+
+/**
+ * VuKatakanaRule -- L1 regex-based rule.
+ *
+ * Detects use of ヴ (U+30F4) in text. Per 文化庁「外来語の表記」,
+ * public documents and formal writing should avoid ヴ and instead
+ * use the standard ba-row (バ行) characters.
+ *
+ * Common substitutions:
+ * - ヴァ → バ (violin: ヴァイオリン → バイオリン)
+ * - ヴィ → ビ (video: ヴィデオ → ビデオ)
+ * - ヴ  → ブ
+ * - ヴェ → ベ
+ * - ヴォ → ボ
+ */
+export class VuKatakanaRule extends AbstractLintRule {
+  readonly id = "vu-katakana";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Avoid ヴ in formal Japanese text";
+  readonly nameJa = "「ヴ」の使用制限";
+  readonly description =
+    "Detects ヴ which should be replaced with バ/ビ/ブ/ベ/ボ in formal text";
+  readonly descriptionJa =
+    "公用文や正式な文書では「ヴ」を避け、バ行の表記を使用してください";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "warning",
+    skipDialogue: true,
+  };
+
+  lint(text: string, config: LintRuleConfig): LintIssue[] {
+    if (!config.enabled || !text) return [];
+
+    const issues: LintIssue[] = [];
+
+    for (const match of text.matchAll(VU_PATTERN)) {
+      if (match.index === undefined) continue;
+
+      const matchedText = match[0];
+      const suggestion = VU_SUBSTITUTIONS.get(matchedText);
+
+      issues.push({
+        ruleId: this.id,
+        severity: config.severity,
+        message: `Avoid "ヴ" in formal text — use バ行 instead (外来語の表記)`,
+        messageJa: `外来語の表記に基づき、公用文では「${matchedText}」を使用せず、バ行で表記してください${suggestion !== undefined ? `（例：「${suggestion}」）` : ""}`,
+        from: match.index,
+        to: match.index + matchedText.length,
+        originalText: matchedText,
+        reference: GAIRAI_REF,
+        ...(suggestion !== undefined
+          ? {
+              fix: {
+                label: `Replace with "${suggestion}"`,
+                labelJa: `「${suggestion}」に変換`,
+                replacement: suggestion,
+              },
+            }
+          : {}),
+      });
+    }
+
+    return issues;
+  }
+}

--- a/lib/linting/rules/wave-dash-unification-rule.ts
+++ b/lib/linting/rules/wave-dash-unification-rule.ts
@@ -1,0 +1,99 @@
+import { AbstractDocumentLintRule } from "../base-rule";
+import type { LintIssue, LintRuleConfig, LintReference, CorrectionEngine } from "../types";
+
+/** JTF reference for wave dash unification rule */
+const JTF_REF: LintReference = {
+  standard: "JTF日本語標準スタイルガイド v3.0",
+  section: "2.1.3",
+};
+
+/** Wave dash (U+301C) — the standard form in Japanese typography */
+const WAVE_DASH = "\u301C"; // 〜
+/** Fullwidth tilde (U+FF5E) — often confused with wave dash */
+const FULLWIDTH_TILDE = "\uFF5E"; // ～
+
+/**
+ * WaveDashUnificationRule -- L1 document-level rule.
+ *
+ * Detects mixed use of U+301C (wave dash 〜) and U+FF5E (fullwidth tilde ～)
+ * within a document. Per JTF 2.1.3, only one form should be used consistently.
+ *
+ * When both forms appear, the minority form is flagged with a suggestion
+ * to convert to the majority form.
+ */
+export class WaveDashUnificationRule extends AbstractDocumentLintRule {
+  readonly id = "wave-dash-unification";
+  override engine: CorrectionEngine = "regex";
+  readonly name = "Unify wave dash usage";
+  readonly nameJa = "波ダッシュの統一";
+  readonly description =
+    "Detects mixed usage of U+301C (〜) and U+FF5E (～) in the document";
+  readonly descriptionJa =
+    "波ダッシュ（U+301C: 〜）と全角チルダ（U+FF5E: ～）の混在を検出します";
+  readonly level = "L1" as const;
+  readonly defaultConfig: LintRuleConfig = {
+    enabled: true,
+    severity: "error",
+  };
+
+  lintDocument(
+    paragraphs: ReadonlyArray<{ text: string; index: number }>,
+    config: LintRuleConfig,
+  ): Array<{ paragraphIndex: number; issues: LintIssue[] }> {
+    if (!config.enabled || paragraphs.length === 0) return [];
+
+    // Count occurrences of each form across the whole document
+    let waveDashCount = 0;
+    let fullwidthTildeCount = 0;
+
+    for (const para of paragraphs) {
+      for (const ch of para.text) {
+        if (ch === WAVE_DASH) waveDashCount++;
+        else if (ch === FULLWIDTH_TILDE) fullwidthTildeCount++;
+      }
+    }
+
+    // Only flag if both forms are present
+    if (waveDashCount === 0 || fullwidthTildeCount === 0) return [];
+
+    // Determine minority and preferred form
+    const minorityChar =
+      waveDashCount <= fullwidthTildeCount ? WAVE_DASH : FULLWIDTH_TILDE;
+    const majorityChar =
+      waveDashCount > fullwidthTildeCount ? WAVE_DASH : FULLWIDTH_TILDE;
+    const majorityName =
+      majorityChar === WAVE_DASH ? "波ダッシュ（U+301C）" : "全角チルダ（U+FF5E）";
+
+    const results: Array<{ paragraphIndex: number; issues: LintIssue[] }> = [];
+
+    for (const para of paragraphs) {
+      const issues: LintIssue[] = [];
+
+      for (let i = 0; i < para.text.length; i++) {
+        if (para.text[i] !== minorityChar) continue;
+
+        issues.push({
+          ruleId: this.id,
+          severity: config.severity,
+          message: `Mixed wave dash usage: convert to "${majorityChar}" (${majorityName}) for consistency (JTF 2.1.3)`,
+          messageJa: `JTF 2.1.3に基づき、文書内で波ダッシュの種類が混在しています。${majorityName}に統一してください`,
+          from: i,
+          to: i + 1,
+          originalText: minorityChar,
+          reference: JTF_REF,
+          fix: {
+            label: `Replace with "${majorityChar}" (${majorityName})`,
+            labelJa: `${majorityName}に統一`,
+            replacement: majorityChar,
+          },
+        });
+      }
+
+      if (issues.length > 0) {
+        results.push({ paragraphIndex: para.index, issues });
+      }
+    }
+
+    return results;
+  }
+}

--- a/lib/linting/rules/word-repetition.ts
+++ b/lib/linting/rules/word-repetition.ts
@@ -3,7 +3,7 @@ import { AbstractMorphologicalLintRule } from "../base-rule";
 import { isInDialogue } from "../helpers/dialogue-mask";
 import type { SentenceSpan } from "../helpers/sentence-splitter";
 import { splitIntoSentences } from "../helpers/sentence-splitter";
-import type { LintIssue, LintRuleConfig, LintReference } from "../types";
+import type { LintIssue, LintRuleConfig, LintReference , CorrectionEngine} from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -103,6 +103,7 @@ function extractContentWords(
  */
 export class WordRepetitionRule extends AbstractMorphologicalLintRule {
   readonly id = "word-repetition";
+  override engine: CorrectionEngine = "morphological";
   readonly name = "Word Repetition";
   readonly nameJa = "近接語句の反復検出";
   readonly description =

--- a/lib/linting/types.ts
+++ b/lib/linting/types.ts
@@ -3,6 +3,9 @@ import type { Token } from "@/lib/nlp-client/types";
 
 export type Severity = "error" | "warning" | "info";
 
+/** The underlying implementation engine for a correction rule */
+export type CorrectionEngine = "regex" | "morphological" | "llm";
+
 export interface LintReference {
   /** Standard name, e.g. "JIS X 4051:2004" */
   standard: string;
@@ -53,6 +56,8 @@ export interface LintRule {
   descriptionJa: string;
   /** Detection level: L1=regex, L2=morphological, L3=advanced */
   level: "L1" | "L2" | "L3";
+  /** The underlying implementation engine for this rule */
+  engine?: CorrectionEngine;
   defaultConfig: LintRuleConfig;
   /** Run the rule on text, return issues found */
   lint(text: string, config: LintRuleConfig): LintIssue[];
@@ -147,4 +152,51 @@ export interface LlmLintRule extends LintRule {
  */
 export function isLlmLintRule(rule: LintRule): rule is LlmLintRule {
   return "lintWithLlm" in rule;
+}
+
+// ============================================================================
+// Unified CorrectionRule interface (Phase D)
+// ============================================================================
+
+/** Unified context passed to all rules */
+export interface AnalysisContext {
+  /** The paragraph text (or full document text for document-scope rules) */
+  text: string;
+  /** Morphological tokens from NLP client (available for morphological rules) */
+  tokens?: Token[];
+  /** All paragraph texts (for document-scope rules) */
+  paragraphs?: string[];
+  /** Current correction mode (e.g. "novel", "official", "academic") */
+  mode: string;
+  /** Active guideline identifiers */
+  guidelines: string[];
+}
+
+/** Candidate issue from any rule, before LLM validation */
+export interface CorrectionCandidate {
+  ruleId: string;
+  from: number;
+  to: number;
+  severity: Severity;
+  message: string;
+  messageJa: string;
+  suggestion?: string;
+  reference?: LintReference;
+  /** Surrounding sentence text (at least one complete sentence) for LLM validation */
+  context: string;
+  /** When true, skip LLM validation (e.g. formatting/structural rules) */
+  skipValidation?: boolean;
+}
+
+/** Unified rule interface — replaces LintRule/DocumentLintRule/MorphologicalLintRule */
+export interface CorrectionRule {
+  id: string;
+  engine: CorrectionEngine;
+  scope: "paragraph" | "document";
+  defaultConfig: LintRuleConfig;
+  /** Optional extra hint for LLM validator */
+  validationHint?: string;
+
+  /** Single entry point — receives full AnalysisContext */
+  analyze(context: AnalysisContext, config: LintRuleConfig): CorrectionCandidate[];
 }

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
@@ -9,6 +9,8 @@ import type { RuleRunner, LintIssue } from '@/lib/linting';
 import type { INlpClient } from '@/lib/nlp-client/types';
 import type { ILlmClient } from '@/lib/llm-client/types';
 import type { IgnoredCorrection } from '@/lib/project-types';
+import type { ConfigChangeReason } from '@/lib/linting/correction-config';
+import type { LintingSettingsUpdate } from './types';
 import { createLintingPlugin, lintingKey } from './decoration-plugin';
 
 // Export the plugin key for external use
@@ -58,21 +60,18 @@ export function linting(options: LintingOptions = {}) {
  *
  * @param view EditorView instance
  * @param settings Settings to update
+ * @param reason Optional reason for the change, enabling smart cache invalidation
  */
 export function updateLintingSettings(
   view: EditorView,
-  settings: {
-    enabled?: boolean;
-    ruleRunner?: RuleRunner | null;
-    nlpClient?: INlpClient | null;
-    llmClient?: ILlmClient | null;
-    llmEnabled?: boolean;
-    llmModelId?: string;
-    forceFullScan?: boolean;
-    forceLlmValidation?: boolean;
-    ignoredCorrections?: IgnoredCorrection[];
-  }
+  settings: LintingSettingsUpdate,
+  reason?: ConfigChangeReason
 ): void {
-  const tr = view.state.tr.setMeta(lintingKey, settings);
+  const meta: LintingSettingsUpdate = { ...settings };
+  // If a reason is provided as a separate argument, it takes precedence
+  if (reason !== undefined) {
+    meta.changeReason = reason;
+  }
+  const tr = view.state.tr.setMeta(lintingKey, meta);
   view.dispatch(tr);
 }

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
@@ -9,6 +9,9 @@ import type { RuleRunner } from '@/lib/linting';
 import type { INlpClient } from '@/lib/nlp-client/types';
 import type { ILlmClient } from '@/lib/llm-client/types';
 import type { IgnoredCorrection } from '@/lib/project-types';
+import type { ConfigChangeReason } from '@/lib/linting/correction-config';
+
+export type { ConfigChangeReason };
 
 /**
  * Options for the linting ProseMirror plugin
@@ -30,4 +33,21 @@ export interface LintingPluginOptions {
 export interface LintingPluginState {
   decorations: DecorationSet;
   enabled: boolean;
+}
+
+/**
+ * Settings that can be passed to updateLintingSettings().
+ * The optional changeReason enables smart cache invalidation.
+ */
+export interface LintingSettingsUpdate {
+  enabled?: boolean;
+  ruleRunner?: RuleRunner | null;
+  nlpClient?: INlpClient | null;
+  llmClient?: ILlmClient | null;
+  llmEnabled?: boolean;
+  /** @deprecated Use changeReason instead */
+  forceFullScan?: boolean;
+  ignoredCorrections?: IgnoredCorrection[];
+  /** Identifies the trigger for this change, enabling precise cache invalidation */
+  changeReason?: ConfigChangeReason;
 }


### PR DESCRIPTION
## Summary

Merges the correction system v2 changes from \`main\` into \`beta\`.

### Changes from main

- **LlmController** — 6-state lifecycle (IDLE→LOADING→READY→ACTIVE→COOLING→UNLOADING)
- **CorrectionConfig** — single source of truth for correction settings
- **CorrectionModeId** — 5 presets (novel/official/blog/academic/sns)
- **GuidelineId** — 11 Japanese language standard guidelines catalog
- **CorrectionRule interface** — unified \`analyze(context, config)\` entry point
- **CorrectionRuleRunner** — orchestrates rule execution
- **41 new correction rules** from official Japanese language standards (JTF, 公用文, 外来語の表記, 現代仮名遣い, 送り仮名の付け方, 漢字使用等)
- **skipDialogue defaults** enabled for 8 lint rules
- **ConfigChangeReason** — smart cache invalidation (replaces \`forceFullScan: boolean\`)

### Merge conflict resolution

| File | Resolution |
|------|-----------|
| \`use-power-saving.ts\` | Kept beta's IPC battery detection (power-save feature active in beta) |
| \`use-editor-settings.ts\` | Kept both: \`autoPowerSaveOnBattery\` (beta) + \`correctionConfig\` (main) |
| \`use-linting.ts\` | Used main's \`ConfigChangeReason\` refresh logic |
| \`decoration-plugin.ts\` | Used main's \`LintingSettingsUpdate\` type; removed stale \`llmModelId\`/\`forceLlmValidation\` checks |
| \`linting-plugin/index.ts\` | Used main's \`LintingSettingsUpdate\` + \`ConfigChangeReason\` signature |

## Test plan

- [x] TypeScript: \`npx tsc --noEmit\` passes with zero errors
- [ ] Linting rules load without errors in the editor
- [ ] Power-save mode toggle still works in beta
- [ ] Manual linting refresh triggers \`"manual-refresh"\` cache invalidation
- [ ] All 41 new correction rules fire correctly on matching text

Closes #433
Closes #439
Closes #440
Closes #441
Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)