### PR TITLE
fix: migrate standalone localStorage to StorageService KV store (#701)

### DIFF
--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -89,7 +89,7 @@ export default function Dictionary({ content, initialSearchTerm, searchTriggerId
         const entries = await dictService.loadEntries();
         setUserEntries(entries);
       } else if (editorMode && isStandaloneMode(editorMode)) {
-        const entries = dictService.loadEntriesStandalone(editorMode.fileName);
+        const entries = await dictService.loadEntriesStandalone(editorMode.fileName);
         setUserEntries(entries);
       }
     } catch {
@@ -102,7 +102,7 @@ export default function Dictionary({ content, initialSearchTerm, searchTriggerId
       if (editorMode && isProjectMode(editorMode)) {
         await dictService.saveEntries(entries);
       } else if (editorMode && isStandaloneMode(editorMode)) {
-        dictService.saveEntriesStandalone(editorMode.fileName, entries);
+        await dictService.saveEntriesStandalone(editorMode.fileName, entries);
       }
     } catch {
       // Silently fail

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -178,6 +178,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     addRecentProject: (project) => ipcRenderer.invoke('storage:add-recent-project', project),
     getRecentProjects: () => ipcRenderer.invoke('storage:get-recent-projects'),
     removeRecentProject: (projectId) => ipcRenderer.invoke('storage:remove-recent-project', projectId),
+    setItem: (key, value) => ipcRenderer.invoke('storage:set-item', key, value),
+    getItem: (key) => ipcRenderer.invoke('storage:get-item', key),
+    removeItem: (key) => ipcRenderer.invoke('storage:remove-item', key),
   },
   vfs: {
     openDirectory: () => ipcRenderer.invoke('vfs:open-directory'),

--- a/electron/storage-ipc-handlers.js
+++ b/electron/storage-ipc-handlers.js
@@ -169,6 +169,36 @@ function registerStorageHandlers() {
     }
   });
 
+  // KV Store: set
+  ipcMain.handle('storage:set-item', async (_event, key, value) => {
+    try {
+      manager.setItem(key, value);
+    } catch (error) {
+      console.error('[Storage IPC] setItem failed:', error);
+      throw error;
+    }
+  });
+
+  // KV Store: get
+  ipcMain.handle('storage:get-item', async (_event, key) => {
+    try {
+      return manager.getItem(key);
+    } catch (error) {
+      console.error('[Storage IPC] getItem failed:', error);
+      throw error;
+    }
+  });
+
+  // KV Store: remove
+  ipcMain.handle('storage:remove-item', async (_event, key) => {
+    try {
+      manager.removeItem(key);
+    } catch (error) {
+      console.error('[Storage IPC] removeItem failed:', error);
+      throw error;
+    }
+  });
+
 }
 
 module.exports = { registerStorageHandlers, getStorageManager };

--- a/lib/editor-page/use-ignored-corrections.ts
+++ b/lib/editor-page/use-ignored-corrections.ts
@@ -1,6 +1,6 @@
 /**
  * React hook for managing ignored corrections.
- * Loads from VFS (project mode) or localStorage (standalone mode),
+ * Loads from VFS (project mode) or StorageService (standalone mode),
  * and provides methods to add/remove/check ignored corrections.
  *
  * 無視された校正指摘を管理するReactフック。
@@ -68,9 +68,15 @@ export function useIgnoredCorrections(
           if (!cancelled) setIgnoredCorrections([]);
         });
     } else if (isStandaloneMode(editorMode)) {
-      setIgnoredCorrections(
-        service.loadIgnoredCorrectionsStandalone(editorMode.fileName),
-      );
+      service
+        .loadIgnoredCorrectionsStandalone(editorMode.fileName)
+        .then((data) => {
+          if (!cancelled) setIgnoredCorrections(data);
+        })
+        .catch((err) => {
+          console.warn("[useIgnoredCorrections] Failed to load standalone:", err);
+          if (!cancelled) setIgnoredCorrections([]);
+        });
     }
 
     return () => {
@@ -104,13 +110,25 @@ export function useIgnoredCorrections(
             console.error("[useIgnoredCorrections] Failed to add:", err),
           );
       } else if (editorMode && isStandaloneMode(editorMode)) {
-        const updated = service.addIgnoredCorrectionStandalone(
-          editorMode.fileName,
-          ruleId,
-          text,
-          context,
-        );
-        setIgnoredCorrections(updated);
+        // Optimistic update for standalone mode too
+        setIgnoredCorrections((prev) => {
+          const already = prev.some(
+            (c) => c.ruleId === ruleId && c.text === text && c.context === context,
+          );
+          if (already) return prev;
+          return [...prev, { ruleId, text, context, addedAt: Date.now() }];
+        });
+        service
+          .addIgnoredCorrectionStandalone(
+            editorMode.fileName,
+            ruleId,
+            text,
+            context,
+          )
+          .then(setIgnoredCorrections)
+          .catch((err) =>
+            console.error("[useIgnoredCorrections] Failed to add standalone:", err),
+          );
       }
     },
     [editorMode],
@@ -128,13 +146,17 @@ export function useIgnoredCorrections(
             console.error("[useIgnoredCorrections] Failed to remove:", err),
           );
       } else if (editorMode && isStandaloneMode(editorMode)) {
-        const updated = service.removeIgnoredCorrectionStandalone(
-          editorMode.fileName,
-          ruleId,
-          text,
-          context,
-        );
-        setIgnoredCorrections(updated);
+        service
+          .removeIgnoredCorrectionStandalone(
+            editorMode.fileName,
+            ruleId,
+            text,
+            context,
+          )
+          .then(setIgnoredCorrections)
+          .catch((err) =>
+            console.error("[useIgnoredCorrections] Failed to remove standalone:", err),
+          );
       }
     },
     [editorMode],

--- a/lib/services/ignored-corrections-service.ts
+++ b/lib/services/ignored-corrections-service.ts
@@ -1,15 +1,17 @@
 /**
  * Ignored corrections service.
  * CRUD operations for .illusions/ignored-corrections.json (project mode)
- * and localStorage (standalone mode).
+ * and StorageService key-value store (standalone mode).
  *
  * 無視された校正指摘の管理サービス。
  * プロジェクトモード: .illusions/ignored-corrections.json
- * スタンドアロンモード: localStorage
+ * スタンドアロンモード: StorageService (IndexedDB / SQLite)
  */
 
 import { getVFS } from "../vfs";
+import { getStorageService } from "../storage/storage-service";
 import type { VirtualFileSystem } from "../vfs/types";
+import type { IStorageService } from "../storage/storage-types";
 import type { IgnoredCorrection, IgnoredCorrectionsFile } from "../project/project-types";
 
 // -----------------------------------------------------------------------
@@ -25,9 +27,11 @@ const STANDALONE_STORAGE_PREFIX = "illusions-ignored-corrections:";
 
 class IgnoredCorrectionsService {
   private vfs: VirtualFileSystem;
+  private storage: IStorageService;
 
   constructor() {
     this.vfs = getVFS();
+    this.storage = getStorageService();
   }
 
   // -------------------------------------------------------------------
@@ -109,17 +113,16 @@ class IgnoredCorrectionsService {
   }
 
   // -------------------------------------------------------------------
-  // Standalone mode (localStorage)
+  // Standalone mode (StorageService key-value store)
   // -------------------------------------------------------------------
 
   /**
-   * Load ignored corrections from localStorage for a specific file.
+   * Load ignored corrections from StorageService for a specific file.
    */
-  loadIgnoredCorrectionsStandalone(fileName: string): IgnoredCorrection[] {
-    if (typeof window === "undefined") return [];
+  async loadIgnoredCorrectionsStandalone(fileName: string): Promise<IgnoredCorrection[]> {
     try {
       const key = STANDALONE_STORAGE_PREFIX + fileName;
-      const raw = localStorage.getItem(key);
+      const raw = await this.storage.getItem(key);
       if (!raw) return [];
       const data: IgnoredCorrectionsFile = JSON.parse(raw);
       return data.ignoredCorrections ?? [];
@@ -129,31 +132,30 @@ class IgnoredCorrectionsService {
   }
 
   /**
-   * Save ignored corrections to localStorage for a specific file.
+   * Save ignored corrections to StorageService for a specific file.
    */
-  saveIgnoredCorrectionsStandalone(
+  async saveIgnoredCorrectionsStandalone(
     fileName: string,
     corrections: IgnoredCorrection[],
-  ): void {
-    if (typeof window === "undefined") return;
+  ): Promise<void> {
     const key = STANDALONE_STORAGE_PREFIX + fileName;
     const data: IgnoredCorrectionsFile = {
       version: "1.0.0",
       ignoredCorrections: corrections,
     };
-    localStorage.setItem(key, JSON.stringify(data));
+    await this.storage.setItem(key, JSON.stringify(data));
   }
 
   /**
    * Add an ignored correction in standalone mode.
    */
-  addIgnoredCorrectionStandalone(
+  async addIgnoredCorrectionStandalone(
     fileName: string,
     ruleId: string,
     text: string,
     context?: string,
-  ): IgnoredCorrection[] {
-    const corrections = this.loadIgnoredCorrectionsStandalone(fileName);
+  ): Promise<IgnoredCorrection[]> {
+    const corrections = await this.loadIgnoredCorrectionsStandalone(fileName);
     const exists = corrections.some(
       (c) => c.ruleId === ruleId && c.text === text && c.context === context,
     );
@@ -166,24 +168,24 @@ class IgnoredCorrectionsService {
       ...(context !== undefined ? { context } : {}),
     };
     corrections.push(entry);
-    this.saveIgnoredCorrectionsStandalone(fileName, corrections);
+    await this.saveIgnoredCorrectionsStandalone(fileName, corrections);
     return corrections;
   }
 
   /**
    * Remove an ignored correction in standalone mode.
    */
-  removeIgnoredCorrectionStandalone(
+  async removeIgnoredCorrectionStandalone(
     fileName: string,
     ruleId: string,
     text: string,
     context?: string,
-  ): IgnoredCorrection[] {
-    const corrections = this.loadIgnoredCorrectionsStandalone(fileName);
+  ): Promise<IgnoredCorrection[]> {
+    const corrections = await this.loadIgnoredCorrectionsStandalone(fileName);
     const filtered = corrections.filter(
       (c) => !(c.ruleId === ruleId && c.text === text && c.context === context),
     );
-    this.saveIgnoredCorrectionsStandalone(fileName, filtered);
+    await this.saveIgnoredCorrectionsStandalone(fileName, filtered);
     return filtered;
   }
 }

--- a/lib/services/user-dictionary-service.ts
+++ b/lib/services/user-dictionary-service.ts
@@ -1,15 +1,17 @@
 /**
  * User dictionary service.
  * CRUD operations for .illusions/user-dictionary.json (project mode)
- * and localStorage (standalone mode).
+ * and StorageService key-value store (standalone mode).
  *
  * ユーザー辞書の管理サービス。
  * プロジェクトモード: .illusions/user-dictionary.json
- * スタンドアロンモード: localStorage
+ * スタンドアロンモード: StorageService (IndexedDB / SQLite)
  */
 
 import { getVFS } from "../vfs";
+import { getStorageService } from "../storage/storage-service";
 import type { VirtualFileSystem } from "../vfs/types";
+import type { IStorageService } from "../storage/storage-types";
 import type { UserDictionaryEntry, UserDictionaryFile } from "../project/project-types";
 
 // -----------------------------------------------------------------------
@@ -25,9 +27,11 @@ const STANDALONE_STORAGE_PREFIX = "illusions-user-dictionary:";
 
 class UserDictionaryService {
   private vfs: VirtualFileSystem;
+  private storage: IStorageService;
 
   constructor() {
     this.vfs = getVFS();
+    this.storage = getStorageService();
   }
 
   // -------------------------------------------------------------------
@@ -107,17 +111,16 @@ class UserDictionaryService {
   }
 
   // -------------------------------------------------------------------
-  // Standalone mode (localStorage)
+  // Standalone mode (StorageService key-value store)
   // -------------------------------------------------------------------
 
   /**
-   * Load user dictionary entries from localStorage for a specific file.
+   * Load user dictionary entries from StorageService for a specific file.
    */
-  loadEntriesStandalone(fileName: string): UserDictionaryEntry[] {
-    if (typeof window === "undefined") return [];
+  async loadEntriesStandalone(fileName: string): Promise<UserDictionaryEntry[]> {
     try {
       const key = STANDALONE_STORAGE_PREFIX + fileName;
-      const raw = localStorage.getItem(key);
+      const raw = await this.storage.getItem(key);
       if (!raw) return [];
       const data: UserDictionaryFile = JSON.parse(raw);
       return data.entries ?? [];
@@ -127,64 +130,63 @@ class UserDictionaryService {
   }
 
   /**
-   * Save user dictionary entries to localStorage for a specific file.
+   * Save user dictionary entries to StorageService for a specific file.
    */
-  saveEntriesStandalone(
+  async saveEntriesStandalone(
     fileName: string,
     entries: UserDictionaryEntry[],
-  ): void {
-    if (typeof window === "undefined") return;
+  ): Promise<void> {
     const key = STANDALONE_STORAGE_PREFIX + fileName;
     const data: UserDictionaryFile = {
       version: "1.0.0",
       entries,
     };
-    localStorage.setItem(key, JSON.stringify(data));
+    await this.storage.setItem(key, JSON.stringify(data));
   }
 
   /**
    * Add an entry in standalone mode.
    */
-  addEntryStandalone(
+  async addEntryStandalone(
     fileName: string,
     entry: UserDictionaryEntry,
-  ): UserDictionaryEntry[] {
-    const entries = this.loadEntriesStandalone(fileName);
+  ): Promise<UserDictionaryEntry[]> {
+    const entries = await this.loadEntriesStandalone(fileName);
     const exists = entries.some((e) => e.id === entry.id);
     if (exists) return entries;
 
     entries.push(entry);
     entries.sort((a, b) => a.word.localeCompare(b.word));
-    this.saveEntriesStandalone(fileName, entries);
+    await this.saveEntriesStandalone(fileName, entries);
     return entries;
   }
 
   /**
    * Update an entry in standalone mode.
    */
-  updateEntryStandalone(
+  async updateEntryStandalone(
     fileName: string,
     id: string,
     updates: Partial<UserDictionaryEntry>,
-  ): UserDictionaryEntry[] {
-    const entries = this.loadEntriesStandalone(fileName);
+  ): Promise<UserDictionaryEntry[]> {
+    const entries = await this.loadEntriesStandalone(fileName);
     const updated = entries.map((e) =>
       e.id === id ? { ...e, ...updates } : e,
     );
-    this.saveEntriesStandalone(fileName, updated);
+    await this.saveEntriesStandalone(fileName, updated);
     return updated;
   }
 
   /**
    * Remove an entry in standalone mode.
    */
-  removeEntryStandalone(
+  async removeEntryStandalone(
     fileName: string,
     id: string,
-  ): UserDictionaryEntry[] {
-    const entries = this.loadEntriesStandalone(fileName);
+  ): Promise<UserDictionaryEntry[]> {
+    const entries = await this.loadEntriesStandalone(fileName);
     const filtered = entries.filter((e) => e.id !== id);
-    this.saveEntriesStandalone(fileName, filtered);
+    await this.saveEntriesStandalone(fileName, filtered);
     return filtered;
   }
 }

--- a/lib/storage/electron-storage-manager.ts
+++ b/lib/storage/electron-storage-manager.ts
@@ -92,6 +92,12 @@ export class ElectronStorageManager {
         data TEXT NOT NULL,
         updated_at INTEGER NOT NULL
       );
+
+      CREATE TABLE IF NOT EXISTS kv_store (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
     `);
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -392,6 +398,32 @@ export class ElectronStorageManager {
     stmt.run(projectId);
   }
 
+  // -------------------------------------------------------------------
+  // Generic key-value store
+  // -------------------------------------------------------------------
+
+  setItem(key: string, value: string): void {
+    const db = this.ensureInitialized();
+    const stmt = db.prepare(`
+      INSERT OR REPLACE INTO kv_store (key, value, updated_at)
+      VALUES (?, ?, ?)
+    `);
+    stmt.run(key, value, Date.now());
+  }
+
+  getItem(key: string): string | null {
+    const db = this.ensureInitialized();
+    const stmt = db.prepare("SELECT value FROM kv_store WHERE key = ?");
+    const row = stmt.get(key) as { value: string } | undefined;
+    return row?.value ?? null;
+  }
+
+  removeItem(key: string): void {
+    const db = this.ensureInitialized();
+    const stmt = db.prepare("DELETE FROM kv_store WHERE key = ?");
+    stmt.run(key);
+  }
+
   /**
    * すべてのデータを削除する
    */
@@ -402,6 +434,7 @@ export class ElectronStorageManager {
       DELETE FROM recent_files;
       DELETE FROM editor_buffer;
       DELETE FROM recent_projects;
+      DELETE FROM kv_store;
     `);
   }
 

--- a/lib/storage/electron-storage.ts
+++ b/lib/storage/electron-storage.ts
@@ -42,6 +42,9 @@ export class ElectronStorageProvider implements IStorageService {
       addRecentProject: (project: RecentProject) => Promise<void>;
       getRecentProjects: () => Promise<RecentProject[]>;
       removeRecentProject: (projectId: string) => Promise<void>;
+      setItem: (key: string, value: string) => Promise<void>;
+      getItem: (key: string) => Promise<string | null>;
+      removeItem: (key: string) => Promise<void>;
     };
   }
 
@@ -133,6 +136,24 @@ export class ElectronStorageProvider implements IStorageService {
     await this.initialize();
     const api = this.getElectronAPI();
     return api.removeRecentProject(projectId);
+  }
+
+  async setItem(key: string, value: string): Promise<void> {
+    await this.initialize();
+    const api = this.getElectronAPI();
+    return api.setItem(key, value);
+  }
+
+  async getItem(key: string): Promise<string | null> {
+    await this.initialize();
+    const api = this.getElectronAPI();
+    return api.getItem(key);
+  }
+
+  async removeItem(key: string): Promise<void> {
+    await this.initialize();
+    const api = this.getElectronAPI();
+    return api.removeItem(key);
   }
 }
 

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -233,6 +233,26 @@ export interface IStorageService {
    */
   removeRecentProject(projectId: string): Promise<void>;
 
+  // -------------------------------------------------------------------
+  // Generic key-value store (standalone mode data, etc.)
+  // -------------------------------------------------------------------
+
+  /**
+   * Store a value by key. Replaces any existing value for the same key.
+   * スタンドアロンモードのデータなど、汎用キーバリューストア。
+   */
+  setItem(key: string, value: string): Promise<void>;
+
+  /**
+   * Retrieve a value by key. Returns null if the key does not exist.
+   */
+  getItem(key: string): Promise<string | null>;
+
+  /**
+   * Remove a value by key.
+   */
+  removeItem(key: string): Promise<void>;
+
   /**
    * すべてのデータを削除する。取り扱い注意。
    */

--- a/lib/storage/web-storage.ts
+++ b/lib/storage/web-storage.ts
@@ -32,6 +32,11 @@ interface StoredEditorBuffer {
   fileHandle?: FileSystemFileHandle; // シリアライズ性のため、ハンドルは別フィールドで保持
 }
 
+interface StoredKvItem {
+  key: string;
+  value: string;
+}
+
 /**
  * Stored project handle for directory-based project persistence.
  * FileSystemDirectoryHandle is stored via Structured Clone Algorithm in IndexedDB.
@@ -53,6 +58,7 @@ class WebStorageDatabase extends Dexie {
   recentFiles!: Table<StoredRecentFile, string>;
   editorBuffer!: Table<StoredEditorBuffer, string>;
   projectHandles!: Table<StoredProjectHandle, string>;
+  kvStore!: Table<StoredKvItem, string>;
 
   constructor() {
     super("illusionsStorage");
@@ -70,6 +76,15 @@ class WebStorageDatabase extends Dexie {
       recentFiles: "id, path",
       editorBuffer: "id",
       projectHandles: "projectId, lastAccessedAt",
+    });
+
+    // v3: Add generic key-value store for standalone mode data
+    this.version(3).stores({
+      appState: "id",
+      recentFiles: "id, path",
+      editorBuffer: "id",
+      projectHandles: "projectId, lastAccessedAt",
+      kvStore: "key",
     });
   }
 }
@@ -336,6 +351,22 @@ export class WebStorageProvider implements IStorageService {
     // Web uses ProjectManager for directory handle persistence, not this API.
   }
 
+  async setItem(key: string, value: string): Promise<void> {
+    await this.initialize();
+    await this.db.kvStore.put({ key, value });
+  }
+
+  async getItem(key: string): Promise<string | null> {
+    await this.initialize();
+    const item = await this.db.kvStore.get(key);
+    return item?.value ?? null;
+  }
+
+  async removeItem(key: string): Promise<void> {
+    await this.initialize();
+    await this.db.kvStore.delete(key);
+  }
+
   async clearAll(): Promise<void> {
     await this.initialize();
 
@@ -345,6 +376,7 @@ export class WebStorageProvider implements IStorageService {
         this.db.recentFiles.clear(),
         this.db.editorBuffer.clear(),
         this.db.projectHandles.clear(),
+        this.db.kvStore.clear(),
       ]);
     } catch (error) {
       console.error("ストレージの全削除に失敗しました:", error);

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -110,6 +110,9 @@ declare global {
       addRecentProject: (project: { id: string; rootPath: string; name: string }) => Promise<void>;
       getRecentProjects: () => Promise<Array<{ id: string; rootPath: string; name: string }>>;
       removeRecentProject: (projectId: string) => Promise<void>;
+      setItem: (key: string, value: string) => Promise<void>;
+      getItem: (key: string) => Promise<string | null>;
+      removeItem: (key: string) => Promise<void>;
     };
     nlp?: {
       /**


### PR DESCRIPTION
## Summary

- Adds generic key-value store (`setItem`/`getItem`/`removeItem`) to `IStorageService` interface
- Implements KV store in both Electron (SQLite `kv_store` table) and Web (Dexie v3 `kvStore` table) storage providers
- Migrates `ignored-corrections-service.ts` and `user-dictionary-service.ts` standalone methods from synchronous `localStorage` to async `StorageService`
- Updates `use-ignored-corrections.ts` hook and `Dictionary.tsx` component for async standalone API
- Adds 3 new IPC channels (`storage:set-item`, `storage:get-item`, `storage:remove-item`) with preload exposure

Closes #701

## Test plan

- [ ] Open a standalone `.mdi` file (not in a project) in Electron
- [ ] Add a word to the user dictionary → verify it persists after app restart (stored in SQLite, not localStorage)
- [ ] Add an ignored correction → verify it persists after app restart
- [ ] Open the same file in web mode → verify dictionary and ignored corrections persist (stored in IndexedDB)
- [ ] Run `npx tsc --noEmit` to verify type safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>