### PR TITLE
fix: add input size validation to NLP API routes

### DIFF
--- a/app/api/nlp/batch/route.ts
+++ b/app/api/nlp/batch/route.ts
@@ -11,6 +11,12 @@ import type { BatchTokenizeRequest, BatchTokenizeResponse } from '@/lib/nlp-clie
 
 const WEB_DIC_PATH = process.cwd() + '/public/dict';
 
+/** Maximum number of paragraphs per batch request (matches Electron IPC limit) */
+const MAX_PARAGRAPHS = 10_000;
+
+/** Maximum text length per paragraph (matches Electron IPC single-paragraph limit) */
+const MAX_PARAGRAPH_TEXT_LENGTH = 1_000_000;
+
 export async function POST(request: NextRequest) {
   try {
     const body: BatchTokenizeRequest = await request.json();
@@ -21,6 +27,29 @@ export async function POST(request: NextRequest) {
         { error: 'Invalid paragraphs parameter' },
         { status: 400 }
       );
+    }
+
+    if (paragraphs.length > MAX_PARAGRAPHS) {
+      return NextResponse.json(
+        { error: `Batch exceeds maximum of ${MAX_PARAGRAPHS} paragraphs` },
+        { status: 413 }
+      );
+    }
+
+    // Validate each paragraph structure and text length
+    for (const p of paragraphs) {
+      if (typeof p?.text !== 'string' || typeof p?.pos !== 'number') {
+        return NextResponse.json(
+          { error: 'Invalid paragraph structure: each entry must have { text: string, pos: number }' },
+          { status: 400 }
+        );
+      }
+      if (p.text.length > MAX_PARAGRAPH_TEXT_LENGTH) {
+        return NextResponse.json(
+          { error: `Paragraph text exceeds maximum length of ${MAX_PARAGRAPH_TEXT_LENGTH} characters` },
+          { status: 413 }
+        );
+      }
     }
 
     if (!nlpProcessor.isInitialized()) {

--- a/app/api/nlp/frequency/route.ts
+++ b/app/api/nlp/frequency/route.ts
@@ -11,6 +11,9 @@ import type { FrequencyAnalysisRequest, FrequencyAnalysisResponse } from '@/lib/
 
 const WEB_DIC_PATH = process.cwd() + '/public/dict';
 
+/** Maximum text length for frequency analysis (matches Electron IPC limit) */
+const MAX_TEXT_LENGTH = 10_000_000;
+
 export async function POST(request: NextRequest) {
   try {
     const body: FrequencyAnalysisRequest = await request.json();
@@ -20,6 +23,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: 'Invalid text parameter' },
         { status: 400 }
+      );
+    }
+
+    if (text.length > MAX_TEXT_LENGTH) {
+      return NextResponse.json(
+        { error: `Text exceeds maximum length of ${MAX_TEXT_LENGTH} characters` },
+        { status: 413 }
       );
     }
 

--- a/app/api/nlp/tokenize/route.ts
+++ b/app/api/nlp/tokenize/route.ts
@@ -11,6 +11,9 @@ import type { ParagraphTokenizeRequest, ParagraphTokenizeResponse } from '@/lib/
 
 const WEB_DIC_PATH = process.cwd() + '/public/dict';
 
+/** Maximum text length for single paragraph tokenization (matches Electron IPC limit) */
+const MAX_TEXT_LENGTH = 1_000_000;
+
 export async function POST(request: NextRequest) {
   try {
     const body: ParagraphTokenizeRequest = await request.json();
@@ -20,6 +23,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: 'Invalid text parameter' },
         { status: 400 }
+      );
+    }
+
+    if (text.length > MAX_TEXT_LENGTH) {
+      return NextResponse.json(
+        { error: `Text exceeds maximum length of ${MAX_TEXT_LENGTH} characters` },
+        { status: 413 }
       );
     }
 


### PR DESCRIPTION
## Summary
- Add input size limits to all three NLP API routes (`/api/nlp/tokenize`, `/api/nlp/batch`, `/api/nlp/frequency`) matching the Electron IPC handler limits
- Return HTTP 413 (Payload Too Large) for oversized requests to prevent potential DoS attacks
- Add per-paragraph structure validation (`{ text: string, pos: number }`) to the batch endpoint, matching the Electron IPC handler's validation

## Details

| Route | Limit | Source |
|-------|-------|--------|
| `/api/nlp/tokenize` | `text.length > 1,000,000` | `nlp-ipc-handlers.js:73` |
| `/api/nlp/batch` | `paragraphs.length > 10,000` + per-paragraph text length check (`1,000,000`) + structure validation | `nlp-ipc-handlers.js:95-102` |
| `/api/nlp/frequency` | `text.length > 10,000,000` | `nlp-ipc-handlers.js:138` |

Fixes #530

## Test plan
- [ ] Send a request to `/api/nlp/tokenize` with text exceeding 1M characters -- should return 413
- [ ] Send a request to `/api/nlp/batch` with >10,000 paragraphs -- should return 413
- [ ] Send a request to `/api/nlp/batch` with a paragraph having text >1M chars -- should return 413
- [ ] Send a request to `/api/nlp/batch` with invalid paragraph structure (missing `pos`) -- should return 400
- [ ] Send a request to `/api/nlp/frequency` with text exceeding 10M characters -- should return 413
- [ ] Normal-sized requests still work correctly on all three endpoints
- [ ] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)