### PR TITLE
fix: update vertical mode minWidth on content resize

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -971,6 +971,29 @@ function MilkdownEditor({
     }
   }, [charsPerLine, isVertical, fontFamily, fontScale, lineHeight, scrollContainerRef, get, savedScrollProgressRef, isModeSwitchingRef]);
 
+  // 縦書き時: コンテンツサイズ変更時に minWidth を再計算し、スクロール範囲を更新する
+  useEffect(() => {
+    if (!isVertical) return;
+
+    const container = scrollContainerRef.current;
+    const editorContainer = editorRef.current;
+    const editorDom = editorContainer?.querySelector('.milkdown .ProseMirror') as HTMLElement;
+    if (!container || !editorDom) return;
+
+    const observer = new ResizeObserver(() => {
+      const containerWidth = container.clientWidth;
+      const padding = 128; // 64px * 2
+      const minWidth = containerWidth - padding;
+      editorDom.style.minWidth = `${minWidth}px`;
+    });
+
+    observer.observe(editorDom);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [isVertical, scrollContainerRef]);
+
   // 縦書き時: マウスホイールの縦スクロールを横スクロールへ変換する
   useEffect(() => {
     const container = scrollContainerRef.current;


### PR DESCRIPTION
## Summary
- Add a `ResizeObserver` on the ProseMirror editor DOM in vertical writing mode that recalculates `minWidth` whenever the element's dimensions change
- Previously, `minWidth` was only set once during style application — content changes (typing, deleting) didn't trigger recalculation, causing the scrollbar to get stuck and preventing users from scrolling to the document's beginning (rightmost position)

## Changes
- `components/Editor.tsx`: New `useEffect` with `ResizeObserver` that watches the ProseMirror element and updates `minWidth` using the same formula as `applyStyles()`

## Test plan
- [ ] Open a long document in vertical mode (縦書き)
- [ ] Scroll around — confirm the scrollbar allows reaching the document start (rightmost)
- [ ] Type additional text — confirm the scroll range updates and the scrollbar doesn't get stuck
- [ ] Delete text — confirm the scroll range shrinks properly
- [ ] Switch between vertical/horizontal modes — confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertical writing mode with dynamic editor width adjustment that automatically responds to content size changes for better layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->