### PR TITLE
fix: add isDestroyed() guard to second-instance handler

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -46,7 +46,7 @@ if (!gotTheLock) {
 } else {
   app.on('second-instance', (_event, commandLine) => {
     // Focus existing window
-    if (mainWindow) {
+    if (mainWindow && !mainWindow.isDestroyed()) {
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.focus()
     }


### PR DESCRIPTION
## Summary
Add `!mainWindow.isDestroyed()` guard in the `second-instance` event handler to prevent calling methods on a destroyed `BrowserWindow`.

## Root Cause
The `second-instance` handler only checked `if (mainWindow)` (null check) but did not verify the window was still alive. Calling `.isMinimized()`, `.restore()`, or `.focus()` on a destroyed window throws `Error: Object has been destroyed`, crashing the main process.

## Changes
- Added `!mainWindow.isDestroyed()` check to the existing null guard in `electron/main.js` line 49

## Testing
- Verified the pattern is consistent with other isDestroyed() guards in the same codebase (e.g., line 85)
- Change is minimal and syntactically correct

Closes Iktahana/illusions#608