### PR TITLE
refactor: update linting type system (#775)

### DIFF
--- a/lib/linting/base-rule.ts
+++ b/lib/linting/base-rule.ts
@@ -2,12 +2,14 @@ import type { Token } from "@/lib/nlp-client/types";
 
 import type {
   CorrectionEngine,
+  JsonRuleMeta,
   LintRule,
   LintRuleConfig,
   LintIssue,
   DocumentLintRule,
   MorphologicalLintRule,
   MorphologicalDocumentLintRule,
+  RuleLevel,
 } from "./types";
 
 /**
@@ -20,7 +22,7 @@ export abstract class AbstractLintRule implements LintRule {
   abstract readonly nameJa: string;
   abstract readonly description: string;
   abstract readonly descriptionJa: string;
-  abstract readonly level: "L1" | "L2";
+  abstract readonly level: RuleLevel;
   abstract readonly defaultConfig: LintRuleConfig;
   /** Default engine for simple regex-based rules */
   engine: CorrectionEngine = "regex";
@@ -98,5 +100,41 @@ export abstract class AbstractMorphologicalDocumentLintRule
     _config: LintRuleConfig,
   ): Array<{ paragraphIndex: number; issues: LintIssue[] }> {
     return [];
+  }
+}
+
+/**
+ * Abstract base class for data-driven L1 (regex) lint rules.
+ * These rules are configured via JsonRuleMeta loaded from rules.json.
+ */
+export abstract class AbstractL1Rule extends AbstractLintRule {
+  readonly meta: JsonRuleMeta;
+  readonly id: string;
+  readonly name: string;
+  readonly nameJa: string;
+  readonly description: string;
+  readonly descriptionJa: string;
+  readonly level: RuleLevel = "L1";
+  readonly defaultConfig: LintRuleConfig;
+
+  constructor(
+    meta: JsonRuleMeta,
+    config: {
+      id: string;
+      name: string;
+      nameJa: string;
+      description: string;
+      descriptionJa: string;
+      defaultConfig: LintRuleConfig;
+    },
+  ) {
+    super();
+    this.meta = meta;
+    this.id = config.id;
+    this.name = config.name;
+    this.nameJa = config.nameJa;
+    this.description = config.description;
+    this.descriptionJa = config.descriptionJa;
+    this.defaultConfig = config.defaultConfig;
   }
 }

--- a/lib/linting/index.ts
+++ b/lib/linting/index.ts
@@ -1,5 +1,7 @@
 export type {
   CorrectionEngine,
+  JsonRuleMeta,
+  RuleLevel,
   Severity,
   LintIssue,
   LintRule,
@@ -15,6 +17,7 @@ export {
   isMorphologicalDocumentLintRule,
 } from "./types";
 export {
+  AbstractL1Rule,
   AbstractLintRule,
   AbstractDocumentLintRule,
   AbstractMorphologicalLintRule,

--- a/lib/linting/types.ts
+++ b/lib/linting/types.ts
@@ -3,8 +3,26 @@ import type { Token } from "@/lib/nlp-client/types";
 
 export type Severity = "error" | "warning" | "info";
 
+/** Detection level: L1=regex, L2=morphological, L3=LLM-assisted */
+export type RuleLevel = "L1" | "L2" | "L3";
+
 /** The underlying implementation engine for a correction rule */
 export type CorrectionEngine = "regex" | "morphological";
+
+/**
+ * Metadata for a JSON-driven lint rule.
+ * Used by data-driven L1 rules loaded from rules.json.
+ */
+export interface JsonRuleMeta {
+  ruleId: string;
+  level: RuleLevel;
+  description: string;
+  patternLogic: string;
+  positiveExample: string;
+  negativeExample: string;
+  sourceReference: string;
+  bookTitle: string;
+}
 
 export interface LintReference {
   /** Standard name, e.g. "JIS X 4051:2004" */
@@ -52,8 +70,8 @@ export interface LintRule {
   nameJa: string;
   description: string;
   descriptionJa: string;
-  /** Detection level: L1=regex, L2=morphological */
-  level: "L1" | "L2";
+  /** Detection level: L1=regex, L2=morphological, L3=LLM-assisted */
+  level: RuleLevel;
   /** The underlying implementation engine for this rule */
   engine?: CorrectionEngine;
   defaultConfig: LintRuleConfig;


### PR DESCRIPTION
## Summary
- Add `RuleLevel` type extending level to include "L3"
- Add `JsonRuleMeta` interface for JSON rule metadata
- Add `AbstractL1Rule` base class for data-driven L1 rules
- Backward compatible — existing rules compile without changes

Closes #775

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Existing L1 and L2 rules still work
- [ ] New types are properly exported from `lib/linting/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)