### PR TITLE
fix(electron): remove stale llm-ipc-handlers reference causing CI failure

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -20,7 +20,6 @@ if (app.isPackaged) {
 }
 
 const { registerNlpHandlers } = require('./nlp/nlp-ipc-handlers')
-const { registerLlmHandlers, disposeLlmEngine } = require('./llm/llm-ipc-handlers')
 const { registerStorageHandlers } = require('./storage-ipc-handlers')
 const { registerVFSHandlers } = require('./vfs-ipc-handlers')
 const { setupAutoUpdater, checkForUpdates } = require('./auto-updater')
@@ -111,7 +110,6 @@ app.whenReady().then(async () => {
 
   // Register IPC handlers
   registerNlpHandlers()
-  registerLlmHandlers()
   registerStorageHandlers()
   registerVFSHandlers()
   registerFileHandlers()
@@ -135,18 +133,8 @@ app.whenReady().then(async () => {
   })
 })
 
-let isQuitting = false
-app.on('before-quit', (event) => {
-  if (isQuitting) return
-  isQuitting = true
-  event.preventDefault()
-  const forceQuitTimeout = setTimeout(() => app.exit(0), 5000)
-  disposeLlmEngine()
-    .catch((err) => console.error('[before-quit] LLM disposal error:', err))
-    .finally(() => {
-      clearTimeout(forceQuitTimeout)
-      app.exit(0)
-    })
+app.on('before-quit', () => {
+  // Cleanup handled by individual IPC modules
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Summary
- Removes stale `require('./llm/llm-ipc-handlers')` from `electron/main.js`
- The local LLM engine was deleted in PR #743 but the import was left behind
- This caused `esbuild` to fail with `Could not resolve "./llm/llm-ipc-handlers"` on every `dev` branch CI run

## Root Cause
PR #771 modularized `main.js` but preserved the broken import from the already-deleted module.

## Changes
- Remove `require('./llm/llm-ipc-handlers')` import
- Remove `registerLlmHandlers()` call
- Replace `disposeLlmEngine()` `before-quit` handler with a no-op (LLM engine no longer exists)

## Test plan
- [ ] CI build passes on Windows (esbuild bundling succeeds)
- [ ] CI build passes on macOS arm64
- [ ] Electron app starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)