### PR TITLE
style: apply snow-country monochrome theme to app and www

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -541,7 +541,7 @@ input[type="range"]::-webkit-slider-thumb {
 
 input[type="range"]::-webkit-slider-thumb:hover {
   transform: scale(1.15);
-  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 0 0 3px rgb(var(--accent) / 0.2);
 }
 
 input[type="range"]::-webkit-slider-thumb:active {
@@ -571,7 +571,7 @@ input[type="range"]::-moz-range-thumb {
 
 input[type="range"]::-moz-range-thumb:hover {
   transform: scale(1.15);
-  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 0 0 3px rgb(var(--accent) / 0.2);
 }
 
 input[type="range"]::-moz-range-thumb:active {

--- a/www/src/style.css
+++ b/www/src/style.css
@@ -227,15 +227,21 @@ h1 {
   display: grid;
   grid-template-rows: subgrid;
   grid-row: span 3;
-  background: var(--color-surface);
+  /* Fallback for browsers without backdrop-filter: use opaque background */
+  background: rgba(12, 12, 12, 0.82);
   border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 1.75rem;
   color: var(--color-text);
   transition: border-color 0.2s ease, background 0.2s ease;
-  /* Subtle glass effect — frosted winter air */
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .feature-card {
+    background: var(--color-surface);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
 }
 
 .feature-card:hover {
@@ -266,15 +272,22 @@ h1 {
 
 .policy-content {
   text-align: left;
-  background: var(--color-surface);
+  /* Fallback for browsers without backdrop-filter */
+  background: rgba(12, 12, 12, 0.82);
   border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 2.5rem;
   max-width: 800px;
   margin: 0 auto;
   line-height: 1.8;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .policy-content {
+    background: var(--color-surface);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
 }
 
 .policy-content h2 {
@@ -492,13 +505,20 @@ h1 {
 }
 
 .platform-card {
-  background: var(--color-surface);
+  /* Fallback for browsers without backdrop-filter */
+  background: rgba(12, 12, 12, 0.82);
   border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 1.5rem;
   transition: border-color 0.2s ease, background 0.2s ease;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+}
+
+@supports (backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px)) {
+  .platform-card {
+    background: var(--color-surface);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+  }
 }
 
 .platform-card:hover {


### PR DESCRIPTION
## Summary

Replaces the warm amber-sepia palette with a pure black-and-white snow-country (雪國) aesthetic across the main app and landing page.

### Main app (`app/globals.css`)
- **Dark mode**: `#080808` background → `#f2f2f2` text → white accent — no warm tints
- **Light mode**: `#fcfcfc` background → `#0c0c0c` text → near-black accent
- Removed all copper/amber color values from surface, border, and interactive states
- Translated Chinese-language CSS comments to English (range input section)

### Landing page (`www/src/style.css`)
- Reduced `body::before` overlay opacity (top: 0.88 → 0.62) so `yukiguni.jpg` shows through
- Replaced blue-gray tinted `rgba(196,200,208,...)` borders with pure `rgba(255,255,255,...)`
- Added `backdrop-filter: blur(8px)` to feature cards, platform cards, and policy page container for frosted-glass effect
- Removed warm brown tints from all surface colors

## Test plan
- [ ] Open app in dark mode — verify pure black background, white text, no amber tints
- [ ] Open app in light mode — verify pure white background, black text, no beige tints
- [ ] Open landing page — verify `yukiguni.jpg` is visible through overlay
- [ ] Verify feature cards, platform cards, and policy page container have frosted-glass appearance on landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)