### PR TITLE
fix: resolve stale closure in auto-save dirty check (#532)

### DIFF
--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -86,7 +86,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
                     ? {
                         ...t,
                         lastSavedContent: sanitized,
-                        isDirty: t.content !== tab.content && sanitizeMdiContent(t.content) !== sanitized,
+                        isDirty: sanitizeMdiContent(t.content) !== sanitized,
                         lastSavedTime: -Date.now(),
                       }
                     : t,
@@ -107,7 +107,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
                           ...t,
                           file: result.descriptor,
                           lastSavedContent: sanitized,
-                          isDirty: t.content !== tab.content && sanitizeMdiContent(t.content) !== sanitized,
+                          isDirty: sanitizeMdiContent(t.content) !== sanitized,
                           lastSavedTime: -Date.now(),
                         }
                       : t,


### PR DESCRIPTION
## Summary
- Fixed stale closure bug in `lib/tab-manager/use-auto-save.ts` where the dirty check after an async save compared against a stale `tab.content` captured before the write operation
- Simplified the `isDirty` expression to `sanitizeMdiContent(t.content) !== sanitized`, matching the correct pattern already used in `use-file-io.ts` (line 216)
- Prevents rare timing scenarios where `isDirty` could be incorrectly cleared, causing silent data loss

## Details

The auto-save callback for non-active tabs captures `tab` from the `for...of` loop at interval tick time. After the async VFS write completes, the `setTabs` updater runs with the latest state (`t`), but the old dirty check was:

```typescript
isDirty: t.content !== tab.content && sanitizeMdiContent(t.content) !== sanitized
```

The `tab.content` here is stale -- it reflects the content at the time the save started, not when the updater runs. If the user edited the tab during the save and the raw content happened to match the stale value (e.g., changes only in HTML tags that sanitization strips), the short-circuit `&&` would incorrectly evaluate `isDirty` to `false`.

The fix removes the stale comparison, leaving only:

```typescript
isDirty: sanitizeMdiContent(t.content) !== sanitized
```

This correctly compares the sanitized form of the **latest** content against what was just written to disk.

Fixes #532

## Test plan
- [ ] Open a file in the editor, enable auto-save
- [ ] Make edits to a non-active tab while a save is in progress
- [ ] Verify the dirty indicator correctly reflects unsaved changes after auto-save completes
- [ ] Verify that closing a tab with unsaved changes still prompts to save

🤖 Generated with [Claude Code](https://claude.com/claude-code)