### PR TITLE
fix: add llmEnabled guard to rebuildDecorationsWithLlm (#510)

### DIFF
--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -659,7 +659,7 @@ export function createLintingPlugin(
 
             // Pessimistic LLM validation: only show issues confirmed by LLM
             const ruleConfig = currentRuleRunner?.getConfig(issue.ruleId);
-            const needsValidation = !ruleConfig?.skipLlmValidation;
+            const needsValidation = llmEnabled && !ruleConfig?.skipLlmValidation;
             if (needsValidation) {
               const vKey = LintIssueValidator.issueKey(issue, paragraph.text);
               if (validationCache.get(vKey) !== true) continue;


### PR DESCRIPTION
## Summary
- Add `llmEnabled &&` guard to `rebuildDecorationsWithLlm` in `decoration-plugin.ts`
- Without this guard, all lint decorations silently disappear when LLM is disabled because `needsValidation` is always true, and unvalidated issues are filtered out
- Matches the existing pattern in the initial decoration builder (line 414)

## Test plan
- [ ] Disable LLM in settings
- [ ] Open a document with lint issues
- [ ] Verify lint decorations remain visible after document edits trigger rebuild

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)