### PR TITLE
fix: correct early-exit in pruneSnapshotsPerFileUnsafe

### DIFF
--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -443,7 +443,8 @@ export class HistoryService {
         (s) => s.sourceFile === sourceFile
       );
 
-      if (fileSnapshots.length <= MAX_SNAPSHOTS_PER_FILE) {
+      const autoCount = fileSnapshots.filter((s) => s.type === "auto").length;
+      if (autoCount <= MAX_SNAPSHOTS_PER_FILE) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- Fixes logical inconsistency in `pruneSnapshotsPerFileUnsafe()` where the early-exit condition counted all snapshot types but the deletion loop only prunes auto snapshots
- Prevents unnecessary pruning overhead on files with many milestone/manual snapshots

## Root Cause
The early-exit checked `fileSnapshots.length <= MAX_SNAPSHOTS_PER_FILE` counting all types (auto + manual + milestone), but the deletion loop skips milestone and manual snapshots. A file with 110 milestones and 0 auto snapshots would enter the full pruning path unnecessarily.

## Changes
- `lib/services/history-service.ts`: Changed early-exit to count only auto snapshots: `fileSnapshots.filter((s) => s.type === "auto").length`

## Testing
- The fix is a targeted one-line change that aligns the early-exit condition with the deletion loop's behavior

Closes Iktahana/illusions#610

🤖 Generated with [Claude Code](https://claude.com/claude-code)