### PR TITLE
fix: eliminate any types and improve type safety

### DIFF
--- a/lib/editor-page/use-electron-events.ts
+++ b/lib/editor-page/use-electron-events.ts
@@ -73,8 +73,7 @@ export function useElectronEvents(params: UseElectronEventsParams): void {
   useEffect(() => {
     if (!isElectron || typeof window === "undefined") return;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const unsubscribe = (window as any).electronAPI?.onPasteAsPlaintext?.(() => {
+    const unsubscribe = window.electronAPI?.onPasteAsPlaintext?.(() => {
       void handlePasteAsPlaintext();
     });
 

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -18,10 +18,9 @@ interface UseExportParams {
  */
 async function saveTxtFile(text: string, suggestedName: string): Promise<boolean> {
   // Try File System Access API first (Chromium browsers + Electron)
-  if ("showSaveFilePicker" in window) {
+  if (hasShowSaveFilePicker(window)) {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const handle = await (window as any).showSaveFilePicker({
+      const handle = await window.showSaveFilePicker({
         suggestedName,
         types: [
           {
@@ -206,4 +205,15 @@ export function useExport({ getContent, getTitle }: UseExportParams): {
   }, [isElectron, exportAs]);
 
   return { exportAs };
+}
+
+/**
+ * Type guard: checks whether window has the File System Access API showSaveFilePicker method.
+ */
+function hasShowSaveFilePicker(
+  w: Window
+): w is Window & {
+  showSaveFilePicker: (options?: object) => Promise<FileSystemFileHandle>;
+} {
+  return "showSaveFilePicker" in w;
 }

--- a/lib/utils/feature-detection.ts
+++ b/lib/utils/feature-detection.ts
@@ -52,8 +52,10 @@ export function isFileSystemHandleSupported(): boolean {
     // createWritable は FileSystemFileHandle のメソッドなので prototype を確認
     const hasCreateWritable =
       hasFileHandle &&
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      typeof (window as any).FileSystemFileHandle?.prototype?.createWritable !== "undefined";
+      typeof (
+        (window as Window & { FileSystemFileHandle?: { prototype?: { createWritable?: unknown } } })
+          .FileSystemFileHandle?.prototype?.createWritable
+      ) !== "undefined";
 
     return hasFileHandle && hasDirHandle && hasCreateWritable;
   } catch (error) {

--- a/packages/milkdown-plugin-japanese-novel/nodes/heading-anchor.ts
+++ b/packages/milkdown-plugin-japanese-novel/nodes/heading-anchor.ts
@@ -82,8 +82,12 @@ export const headingAnchorSchema = $nodeSchema('heading', (ctx) => {
         // 見出しの本文からID生成用テキストを抽出
         let textContent = ''
         if (node.children && Array.isArray(node.children)) {
-          textContent = node.children
-            .map((child: any) => child.value || '')
+          textContent = (node.children as unknown[])
+            .map((child) =>
+              (child !== null && typeof child === 'object' && 'value' in child)
+                ? String((child as { value: unknown }).value)
+                : ''
+            )
             .join('')
         }
         

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -49,6 +49,7 @@ declare global {
     revealInFileManager?: (filePath: string) => Promise<boolean>;
     openExternal?: (url: string) => Promise<boolean>;
     onMenuShowInFileManager?: (callback: () => void) => (() => void) | void;
+    onPasteAsPlaintext?: (callback: () => void) => (() => void) | void;
     onToggleCompactMode?: (callback: () => void) => (() => void) | void;
     onFormatChange?: (callback: (setting: string, action: string) => void) => (() => void) | void;
     onThemeChange?: (callback: (mode: "auto" | "light" | "dark") => void) => (() => void) | void;


### PR DESCRIPTION
## Summary
Closes #750 — removes `any` types and `@ts-ignore` in key files.

## Changes
- `types/electron.d.ts`: add missing `onPasteAsPlaintext` method to `ElectronAPI` interface
- `lib/editor-page/use-electron-events.ts`: remove `(window as any)` cast, use properly typed `window.electronAPI`
- `lib/export/use-export.ts`: replace `(window as any).showSaveFilePicker` with a type-narrowing guard function (same pattern as `mdi-file.ts`)
- `lib/utils/feature-detection.ts`: replace `(window as any).FileSystemFileHandle` with an inline intersection type cast
- `packages/milkdown-plugin-japanese-novel/nodes/heading-anchor.ts`: replace `child: any` with `unknown` + type guard for MDAST children

## Notes
- `components/Editor.tsx` and `components/editor/MilkdownEditor.tsx` had no `any` types to fix (already clean)
- `lib/storage/electron-storage-manager.ts` and `lib/project/mdi-file.ts` had no `@ts-ignore` or `any` (already clean)
- `lib/vfs/electron-vfs.ts` does not exist in this codebase

## Test plan
- [ ] `npx tsc --noEmit` passes (zero errors on main repo, pre-existing serwist typings issue only appears when running tsc from worktree without `node_modules`)
- [ ] Editor search functionality works
- [ ] Paste as plaintext menu action works
- [ ] TXT export / save file picker works
- [ ] File System Access API feature detection works
- [ ] Heading anchors render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)