### PR TITLE
fix: bundle all transitive deps of external modules for Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,10 +117,7 @@
       "!www/**/*"
     ],
     "asarUnpack": [
-      "dist-main/node_modules/better-sqlite3/**",
-      "dist-main/node_modules/bindings/**",
-      "dist-main/node_modules/file-uri-to-path/**",
-      "dist-main/node_modules/node-llama-cpp/**"
+      "dist-main/node_modules/**"
     ],
     "publish": [
       {


### PR DESCRIPTION
## Summary
- Fixes the `ERR_MODULE_NOT_FOUND: Cannot find package 'lifecycle-utils'` error on Windows when loading LLM models
- Replaces manual dependency list in `scripts/bundle-electron.mjs` with automatic recursive collection of all production dependencies for external modules (`kuromoji`, `better-sqlite3`, `node-llama-cpp`)
- Simplifies `asarUnpack` config in `package.json` to unpack all of `dist-main/node_modules/**` instead of listing individual packages

## Root Cause
`node-llama-cpp` depends on `lifecycle-utils` (and ~160 other transitive packages). npm hoists these to the top-level `node_modules/`. The bundle script only copied the 3 root external packages plus a handful of manually-listed sub-deps, so the hoisted transitive dependencies were missing in the packaged app.

## Test plan
- [ ] Build Electron app on Windows and verify LLM model loading works
- [ ] Build Electron app on macOS and verify no regressions
- [ ] Verify `dist-main/node_modules/lifecycle-utils/` exists after running `node scripts/bundle-electron.mjs`

Fixes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified and improved the application build and dependency bundling process. Enhanced the dependency collection mechanism to automatically detect and handle all required dependencies more efficiently, ensuring more robust application packaging and reducing manual maintenance of dependency lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->