### PR TITLE
fix: resolve Finder .mdi file open race condition & cross-platform support

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -58,6 +58,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('open-as-project', handler)
     return () => ipcRenderer.removeListener('open-as-project', handler)
   },
+  getPendingFile: () => ipcRenderer.invoke('get-pending-file'),
   onPasteAsPlaintext: (callback) => {
     const handler = () => callback()
     ipcRenderer.on('menu-paste-as-plaintext', handler)

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -28,6 +28,11 @@ declare global {
     onOpenAsProject?: (
       callback: (payload: { projectPath: string; initialFile: string }) => void
     ) => (() => void) | void;
+    getPendingFile?: () => Promise<
+      | { type: 'project'; projectPath: string; initialFile: string }
+      | { type: 'standalone'; path: string; content: string }
+      | null
+    >;
     onMenuNew?: (callback: () => void) => (() => void) | void;
     onMenuOpen?: (callback: () => void) => (() => void) | void;
     onMenuSave?: (callback: () => void) => (() => void) | void;


### PR DESCRIPTION
## Summary

Fixes the race condition where double-clicking a `.mdi` file in Finder (macOS) while the app is **not running** fails to open the file. Also adds Windows/Linux file association and single-instance support.

- **Pull model**: Replace `did-finish-load` push IPC with `get-pending-file` handler that the renderer calls after React hooks mount
- **`?pending-file` query param**: Ensures `skipAutoRestore = true` synchronously during `useState` init, preventing auto-restore from racing with pending file
- **Single-instance lock**: Prevents duplicate windows on Windows/Linux; second instance forwards `.mdi` path to the existing window
- **`process.argv` scan**: Picks up `.mdi` file path from CLI args on Windows/Linux

## Files changed

| File | Change |
|------|--------|
| `main.js` | Single-instance lock, process.argv scan, `createWindow` signature, `get-pending-file` handler, remove `did-finish-load` block |
| `preload.js` | Add `getPendingFile` bridge |
| `types/electron.d.ts` | Add `getPendingFile` type |
| `app/page.tsx` | `?pending-file` param detection, URL cleanup, pull pending file on mount |

## Test plan

- [ ] **macOS cold start (project)**: Quit app → double-click `.mdi` in a project directory → app opens with project loaded
- [ ] **macOS cold start (standalone)**: Quit app → double-click `.mdi` without `.illusions/` folder → app opens with the file
- [ ] **macOS warm start**: App running → double-click `.mdi` in Finder → file opens (no regression)
- [ ] **Auto-restore skipped**: Quit app with project A open → double-click `.mdi` from project B → project B loads, not A
- [ ] **TypeScript check**: `npx tsc --noEmit` passes with zero errors ✅

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)