### PR TITLE
fix: improve filter button visibility in dark mode

### DIFF
--- a/components/inspector/CorrectionsPanel.tsx
+++ b/components/inspector/CorrectionsPanel.tsx
@@ -642,7 +642,7 @@ export default function CorrectionsPanel({
               "flex-1 flex items-center justify-center px-2 py-1.5 rounded transition-colors",
               severityFilter === option.value
                 ? "bg-accent text-white"
-                : "bg-background-secondary text-foreground-tertiary hover:text-foreground-secondary border border-border"
+                : "bg-background-tertiary text-foreground-secondary hover:text-foreground border border-border-secondary"
             )}
           >
             {option.icon}


### PR DESCRIPTION
## 問題
校正パネルの絞り込みボタン（×・⚠・ℹ）が背景と区別できない。

## 原因
| token | 深色値 | 備考 |
|-------|--------|------|
| `background` | `#080808` | パネル背景 |
| `background-secondary`（修正前の按鈕背景）| `#121212` | 差が10しかなく視認不可 |
| `border` | `#2D2D2D` | ほぼ見えない枠線 |
| `foreground-tertiary`（图标）| `rgb(150,150,150)` | 暗すぎ |

## 修正内容
`components/inspector/CorrectionsPanel.tsx:645` の未選択ボタンのクラスを変更：

| 変更前 | 変更後 |
|--------|--------|
| `bg-background-secondary` | `bg-background-tertiary` (#1E1E1E) |
| `border-border` | `border-border-secondary` (#3C3C3C) |
| `text-foreground-tertiary` | `text-foreground-secondary` (rgb 200) |
| `hover:text-foreground-secondary` | `hover:text-foreground` |

選択中ボタン（`bg-accent text-white`）は変更なし。

## テスト
- TypeScript check: pass（エラーなし）
- 変更はTailwindクラス1行のみ、ロジック変更なし