### PR TITLE
refactor(vfs): deduplicate path utilities into shared path-utils.ts

### DIFF
--- a/lib/vfs/electron-vfs.ts
+++ b/lib/vfs/electron-vfs.ts
@@ -15,6 +15,7 @@ import type {
   VFSWatcher,
   VirtualFileSystem,
 } from "./types";
+import { basename, dirname, isAbsolutePath, joinPath } from "./path-utils";
 
 // -----------------------------------------------------------------------
 // Type declarations for the Electron VFS IPC bridge
@@ -55,47 +56,6 @@ interface ElectronVFSBridge {
 // -----------------------------------------------------------------------
 // Helpers
 // -----------------------------------------------------------------------
-
-/**
- * Join path segments using "/" separator, handling trailing/leading slashes.
- * Normalizes Windows backslashes to forward slashes for consistent IPC communication.
- */
-function joinPath(base: string, ...parts: string[]): string {
-  // First, normalize any backslashes in the base to forward slashes
-  const normalizedBase = base.replace(/\\/g, "/").replace(/\/+$/, "");
-  const normalizedParts = parts.map((p) =>
-    p.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "")
-  ).filter((p) => p.length > 0);
-  return [normalizedBase, ...normalizedParts].join("/");
-}
-
-/**
- * Extract the basename from a path string.
- */
-function basename(path: string): string {
-  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
-  const parts = normalized.split("/");
-  return parts[parts.length - 1] || path;
-}
-
-/**
- * Extract the parent directory path from a file path.
- */
-function dirname(path: string): string {
-  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
-  const lastSlash = normalized.lastIndexOf("/");
-  if (lastSlash <= 0) return "/";
-  return normalized.substring(0, lastSlash);
-}
-
-/**
- * Check if a path is absolute.
- * Handles both Unix ("/path") and Windows ("C:\path", "D:/path", "\\server\share") formats.
- */
-function isAbsolutePath(p: string): boolean {
-  // Unix absolute path, or Windows UNC path (\\server\share)
-  return p.startsWith("/") || p.startsWith("\\\\") || /^[a-zA-Z]:[/\\]/.test(p);
-}
 
 /**
  * Get the Electron VFS bridge from window.electronAPI.

--- a/lib/vfs/path-utils.ts
+++ b/lib/vfs/path-utils.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared path utility functions for VFS implementations.
+ *
+ * Used by both electron-vfs.ts (absolute paths, Windows backslash support)
+ * and web-vfs.ts (relative paths, forward slashes only).
+ */
+
+/**
+ * Join path segments using "/" separator.
+ * - Normalizes backslashes to forward slashes.
+ * - Preserves any leading slash on the first segment (absolute path support).
+ * - Strips trailing slashes from all segments.
+ * - Strips leading slashes from subsequent segments.
+ */
+export function joinPath(...segments: string[]): string {
+  if (segments.length === 0) return "";
+  const [first, ...rest] = segments;
+  const normalizedFirst = first.replace(/\\/g, "/").replace(/\/+$/, "");
+  const normalizedRest = rest
+    .map((s) => s.replace(/\\/g, "/").replace(/^\/+|\/+$/g, ""))
+    .filter((s) => s.length > 0);
+  return [normalizedFirst, ...normalizedRest].join("/");
+}
+
+/**
+ * Extract the basename (final path component) from a path string.
+ * Normalizes backslashes and strips trailing slashes before extracting.
+ */
+export function basename(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  const parts = normalized.split("/");
+  return parts[parts.length - 1] || path;
+}
+
+/**
+ * Extract the parent directory path from a file path.
+ * Returns "/" if the path has no parent (e.g. root-level file).
+ */
+export function dirname(path: string): string {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  const lastSlash = normalized.lastIndexOf("/");
+  if (lastSlash <= 0) return "/";
+  return normalized.substring(0, lastSlash);
+}
+
+/**
+ * Check if a path is absolute.
+ * Handles Unix ("/path"), Windows drive ("C:\path", "D:/path"),
+ * and UNC ("\\server\share") formats.
+ */
+export function isAbsolutePath(p: string): boolean {
+  return p.startsWith("/") || p.startsWith("\\\\") || /^[a-zA-Z]:[/\\]/.test(p);
+}

--- a/lib/vfs/web-vfs.ts
+++ b/lib/vfs/web-vfs.ts
@@ -13,6 +13,7 @@ import type {
   VFSFileMetadata,
   VirtualFileSystem,
 } from "./types";
+import { joinPath } from "./path-utils";
 
 // -----------------------------------------------------------------------
 // Helpers
@@ -24,16 +25,6 @@ import type {
  */
 function splitPath(path: string): string[] {
   return path.split("/").filter((segment) => segment.length > 0);
-}
-
-/**
- * Join path segments with "/", ensuring no double slashes.
- */
-function joinPath(...parts: string[]): string {
-  return parts
-    .map((p) => p.replace(/^\/+|\/+$/g, ""))
-    .filter((p) => p.length > 0)
-    .join("/");
 }
 
 /**


### PR DESCRIPTION
## Summary

- Creates `lib/vfs/path-utils.ts` with shared `joinPath`, `basename`, `dirname`, and `isAbsolutePath` utilities
- Removes duplicate implementations from `electron-vfs.ts` and `web-vfs.ts`
- Both VFS implementations now import from the shared module

Closes #752

## Test plan
- [ ] `npx tsc --noEmit` passes with no new errors (pre-existing errors unrelated to VFS remain)
- [ ] Electron VFS path operations work correctly (absolute paths, backslash normalization)
- [ ] Web VFS path operations work correctly (relative paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)