### PR TITLE
fix: resolve vertical-rl scroll range and selection jump bugs

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -1097,9 +1097,10 @@ function MilkdownEditor({
       if (userScrollingRef.current || isModeSwitchingRef.current || programmaticScrollRef?.current) {
         // User interaction, mode switch, or programmatic navigation: save position
         savedScrollPosRef.current = { left: container.scrollLeft, top: container.scrollTop };
-      } else if (isPointerDown) {
-        // Mouse drag (text selection): browser may fire native caret-scroll-into-view
-        // which computes wrong positions in vertical-rl. Detect large jumps and revert them.
+      } else if (isPointerDown && isVertical) {
+        // Mouse drag (text selection) in vertical-rl: browser may fire native caret-scroll-into-view
+        // which computes wrong positions. Detect large jumps and revert them.
+        // Only applies to vertical mode — horizontal selection scrolls are legitimate.
         const dx = Math.abs(container.scrollLeft - savedScrollPosRef.current.left);
         const dy = Math.abs(container.scrollTop - savedScrollPosRef.current.top);
         if (dx > 50 || dy > 50) {
@@ -1112,6 +1113,9 @@ function MilkdownEditor({
           // Small movement → legitimate edge-drag scroll, allow
           savedScrollPosRef.current = { left: container.scrollLeft, top: container.scrollTop };
         }
+      } else if (isPointerDown) {
+        // Horizontal mode pointer drag: save position normally
+        savedScrollPosRef.current = { left: container.scrollLeft, top: container.scrollTop };
       } else {
         // Browser auto-scroll (e.g., DOM update): revert
         isReverting = true;

--- a/main.js
+++ b/main.js
@@ -1273,7 +1273,7 @@ app.whenReady().then(async () => {
         'Content-Security-Policy': [
           [
             "default-src 'self'",
-            `script-src 'self'${isDev ? " 'unsafe-eval' 'unsafe-inline'" : ''}`,
+            `script-src 'self'${isDev && !app.isPackaged ? " 'unsafe-eval' 'unsafe-inline'" : ''}`,
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
             "img-src 'self' data: blob:",
             "font-src 'self' data: https://fonts.gstatic.com",


### PR DESCRIPTION
## Summary

- Fix scroll range bug in vertical writing mode: move horizontal padding from child element to scroll container to avoid Chromium's `scrollWidth` miscalculation in `vertical-rl`
- Fix selection jump bug: detect and revert large (>50px) browser-triggered scroll jumps during text selection, while allowing legitimate edge-drag scrolling
- Fix CSP blank screen in Electron dev mode: restore `'unsafe-inline'` in `script-src` for dev only (removed by #527)

Closes #557

## Test plan

- [ ] 縦書きモードでスクロールバーが最右端まで到達できる
- [ ] テキスト選択時にスクロールジャンプが発生しない
- [ ] ドラッグによるエッジスクロールが正常に機能する
- [ ] 横書きモードの動作に影響がない
- [ ] Electron dev モードで白屏にならない

🤖 Generated with [Claude Code](https://claude.com/claude-code)