### PR TITLE
fix: show error notification when project main file fails to load

### DIFF
--- a/lib/editor-page/use-project-lifecycle.ts
+++ b/lib/editor-page/use-project-lifecycle.ts
@@ -252,6 +252,9 @@ export function useProjectLifecycle(params: UseProjectLifecycleParams): UseProje
         "Failed to load project main file:",
         error
       );
+      notificationManager.error(
+        "プロジェクトのメインファイルを読み込めませんでした。ファイルが移動または削除された可能性があります。"
+      );
     }
   }, [isElectron, tabLoadSystemFile, incrementEditorKey]);
 


### PR DESCRIPTION
## Summary
- Add `notificationManager.error()` when `loadProjectContent()` fails to read the project's main file
- Previously, failures were only logged to console, leaving users with an empty editor and no explanation
- This prevents potential data loss where users might save the empty content back to disk

Closes #581

## Test plan
- [ ] Create a project and save some content
- [ ] Close the application
- [ ] Rename or delete the project's main file on disk
- [ ] Reopen the application → verify error notification appears
- [ ] Verify the notification message is clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>