### PR TITLE
fix: allow VFS set-root for paths outside home directory on Windows

### DIFF
--- a/electron-vfs-ipc-handlers.js
+++ b/electron-vfs-ipc-handlers.js
@@ -267,20 +267,9 @@ function registerVFSHandlers() {
       throw error;
     }
 
-    // 3. Allow if path is dialog-approved or child of a dialog-approved path
-    const isDialogApproved = [...dialogApprovedPaths.keys()].some(approved => {
-      const normalizedApproved = normalizePath(approved);
-      return normalizedResolved === normalizedApproved
-        || normalizedResolved.startsWith(normalizedApproved + '/');
-    });
-
-    // 4. Allow if path is within user's home directory (for session restore, double-click open)
-    const normalizedHome = normalizePath(os.homedir());
-    const isUnderHome = normalizedResolved.startsWith(normalizedHome + '/');
-
-    if (!isDialogApproved && !isUnderHome) {
-      throw new Error('セキュリティ上の理由により、ホームディレクトリ外のパスには直接アクセスできません');
-    }
+    // 3. Path is allowed — isDeniedPath already blocks sensitive paths,
+    //    and fs.stat above verifies the directory exists.
+    //    No additional restrictions needed for vfs:set-root.
 
     allowedRoots.set(event.sender.id, resolved);
     return { path: resolved, name: path.basename(resolved) };

--- a/lib/vfs/electron-vfs.ts
+++ b/lib/vfs/electron-vfs.ts
@@ -429,8 +429,13 @@ export class ElectronVFS implements VirtualFileSystem {
           rootPath
         );
       }
-    } catch {
-      // Bridge may not be available yet
+    } catch (error: unknown) {
+      // Bridge may not be available during early initialization — that's expected.
+      // But security/validation errors from the main process must propagate.
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes("bridge") && !message.includes("not available")) {
+        throw error;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Remove the overly restrictive `isDialogApproved`/`isUnderHome` gate in `vfs:set-root` that rejected legitimate paths (Google Drive, `D:\Projects`, external drives) after app restart — the existing `isDeniedPath` check already blocks all dangerous system paths
- Stop silently swallowing all errors in `setRootPath()` so security/validation errors from the main process propagate correctly

## Test plan

- [ ] Open a project from a non-home path (Google Drive, `D:\`, etc.) on Windows
- [ ] Close and reopen app — auto-restore should succeed
- [ ] Save files — should work without errors
- [ ] Try setting root to `C:\Windows` — should still be blocked by `isDeniedPath`
- [ ] Verify macOS still works normally (no behavioral change for under-home paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)