### PR TITLE
feat: 品詞ハイライトの個別トグル機能

### DIFF
--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -85,7 +85,7 @@ export default function MilkdownEditor({
   } = useTypographySettings();
   const { lintingEnabled } = useLintingSettings();
   const { llmEnabled } = useLlmSettings();
-  const { posHighlightEnabled, posHighlightColors } = usePosHighlightSettings();
+  const { posHighlightEnabled, posHighlightColors, posHighlightDisabledTypes } = usePosHighlightSettings();
   const { verticalScrollBehavior, scrollSensitivity } = useScrollSettings();
   const editorRef = useRef<HTMLDivElement>(null);
   const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
@@ -244,11 +244,12 @@ export default function MilkdownEditor({
       updatePosHighlightSettings(editorViewInstance, {
         enabled: posHighlightEnabled,
         colors: posHighlightColors,
+        disabledTypes: posHighlightDisabledTypes,
       });
     }).catch(err => {
       console.error('[Editor] Failed to update POS highlight settings:', err);
     });
-  }, [editorViewInstance, posHighlightEnabled, posHighlightColors]);
+  }, [editorViewInstance, posHighlightEnabled, posHighlightColors, posHighlightDisabledTypes]);
 
   // linting 設定を動的に更新（Editor を再作成せずに）
   useEffect(() => {

--- a/components/inspector/CorrectionsPanel.tsx
+++ b/components/inspector/CorrectionsPanel.tsx
@@ -241,8 +241,8 @@ export default function CorrectionsPanel({
   activeLintPresetId = "",
 }: CorrectionsPanelProps): React.JSX.Element {
   const {
-    posHighlightEnabled, posHighlightColors,
-    onPosHighlightEnabledChange,
+    posHighlightEnabled, posHighlightColors, posHighlightDisabledTypes,
+    onPosHighlightEnabledChange, onPosHighlightDisabledTypesChange,
   } = usePosHighlightSettings();
   const {
     lintingEnabled, lintingRuleConfigs,
@@ -534,15 +534,35 @@ export default function CorrectionsPanel({
         {posHighlightEnabled && (
           <div className="mt-2 space-y-2">
             <div className="flex flex-wrap gap-x-3 gap-y-1">
-              {POS_LEGEND_ITEMS.map(({ key, label }) => (
-                <span key={key} className="inline-flex items-center gap-1 text-xs text-foreground-secondary">
-                  <span
-                    className="inline-block w-2.5 h-2.5 rounded-sm"
-                    style={{ backgroundColor: posHighlightColors[key] || DEFAULT_POS_COLORS[key] || "#000" }}
-                  />
-                  {label}
-                </span>
-              ))}
+              {POS_LEGEND_ITEMS.map(({ key, label }) => {
+                const isDisabled = posHighlightDisabledTypes.includes(key);
+                return (
+                  <button
+                    key={key}
+                    className={clsx(
+                      "inline-flex items-center gap-1 text-xs transition-opacity cursor-pointer",
+                      isDisabled ? "opacity-40 text-foreground-muted" : "text-foreground-secondary"
+                    )}
+                    title={isDisabled ? "クリックで表示" : "クリックで非表示"}
+                    onClick={() => {
+                      const next = isDisabled
+                        ? posHighlightDisabledTypes.filter(t => t !== key)
+                        : [...posHighlightDisabledTypes, key];
+                      onPosHighlightDisabledTypesChange(next);
+                    }}
+                  >
+                    <span
+                      className="inline-block w-2.5 h-2.5 rounded-sm"
+                      style={{
+                        backgroundColor: isDisabled
+                          ? "#ccc"
+                          : (posHighlightColors[key] || DEFAULT_POS_COLORS[key] || "#000"),
+                      }}
+                    />
+                    {label}
+                  </button>
+                );
+              })}
             </div>
             {onOpenPosHighlightSettings && (
               <button

--- a/contexts/EditorSettingsContext.tsx
+++ b/contexts/EditorSettingsContext.tsx
@@ -121,8 +121,10 @@ export function usePosHighlightSettings() {
   return useMemo(() => ({
     posHighlightEnabled: settings.posHighlightEnabled,
     posHighlightColors: settings.posHighlightColors,
+    posHighlightDisabledTypes: settings.posHighlightDisabledTypes,
     onPosHighlightEnabledChange: handlers.handlePosHighlightEnabledChange,
     onPosHighlightColorsChange: handlers.handlePosHighlightColorsChange,
+    onPosHighlightDisabledTypesChange: handlers.handlePosHighlightDisabledTypesChange,
   }), [settings, handlers]);
 }
 

--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -19,6 +19,7 @@ export interface EditorSettings {
   autoSave: boolean;
   posHighlightEnabled: boolean;
   posHighlightColors: Record<string, string>;
+  posHighlightDisabledTypes: string[];
   verticalScrollBehavior: "auto" | "mouse" | "trackpad";
   scrollSensitivity: number;
   compactMode: boolean;
@@ -52,6 +53,7 @@ export interface EditorSettingsHandlers {
   handleAutoSaveChange: (value: boolean) => void;
   handlePosHighlightEnabledChange: (value: boolean) => void;
   handlePosHighlightColorsChange: (value: Record<string, string>) => void;
+  handlePosHighlightDisabledTypesChange: (value: string[]) => void;
   handleVerticalScrollBehaviorChange: (value: "auto" | "mouse" | "trackpad") => void;
   handleScrollSensitivityChange: (value: number) => void;
   handleToggleCompactMode: () => void;
@@ -110,6 +112,7 @@ export function useEditorSettings(
   const [autoSave, setAutoSave] = useState(true);
   const [posHighlightEnabled, setPosHighlightEnabled] = useState(false);
   const [posHighlightColors, setPosHighlightColors] = useState<Record<string, string>>({});
+  const [posHighlightDisabledTypes, setPosHighlightDisabledTypes] = useState<string[]>([]);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
   const [verticalScrollBehavior, setVerticalScrollBehavior] = useState<"auto" | "mouse" | "trackpad">("auto");
   const [scrollSensitivity, setScrollSensitivity] = useState(1.0);
@@ -170,6 +173,9 @@ export function useEditorSettings(
         }
         if (appState.posHighlightColors && typeof appState.posHighlightColors === "object") {
           setPosHighlightColors(appState.posHighlightColors);
+        }
+        if (Array.isArray(appState.posHighlightDisabledTypes)) {
+          setPosHighlightDisabledTypes(appState.posHighlightDisabledTypes);
         }
         if (appState.verticalScrollBehavior) {
           setVerticalScrollBehavior(appState.verticalScrollBehavior);
@@ -323,6 +329,13 @@ export function useEditorSettings(
     setPosHighlightColors(value);
     void persistAppState({ posHighlightColors: value }).catch((error) => {
       console.error("Failed to persist posHighlightColors:", error);
+    });
+  }, []);
+
+  const handlePosHighlightDisabledTypesChange = useCallback((value: string[]) => {
+    setPosHighlightDisabledTypes(value);
+    void persistAppState({ posHighlightDisabledTypes: value }).catch((error) => {
+      console.error("Failed to persist posHighlightDisabledTypes:", error);
     });
   }, []);
 
@@ -512,6 +525,7 @@ export function useEditorSettings(
     autoSave,
     posHighlightEnabled,
     posHighlightColors,
+    posHighlightDisabledTypes,
     verticalScrollBehavior,
     scrollSensitivity,
     compactMode,
@@ -544,7 +558,7 @@ export function useEditorSettings(
   }), [
     fontScale, lineHeight, paragraphSpacing, textIndent, fontFamily,
     charsPerLine, autoCharsPerLine, showParagraphNumbers, autoSave,
-    posHighlightEnabled, posHighlightColors, verticalScrollBehavior,
+    posHighlightEnabled, posHighlightColors, posHighlightDisabledTypes, verticalScrollBehavior,
     scrollSensitivity, compactMode, showSettingsModal,
     lintingEnabled, lintingRuleConfigs, llmEnabled, llmModelId, llmIdlingStop,
     characterExtractionBatchSize, characterExtractionConcurrency,
@@ -564,6 +578,7 @@ export function useEditorSettings(
     handleAutoSaveChange,
     handlePosHighlightEnabledChange,
     handlePosHighlightColorsChange,
+    handlePosHighlightDisabledTypesChange,
     handleVerticalScrollBehaviorChange,
     handleScrollSensitivityChange,
     handleToggleCompactMode,
@@ -588,7 +603,8 @@ export function useEditorSettings(
     handleTextIndentChange, handleFontFamilyChange, handleCharsPerLineChange,
     handleAutoCharsPerLineChange, handleShowParagraphNumbersChange,
     handleAutoSaveChange, handlePosHighlightEnabledChange,
-    handlePosHighlightColorsChange, handleVerticalScrollBehaviorChange,
+    handlePosHighlightColorsChange, handlePosHighlightDisabledTypesChange,
+    handleVerticalScrollBehaviorChange,
     handleScrollSensitivityChange, handleToggleCompactMode, setShowSettingsModal,
     handleLintingEnabledChange, handleLintingRuleConfigChange,
     handleLintingRuleConfigsBatchChange, handleLlmEnabledChange,

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -61,6 +61,7 @@ export interface AppState {
   // 品詞着色設定
   posHighlightEnabled?: boolean;
   posHighlightColors?: Record<string, string>;
+  posHighlightDisabledTypes?: string[];
 
   // プロジェクト管理
   currentProjectId?: string;

--- a/packages/milkdown-plugin-japanese-novel/pos-highlight/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/pos-highlight/decoration-plugin.ts
@@ -17,15 +17,26 @@ import type { PosColorConfig } from './types';
 
 export const posHighlightKey = new PluginKey('posHighlight');
 
+/** Compare two Sets for equality */
+function setsEqual(a?: Set<string>, b?: Set<string>): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}
+
 interface PosHighlightState {
   decorations: DecorationSet;
   enabled: boolean;
   colors: PosColorConfig;
+  disabledTypes: Set<string>;
 }
 
 export interface PosHighlightPluginOptions {
   enabled: boolean;
   colors: PosColorConfig;
+  disabledTypes?: string[];
   debounceMs?: number;
 }
 
@@ -35,7 +46,7 @@ export interface PosHighlightPluginOptions {
 export function createPosHighlightPlugin(
   options: PosHighlightPluginOptions
 ): Plugin<PosHighlightState> {
-  const { enabled, colors, debounceMs = 300 } = options;
+  const { enabled, colors, disabledTypes = [], debounceMs = 300 } = options;
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let processingVersion = 0;
@@ -54,6 +65,7 @@ export function createPosHighlightPlugin(
           decorations: DecorationSet.empty,
           enabled,
           colors,
+          disabledTypes: new Set(disabledTypes),
         };
       },
 
@@ -70,6 +82,10 @@ export function createPosHighlightPlugin(
             tokenCache.clear();
           }
           const updated = { ...pluginState, ...meta };
+          // disabledTypes が配列で渡された場合は Set に変換
+          if (Array.isArray(meta.disabledTypes)) {
+            updated.disabledTypes = new Set(meta.disabledTypes);
+          }
           // enabled が false になった場合は decorations をクリア
           if (meta.enabled === false) {
             updated.decorations = DecorationSet.empty;
@@ -170,6 +186,9 @@ export function createPosHighlightPlugin(
             decoratedCount++;
 
             for (const token of tokens) {
+              // Skip disabled POS types
+              if (state.disabledTypes.has(token.pos)) continue;
+
               const color = getPosColor(
                 token.pos,
                 token.pos_detail_1,
@@ -216,9 +235,11 @@ export function createPosHighlightPlugin(
             return;
           }
 
-          // colors が変更された場合
-          if (state?.enabled && JSON.stringify(state.colors) !== JSON.stringify(prevPluginState?.colors)) {
-            tokenCache.clear();
+          // colors or disabledTypes が変更された場合
+          if (state?.enabled && (
+            JSON.stringify(state.colors) !== JSON.stringify(prevPluginState?.colors) ||
+            !setsEqual(state.disabledTypes, prevPluginState?.disabledTypes)
+          )) {
             scheduleViewportUpdate(view);
             return;
           }

--- a/packages/milkdown-plugin-japanese-novel/pos-highlight/types.ts
+++ b/packages/milkdown-plugin-japanese-novel/pos-highlight/types.ts
@@ -64,6 +64,8 @@ export interface PosHighlightSettings {
   enabled: boolean;
   /** 品詞ごとの色設定 */
   colors: PosColorConfig;
+  /** 非表示にする品詞タイプ */
+  disabledTypes?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- 品詞ハイライトパネルで品詞名をクリックすると、その品詞のハイライトを個別にON/OFFできるようになりました
- 無効化された品詞は灰色表示になり、エディタ内のテキストはデフォルト色に戻ります
- 設定はストレージに永続化されます

## Changes
- `storage-types.ts`: `posHighlightDisabledTypes` を AppState に追加
- `pos-highlight/types.ts`: `disabledTypes` を PosHighlightSettings に追加
- `decoration-plugin.ts`: 無効化された品詞のトークンをスキップするロジック追加
- `use-editor-settings.ts`: state/handler/persist/load 追加
- `EditorSettingsContext.tsx`: `usePosHighlightSettings()` に expose
- `MilkdownEditor.tsx`: `disabledTypes` をプラグインに渡す
- `CorrectionsPanel.tsx`: 品詞名をクリック可能なボタンに変更

## Test plan
- [ ] 品詞ハイライトを有効化し、品詞名をクリックして灰色になることを確認
- [ ] エディタ内で該当品詞のテキストがデフォルト色に戻ることを確認
- [ ] 再度クリックしてハイライトが復活することを確認
- [ ] アプリを再起動して設定が永続化されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)