### PR TITLE
fix: rebuild stale electron-storage-manager.js with recent_projects support (#512)

### DIFF
--- a/lib/electron-storage-manager.js
+++ b/lib/electron-storage-manager.js
@@ -54,6 +54,14 @@ export class ElectronStorageManager {
         data TEXT NOT NULL,
         updated_at INTEGER NOT NULL
       );
+
+      CREATE TABLE IF NOT EXISTS recent_projects (
+        id TEXT PRIMARY KEY,
+        root_path TEXT NOT NULL UNIQUE,
+        name TEXT NOT NULL,
+        data TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
     `);
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         return this.db;
@@ -234,6 +242,59 @@ export class ElectronStorageManager {
         stmt.run();
     }
     /**
+      * 最近使ったプロジェクトへ追加する（最大10件）
+      */
+    addRecentProject(project) {
+        const db = this.ensureInitialized();
+        try {
+            db.exec("BEGIN TRANSACTION");
+            // Remove existing entry for this root path
+            const deleteStmt = db.prepare("DELETE FROM recent_projects WHERE root_path = ?");
+            deleteStmt.run(project.rootPath);
+            // Insert new entry
+            const insertStmt = db.prepare(`
+        INSERT INTO recent_projects (id, root_path, name, data, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+            insertStmt.run(project.id, project.rootPath, project.name, JSON.stringify(project), Date.now());
+            // Trim to 10 entries
+            const countStmt = db.prepare("SELECT COUNT(*) as count FROM recent_projects");
+            const countResult = countStmt.get();
+            if (countResult.count > 10) {
+                const trimStmt = db.prepare(`
+          DELETE FROM recent_projects WHERE id IN (
+            SELECT id FROM recent_projects
+            ORDER BY updated_at ASC
+            LIMIT ?
+          )
+        `);
+                trimStmt.run(countResult.count - 10);
+            }
+            db.exec("COMMIT");
+        }
+        catch (error) {
+            db.exec("ROLLBACK");
+            throw error;
+        }
+    }
+    /**
+      * 最近使ったプロジェクト一覧を取得する
+      */
+    getRecentProjects() {
+        const db = this.ensureInitialized();
+        const stmt = db.prepare("SELECT data FROM recent_projects ORDER BY updated_at DESC LIMIT 10");
+        const rows = stmt.all();
+        return rows.map((row) => JSON.parse(row.data));
+    }
+    /**
+      * 最近使ったプロジェクトから削除する
+      */
+    removeRecentProject(projectId) {
+        const db = this.ensureInitialized();
+        const stmt = db.prepare("DELETE FROM recent_projects WHERE id = ?");
+        stmt.run(projectId);
+    }
+    /**
       * すべてのデータを削除する
       */
     clearAll() {
@@ -242,6 +303,7 @@ export class ElectronStorageManager {
       DELETE FROM app_state;
       DELETE FROM recent_files;
       DELETE FROM editor_buffer;
+      DELETE FROM recent_projects;
     `);
     }
     /**


### PR DESCRIPTION
## Summary
- Add `recent_projects` table creation to `initDatabase()` in the compiled JS file
- Add `addRecentProject()`, `getRecentProjects()`, `removeRecentProject()` methods
- Update `clearAll()` to include `DELETE FROM recent_projects`
- JS file now matches the TypeScript source (`electron-storage-manager.ts`)

## Test plan
- [ ] Open the app in Electron — no startup errors
- [ ] Open a project — it should appear in Recent Projects menu
- [ ] Verify `storage:add-recent-project` IPC handler works
- [ ] Verify `storage:get-recent-projects` IPC handler returns data
- [ ] Verify `storage:remove-recent-project` IPC handler works
- [ ] Run "Clear All" — recent_projects table should be emptied

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)