### PR TITLE
perf: add React memoization to large components

### DIFF
--- a/components/GuidelineList.tsx
+++ b/components/GuidelineList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo, useCallback } from "react";
 import { ChevronUp, ChevronDown } from "lucide-react";
 import clsx from "clsx";
 
@@ -65,19 +66,19 @@ function LicenseBadge({ license }: { license: GuidelineLicense }) {
  * Reordering uses up/down arrow buttons (no external DnD dependency required).
  */
 export default function GuidelineList({ guidelines, onChange }: GuidelineListProps) {
-  const enabledSet = new Set(guidelines);
+  const enabledSet = useMemo(() => new Set(guidelines), [guidelines]);
 
   /**
    * Build the full display order:
    * 1. Enabled guidelines in their current priority order.
    * 2. Disabled guidelines in canonical order (appended at the end).
    */
-  const displayOrder: GuidelineId[] = [
+  const displayOrder = useMemo<GuidelineId[]>(() => [
     ...guidelines,
     ...ALL_GUIDELINE_IDS.filter((id) => !enabledSet.has(id)),
-  ];
+  ], [guidelines, enabledSet]);
 
-  const handleToggle = (id: GuidelineId) => {
+  const handleToggle = useCallback((id: GuidelineId) => {
     if (enabledSet.has(id)) {
       // Disable: remove from the enabled list
       onChange(guidelines.filter((g) => g !== id));
@@ -85,23 +86,23 @@ export default function GuidelineList({ guidelines, onChange }: GuidelineListPro
       // Enable: append to the end of the enabled list
       onChange([...guidelines, id]);
     }
-  };
+  }, [enabledSet, guidelines, onChange]);
 
-  const handleMoveUp = (id: GuidelineId) => {
+  const handleMoveUp = useCallback((id: GuidelineId) => {
     const idx = guidelines.indexOf(id);
     if (idx <= 0) return;
     const next = [...guidelines];
     [next[idx - 1], next[idx]] = [next[idx], next[idx - 1]];
     onChange(next);
-  };
+  }, [guidelines, onChange]);
 
-  const handleMoveDown = (id: GuidelineId) => {
+  const handleMoveDown = useCallback((id: GuidelineId) => {
     const idx = guidelines.indexOf(id);
     if (idx < 0 || idx >= guidelines.length - 1) return;
     const next = [...guidelines];
     [next[idx], next[idx + 1]] = [next[idx + 1], next[idx]];
     onChange(next);
-  };
+  }, [guidelines, onChange]);
 
   return (
     <div className="divide-y divide-border border border-border rounded-lg overflow-hidden">

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { AlertCircle, BarChart3, Edit2, X, History } from "lucide-react";
 import clsx from "clsx";
 
@@ -14,6 +14,20 @@ import type { ProjectMode } from "@/lib/project/project-types";
 import type { InspectorProps } from "./inspector/types";
 import type { Tab } from "./inspector/types";
 import { isValidTab, getMdiExtension, getBaseName } from "./inspector/types";
+
+function formatTime(timestamp: number | null): string {
+  if (!timestamp || timestamp <= 0) return "未保存";
+  const date = new Date(timestamp);
+  if (isNaN(date.getTime())) return "未保存";
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+
+  if (diffSecs < 60) return "今";
+  if (diffSecs < 3600) return `${Math.floor(diffSecs / 60)}分前`;
+  if (diffSecs < 86400) return `${Math.floor(diffSecs / 3600)}時間前`;
+  return date.toLocaleDateString();
+}
 
 export default function Inspector({
   className,
@@ -133,12 +147,12 @@ export default function Inspector({
     }
   }, [isEditingFileName]);
 
-  const handleStartEdit = () => {
+  const handleStartEdit = useCallback(() => {
     setIsEditingFileName(true);
     setEditedBaseName(baseName);
-  };
+  }, [baseName]);
 
-  const handleSaveFileName = () => {
+  const handleSaveFileName = useCallback(() => {
     const trimmedBase = editedBaseName.trim();
     if (trimmedBase) {
       const newName = extension ? `${trimmedBase}${extension}` : trimmedBase;
@@ -147,29 +161,15 @@ export default function Inspector({
       }
     }
     setIsEditingFileName(false);
-  };
+  }, [editedBaseName, extension, fileName, onFileNameChange]);
 
-  const handleCancelEdit = () => {
+  const handleCancelEdit = useCallback(() => {
     setEditedBaseName(baseName);
     setIsEditingFileName(false);
-  };
+  }, [baseName]);
 
   // 原稿用紙換算（400字/枚）
   const manuscriptPages = Math.ceil(charCount / 400);
-
-   const formatTime = (timestamp: number | null): string => {
-     if (!timestamp || timestamp <= 0) return "未保存";
-     const date = new Date(timestamp);
-     if (isNaN(date.getTime())) return "未保存";
-     const now = new Date();
-     const diffMs = now.getTime() - date.getTime();
-     const diffSecs = Math.floor(diffMs / 1000);
-
-     if (diffSecs < 60) return "今";
-     if (diffSecs < 3600) return `${Math.floor(diffSecs / 60)}分前`;
-     if (diffSecs < 86400) return `${Math.floor(diffSecs / 3600)}時間前`;
-     return date.toLocaleDateString();
-   };
 
   return (
     <aside

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState, useRef, useCallback } from "react";
 import { Search, X, Replace, ReplaceAll, ChevronRight, ChevronDown } from "lucide-react";
 import { EditorView, Decoration } from "@milkdown/prose/view";
 import { TextSelection } from "@milkdown/prose/state";
@@ -96,34 +96,34 @@ export default function SearchResults({
     dispatch(tr);
   }, [searchTerm, caseSensitive, editorView]);
   // Get context text for match
-  const getMatchContext = (match: SearchMatch): { before: string; text: string; after: string } => {
+  const getMatchContext = useCallback((match: SearchMatch): { before: string; text: string; after: string } => {
     if (!editorView) {
       return { before: "", text: "", after: "" };
     }
 
     const { state } = editorView;
     const { doc } = state;
-    
+
     // Get match text
     const matchText = doc.textBetween(match.from, match.to);
-    
+
     // Get surrounding text (30 characters before and after)
     const contextLength = 30;
     const beforeStart = Math.max(0, match.from - contextLength);
     const afterEnd = Math.min(doc.content.size, match.to + contextLength);
-    
+
     const beforeText = doc.textBetween(beforeStart, match.from);
     const afterText = doc.textBetween(match.to, afterEnd);
-    
+
     return {
       before: beforeText.length > contextLength ? "..." + beforeText.slice(-contextLength) : beforeText,
       text: matchText,
       after: afterText.length > contextLength ? afterText.slice(0, contextLength) + "..." : afterText,
     };
-  };
+  }, [editorView]);
 
   // Jump to specified match and highlight
-  const goToMatch = (match: SearchMatch, index: number) => {
+  const goToMatch = useCallback((match: SearchMatch, index: number) => {
     if (!editorView) return;
 
     const { state, dispatch } = editorView;
@@ -187,10 +187,10 @@ export default function SearchResults({
     }, 500);
 
     editorView.focus();
-  };
+  }, [editorView, matches, programmaticScrollRef]);
 
   // Replace single match
-  const replaceMatch = (match: SearchMatch) => {
+  const replaceMatch = useCallback((match: SearchMatch) => {
     if (!editorView) return;
 
     const { state, dispatch } = editorView;
@@ -206,10 +206,10 @@ export default function SearchResults({
       setSearchTerm(searchTerm + " ");
       setTimeout(() => setSearchTerm(searchTerm.trim()), 0);
     }, 100);
-  };
+  }, [editorView, replaceTerm, searchTerm]);
 
   // Replace all matches
-  const replaceAllMatches = () => {
+  const replaceAllMatches = useCallback(() => {
     if (!editorView || matches.length === 0) return;
 
     const { state, dispatch } = editorView;
@@ -231,7 +231,7 @@ export default function SearchResults({
     setMatches([]);
     setSearchTerm("");
     setReplaceTerm("");
-  };
+  }, [editorView, matches, replaceTerm]);
 
   return (
     <div className="h-full bg-background-secondary border-r border-border flex flex-col">


### PR DESCRIPTION
## Summary

Addresses GH #751 — adds missing `useCallback` and `useMemo` optimizations to large components causing unnecessary re-renders.

### Changes

- **SearchResults.tsx**: wrap `getMatchContext`, `goToMatch`, `replaceMatch`, `replaceAllMatches` in `useCallback` — re-created on every keystroke in search input
- **GuidelineList.tsx**: memoize `enabledSet` and `displayOrder` with `useMemo`; wrap `handleToggle`, `handleMoveUp`, `handleMoveDown` in `useCallback`
- **Inspector.tsx**: move `formatTime` to module scope (pure function); wrap `handleStartEdit`, `handleSaveFileName`, `handleCancelEdit` in `useCallback`

Closes #751

🤖 Generated with [Claude Code](https://claude.com/claude-code)