### PR TITLE
fix: add .catch() handler for LLM disposal in before-quit event

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1329,10 +1329,12 @@ app.on('before-quit', (event) => {
   isQuitting = true
   event.preventDefault()
   const forceQuitTimeout = setTimeout(() => app.exit(0), 5000)
-  disposeLlmEngine().finally(() => {
-    clearTimeout(forceQuitTimeout)
-    app.exit(0)
-  })
+  disposeLlmEngine()
+    .catch((err) => console.error('[before-quit] LLM disposal error:', err))
+    .finally(() => {
+      clearTimeout(forceQuitTimeout)
+      app.exit(0)
+    })
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Summary
- Adds `.catch()` handler before `.finally()` in the `before-quit` event's `disposeLlmEngine()` call
- Prevents unhandled promise rejection from crashing the Electron main process when LLM teardown fails

## Root Cause
`disposeLlmEngine().finally(...)` had no `.catch()` handler. If `disposeLlmEngine()` rejected, the rejection propagated as an unhandled promise rejection, which can terminate the Electron main process in Node 18+.

## Changes
- `electron/main.js`: Added `.catch((err) => console.error(...))` before `.finally()`

## Testing
- Verified the fix is syntactically correct and follows the existing error-handling patterns in the codebase

Closes Iktahana/illusions#607

🤖 Generated with [Claude Code](https://claude.com/claude-code)