### PR TITLE
feat(ci): stop creating prerelease on dev branch pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -463,6 +463,7 @@ jobs:
     name: Create GitHub Release
     if: |
       github.event_name != 'pull_request' &&
+      github.ref != 'refs/heads/dev' &&
       needs.detect-changes.outputs.desktop_changed == 'true'
     needs: [detect-changes, compute-version, build-macos, package-windows-nsis, package-windows-msix]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add `github.ref != 'refs/heads/dev'` guard to the `release` job in `build.yml`
- Pushes to `dev` will still run type-check + build jobs, but will NOT create GitHub Releases

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merging, push a test commit to `dev` and confirm no Release is created
- [ ] Confirm merging to `main` still creates a Release

## Notes
⚠️ **Merge this PR BEFORE creating the `dev` remote branch**, to avoid accidentally triggering prerelease builds.

Closes #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)