### PR TITLE
fix: resolve RSC client manifest error breaking all builds

### DIFF
--- a/prompts/lint-validation/index.ts
+++ b/prompts/lint-validation/index.ts
@@ -1,13 +1,56 @@
 /**
  * LLM validation prompt templates.
- * Source of truth: shared-rules.md, candidate-validator.md
+ *
+ * Prompt content is inlined as TypeScript strings to avoid webpack
+ * asset/source .md imports that break the Next.js RSC bundler.
  *
  * Placeholders resolved at runtime:
  *   {{CONTEXT}}, {{RULE_ID}}, {{FROM}}, {{TO}}, {{MESSAGE_JA}}, {{VALIDATION_HINT}}
  */
 
-import sharedRulesMd from "./shared-rules.md";
-import candidateValidatorMd from "./candidate-validator.md";
+// ---------------------------------------------------------------------------
+// Shared rules (source of truth: shared-rules.md)
+// ---------------------------------------------------------------------------
+
+const sharedRulesMd = `1. **判定基準（絶対原則）**
+   - \`{"valid": true}\`: 指摘が【完全に正しく】著者が修正すべき場合のみ。
+   - \`{"valid": false}\`: 機械の誤検知、または表現技法。迷った場合はすべて \`false\`。
+2. **トークン分割エラー（即時 false）**
+   - 対象箇所 \`<< >>\` の前後を必ず確認してください。
+   - \`<<カウンタ>>ー\`、\`深夜三<<時>>\`、\`<<しれ>>ない\` のように、一つの単語・熟語・単位を不自然に分断している形態素解析のエラーはすべて \`false\`。
+3. **純文学の表現技法（false）**
+   - 小説におけるリズム作りのための「の」の連続、体言止めの連続、意図的な表記ゆれ（時/とき、物/もの、為/ため）は表現技法です。機械的な統一ルールは適用せず \`false\`。
+4. **文法・品詞の誤認（false）**
+   - 擬音語（ぽたり等）や、現代の並列表現（〜たり〜たり）を、文語調や古文法と誤認している指摘は \`false\`。
+5. **除外対象（false）**
+   - 固有名詞、引用文に対する指摘。`;
+
+// ---------------------------------------------------------------------------
+// Candidate validator (source of truth: candidate-validator.md)
+// ---------------------------------------------------------------------------
+
+const candidateValidatorMd = `/no_think
+日本語校正の専門家として、以下の指摘が正しいか判定してください。
+
+## 判定の絶対ルール（JSONの \\\`valid\\\` の意味）
+- {"valid": true} : この指摘は正しい。著者に修正を促すべき。（True Positive）
+- {"valid": false} : この指摘は機械の誤検知、または小説表現として許容すべき。無視してよい。（False Positive）
+
+## ルール
+{{SHARED_RULES}}
+
+## 文脈
+{{CONTEXT}}
+
+## 指摘
+- 文体モード: {{MODE}}
+- ルールID: {{RULE_ID}}
+- 対象: {{FROM}}–{{TO}}
+- 問題: {{MESSAGE_JA}}
+{{VALIDATION_HINT}}
+
+## 回答
+JSON: {"valid":true, "reason":"16文字以内で理由を記述"} // validがtrueなら正しい指摘、falseなら誤検知`;
 
 // ---------------------------------------------------------------------------
 // Single-candidate validator prompt (used by LintIssueValidator)

--- a/types/generated.d.ts
+++ b/types/generated.d.ts
@@ -1,0 +1,11 @@
+/** Type declarations for build-time generated files (may not exist during tsc) */
+declare module "@/generated/credits.json" {
+  interface CreditEntry {
+    name: string;
+    version: string;
+    license: string;
+    repository: string;
+  }
+  const value: CreditEntry[];
+  export default value;
+}


### PR DESCRIPTION
## Summary
- **Root cause**: `require("@/generated/credits.json")` in `SettingsModal.tsx` prevented webpack from registering `app/page.tsx` in the React Client Manifest, causing prerender failures
- Replace CommonJS `require()` with dynamic `import()` in `AboutSection` component
- Inline `.md` prompt templates as TypeScript strings to eliminate `asset/source` loader dependency
- Add `types/generated.d.ts` for type-safe dynamic imports of build-time generated files

Fixes #494, fixes #501

## Root Cause Analysis
The `clientModules` section of `page_client-reference-manifest.js` was missing `app/page.tsx` entirely — despite it having `"use client"`. The cause: a transitive `require()` call in `SettingsModal.tsx` (imported by `page.tsx`) broke webpack's ability to register the module in the RSC client manifest.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` succeeds (Vercel/web build)
- [x] `ELECTRON_BUILD=1 npm run build` succeeds (static export for Electron)
- [ ] Verify Desktop Build CI passes
- [ ] Verify Vercel deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized application startup and data loading performance.
  * Refactored internal code organization for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->