### PR TITLE
fix: notify user on auto-save failure instead of silent console.error

### DIFF
--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { saveMdiFile } from "../mdi-file";
 import { getVFS } from "../vfs";
 import { suppressFileWatch } from "../file-watcher";
+import { notificationManager } from "../notification-manager";
 import type { TabManagerCore } from "./types";
 import { AUTO_SAVE_INTERVAL, sanitizeMdiContent } from "./types";
 
@@ -121,6 +122,9 @@ export function useAutoSave(params: UseAutoSaveParams): void {
             console.error(
               `自動保存に失敗しました (${tab.file?.name}):`,
               error,
+            );
+            notificationManager.warning(
+              `自動保存に失敗しました: ${tab.file?.name ?? "不明なファイル"}`
             );
           } finally {
             savingTabIdsRef.current.delete(tab.id);


### PR DESCRIPTION
## Summary
- Add `notificationManager.warning()` call when auto-save fails for non-active tabs
- Previously, failures were only logged to console, leaving users unaware their changes weren't being saved

Closes #580

## Test plan
- [ ] Open multiple files in project mode with auto-save enabled
- [ ] Edit content in several tabs to make them dirty
- [ ] Switch to a different tab so edited tabs become inactive
- [ ] Simulate a write failure (e.g., change file permissions to read-only)
- [ ] Wait for auto-save interval (30s) → verify a warning notification appears
- [ ] Verify the notification mentions the affected file name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>