### PR TITLE
fix: add before-quit timeout and LLM inference/unload race guard (#509, #514)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1299,9 +1299,14 @@ app.whenReady().then(async () => {
   })
 })
 
+let isQuitting = false
 app.on('before-quit', (event) => {
+  if (isQuitting) return
+  isQuitting = true
   event.preventDefault()
+  const forceQuitTimeout = setTimeout(() => app.exit(0), 5000)
   disposeLlmEngine().finally(() => {
+    clearTimeout(forceQuitTimeout)
     app.exit(0)
   })
 })


### PR DESCRIPTION
## Summary
- Add re-entrancy guard (`isQuitting` flag) and 5-second timeout to `before-quit` handler in `main.js` so the app cannot become un-closeable if `disposeLlmEngine()` hangs
- Add `#inferring` counter to `LlmEngine` to prevent idle timer from triggering `unloadModel()` during active inference, avoiding a native crash in llama.cpp
- Add null check for `#context` inside the inference queue to handle the case where the model was unloaded between queue entry and execution

## Test plan
- [ ] Quit app while LLM model is loaded — should exit within 5 seconds
- [ ] Run inference, then immediately close app — should not crash
- [ ] Let idle timer trigger after inference completes — model should unload normally
- [ ] Rapid quit/re-quit should not cause double disposal

Closes #509
Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)