### PR TITLE
feat(www): add hamburger menu and GitHub API response cache

### DIFF
--- a/www/src/downloads.ts
+++ b/www/src/downloads.ts
@@ -509,25 +509,56 @@ if (bgImageUrl) {
   img.src = bgImageUrl
 }
 
-// Show loading state immediately
-renderPage(null, null)
+const CACHE_KEY = 'illusions_release_cache'
+const CACHE_TTL_MS = 60 * 60 * 1000 // 1 hour
 
-// Fetch latest release
-const fetchOptions: RequestInit = {
-  headers: {
-    // クライアント側ではアクセストークンを送信しない
-    Accept: 'application/vnd.github.v3+json',
-  },
+interface ReleaseCache {
+  data: GitHubRelease
+  fetchedAt: number
 }
 
-fetch(API_URL, fetchOptions)
-  .then(async (res) => {
-    if (!res.ok) {
-      throw new Error(`GitHub API returned ${res.status}`)
-    }
-    const data = (await res.json()) as GitHubRelease
-    renderPage(data, null)
-  })
-  .catch((err: Error) => {
-    renderPage(null, err.message)
-  })
+function loadCache(): GitHubRelease | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    const cache = JSON.parse(raw) as ReleaseCache
+    if (Date.now() - cache.fetchedAt > CACHE_TTL_MS) return null
+    return cache.data
+  } catch {
+    return null
+  }
+}
+
+function saveCache(data: GitHubRelease): void {
+  try {
+    const cache: ReleaseCache = { data, fetchedAt: Date.now() }
+    localStorage.setItem(CACHE_KEY, JSON.stringify(cache))
+  } catch {
+    // localStorage unavailable — ignore
+  }
+}
+
+// Serve from cache immediately if available, otherwise show loading
+const cached = loadCache()
+if (cached) {
+  renderPage(cached, null)
+} else {
+  renderPage(null, null)
+
+  fetch(API_URL, { headers: { Accept: 'application/vnd.github.v3+json' } })
+    .then(async (res) => {
+      if (res.status === 403 || res.status === 429) {
+        window.location.href = 'https://github.com/Iktahana/illusions/blob/main/README.md'
+        return
+      }
+      if (!res.ok) {
+        throw new Error(`GitHub API returned ${res.status}`)
+      }
+      const data = (await res.json()) as GitHubRelease
+      saveCache(data)
+      renderPage(data, null)
+    })
+    .catch((err: Error) => {
+      renderPage(null, err.message)
+    })
+}

--- a/www/src/main.ts
+++ b/www/src/main.ts
@@ -28,6 +28,14 @@ if (bgImageUrl) {
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <nav class="top-nav">
     <a href="https://my.illusions.app" class="nav-login-link">ログイン / 新規登録</a>
+    <button class="hamburger" id="hamburger-btn" aria-label="メニューを開く" aria-expanded="false">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+    <div class="mobile-menu" id="mobile-menu">
+      <a href="https://my.illusions.app" class="mobile-menu-link">ログイン / 新規登録</a>
+    </div>
   </nav>
   <div class="hero">
     <div class="title-logo">${logoSvg}</div>
@@ -81,3 +89,28 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
     </footer>
   </div>
 `
+
+// Hamburger menu toggle
+const hamburgerBtn = document.getElementById('hamburger-btn')
+const mobileMenu = document.getElementById('mobile-menu')
+
+if (hamburgerBtn && mobileMenu) {
+  hamburgerBtn.addEventListener('click', () => {
+    const isOpen = hamburgerBtn.classList.toggle('is-open')
+    hamburgerBtn.setAttribute('aria-expanded', String(isOpen))
+    mobileMenu.classList.toggle('is-open')
+  })
+
+  // Close menu when clicking outside
+  document.addEventListener('click', (e) => {
+    if (
+      mobileMenu.classList.contains('is-open') &&
+      !hamburgerBtn.contains(e.target as Node) &&
+      !mobileMenu.contains(e.target as Node)
+    ) {
+      hamburgerBtn.classList.remove('is-open')
+      hamburgerBtn.setAttribute('aria-expanded', 'false')
+      mobileMenu.classList.remove('is-open')
+    }
+  })
+}

--- a/www/src/style.css
+++ b/www/src/style.css
@@ -93,6 +93,81 @@ body::before {
   box-shadow: var(--shadow-accent);
 }
 
+/* Hamburger button — hidden on desktop */
+.hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  width: 40px;
+  height: 40px;
+  padding: 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.hamburger span {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background: var(--color-text);
+  border-radius: 2px;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+  transform-origin: center;
+}
+
+/* X animation when open */
+.hamburger.is-open span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+.hamburger.is-open span:nth-child(2) {
+  opacity: 0;
+  transform: scaleX(0);
+}
+.hamburger.is-open span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+/* Mobile dropdown menu */
+.mobile-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  min-width: 180px;
+  background: rgba(12, 12, 12, 0.92);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(-6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+.mobile-menu.is-open {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.mobile-menu-link {
+  display: block;
+  padding: 0.875rem 1.25rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-text);
+  text-decoration: none;
+  transition: background 0.15s ease;
+}
+
+.mobile-menu-link:hover {
+  background: var(--color-surface-hover);
+}
+
 .hero {
   text-align: center;
   color: white;
@@ -761,7 +836,21 @@ h1 {
   }
 
   .hero {
-    padding: 2rem 1rem;
+    /* Extra top padding to clear the fixed nav and add breathing room below it */
+    padding: 5rem 1rem 2rem;
+  }
+
+  /* Switch to hamburger on mobile */
+  .nav-login-link {
+    display: none;
+  }
+
+  .hamburger {
+    display: flex;
+  }
+
+  .mobile-menu {
+    display: block;
   }
 
   h1 {
@@ -845,7 +934,7 @@ h1 {
 /* Small mobile breakpoint */
 @media (max-width: 480px) {
   .hero {
-    padding: 1.5rem 0.5rem;
+    padding: 4.5rem 0.5rem 1.5rem;
   }
 
   h1 {


### PR DESCRIPTION
## Summary
- Add responsive hamburger menu for mobile navigation with smooth open/close animation
- Cache GitHub release API responses in localStorage with 1-hour TTL to reduce API calls
- Redirect users to GitHub README on API rate limit errors (403/429) instead of showing a blank error
- Fix mobile hero section padding to account for fixed navigation bar clearance

## Test plan
- [ ] Verify hamburger menu appears on mobile viewport and toggles navigation links
- [ ] Confirm GitHub release data is cached in localStorage and reused within 1h
- [ ] Simulate 403/429 API response and verify redirect to GitHub README
- [ ] Check mobile hero section has proper padding below fixed nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)