### PR TITLE
refactor: eliminate any types and improve type safety

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -10,7 +10,7 @@ import {
 import clsx from "clsx";
 import type { EditorView } from "@milkdown/prose/view";
 import { useSpeech } from "@/lib/hooks/use-speech";
-import SearchDialog from "./SearchDialog";
+import SearchDialog, { type SearchMatch } from "./SearchDialog";
 import SelectionCounter from "./SelectionCounter";
 import EditorToolbar from "./editor/EditorToolbar";
 import MilkdownEditor from "./editor/MilkdownEditor";
@@ -36,8 +36,7 @@ interface EditorProps {
   onEditorViewReady?: (view: EditorView) => void;
   /** Ref that external code sets to true before programmatic scrolling */
   programmaticScrollRef?: React.MutableRefObject<boolean>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onShowAllSearchResults?: (matches: any[], searchTerm: string) => void;
+  onShowAllSearchResults?: (matches: SearchMatch[], searchTerm: string) => void;
   // リンティング設定
   lintingRuleRunner?: RuleRunner | null;
   onLintIssuesUpdated?: (issues: LintIssue[], options?: { llmPending?: boolean }) => void;

--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -14,7 +14,7 @@ interface SearchDialogProps {
   programmaticScrollRef?: React.MutableRefObject<boolean>;
 }
 
-interface SearchMatch {
+export interface SearchMatch {
   from: number;
   to: number;
 }

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -650,14 +650,25 @@ export default function MilkdownEditor({
     };
   }, [isVertical, scrollContainerRef, isModeSwitchingRef, savedScrollPosRef, userScrollingRef]);
 
+  // Union of all Milkdown command keys used in handleFormat.
+  // Each .key property is a branded CmdKey<T> string exported by @milkdown.
+  type MilkdownCommandKey =
+    | typeof toggleStrongCommand.key
+    | typeof toggleEmphasisCommand.key
+    | typeof toggleInlineCodeCommand.key
+    | typeof wrapInHeadingCommand.key
+    | typeof wrapInBlockquoteCommand.key
+    | typeof wrapInBulletListCommand.key
+    | typeof wrapInOrderedListCommand.key
+    | typeof toggleStrikethroughCommand.key;
+
   // BubbleMenu からの書式コマンドを処理する
   const handleFormat = (format: FormatType, level?: number) => {
     try {
       const editor = get();
       if (!editor) return;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const execute = (commandKey: any, payload?: unknown) => {
+      const execute = (commandKey: MilkdownCommandKey, payload?: unknown): void => {
         editor.action((ctx) => {
           const commands = ctx.get(commandsCtx);
           commands.call(commandKey, payload);

--- a/lib/project/mdi-file.ts
+++ b/lib/project/mdi-file.ts
@@ -179,8 +179,8 @@ export async function saveMdiFile(
     if (!handle && hasShowSaveFilePicker(window)) {
       const defaultName = descriptor?.name ?? getDefaultFileName(fileType);
       const suggestedName = ensureExtension(defaultName, fileType);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      handle = await (window as any).showSaveFilePicker({
+      // window is narrowed by hasShowSaveFilePicker to include showSaveFilePicker
+      handle = await window.showSaveFilePicker({
         suggestedName,
         types: getSaveFilters(fileType),
       });
@@ -193,11 +193,15 @@ export async function saveMdiFile(
     // 永続化されたハンドルの場合、必要なら権限確認/要求を行う
     if (descriptor?.handle && "queryPermission" in handle) {
       try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const permission = await (handle as any).queryPermission({ mode: "readwrite" });
+        // queryPermission / requestPermission are File System Access API extensions
+        // not yet in standard TS lib types; cast through unknown to avoid any.
+        const permHandle = handle as unknown as {
+          queryPermission(d: { mode: string }): Promise<string>;
+          requestPermission(d: { mode: string }): Promise<string>;
+        };
+        const permission = await permHandle.queryPermission({ mode: "readwrite" });
         if (permission !== "granted") {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const requestResult = await (handle as any).requestPermission({ mode: "readwrite" });
+          const requestResult = await permHandle.requestPermission({ mode: "readwrite" });
           if (requestResult !== "granted") {
             console.warn("ファイルハンドルの書き込み権限が許可されませんでした");
             return null;
@@ -208,8 +212,11 @@ export async function saveMdiFile(
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const writable = await (handle as any).createWritable();
+    // createWritable is a File System Access API extension not yet in standard TS lib types
+    const writableHandle = handle as unknown as {
+      createWritable(): Promise<{ write(data: string): Promise<void>; close(): Promise<void> }>;
+    };
+    const writable = await writableHandle.createWritable();
     await writable.write(content);
     await writable.close();
 

--- a/lib/storage/electron-storage-manager.ts
+++ b/lib/storage/electron-storage-manager.ts
@@ -59,13 +59,12 @@ export class ElectronStorageManager {
       throw new Error("better-sqlite3 モジュールが利用できません");
     }
 
-    this.db = new DatabaseModule(this.dbPath);
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.db!.pragma("journal_mode = WAL");
+    const db = new DatabaseModule(this.dbPath);
+    this.db = db;
+    db.pragma("journal_mode = WAL");
 
     // 必要ならテーブルを作成
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    this.db!.exec(`
+    db.exec(`
       CREATE TABLE IF NOT EXISTS app_state (
         id TEXT PRIMARY KEY,
         data TEXT NOT NULL,
@@ -100,8 +99,7 @@ export class ElectronStorageManager {
       );
     `);
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return this.db!;
+    return db;
   }
 
   /**

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -60,8 +60,7 @@ export function formatRelativeTime(date: Date): string {
 /**
  * 自動保存などに使うデバウンス
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function debounce<T extends (...args: any[]) => any>(
+export function debounce<T extends (...args: unknown[]) => unknown>(
   func: T,
   wait: number
 ): (...args: Parameters<T>) => void {

--- a/lib/vfs/electron-vfs.ts
+++ b/lib/vfs/electron-vfs.ts
@@ -107,8 +107,9 @@ function getVFSBridge(): ElectronVFSBridge {
     throw new Error("Electron API is not available (window.electronAPI is undefined).");
   }
 
-  // Access the vfs sub-object on electronAPI
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // Access the vfs sub-object on electronAPI.
+  // electronAPI is typed by electron.d.ts but its vfs shape differs from
+  // ElectronVFSBridge, so we cast through unknown to get the stricter type.
   const vfsBridge = (api as unknown as { vfs?: ElectronVFSBridge }).vfs;
   if (!vfsBridge) {
     throw new Error(

--- a/lib/vfs/web-vfs.ts
+++ b/lib/vfs/web-vfs.ts
@@ -126,7 +126,7 @@ class WebVFSFileHandle implements VFSFileHandle {
   async write(content: string): Promise<void> {
     // FileSystemFileHandle.createWritable() is not in the base TS types,
     // but is available in browsers that support File System Access API.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     const writable = await (this.handle as unknown as { createWritable(): Promise<WritableStream & { write(data: string): Promise<void>; close(): Promise<void> }> }).createWritable();
     await writable.write(content);
     await writable.close();
@@ -181,7 +181,7 @@ class WebVFSDirectoryHandle implements VFSDirectoryHandle {
     options?: { recursive?: boolean }
   ): Promise<void> {
     // FileSystemDirectoryHandle.removeEntry is part of the File System Access API
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     await (this.handle as unknown as { removeEntry(name: string, options?: { recursive?: boolean }): Promise<void> }).removeEntry(name, {
       recursive: options?.recursive ?? false,
     });
@@ -189,7 +189,7 @@ class WebVFSDirectoryHandle implements VFSDirectoryHandle {
 
   async *entries(): AsyncIterable<[string, VFSEntry]> {
     // FileSystemDirectoryHandle is an AsyncIterable in supporting browsers
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     const iterable = this.handle as unknown as AsyncIterable<[string, FileSystemHandle & { kind: "file" | "directory" }]>;
     for await (const [entryName, entryHandle] of iterable) {
       const entryPath = joinPath(this.path, entryName);
@@ -294,7 +294,7 @@ export class WebVFS implements VirtualFileSystem {
     const root = this.ensureRoot();
     try {
       const fileHandle = await resolveFileHandle(root, path, true);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  
       const writable = await (fileHandle as unknown as { createWritable(): Promise<WritableStream & { write(data: string): Promise<void>; close(): Promise<void> }> }).createWritable();
       await writable.write(content);
       await writable.close();
@@ -320,7 +320,7 @@ export class WebVFS implements VirtualFileSystem {
 
     try {
       const parentHandle = await resolveDirectoryHandle(root, segments);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  
       await (parentHandle as unknown as { removeEntry(name: string): Promise<void> }).removeEntry(fileName);
     } catch (error) {
       throw new Error(
@@ -403,7 +403,7 @@ export class WebVFS implements VirtualFileSystem {
     }
     const dirName = segments.pop()!;
     const parentHandle = await resolveDirectoryHandle(root, segments);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
     await (parentHandle as unknown as { removeEntry(name: string, options?: { recursive?: boolean }): Promise<void> }).removeEntry(dirName, { recursive: true });
   }
 
@@ -444,7 +444,7 @@ export class WebVFS implements VirtualFileSystem {
           : await resolveDirectoryHandle(root, segments);
 
       const entries: VFSEntry[] = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  
       const iterable = dirHandle as unknown as AsyncIterable<[string, FileSystemHandle & { kind: "file" | "directory" }]>;
       for await (const [entryName, entryHandle] of iterable) {
         entries.push({


### PR DESCRIPTION
## Summary

- Replace 17 instances of `any` / ESLint suppression comments across 8 files
- Export `SearchMatch` type from `SearchDialog.tsx` for reuse in `Editor.tsx`
- Create `MilkdownCommandKey` union type replacing `commandKey: any` in `MilkdownEditor.tsx`
- Use `unknown` constraint in `debounce` generic (`lib/utils/index.ts`)
- Eliminate 3 non-null assertions in `ElectronStorageManager.ensureInitialized()` via local variable
- Remove misleading `eslint-disable no-explicit-any` comments where `unknown` was already used (VFS files)
- Replace `(window as any)` and `(handle as any)` with typed intermediate casts using `unknown` in `mdi-file.ts`

## Test plan

- [ ] TypeScript check passes: `npx tsc --noEmit`
- [ ] Open, edit, save a file in both Web and Electron mode
- [ ] Search dialog finds matches and shows all results correctly
- [ ] Bold/italic/heading/strikethrough formatting still applies in editor

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)