### PR TITLE
fix: correct msstore-cli asset filename

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -379,7 +379,7 @@ jobs:
         env:
           MSSTORE_CLI_VERSION: "v0.3.9"
         run: |
-          $url = "https://github.com/microsoft/msstore-cli/releases/download/$env:MSSTORE_CLI_VERSION/msstore-win-x64.zip"
+          $url = "https://github.com/microsoft/msstore-cli/releases/download/$env:MSSTORE_CLI_VERSION/MSStoreCLI-win-x64.zip"
           Invoke-WebRequest $url -OutFile msstore.zip
           Expand-Archive msstore.zip -DestinationPath "$env:LOCALAPPDATA\msstore-cli" -Force
           echo "$env:LOCALAPPDATA\msstore-cli" >> $env:GITHUB_PATH


### PR DESCRIPTION
## Summary
- `msstore-win-x64.zip` → `MSStoreCLI-win-x64.zip` に修正
- v0.3.9 の実際のリリースアセット名と一致させる

Fixes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)