### PR TITLE
fix: show error notification when project file fails to open

### DIFF
--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -410,6 +410,9 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           fileContent = await vfs.readFile(vfsPath);
         } catch (error) {
           console.error("ファイルの読み込みに失敗しました:", error);
+          notificationManager.error(
+            `ファイルを開けませんでした: ${vfsPath.split("/").pop() || vfsPath}`
+          );
           return;
         }
 


### PR DESCRIPTION
## Summary
- Add `notificationManager.error()` when `openProjectFile()` fails to read a file from VFS
- Previously, clicking a deleted/moved file in the project explorer produced no feedback at all
- Now users see a clear error notification with the file name

Closes #582

## Test plan
- [ ] Open a project with multiple files
- [ ] While the editor is open, delete or rename a project file externally
- [ ] Click the deleted file in the project explorer panel
- [ ] Verify an error notification appears with the file name
- [ ] Verify no tab is created for the failed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>