### PR TITLE
fix: use msstore reconfigure instead of configure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -392,7 +392,7 @@ jobs:
           MSSTORE_CLIENT_SECRET: ${{ secrets.MSSTORE_CLIENT_SECRET }}
           MSSTORE_SELLER_ID: ${{ secrets.MSSTORE_SELLER_ID }}
         run: |
-          msstore configure `
+          msstore reconfigure `
             --tenantId $env:MSSTORE_TENANT_ID `
             --clientId $env:MSSTORE_CLIENT_ID `
             --clientSecret $env:MSSTORE_CLIENT_SECRET `


### PR DESCRIPTION
## Summary
- `msstore configure` does not exist as a subcommand — the CLI only provides `reconfigure`
- This caused the "Publish to Microsoft Store" CI job to fail with exit code 1

## Test plan
- [ ] Verify the "Publish to Microsoft Store" job runs without the unrecognized command error

🤖 Generated with [Claude Code](https://claude.com/claude-code)