### PR TITLE
fix: await load handlers so catch block captures IPC errors

### DIFF
--- a/electron/storage-ipc-handlers.js
+++ b/electron/storage-ipc-handlers.js
@@ -32,7 +32,7 @@ function registerStorageHandlers() {
   // セッション読み込み
   ipcMain.handle('storage:load-session', async () => {
     try {
-      return manager.loadSession();
+      return await manager.loadSession();
     } catch (error) {
       console.error('[Storage IPC] loadSession failed:', error);
       throw error;
@@ -52,7 +52,7 @@ function registerStorageHandlers() {
   // AppState 読み込み
   ipcMain.handle('storage:load-app-state', async () => {
     try {
-      return manager.loadAppState();
+      return await manager.loadAppState();
     } catch (error) {
       console.error('[Storage IPC] loadAppState failed:', error);
       throw error;


### PR DESCRIPTION
## Summary
Add `await` to `loadSession()` and `loadAppState()` calls in the Electron storage IPC handlers for consistency and forward-compatibility.

## Background
Issue #698 identified these two handlers as missing `await`. While both `ElectronStorageManager.loadSession()` and `loadAppState()` are currently **synchronous** (using better-sqlite3's synchronous API), adding `await` is correct defensive practice:

- Consistent with all other IPC handlers in this file (all other calls use `await`)
- Forward-compatible if either method is later changed to return a Promise
- For truly synchronous methods, `await` is a no-op — no behavioral change on the happy path

**Note:** `loadSession()` already catches and logs its own errors internally (returns `null` on failure). `loadAppState()` does not catch internally, so any sqlite errors from it would propagate to the IPC handler's `catch` block regardless of `await` (since synchronous throws are captured by the outer `async` function). The net behavioral impact of this PR is therefore limited to code consistency.

## Changes
- `electron/storage-ipc-handlers.js:35` — `return manager.loadSession()` → `return await manager.loadSession()`
- `electron/storage-ipc-handlers.js:55` — `return manager.loadAppState()` → `return await manager.loadAppState()`

## Testing
- No behavioral change on the happy path
- Consistent await usage across all IPC handlers

Closes #698