### PR TITLE
fix: defer initial tab creation to eliminate cold-start flicker

### DIFF
--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -7,6 +7,7 @@ import type { TabState, SerializedTab, TabPersistenceState } from "./tab-types";
 import type { TabManagerCore } from "./types";
 import {
   TAB_PERSIST_DEBOUNCE,
+  createNewTab,
   generateTabId,
   inferFileType,
 } from "./types";
@@ -39,6 +40,10 @@ export interface UseTabPersistenceReturn {
  * Handles two responsibilities:
  * 1. Persist open tabs to AppState (debounced, Electron only).
  * 2. Restore tabs from AppState / storage on mount.
+ *
+ * Coordinates with useTabState which starts with an empty tabs array.
+ * This hook is responsible for populating the first tab after determining
+ * the correct initial state (saved tabs, Web buffer restore, or a blank default).
  */
 export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersistenceReturn {
   const {
@@ -90,12 +95,20 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
   }, [tabs, activeTabId, isElectron]);
 
   // --- Storage initialization & Web file restore --------------------------
+  //
+  // This effect always ensures at least one tab exists after storage loads.
+  // For Electron, restoreTabs (below) may override the tab set here when
+  // file-backed saved tabs are found.
 
   useEffect(() => {
     const initializeStorage = async () => {
       try {
         const storage = getStorageService();
         await storage.initialize();
+
+        // Determine the initial tab using a local variable to make the
+        // fallback logic explicit and avoid multiple setTabs calls.
+        let initialTab: TabState | null = null;
 
         if (!skipAutoRestore && !isElectron) {
           // Web: restore file handle from editor buffer
@@ -104,42 +117,52 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
             try {
               const file = await buffer.fileHandle.getFile();
               const fileContent = await file.text();
-              setTabs((prev) =>
-                prev.map((tab, i) =>
-                  i === 0
-                    ? {
-                        ...tab,
-                        file: {
-                          path: null,
-                          handle: buffer.fileHandle!,
-                          name: file.name,
-                        },
-                        content: fileContent,
-                        lastSavedContent: fileContent,
-                        lastSavedTime: Date.now(),
-                        fileType: inferFileType(file.name),
-                      }
-                    : tab,
-                ),
-              );
+              initialTab = {
+                id: generateTabId(),
+                file: { path: null, handle: buffer.fileHandle, name: file.name },
+                content: fileContent,
+                lastSavedContent: fileContent,
+                isDirty: false,
+                lastSavedTime: Date.now(),
+                lastSaveWasAuto: false,
+                isSaving: false,
+                isPreview: false,
+                fileType: inferFileType(file.name),
+              };
               setWasAutoRecovered(true);
-              return;
             } catch (error) {
-              console.warn(
-                "前回のファイルを復元できませんでした:",
-                error,
-              );
+              console.warn("前回のファイルを復元できませんでした:", error);
               await storage.clearEditorBuffer();
             }
           }
         }
+
+        // Fallback: create a default blank tab when no restore path fired.
+        // For Electron (non-skipAutoRestore), restoreTabs handles the case where
+        // file-backed tabs were previously saved; skip creating a fallback here
+        // to avoid a visible flash before restoreTabs completes.
+        if (!initialTab && (!isElectron || skipAutoRestore)) {
+          initialTab = createNewTab();
+        }
+
+        if (initialTab) {
+          const tab = initialTab;
+          // Use functional updates so a concurrently-running restoreTabs (Electron)
+          // that already set tabs is not overridden.
+          setTabs((prev) => (prev.length > 0 ? prev : [tab]));
+          setActiveTabId((prev) => (prev === "" ? tab.id : prev));
+        }
       } catch (error) {
         console.error("ストレージの初期化に失敗しました:", error);
+        // Ensure at least one tab even on storage error
+        const errorTab = createNewTab();
+        setTabs((prev) => (prev.length > 0 ? prev : [errorTab]));
+        setActiveTabId((prev) => (prev === "" ? errorTab.id : prev));
       }
     };
 
     void initializeStorage();
-  }, [isElectron, skipAutoRestore, setTabs]);
+  }, [isElectron, skipAutoRestore, setTabs, setActiveTabId]);
 
   // --- Restore tabs from AppState on mount (Electron only) ----------------
   // Wait for VFS root to be set so that the main process has a registered
@@ -161,7 +184,12 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
 
         const appState = await fetchAppState();
         const openTabs = appState?.openTabs;
-        if (!openTabs || openTabs.tabs.length === 0) return;
+
+        // No saved state at all: first use — initializeStorage handles default tab.
+        if (!openTabs) return;
+
+        // Saved state is explicitly empty (user closed all tabs last session).
+        if (openTabs.tabs.length === 0) return;
 
         const restoredTabs: TabState[] = [];
         for (const serialized of openTabs.tabs) {
@@ -201,6 +229,11 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
             restoredTabs.length - 1,
           );
           setActiveTabId(restoredTabs[activeIdx].id);
+        } else {
+          // Saved tabs were all untitled (no file path) — create a default tab.
+          const defaultTab = createNewTab();
+          setTabs((prev) => (prev.length > 0 ? prev : [defaultTab]));
+          setActiveTabId((prev) => (prev === "" ? defaultTab.id : prev));
         }
       } catch (error) {
         console.error("タブの復元に失敗しました:", error);

--- a/lib/tab-manager/use-tab-state.ts
+++ b/lib/tab-manager/use-tab-state.ts
@@ -14,8 +14,8 @@ import { isElectronRenderer } from "../utils/runtime-env";
 // ---------------------------------------------------------------------------
 
 export interface UseTabStateReturn extends TabManagerCore {
-  /** Derived: active tab object (falls back to tabs[0]). */
-  activeTab: TabState;
+  /** Derived: active tab object (falls back to tabs[0]). Undefined while persistence is loading. */
+  activeTab: TabState | undefined;
   /** Derived: file descriptor of the active tab. */
   currentFile: MdiFileDescriptor | null;
   /** Derived: content string of the active tab. */
@@ -75,9 +75,10 @@ export function useTabState(): UseTabStateReturn {
 
   // --- Core state ---------------------------------------------------------
 
-  const [initialTab] = useState(() => createNewTab());
-  const [tabs, setTabs] = useState<TabState[]>([initialTab]);
-  const [activeTabId, setActiveTabId] = useState<TabId>(initialTab.id);
+  // Start empty — useTabPersistence populates the first tab after loading saved state,
+  // preventing a brief flash of randomly-generated tab content on cold start.
+  const [tabs, setTabs] = useState<TabState[]>([]);
+  const [activeTabId, setActiveTabId] = useState<TabId>("");
   const [pendingCloseTabId, setPendingCloseTabId] = useState<TabId | null>(
     null,
   );


### PR DESCRIPTION
## Summary

Fix race condition that causes brief flash of random tab content on cold start when saved state is empty.

- `useTabState` now starts with `tabs = []` instead of creating a random-content tab
- `useTabPersistence` creates the first tab after loading saved state
- Functional `setTabs`/`setActiveTabId` updaters prevent race conditions between concurrent effects
- Handles the untitled-tabs-only Electron case that previously left tabs empty on restart

Closes #755

Co-Authored-By: Paperclip <noreply@paperclip.ing>