### PR TITLE
fix: HTML-encode sanitized href to prevent attribute injection

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -950,7 +950,8 @@ function inlineFormat(text: string): string {
     (_match: string, linkText: string, url: string) => {
       const safeUrl = sanitizeHref(url);
       if (safeUrl) {
-        return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-hover underline">${linkText}</a>`;
+        const escapedUrl = safeUrl.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
+        return `<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-hover underline">${linkText}</a>`;
       }
       // Unsafe URL — render as plain text without a link
       return linkText;


### PR DESCRIPTION
## Summary
HTML-encode the sanitized URL before injecting it into the `href` attribute in `inlineFormat()` to prevent attribute breakout via unescaped quote characters.

## Root Cause
`sanitizeHref()` validates URL protocols but returns the raw URL string. When injected into `href="..."`, a URL containing `"` can break out of the attribute context, enabling event handler injection (XSS). For example: `[click](" onclick="alert(1))` would produce `<a href="" onclick="alert(1)" ...>`.

## Changes
- Added HTML entity encoding (`&` → `&amp;`, `"` → `&quot;`, `'` → `&#x27;`) to the sanitized URL before template literal injection in `components/SettingsModal.tsx`

## Testing
- Verified that URLs with quotes are now safely encoded
- Normal URLs (http/https/mailto) are unaffected by the encoding
- The fix addresses OWASP A03:2021 (Injection)

Closes Iktahana/illusions#609