### PR TITLE
fix: clear pendingCloseTabId on save failure to unstick close dialog

### DIFF
--- a/lib/tab-manager/use-close-dialog.ts
+++ b/lib/tab-manager/use-close-dialog.ts
@@ -85,6 +85,7 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
       console.error("保存に失敗しました:", error);
       const message = getErrorMessage(error);
       notificationManager.error(`保存に失敗しました: ${message}`);
+      setPendingCloseTabId(null);
       return;
     }
 


### PR DESCRIPTION
## Summary
- Clear `pendingCloseTabId` in the catch block of `handleCloseTabSave()` so the close dialog is dismissed when save fails
- Previously, the dialog stayed open indefinitely after a save error, with no way for the user to retry or cancel

Closes #579

## Test plan
- [ ] Open a file, edit it, make it dirty
- [ ] Simulate save failure (e.g., make file read-only)
- [ ] Click close tab → "Save changes?" dialog appears
- [ ] Click "Save" → save fails → verify dialog is dismissed and error notification shown
- [ ] Verify user can retry closing the tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>