### PR TITLE
feat(keymap): keyboard shortcut system redesign with customization

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { ThemeProvider } from "../contexts/ThemeContext";
 import { EditorModeProvider } from "../contexts/EditorModeContext";
+import { KeymapProvider } from "../contexts/KeymapContext";
 import { NotificationContainer } from "@/components/NotificationContainer";
 import AnalyticsLoader from "@/components/AnalyticsLoader";
 
@@ -30,7 +31,9 @@ export default function RootLayout({
       </head>
       <body className="antialiased">
         <ThemeProvider>
-          <EditorModeProvider>{children}</EditorModeProvider>
+          <EditorModeProvider>
+            <KeymapProvider>{children}</KeymapProvider>
+          </EditorModeProvider>
         </ThemeProvider>
         <NotificationContainer />
         {/* Only load analytics in web environment (client-side check) */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -574,6 +574,9 @@ export default function EditorPage() {
     activeTabId,
     splitEditorRight: useCallback(() => splitEditor("right"), [splitEditor]),
     splitEditorDown: useCallback(() => splitEditor("down"), [splitEditor]),
+    toggleExplorer: useCallback(() => setTopView(topView === "explorer" ? "none" : "explorer"), [setTopView, topView]),
+    toggleSearch: useCallback(() => setTopView(topView === "search" ? "none" : "search"), [setTopView, topView]),
+    toggleOutline: useCallback(() => setTopView(topView === "outline" ? "none" : "outline"), [setTopView, topView]),
   });
 
   // Detect feature availability after mount to avoid SSR hydration mismatch

--- a/components/ActivityBar.tsx
+++ b/components/ActivityBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import {
   FileText,
   Settings,
@@ -14,6 +14,9 @@ import {
 } from "lucide-react";
 import clsx from "clsx";
 import { localPreferences } from "@/lib/storage/local-preferences";
+import { useKeymap } from "@/contexts/KeymapContext";
+import { formatBinding } from "@/lib/keymap/keymap-utils";
+import type { CommandId } from "@/lib/keymap/command-ids";
 import {
   DndContext,
   PointerSensor,
@@ -40,6 +43,14 @@ interface ActivityBarItem {
   tooltip: string;
 }
 
+/** Maps ActivityBarView IDs to their keyboard shortcut CommandId */
+const VIEW_TO_COMMAND_ID: Partial<Record<ActivityBarView, CommandId>> = {
+  explorer: "panel.explorer",
+  search: "panel.search",
+  outline: "panel.outline",
+  settings: "nav.settings",
+};
+
 /** Top group: primary navigation (document/project structure) */
 const DEFAULT_TOP_ITEMS: ActivityBarItem[] = [
   {
@@ -52,19 +63,19 @@ const DEFAULT_TOP_ITEMS: ActivityBarItem[] = [
     id: "explorer",
     icon: Layers,
     label: "エクスプローラー",
-    tooltip: "エクスプローラー (Ctrl+Shift+E)"
+    tooltip: "エクスプローラー"
   },
   {
     id: "search",
     icon: Search,
     label: "検索",
-    tooltip: "検索 (Ctrl+Shift+F)"
+    tooltip: "検索"
   },
   {
     id: "outline",
     icon: Book,
     label: "アウトライン",
-    tooltip: "アウトライン (Ctrl+Shift+O)"
+    tooltip: "アウトライン"
   },
 ];
 
@@ -92,7 +103,7 @@ const DEFAULT_BOTTOM_ITEMS: ActivityBarItem[] = [
     id: "settings",
     icon: Settings,
     label: "設定",
-    tooltip: "設定 (Ctrl+,)"
+    tooltip: "設定"
   },
 ];
 
@@ -220,6 +231,27 @@ export default function ActivityBar({
     loadOrder(() => localPreferences.getSidebarBottomOrder(), DEFAULT_BOTTOM_ITEMS)
   );
 
+  const { effectiveBindings } = useKeymap();
+
+  /** Adds the keyboard shortcut to the tooltip if this view has a CommandId */
+  const withTooltip = useCallback((item: ActivityBarItem): ActivityBarItem => {
+    const commandId = VIEW_TO_COMMAND_ID[item.id];
+    if (!commandId) return item;
+    const binding = effectiveBindings[commandId];
+    const shortcut = formatBinding(binding);
+    if (shortcut === "未設定") return item;
+    return { ...item, tooltip: `${item.label} (${shortcut})` };
+  }, [effectiveBindings]);
+
+  const topItemsWithTooltips = useMemo(
+    () => topItems.map(withTooltip),
+    [topItems, withTooltip]
+  );
+  const bottomItemsWithTooltips = useMemo(
+    () => bottomItems.map(withTooltip),
+    [bottomItems, withTooltip]
+  );
+
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor)
@@ -269,7 +301,7 @@ export default function ActivityBar({
           items={topItems.map((item) => item.id)}
           strategy={verticalListSortingStrategy}
         >
-          {topItems.map((item) => (
+          {topItemsWithTooltips.map((item) => (
             <SortableButton
               key={item.id}
               item={item}
@@ -290,7 +322,7 @@ export default function ActivityBar({
           items={bottomItems.map((item) => item.id)}
           strategy={verticalListSortingStrategy}
         >
-          {bottomItems.map((item) => (
+          {bottomItemsWithTooltips.map((item) => (
             <SortableButton
               key={item.id}
               item={item}

--- a/components/EditorContextMenu.tsx
+++ b/components/EditorContextMenu.tsx
@@ -5,6 +5,8 @@ import { Scissors, Copy, ClipboardPaste, Search, CheckSquare, Languages, ALargeS
 import type { ReactNode, MouseEvent } from "react";
 
 import type { LintIssue } from "@/lib/linting";
+import { useKeymap } from "@/contexts/KeymapContext";
+import { formatBinding } from "@/lib/keymap/keymap-utils";
 
 export type ContextMenuAction =
   | "cut"
@@ -68,7 +70,9 @@ export default function EditorContextMenu({
   lintIssueAtCursor,
   onContextMenuOpen,
 }: EditorContextMenuProps) {
-  // Detect platform for keyboard shortcuts
+  const { effectiveBindings } = useKeymap();
+
+  // Detect platform for native shortcuts (cut/copy/paste are browser built-ins not in registry)
   const isMac = typeof navigator !== "undefined" && /Mac/.test(navigator.platform);
   const cmdKey = isMac ? "⌘" : "Ctrl+";
 
@@ -128,7 +132,7 @@ export default function EditorContextMenu({
           <MenuItem
             icon={<ClipboardPaste className="w-4 h-4" />}
             label="プレーンテキストとして貼り付け"
-            shortcut={`Shift+${cmdKey}V`}
+            shortcut={formatBinding(effectiveBindings["edit.pasteAsPlaintext"])}
             onClick={() => onAction("paste-plaintext")}
           />
 
@@ -138,14 +142,14 @@ export default function EditorContextMenu({
           <MenuItem
             icon={<Languages className="w-4 h-4" />}
             label="ルビ"
-            shortcut={`Shift+${cmdKey}R`}
+            shortcut={formatBinding(effectiveBindings["format.ruby"])}
             onClick={() => onAction("ruby")}
             disabled={!hasSelection}
           />
           <MenuItem
             icon={<ALargeSmall className="w-4 h-4" />}
             label="縦中横"
-            shortcut={`Shift+${cmdKey}T`}
+            shortcut={formatBinding(effectiveBindings["format.tcy"])}
             onClick={() => onAction("tcy")}
             disabled={!hasSelection}
           />
@@ -156,7 +160,7 @@ export default function EditorContextMenu({
           <MenuItem
             icon={<Search className="w-4 h-4" />}
             label="検索"
-            shortcut={`${cmdKey}F`}
+            shortcut={formatBinding(effectiveBindings["nav.search"])}
             onClick={() => onAction("find")}
           />
           <MenuItem

--- a/components/KeybindingInput.tsx
+++ b/components/KeybindingInput.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { KeyBinding } from "@/lib/keymap/keymap-types";
+import { buildBindingFromEvent, formatBinding } from "@/lib/keymap/keymap-utils";
+
+interface KeybindingInputProps {
+  onRecord: (binding: KeyBinding) => void;
+  onCancel: () => void;
+}
+
+/**
+ * An input area that listens for a key combination and records it as a KeyBinding.
+ * Press Escape to cancel.
+ */
+export default function KeybindingInput({ onRecord, onCancel }: KeybindingInputProps) {
+  const [preview, setPreview] = useState<string>("キーを押してください...");
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (e.key === "Escape") {
+      onCancel();
+      return;
+    }
+
+    const binding = buildBindingFromEvent(e.nativeEvent);
+    if (!binding) return;
+
+    setPreview(formatBinding(binding));
+
+    // Require at least one modifier for non-Tab keys
+    if (binding.key !== "Tab" && binding.modifiers.length === 0) {
+      setPreview(`${formatBinding(binding)} (修飾キーが必要です)`);
+      return;
+    }
+
+    onRecord(binding);
+  };
+
+  return (
+    <div
+      ref={ref}
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      className="px-3 py-2 rounded border border-accent bg-accent/10 text-sm text-foreground font-mono outline-none focus:ring-2 focus:ring-accent cursor-text min-w-[160px] text-center"
+    >
+      {preview}
+    </div>
+  );
+}

--- a/components/KeymapSettings.tsx
+++ b/components/KeymapSettings.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import { RotateCcw, Edit2 } from "lucide-react";
+import clsx from "clsx";
+
+import type { CommandId } from "@/lib/keymap/command-ids";
+import type { KeyBinding, ShortcutCategory } from "@/lib/keymap/keymap-types";
+import { ALL_COMMAND_IDS } from "@/lib/keymap/command-ids";
+import { SHORTCUT_REGISTRY } from "@/lib/keymap/shortcut-registry";
+import { formatBinding } from "@/lib/keymap/keymap-utils";
+import { useKeymap } from "@/contexts/KeymapContext";
+import KeybindingInput from "./KeybindingInput";
+
+/** Japanese display names for each category */
+const CATEGORY_LABELS: Record<ShortcutCategory, string> = {
+  file: "ファイル",
+  edit: "編集",
+  format: "書式",
+  view: "表示",
+  nav: "ナビゲーション",
+  panel: "パネル",
+  app: "アプリ",
+};
+
+const CATEGORY_ORDER: ShortcutCategory[] = ["file", "edit", "format", "view", "nav", "panel", "app"];
+
+export default function KeymapSettings() {
+  const { effectiveBindings, overrides, setOverride, resetOverride, resetAll } = useKeymap();
+  const [recording, setRecording] = useState<CommandId | null>(null);
+
+  /** Find all commands that bind to a given binding string (for conflict detection) */
+  const bindingConflicts = useMemo(() => {
+    const bindingKey = (b: KeyBinding | null): string => {
+      if (!b) return "";
+      return `${b.modifiers.sort().join("+")}_${b.key.toLowerCase()}`;
+    };
+
+    const keyToCommands = new Map<string, CommandId[]>();
+    for (const id of ALL_COMMAND_IDS) {
+      const b = effectiveBindings[id];
+      const k = bindingKey(b);
+      if (!k) continue;
+      const existing = keyToCommands.get(k) ?? [];
+      keyToCommands.set(k, [...existing, id]);
+    }
+
+    const conflicts = new Map<CommandId, CommandId[]>();
+    for (const [, ids] of keyToCommands) {
+      if (ids.length > 1) {
+        for (const id of ids) {
+          conflicts.set(id, ids.filter(x => x !== id));
+        }
+      }
+    }
+    return conflicts;
+  }, [effectiveBindings]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<ShortcutCategory, CommandId[]>();
+    for (const cat of CATEGORY_ORDER) map.set(cat, []);
+    for (const id of ALL_COMMAND_IDS) {
+      const entry = SHORTCUT_REGISTRY[id];
+      const list = map.get(entry.category) ?? [];
+      list.push(id);
+      map.set(entry.category, list);
+    }
+    return map;
+  }, []);
+
+  const handleRecord = async (id: CommandId, binding: KeyBinding) => {
+    await setOverride(id, binding);
+    setRecording(null);
+  };
+
+  const handleReset = async (id: CommandId) => {
+    await resetOverride(id);
+  };
+
+  const handleResetAll = async () => {
+    await resetAll();
+  };
+
+  const isOverridden = (id: CommandId) => id in overrides;
+
+  return (
+    <div className="space-y-6">
+      {/* Header with reset all button */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-foreground-secondary">
+          各コマンドのキーバインドを変更できます。「変更」ボタンを押してキーを入力してください。
+        </p>
+        <button
+          type="button"
+          onClick={handleResetAll}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded border border-border hover:bg-hover transition-colors text-foreground-secondary"
+        >
+          <RotateCcw className="w-3.5 h-3.5" />
+          すべてデフォルトにリセット
+        </button>
+      </div>
+
+      {/* Commands grouped by category */}
+      {CATEGORY_ORDER.map((cat) => {
+        const ids = grouped.get(cat) ?? [];
+        if (ids.length === 0) return null;
+
+        return (
+          <section key={cat}>
+            <h3 className="text-xs font-semibold text-foreground-tertiary uppercase tracking-wider mb-2">
+              {CATEGORY_LABELS[cat]}
+            </h3>
+            <div className="rounded-lg border border-border overflow-hidden">
+              {ids.map((id, idx) => {
+                const entry = SHORTCUT_REGISTRY[id];
+                const binding = effectiveBindings[id];
+                const conflictWith = bindingConflicts.get(id);
+                const modified = isOverridden(id);
+                const isRecording = recording === id;
+
+                return (
+                  <div
+                    key={id}
+                    className={clsx(
+                      "flex items-center gap-3 px-4 py-2.5 text-sm",
+                      idx > 0 && "border-t border-border",
+                      "bg-background hover:bg-hover transition-colors"
+                    )}
+                  >
+                    {/* Label */}
+                    <span className={clsx("flex-1 text-foreground", modified && "font-medium")}>
+                      {entry.label}
+                    </span>
+
+                    {/* Conflict warning */}
+                    {conflictWith && conflictWith.length > 0 && (
+                      <span className="text-xs text-destructive">
+                        「{SHORTCUT_REGISTRY[conflictWith[0]].label}」と競合しています
+                      </span>
+                    )}
+
+                    {/* Binding display or recording input */}
+                    {isRecording ? (
+                      <KeybindingInput
+                        onRecord={(b) => void handleRecord(id, b)}
+                        onCancel={() => setRecording(null)}
+                      />
+                    ) : (
+                      <span className={clsx(
+                        "font-mono text-xs px-2 py-1 rounded border min-w-[120px] text-center",
+                        modified
+                          ? "border-accent text-accent bg-accent/10"
+                          : "border-border text-foreground-secondary bg-background-elevated"
+                      )}>
+                        {formatBinding(binding)}
+                      </span>
+                    )}
+
+                    {/* Action buttons */}
+                    {!isRecording && (
+                      <div className="flex items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => setRecording(id)}
+                          className="p-1.5 rounded hover:bg-hover transition-colors text-foreground-secondary hover:text-foreground"
+                          title="変更"
+                        >
+                          <Edit2 className="w-3.5 h-3.5" />
+                        </button>
+                        {modified && (
+                          <button
+                            type="button"
+                            onClick={() => void handleReset(id)}
+                            className="p-1.5 rounded hover:bg-hover transition-colors text-foreground-secondary hover:text-foreground"
+                            title="リセット"
+                          >
+                            <RotateCcw className="w-3.5 h-3.5" />
+                          </button>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { X, Settings, Columns2, Highlighter, SpellCheck, BatteryMedium, AudioLines } from "lucide-react";
+import { X, Settings, Columns2, Highlighter, SpellCheck, BatteryMedium, AudioLines, Keyboard } from "lucide-react";
 import AboutSection from "./SettingsModal/AboutSection";
 import dynamic from "next/dynamic";
 
@@ -20,6 +20,7 @@ import {
 } from "@/contexts/EditorSettingsContext";
 import ColorPicker from "./ColorPicker";
 import LintingSettings from "./LintingSettings";
+import KeymapSettings from "./KeymapSettings";
 
 const PosHighlightPreview = dynamic(() => import("./PosHighlightPreview"), {
   ssr: false,
@@ -33,7 +34,7 @@ interface SettingsModalProps {
   initialCategory?: SettingsCategory;
 }
 
-export type SettingsCategory = "editor" | "vertical" | "pos-highlight" | "linting" | "speech" | "power" | "about";
+export type SettingsCategory = "editor" | "vertical" | "pos-highlight" | "linting" | "speech" | "keymap" | "power" | "about";
 
 const SCROLL_BEHAVIORS = [
   {
@@ -258,6 +259,18 @@ export default function SettingsModal({
               >
                 <AudioLines className="w-4 h-4" />
                 聴写/朗読
+              </button>
+              <button
+                onClick={() => setActiveCategory("keymap")}
+                className={clsx(
+                  "w-full text-left px-3 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5",
+                  activeCategory === "keymap"
+                    ? "bg-accent text-accent-foreground"
+                    : "text-foreground-secondary hover:bg-hover hover:text-foreground"
+                )}
+              >
+                <Keyboard className="w-4 h-4" />
+                キーマップ
               </button>
               {isElectronRenderer() && (
                 <button
@@ -731,6 +744,14 @@ export default function SettingsModal({
                     </div>
                   </div>
                 </div>
+              </div>
+            )}
+
+            {/* Keymap section */}
+            {activeCategory === "keymap" && (
+              <div className="p-6">
+                <h3 className="text-lg font-semibold text-foreground mb-1">キーマップ</h3>
+                <KeymapSettings />
               </div>
             )}
 

--- a/contexts/KeymapContext.tsx
+++ b/contexts/KeymapContext.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import type { CommandId } from "@/lib/keymap/command-ids";
+import type { KeyBinding, KeymapOverrides } from "@/lib/keymap/keymap-types";
+import { loadKeymapOverrides, saveKeymapOverrides } from "@/lib/keymap/keymap-storage";
+import { SHORTCUT_REGISTRY } from "@/lib/keymap/shortcut-registry";
+
+/**
+ * The effective binding for a command: either the user override or the default.
+ */
+export type EffectiveBindings = Record<CommandId, KeyBinding | null>;
+
+export interface KeymapContextValue {
+  /** Merged bindings (defaults + user overrides) */
+  effectiveBindings: EffectiveBindings;
+  /** Raw user overrides (only differences from defaults) */
+  overrides: KeymapOverrides;
+  /** Set or clear a binding override for a command */
+  setOverride: (id: CommandId, binding: KeyBinding | null) => Promise<void>;
+  /** Reset a single command back to its default */
+  resetOverride: (id: CommandId) => Promise<void>;
+  /** Reset all commands to their defaults */
+  resetAll: () => Promise<void>;
+}
+
+const KeymapContext = createContext<KeymapContextValue | null>(null);
+
+interface KeymapProviderProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Builds the default bindings map from the registry.
+ */
+function buildDefaultBindings(): EffectiveBindings {
+  const result = {} as EffectiveBindings;
+  for (const entry of Object.values(SHORTCUT_REGISTRY)) {
+    result[entry.id] = entry.defaultBinding;
+  }
+  return result;
+}
+
+/**
+ * Merges default bindings with user overrides.
+ */
+function mergeBindings(defaults: EffectiveBindings, overrides: KeymapOverrides): EffectiveBindings {
+  return { ...defaults, ...overrides } as EffectiveBindings;
+}
+
+/**
+ * Provider that loads keymap overrides from storage and exposes
+ * effective (merged) bindings to all child components.
+ */
+export function KeymapProvider({ children }: KeymapProviderProps): React.JSX.Element {
+  const defaultBindings = useMemo(() => buildDefaultBindings(), []);
+  const [overrides, setOverrides] = useState<KeymapOverrides>({});
+
+  useEffect(() => {
+    void loadKeymapOverrides().then(setOverrides);
+  }, []);
+
+  const effectiveBindings = useMemo(
+    () => mergeBindings(defaultBindings, overrides),
+    [defaultBindings, overrides],
+  );
+
+  /** Notifies Electron main process to rebuild native menu with new accelerators */
+  const syncElectronMenu = useCallback(async (next: KeymapOverrides) => {
+    if (typeof window !== "undefined") {
+      const api = (window as Window & { electronAPI?: { updateKeymapOverrides?: (o: KeymapOverrides) => Promise<boolean> } }).electronAPI;
+      await api?.updateKeymapOverrides?.(next);
+    }
+  }, []);
+
+  const setOverride = useCallback(async (id: CommandId, binding: KeyBinding | null) => {
+    const next: KeymapOverrides = { ...overrides, [id]: binding };
+    setOverrides(next);
+    await saveKeymapOverrides(next);
+    await syncElectronMenu(next);
+  }, [overrides, syncElectronMenu]);
+
+  const resetOverride = useCallback(async (id: CommandId) => {
+    const next = { ...overrides };
+    delete next[id];
+    setOverrides(next);
+    await saveKeymapOverrides(next);
+    await syncElectronMenu(next);
+  }, [overrides, syncElectronMenu]);
+
+  const resetAll = useCallback(async () => {
+    setOverrides({});
+    await saveKeymapOverrides({});
+    await syncElectronMenu({});
+  }, [syncElectronMenu]);
+
+  const value = useMemo<KeymapContextValue>(
+    () => ({ effectiveBindings, overrides, setOverride, resetOverride, resetAll }),
+    [effectiveBindings, overrides, setOverride, resetOverride, resetAll],
+  );
+
+  return (
+    <KeymapContext.Provider value={value}>
+      {children}
+    </KeymapContext.Provider>
+  );
+}
+
+/**
+ * Hook to consume keymap context.
+ * Must be called within a KeymapProvider.
+ */
+export function useKeymap(): KeymapContextValue {
+  const ctx = useContext(KeymapContext);
+  if (!ctx) {
+    throw new Error("useKeymap must be used within a KeymapProvider");
+  }
+  return ctx;
+}

--- a/electron/ipc/system-ipc.js
+++ b/electron/ipc/system-ipc.js
@@ -49,6 +49,14 @@ function registerSystemHandlers() {
     return true
   })
 
+  // Sync keymap overrides from renderer to update menu accelerators
+  ipcMain.handle('menu:update-keymap-overrides', async (_event, overrides) => {
+    const { setKeymapOverrides, rebuildApplicationMenu } = require('../menu')
+    setKeymapOverrides(overrides)
+    await rebuildApplicationMenu()
+    return true
+  })
+
   // safeStorage: OS-level encryption (macOS Keychain / Windows DPAPI)
   ipcMain.handle('safe-storage:encrypt', (_event, plaintext) => {
     if (typeof plaintext !== 'string' || !plaintext) return null

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -13,12 +13,61 @@ let menuUiState = {
   autoCharsPerLine: true,
 }
 
+// Keymap overrides synced from renderer (only differences from defaults)
+let keymapOverrides = {}
+
+/**
+ * Default Electron accelerator strings keyed by CommandId.
+ * Mirrors the defaults in lib/keymap/shortcut-registry.ts.
+ */
+const DEFAULT_ACCELERATORS = {
+  'file.save': 'CmdOrCtrl+S',
+  'file.saveAs': 'CmdOrCtrl+Shift+S',
+  'file.open': 'CmdOrCtrl+O',
+  'file.newWindow': 'CmdOrCtrl+N',
+  'file.newTab': 'CmdOrCtrl+T',
+  'file.closeTab': 'CmdOrCtrl+W',
+  'edit.undo': 'CmdOrCtrl+Z',
+  'edit.redo': 'CmdOrCtrl+Y',
+  'edit.pasteAsPlaintext': 'CmdOrCtrl+Shift+V',
+  'edit.selectAll': 'CmdOrCtrl+A',
+  'view.compactMode': 'CmdOrCtrl+Shift+M',
+}
+
+/**
+ * Resolves the Electron accelerator for a command, applying user overrides.
+ * @param {string} commandId
+ * @returns {string | undefined}
+ */
+function resolveAccelerator(commandId) {
+  const override = keymapOverrides[commandId]
+  if (override === null) return undefined // intentionally unbound
+  if (override) {
+    // Convert KeyBinding { modifiers: [...], key: "s" } to "CmdOrCtrl+Shift+S"
+    const keyMap = {
+      Tab: 'Tab', Escape: 'Escape', Backspace: 'Backspace', Delete: 'Delete',
+      Enter: 'Return', ArrowUp: 'Up', ArrowDown: 'Down', ArrowLeft: 'Left', ArrowRight: 'Right',
+    }
+    const key = keyMap[override.key] ?? override.key.toUpperCase()
+    return [...override.modifiers, key].join('+')
+  }
+  return DEFAULT_ACCELERATORS[commandId]
+}
+
 function getMenuUiState() {
   return menuUiState
 }
 
 function setMenuUiState(state) {
   menuUiState = { ...menuUiState, ...state }
+}
+
+function getKeymapOverrides() {
+  return keymapOverrides
+}
+
+function setKeymapOverrides(overrides) {
+  keymapOverrides = overrides ?? {}
 }
 
 function buildApplicationMenu(recentProjects = []) {
@@ -56,7 +105,7 @@ function buildApplicationMenu(recentProjects = []) {
     submenu: [
       {
         label: '新規ウィンドウ',
-        accelerator: 'CmdOrCtrl+N',
+        accelerator: resolveAccelerator('file.newWindow'),
         click: () => {
           // Defer require to avoid circular dependency with window-manager.js
           const { createWindow } = require('./window-manager')
@@ -83,21 +132,21 @@ function buildApplicationMenu(recentProjects = []) {
       { type: 'separator' },
       {
         label: 'ファイルを開く...',
-        accelerator: 'CmdOrCtrl+O',
+        accelerator: resolveAccelerator('file.open'),
         click: () => {
           sendToFocused('menu-open-triggered')
         },
       },
       {
         label: '保存',
-        accelerator: 'CmdOrCtrl+S',
+        accelerator: resolveAccelerator('file.save'),
         click: () => {
           sendToFocused('menu-save-triggered')
         },
       },
       {
         label: '別名で保存...',
-        accelerator: 'Shift+CmdOrCtrl+S',
+        accelerator: resolveAccelerator('file.saveAs'),
         click: () => {
           sendToFocused('menu-save-as-triggered')
         },
@@ -123,14 +172,14 @@ function buildApplicationMenu(recentProjects = []) {
       { type: 'separator' },
       {
         label: '新しいタブ',
-        accelerator: 'CmdOrCtrl+T',
+        accelerator: resolveAccelerator('file.newTab'),
         click: () => {
           sendToFocused('menu-new-tab')
         },
       },
       {
         label: 'タブを閉じる',
-        accelerator: 'CmdOrCtrl+W',
+        accelerator: resolveAccelerator('file.closeTab'),
         click: () => {
           sendToFocused('menu-close-tab')
         },
@@ -152,7 +201,7 @@ function buildApplicationMenu(recentProjects = []) {
       { role: 'paste', label: '貼り付け' },
       {
         label: 'プレーンテキストとして貼り付け',
-        accelerator: 'Shift+CmdOrCtrl+V',
+        accelerator: resolveAccelerator('edit.pasteAsPlaintext'),
         click: () => {
           sendToFocused('menu-paste-as-plaintext')
         },
@@ -237,7 +286,7 @@ function buildApplicationMenu(recentProjects = []) {
         label: 'コンパクトモード',
         type: 'checkbox',
         checked: menuUiState.compactMode,
-        accelerator: 'CmdOrCtrl+Shift+M',
+        accelerator: resolveAccelerator('view.compactMode'),
         click: () => {
           sendToFocused('menu-toggle-compact-mode')
         },
@@ -314,4 +363,6 @@ module.exports = {
   rebuildApplicationMenu,
   getMenuUiState,
   setMenuUiState,
+  getKeymapOverrides,
+  setKeymapOverrides,
 }

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -79,6 +79,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   rebuildMenu: () => ipcRenderer.invoke('menu:rebuild'),
   syncMenuUiState: (state) => ipcRenderer.invoke('menu:sync-ui-state', state),
+  updateKeymapOverrides: (overrides) => ipcRenderer.invoke('menu:update-keymap-overrides', overrides),
   onMenuShowInFileManager: (callback) => {
     const handler = () => callback()
     ipcRenderer.on('menu-show-in-file-manager', handler)

--- a/lib/editor-page/use-keyboard-shortcuts.ts
+++ b/lib/editor-page/use-keyboard-shortcuts.ts
@@ -1,8 +1,11 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useEffect } from "react";
+import { useMemo } from "react";
 
 import type { MdiFileDescriptor } from "@/lib/project/mdi-file";
 import type { SupportedFileExtension } from "@/lib/project/project-types";
+import type { CommandId } from "@/lib/keymap/command-ids";
+import { useKeymapListener } from "@/lib/keymap/use-keymap-listener";
+import { useKeymap } from "@/contexts/KeymapContext";
 
 interface TabInfo {
   id: string;
@@ -31,13 +34,15 @@ interface UseKeyboardShortcutsParams {
   // Split editor operations
   splitEditorRight?: () => void;
   splitEditorDown?: () => void;
+  // Panel toggle operations
+  toggleExplorer?: () => void;
+  toggleSearch?: () => void;
+  toggleOutline?: () => void;
 }
 
 /**
  * Keyboard shortcut handler for the editor page.
- *
- * Handles: save, search, settings, paste-as-plaintext, compact mode,
- * ruby dialog, tcy toggle, and tab navigation.
+ * Delegates to useKeymapListener using the centralized keymap registry.
  */
 export function useKeyboardShortcuts({
   isElectron,
@@ -58,132 +63,77 @@ export function useKeyboardShortcuts({
   activeTabId,
   splitEditorRight,
   splitEditorDown,
+  toggleExplorer,
+  toggleSearch,
+  toggleOutline,
 }: UseKeyboardShortcutsParams): void {
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
-      const isMac = nav.userAgentData
-        ? nav.userAgentData.platform === "macOS"
-        : /mac/i.test(navigator.userAgent);
+  const { effectiveBindings } = useKeymap();
 
-      // Cmd+, (macOS) / Ctrl+, (Windows/Linux): Settings
-      const isSettingsShortcut = isMac
-        ? event.metaKey && event.key === ","
-        : event.ctrlKey && event.key === ",";
-
-      // Cmd+S (macOS) / Ctrl+S (Windows/Linux): Save
-      const isSaveShortcut = isMac
-        ? event.metaKey && event.key === "s"
-        : event.ctrlKey && event.key === "s";
-
-      // Cmd+F (macOS) / Ctrl+F (Windows/Linux): Search
-      const isSearchShortcut = isMac
-        ? event.metaKey && event.key === "f"
-        : event.ctrlKey && event.key === "f";
-
-      // Shift+Cmd+V (macOS) / Shift+Ctrl+V (Windows/Linux): Paste as plaintext
-      const isPasteAsPlaintextShortcut = isMac
-        ? event.shiftKey && event.metaKey && event.key === "v"
-        : event.shiftKey && event.ctrlKey && event.key === "v";
-
-      // Shift+Cmd+M (macOS) / Shift+Ctrl+M (Windows/Linux): Compact mode toggle
-      const isCompactModeShortcut = isMac
-        ? event.shiftKey && event.metaKey && event.key === "m"
-        : event.shiftKey && event.ctrlKey && event.key === "m";
-
-      // Shift+Cmd+R (macOS) / Shift+Ctrl+R (Windows/Linux): Ruby dialog
-      const isRubyShortcut = isMac
-        ? event.shiftKey && event.metaKey && event.key === "r"
-        : event.shiftKey && event.ctrlKey && event.key === "r";
-
-      // Shift+Cmd+T (macOS) / Shift+Ctrl+T (Windows/Linux): Tcy
-      const isTcyShortcut = isMac
-        ? event.shiftKey && event.metaKey && event.key === "t"
-        : event.shiftKey && event.ctrlKey && event.key === "t";
-
-      // Tab shortcuts (Web only; Electron handles Cmd+W/T via menu)
-      const isNextTab = event.ctrlKey && !event.shiftKey && event.key === "Tab";
-      const isPrevTab = event.ctrlKey && event.shiftKey && event.key === "Tab";
-      const isNewTabShortcut = !isElectron && (isMac
-        ? event.metaKey && !event.shiftKey && event.key === "t"
-        : event.ctrlKey && !event.shiftKey && event.key === "t");
-      const isCloseTabShortcut = !isElectron && (isMac
-        ? event.metaKey && event.key === "w"
-        : event.ctrlKey && event.key === "w");
-      const isTabJump = (isMac ? event.metaKey : event.ctrlKey) &&
-        !event.shiftKey && event.key >= "1" && event.key <= "9";
-
-      // Cmd+\ (macOS) / Ctrl+\ (Windows/Linux): Split editor right
-      const isSplitRight = isMac
-        ? event.metaKey && !event.shiftKey && event.key === "\\"
-        : event.ctrlKey && !event.shiftKey && event.key === "\\";
-
-      // Shift+Cmd+\ (macOS) / Shift+Ctrl+\ (Windows/Linux): Split editor down
-      const isSplitDown = isMac
-        ? event.shiftKey && event.metaKey && event.key === "\\"
-        : event.shiftKey && event.ctrlKey && event.key === "\\";
-
-      if (isSplitRight && splitEditorRight) {
-        event.preventDefault();
-        splitEditorRight();
-      } else if (isSplitDown && splitEditorDown) {
-        event.preventDefault();
-        splitEditorDown();
-      } else if (isTcyShortcut) {
-        event.preventDefault();
-        handleToggleTcy();
-      } else if (isRubyShortcut) {
-        event.preventDefault();
-        handleOpenRubyDialog();
-      } else if (isCompactModeShortcut) {
-        event.preventDefault();
-        handleToggleCompactMode();
-      } else if (isSettingsShortcut) {
-        event.preventDefault();
-        setShowSettingsModal(true);
-      } else if (isSaveShortcut) {
-        event.preventDefault();
-        void saveFile();
-      } else if (isSearchShortcut) {
-        event.preventDefault();
-        setSearchOpenTrigger(prev => prev + 1);
-      } else if (isPasteAsPlaintextShortcut) {
-        event.preventDefault();
-        void handlePasteAsPlaintext();
-      } else if (isNextTab) {
-        event.preventDefault();
-        nextTab();
-        incrementEditorKey();
-      } else if (isPrevTab) {
-        event.preventDefault();
-        prevTab();
-        incrementEditorKey();
-      } else if (isNewTabShortcut) {
-        event.preventDefault();
-        newTab();
-        incrementEditorKey();
-      } else if (isCloseTabShortcut) {
-        if (tabs.length === 0) {
-          // No internal tabs open — let the browser handle Cmd/Ctrl+W naturally
-          return;
-        }
-        event.preventDefault();
-        if (tabs.length === 1 && !tabs[0].file && !tabs[0].isDirty) {
-          window.close();
-          return;
-        }
-        closeTab(activeTabId);
-      } else if (isTabJump) {
-        event.preventDefault();
-        const idx = parseInt(event.key, 10) - 1;
-        switchToIndex(idx);
-        incrementEditorKey();
-      }
+  const handlers = useMemo<Partial<Record<CommandId, () => void>>>(() => {
+    const tabHandlers: Partial<Record<CommandId, () => void>> = {
+      "nav.tab1": () => { switchToIndex(0); incrementEditorKey(); },
+      "nav.tab2": () => { switchToIndex(1); incrementEditorKey(); },
+      "nav.tab3": () => { switchToIndex(2); incrementEditorKey(); },
+      "nav.tab4": () => { switchToIndex(3); incrementEditorKey(); },
+      "nav.tab5": () => { switchToIndex(4); incrementEditorKey(); },
+      "nav.tab6": () => { switchToIndex(5); incrementEditorKey(); },
+      "nav.tab7": () => { switchToIndex(6); incrementEditorKey(); },
+      "nav.tab8": () => { switchToIndex(7); incrementEditorKey(); },
+      "nav.tab9": () => { switchToIndex(8); incrementEditorKey(); },
     };
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
+    const closeTabHandler = isElectron
+      ? undefined
+      : () => {
+          if (tabs.length === 1 && !tabs[0]?.file && !tabs[0]?.isDirty) {
+            window.close();
+            return;
+          }
+          closeTab(activeTabId);
+        };
+
+    return {
+      "file.save": () => void saveFile(),
+      "edit.pasteAsPlaintext": () => void handlePasteAsPlaintext(),
+      "view.compactMode": handleToggleCompactMode,
+      "format.ruby": handleOpenRubyDialog,
+      "format.tcy": handleToggleTcy,
+      "nav.settings": () => setShowSettingsModal(true),
+      "nav.search": () => setSearchOpenTrigger(prev => prev + 1),
+      "nav.nextTab": () => { nextTab(); incrementEditorKey(); },
+      "nav.prevTab": () => { prevTab(); incrementEditorKey(); },
+      "file.newTab": isElectron ? undefined : () => { newTab(); incrementEditorKey(); },
+      "file.closeTab": closeTabHandler,
+      "view.splitRight": splitEditorRight,
+      "view.splitDown": splitEditorDown,
+      "panel.explorer": toggleExplorer,
+      "panel.search": toggleSearch,
+      "panel.outline": toggleOutline,
+      ...tabHandlers,
     };
-  }, [saveFile, handlePasteAsPlaintext, handleToggleCompactMode, handleOpenRubyDialog, handleToggleTcy, isElectron, nextTab, prevTab, newTab, closeTab, tabs, activeTabId, switchToIndex, setShowSettingsModal, incrementEditorKey, setSearchOpenTrigger, splitEditorRight, splitEditorDown]);
+  }, [
+    isElectron,
+    saveFile,
+    handlePasteAsPlaintext,
+    handleToggleCompactMode,
+    handleOpenRubyDialog,
+    handleToggleTcy,
+    setShowSettingsModal,
+    setSearchOpenTrigger,
+    incrementEditorKey,
+    nextTab,
+    prevTab,
+    newTab,
+    closeTab,
+    switchToIndex,
+    tabs,
+    activeTabId,
+    splitEditorRight,
+    splitEditorDown,
+    toggleExplorer,
+    toggleSearch,
+    toggleOutline,
+  ]);
+
+  useKeymapListener(handlers, effectiveBindings);
 }

--- a/lib/hooks/use-global-shortcuts.ts
+++ b/lib/hooks/use-global-shortcuts.ts
@@ -1,15 +1,22 @@
 'use client';
 
+import type { RefObject } from "react";
 import { useEffect } from 'react';
 
+import { useKeymap } from '@/contexts/KeymapContext';
+import { matchesEvent } from '@/lib/keymap/keymap-utils';
+
 /**
- * Global keyboard shortcuts for Web menu bar
- * Only triggers when focus is outside the editor
+ * Global keyboard shortcuts for the Web menu bar.
+ * Only triggers when focus is outside the editor.
+ * Uses the centralized keymap registry for binding lookups.
  */
 export function useGlobalShortcuts(
   onAction: (action: string) => void,
-  editorContainerRef?: React.RefObject<HTMLElement>
-) {
+  editorContainerRef?: RefObject<HTMLElement>
+): void {
+  const { effectiveBindings } = useKeymap();
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const isMac = typeof navigator !== 'undefined' &&
@@ -24,54 +31,53 @@ export function useGlobalShortcuts(
 
       // Check if focus is inside the editor
       if (editorContainerRef?.current?.contains(document.activeElement)) {
-        // Inside editor, don't intercept other shortcuts
         return;
       }
 
-      // Ctrl/Cmd + S: Save
-      if (modifier && e.key === 's' && !e.shiftKey) {
+      if (matchesEvent(effectiveBindings['file.save'], e)) {
         e.preventDefault();
         onAction('save-file');
         return;
       }
 
-      // Ctrl/Cmd + Shift + S: Save As
-      if (modifier && e.key === 'S' && e.shiftKey) {
+      if (matchesEvent(effectiveBindings['file.saveAs'], e)) {
         e.preventDefault();
         onAction('save-as');
         return;
       }
 
-      // Ctrl/Cmd + O: Open
-      if (modifier && e.key === 'o') {
+      if (matchesEvent(effectiveBindings['file.open'], e)) {
         e.preventDefault();
         onAction('open-file');
         return;
       }
 
-      // Ctrl/Cmd + N: New Window
-      if (modifier && e.key === 'n') {
+      if (matchesEvent(effectiveBindings['file.newWindow'], e)) {
         e.preventDefault();
         onAction('new-window');
         return;
       }
 
-      // Ctrl/Cmd + 0: Reset Zoom
-      if (modifier && e.key === '0') {
+      if (matchesEvent(effectiveBindings['view.resetZoom'], e)) {
         e.preventDefault();
         onAction('reset-zoom');
         return;
       }
 
-      // Ctrl/Cmd + +: Zoom In
-      if (modifier && (e.key === '+' || e.key === '=')) {
+      if (matchesEvent(effectiveBindings['view.zoomIn'], e)) {
         e.preventDefault();
         onAction('zoom-in');
         return;
       }
 
-      // Ctrl/Cmd + -: Zoom Out
-      if (modifier && e.key === '-') {
+      // Also match Ctrl/Cmd + = as zoom-in (common alternative)
+      if (modifier && e.key === '=') {
+        e.preventDefault();
+        onAction('zoom-in');
+        return;
+      }
+
+      if (matchesEvent(effectiveBindings['view.zoomOut'], e)) {
         e.preventDefault();
         onAction('zoom-out');
         return;
@@ -80,5 +86,5 @@ export function useGlobalShortcuts(
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onAction, editorContainerRef]);
+  }, [onAction, editorContainerRef, effectiveBindings]);
 }

--- a/lib/keymap/command-ids.ts
+++ b/lib/keymap/command-ids.ts
@@ -1,0 +1,82 @@
+/**
+ * All command IDs used in the keymap registry.
+ * This is the single source of truth for command identifiers.
+ */
+export type CommandId =
+  // File operations
+  | "file.save"
+  | "file.saveAs"
+  | "file.open"
+  | "file.newWindow"
+  | "file.newTab"
+  | "file.closeTab"
+  // Edit operations
+  | "edit.undo"
+  | "edit.redo"
+  | "edit.pasteAsPlaintext"
+  | "edit.selectAll"
+  // View operations
+  | "view.zoomIn"
+  | "view.zoomOut"
+  | "view.resetZoom"
+  | "view.compactMode"
+  | "view.splitRight"
+  | "view.splitDown"
+  // Navigation
+  | "nav.nextTab"
+  | "nav.prevTab"
+  | "nav.tab1"
+  | "nav.tab2"
+  | "nav.tab3"
+  | "nav.tab4"
+  | "nav.tab5"
+  | "nav.tab6"
+  | "nav.tab7"
+  | "nav.tab8"
+  | "nav.tab9"
+  | "nav.settings"
+  | "nav.search"
+  // Panel toggles
+  | "panel.explorer"
+  | "panel.search"
+  | "panel.outline"
+  // Format operations
+  | "format.ruby"
+  | "format.tcy";
+
+export const ALL_COMMAND_IDS: CommandId[] = [
+  "file.save",
+  "file.saveAs",
+  "file.open",
+  "file.newWindow",
+  "file.newTab",
+  "file.closeTab",
+  "edit.undo",
+  "edit.redo",
+  "edit.pasteAsPlaintext",
+  "edit.selectAll",
+  "view.zoomIn",
+  "view.zoomOut",
+  "view.resetZoom",
+  "view.compactMode",
+  "view.splitRight",
+  "view.splitDown",
+  "nav.nextTab",
+  "nav.prevTab",
+  "nav.tab1",
+  "nav.tab2",
+  "nav.tab3",
+  "nav.tab4",
+  "nav.tab5",
+  "nav.tab6",
+  "nav.tab7",
+  "nav.tab8",
+  "nav.tab9",
+  "nav.settings",
+  "nav.search",
+  "panel.explorer",
+  "panel.search",
+  "panel.outline",
+  "format.ruby",
+  "format.tcy",
+];

--- a/lib/keymap/keymap-storage.ts
+++ b/lib/keymap/keymap-storage.ts
@@ -1,0 +1,22 @@
+import { getStorageService } from "@/lib/storage/storage-service";
+import type { KeymapOverrides } from "./keymap-types";
+
+/**
+ * Persists user keymap overrides via StorageService.
+ * Overrides are stored as part of AppState.keymapOverrides.
+ */
+export async function saveKeymapOverrides(overrides: KeymapOverrides): Promise<void> {
+  const storage = getStorageService();
+  const appState = await storage.loadAppState() ?? {};
+  await storage.saveAppState({ ...appState, keymapOverrides: overrides });
+}
+
+/**
+ * Loads user keymap overrides from StorageService.
+ * Returns an empty object if no overrides have been saved.
+ */
+export async function loadKeymapOverrides(): Promise<KeymapOverrides> {
+  const storage = getStorageService();
+  const appState = await storage.loadAppState();
+  return appState?.keymapOverrides ?? {};
+}

--- a/lib/keymap/keymap-types.ts
+++ b/lib/keymap/keymap-types.ts
@@ -1,0 +1,41 @@
+import type { CommandId } from "./command-ids";
+
+/**
+ * A key binding consisting of modifier keys and a primary key.
+ * Uses Electron-compatible modifier names.
+ */
+export interface KeyBinding {
+  modifiers: Array<"CmdOrCtrl" | "Shift" | "Alt" | "Ctrl">;
+  key: string;
+}
+
+/**
+ * Category for grouping shortcuts in the settings UI.
+ */
+export type ShortcutCategory =
+  | "file"
+  | "edit"
+  | "format"
+  | "view"
+  | "nav"
+  | "panel"
+  | "app";
+
+/**
+ * A single entry in the shortcut registry.
+ */
+export interface ShortcutEntry {
+  id: CommandId;
+  /** Japanese display label */
+  label: string;
+  category: ShortcutCategory;
+  defaultBinding: KeyBinding | null;
+  /** Platform scope for this shortcut */
+  scope: "all" | "electron-only" | "web-only";
+}
+
+/**
+ * User-defined overrides: only differences from defaults are stored.
+ * A null value means the shortcut is intentionally unbound.
+ */
+export type KeymapOverrides = Partial<Record<CommandId, KeyBinding | null>>;

--- a/lib/keymap/keymap-utils.ts
+++ b/lib/keymap/keymap-utils.ts
@@ -1,0 +1,174 @@
+import type { KeyBinding } from "./keymap-types";
+
+/**
+ * Detects if the current platform is macOS.
+ */
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
+  if (nav.userAgentData?.platform) {
+    return nav.userAgentData.platform === "macOS";
+  }
+  return /mac/i.test(navigator.userAgent);
+}
+
+/**
+ * Returns the platform-specific display string for a key binding.
+ * e.g. { modifiers: ["CmdOrCtrl", "Shift"], key: "s" } -> "Cmd+Shift+S" (macOS) / "Ctrl+Shift+S" (Win/Linux)
+ */
+export function formatBinding(binding: KeyBinding | null): string {
+  if (!binding) return "未設定";
+
+  const isMac = isMacPlatform();
+  const parts: string[] = [];
+
+  for (const mod of binding.modifiers) {
+    if (mod === "CmdOrCtrl") {
+      parts.push(isMac ? "\u2318" : "Ctrl");
+    } else if (mod === "Shift") {
+      parts.push(isMac ? "\u21E7" : "Shift");
+    } else if (mod === "Alt") {
+      parts.push(isMac ? "\u2325" : "Alt");
+    } else if (mod === "Ctrl") {
+      parts.push(isMac ? "\u2303" : "Ctrl");
+    }
+  }
+
+  const keyDisplay = formatKey(binding.key, isMac);
+  if (isMac) {
+    return parts.join("") + keyDisplay;
+  }
+  return [...parts, keyDisplay].join("+");
+}
+
+/**
+ * Formats a key name for display.
+ */
+function formatKey(key: string, isMac: boolean): string {
+  const keyMap: Record<string, string> = {
+    Tab: "Tab",
+    Escape: "Esc",
+    Backspace: isMac ? "\u232B" : "Backspace",
+    Delete: isMac ? "\u2326" : "Delete",
+    Enter: isMac ? "\u21A9" : "Enter",
+    ArrowUp: "\u2191",
+    ArrowDown: "\u2193",
+    ArrowLeft: "\u2190",
+    ArrowRight: "\u2192",
+    "\\": "\\",
+  };
+  return keyMap[key] ?? key.toUpperCase();
+}
+
+/**
+ * Checks whether a keyboard event matches the given binding.
+ * Handles CmdOrCtrl as either Cmd (macOS) or Ctrl (Win/Linux).
+ */
+export function matchesEvent(binding: KeyBinding | null, event: KeyboardEvent): boolean {
+  if (!binding) return false;
+
+  const isMac = isMacPlatform();
+
+  for (const mod of binding.modifiers) {
+    if (mod === "CmdOrCtrl") {
+      const required = isMac ? event.metaKey : event.ctrlKey;
+      if (!required) return false;
+    } else if (mod === "Shift") {
+      if (!event.shiftKey) return false;
+    } else if (mod === "Alt") {
+      if (!event.altKey) return false;
+    } else if (mod === "Ctrl") {
+      if (!event.ctrlKey) return false;
+    }
+  }
+
+  // Ensure modifiers NOT in binding are not pressed
+  const hasCmdOrCtrl = binding.modifiers.includes("CmdOrCtrl");
+  const hasCtrl = binding.modifiers.includes("Ctrl");
+
+  if (!hasCmdOrCtrl && !hasCtrl) {
+    // Neither CmdOrCtrl nor Ctrl required: both must be absent
+    if (event.ctrlKey || event.metaKey) return false;
+  } else if (hasCmdOrCtrl && !hasCtrl) {
+    // CmdOrCtrl is required; the opposite platform modifier must be absent
+    if (isMac && event.ctrlKey) return false;
+    if (!isMac && event.metaKey) return false;
+  }
+
+  if (!binding.modifiers.includes("Shift") && event.shiftKey) return false;
+  if (!binding.modifiers.includes("Alt") && event.altKey) return false;
+
+  // Normalize the event key for comparison
+  const eventKey = event.key.toLowerCase();
+  const bindingKey = binding.key.toLowerCase();
+
+  return eventKey === bindingKey;
+}
+
+/**
+ * Converts a KeyBinding to an Electron menu accelerator string.
+ * e.g. { modifiers: ["CmdOrCtrl", "Shift"], key: "s" } -> "CmdOrCtrl+Shift+S"
+ */
+export function toElectronAccelerator(binding: KeyBinding | null): string | undefined {
+  if (!binding) return undefined;
+
+  const parts: string[] = [...binding.modifiers];
+
+  const keyMap: Record<string, string> = {
+    Tab: "Tab",
+    Escape: "Escape",
+    Backspace: "Backspace",
+    Delete: "Delete",
+    Enter: "Return",
+    ArrowUp: "Up",
+    ArrowDown: "Down",
+    ArrowLeft: "Left",
+    ArrowRight: "Right",
+    "+": "Plus",
+    "=": "=",
+    "-": "-",
+    "\\": "\\",
+    ",": ",",
+    ".": ".",
+    "/": "/",
+    "[": "[",
+    "]": "]",
+  };
+
+  const key = keyMap[binding.key] ?? binding.key.toUpperCase();
+  return [...parts, key].join("+");
+}
+
+/**
+ * Converts a KeyBinding to a web menu accelerator string in "Ctrl+Shift+S" format.
+ * Uses "Ctrl" (not "CmdOrCtrl") so that formatAccelerator() in menu-definitions can
+ * apply the macOS symbol transformation (Ctrl+ -> Cmd).
+ */
+export function toWebMenuAccelerator(binding: KeyBinding | null): string | undefined {
+  if (!binding) return undefined;
+  const mods = binding.modifiers.map(m => m === "CmdOrCtrl" ? "Ctrl" : m);
+  const key = binding.key === "+" ? "+" : binding.key.toUpperCase();
+  return [...mods, key].join("+");
+}
+
+/**
+ * Builds a KeyBinding from a keyboard event.
+ * Used by the KeybindingInput recording component.
+ */
+export function buildBindingFromEvent(event: KeyboardEvent): KeyBinding | null {
+  const modifierKeys = new Set(["Control", "Meta", "Shift", "Alt"]);
+  if (modifierKeys.has(event.key)) return null;
+
+  const isMac = isMacPlatform();
+  const modifiers: KeyBinding["modifiers"] = [];
+
+  if (isMac ? event.metaKey : event.ctrlKey) modifiers.push("CmdOrCtrl");
+  if (!isMac && event.metaKey) {
+    // Meta on non-Mac is unusual; treat as Ctrl
+  }
+  if (event.shiftKey) modifiers.push("Shift");
+  if (event.altKey) modifiers.push("Alt");
+  if (!isMac && event.ctrlKey && !modifiers.includes("CmdOrCtrl")) modifiers.push("Ctrl");
+
+  return { modifiers, key: event.key };
+}

--- a/lib/keymap/shortcut-registry.ts
+++ b/lib/keymap/shortcut-registry.ts
@@ -1,0 +1,258 @@
+import type { CommandId } from "./command-ids";
+import type { ShortcutEntry } from "./keymap-types";
+
+/**
+ * Single source of truth for all keyboard shortcuts.
+ * All command IDs, default bindings, labels, and scopes are defined here.
+ */
+export const SHORTCUT_REGISTRY: Record<CommandId, ShortcutEntry> = {
+  // -- File ------------------------------------------------------------------
+  "file.save": {
+    id: "file.save",
+    label: "保存",
+    category: "file",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "s" },
+    scope: "all",
+  },
+  "file.saveAs": {
+    id: "file.saveAs",
+    label: "別名で保存",
+    category: "file",
+    defaultBinding: { modifiers: ["CmdOrCtrl", "Shift"], key: "s" },
+    scope: "all",
+  },
+  "file.open": {
+    id: "file.open",
+    label: "ファイルを開く",
+    category: "file",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "o" },
+    scope: "all",
+  },
+  "file.newWindow": {
+    id: "file.newWindow",
+    label: "新規ウィンドウ",
+    category: "file",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "n" },
+    scope: "all",
+  },
+  "file.newTab": {
+    id: "file.newTab",
+    label: "新規タブ",
+    category: "file",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "t" },
+    scope: "all",
+  },
+  "file.closeTab": {
+    id: "file.closeTab",
+    label: "タブを閉じる",
+    category: "file",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "w" },
+    scope: "all",
+  },
+
+  // -- Edit ------------------------------------------------------------------
+  "edit.undo": {
+    id: "edit.undo",
+    label: "元に戻す",
+    category: "edit",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "z" },
+    scope: "all",
+  },
+  "edit.redo": {
+    id: "edit.redo",
+    label: "やり直す",
+    category: "edit",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "y" },
+    scope: "all",
+  },
+  "edit.pasteAsPlaintext": {
+    id: "edit.pasteAsPlaintext",
+    label: "プレーンテキストとして貼り付け",
+    category: "edit",
+    defaultBinding: { modifiers: ["CmdOrCtrl", "Shift"], key: "v" },
+    scope: "all",
+  },
+  "edit.selectAll": {
+    id: "edit.selectAll",
+    label: "すべて選択",
+    category: "edit",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "a" },
+    scope: "all",
+  },
+
+  // -- View ------------------------------------------------------------------
+  "view.zoomIn": {
+    id: "view.zoomIn",
+    label: "拡大",
+    category: "view",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "+" },
+    scope: "all",
+  },
+  "view.zoomOut": {
+    id: "view.zoomOut",
+    label: "縮小",
+    category: "view",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "-" },
+    scope: "all",
+  },
+  "view.resetZoom": {
+    id: "view.resetZoom",
+    label: "ズームをリセット",
+    category: "view",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "0" },
+    scope: "all",
+  },
+  "view.compactMode": {
+    id: "view.compactMode",
+    label: "コンパクトモード切替",
+    category: "view",
+    defaultBinding: { modifiers: ["CmdOrCtrl", "Shift"], key: "m" },
+    scope: "all",
+  },
+  "view.splitRight": {
+    id: "view.splitRight",
+    label: "右に分割",
+    category: "view",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "\\" },
+    scope: "all",
+  },
+  "view.splitDown": {
+    id: "view.splitDown",
+    label: "下に分割",
+    category: "view",
+    defaultBinding: { modifiers: ["CmdOrCtrl", "Shift"], key: "\\" },
+    scope: "all",
+  },
+
+  // -- Navigation ------------------------------------------------------------
+  "nav.nextTab": {
+    id: "nav.nextTab",
+    label: "次のタブ",
+    category: "nav",
+    defaultBinding: { modifiers: ["Ctrl"], key: "Tab" },
+    scope: "all",
+  },
+  "nav.prevTab": {
+    id: "nav.prevTab",
+    label: "前のタブ",
+    category: "nav",
+    defaultBinding: { modifiers: ["Ctrl", "Shift"], key: "Tab" },
+    scope: "all",
+  },
+  "nav.tab1": {
+    id: "nav.tab1",
+    label: "タブ 1 へ移動",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "1" },
+    scope: "all",
+  },
+  "nav.tab2": {
+    id: "nav.tab2",
+    label: "タブ 2 へ移動",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "2" },
+    scope: "all",
+  },
+  "nav.tab3": {
+    id: "nav.tab3",
+    label: "タブ 3 へ移動",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "3" },
+    scope: "all",
+  },
+  "nav.tab4": {
+    id: "nav.tab4",
+    label: "タブ 4 へ移動",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "4" },
+    scope: "all",
+  },
+  "nav.tab5": {
+    id: "nav.tab5",
+    label: "タブ 5 へ移動",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "5" },
+    scope: "all",
+  },
+  "nav.tab6": {
+    id: "nav.tab6",
+    label: "タブ 6 へ移動",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "6" },
+    scope: "all",
+  },
+  "nav.tab7": {
+    id: "nav.tab7",
+    label: "タブ 7 へ移動",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "7" },
+    scope: "all",
+  },
+  "nav.tab8": {
+    id: "nav.tab8",
+    label: "タブ 8 へ移動",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "8" },
+    scope: "all",
+  },
+  "nav.tab9": {
+    id: "nav.tab9",
+    label: "タブ 9 へ移動",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "9" },
+    scope: "all",
+  },
+  "nav.settings": {
+    id: "nav.settings",
+    label: "設定を開く",
+    category: "app",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "," },
+    scope: "all",
+  },
+  "nav.search": {
+    id: "nav.search",
+    label: "検索",
+    category: "nav",
+    defaultBinding: { modifiers: ["CmdOrCtrl"], key: "f" },
+    scope: "all",
+  },
+
+  // -- Panel toggles ---------------------------------------------------------
+  "panel.explorer": {
+    id: "panel.explorer",
+    label: "エクスプローラーを切替",
+    category: "panel",
+    defaultBinding: { modifiers: ["Ctrl", "Shift"], key: "e" },
+    scope: "all",
+  },
+  "panel.search": {
+    id: "panel.search",
+    label: "検索パネルを切替",
+    category: "panel",
+    defaultBinding: { modifiers: ["Ctrl", "Shift"], key: "f" },
+    scope: "all",
+  },
+  "panel.outline": {
+    id: "panel.outline",
+    label: "アウトラインを切替",
+    category: "panel",
+    defaultBinding: { modifiers: ["Ctrl", "Shift"], key: "o" },
+    scope: "all",
+  },
+
+  // -- Format ----------------------------------------------------------------
+  "format.ruby": {
+    id: "format.ruby",
+    label: "ルビを挿入",
+    category: "format",
+    defaultBinding: { modifiers: ["CmdOrCtrl", "Shift"], key: "r" },
+    scope: "all",
+  },
+  "format.tcy": {
+    id: "format.tcy",
+    label: "縦中横を切替",
+    category: "format",
+    defaultBinding: { modifiers: ["CmdOrCtrl", "Shift"], key: "t" },
+    scope: "all",
+  },
+};

--- a/lib/keymap/use-keymap-listener.ts
+++ b/lib/keymap/use-keymap-listener.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+
+import type { CommandId } from "./command-ids";
+import type { EffectiveBindings } from "@/contexts/KeymapContext";
+import { matchesEvent } from "./keymap-utils";
+
+/**
+ * Listens for keyboard events and dispatches to command handlers.
+ * Replaces the manual if-chain in use-keyboard-shortcuts.ts.
+ *
+ * @param handlers - Map of CommandId to handler function
+ * @param effectiveBindings - Merged bindings from KeymapContext (defaults + user overrides)
+ */
+export function useKeymapListener(
+  handlers: Partial<Record<CommandId, () => void>>,
+  effectiveBindings: EffectiveBindings,
+): void {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      for (const [commandId, handler] of Object.entries(handlers) as Array<[CommandId, (() => void) | undefined]>) {
+        if (!handler) continue;
+
+        const binding = effectiveBindings[commandId];
+        if (matchesEvent(binding, event)) {
+          event.preventDefault();
+          handler();
+          return;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handlers, effectiveBindings]);
+}

--- a/lib/menu/menu-definitions.ts
+++ b/lib/menu/menu-definitions.ts
@@ -2,6 +2,7 @@
  * Menu definitions for Web menu bar
  * Mirrors Electron native menu structure
  */
+import type { CommandId } from "@/lib/keymap/command-ids";
 
 const APP_VERSION = (() => {
   const v = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
@@ -87,6 +88,26 @@ export const WEB_MENU_STRUCTURE: MenuSection[] = [
     ]
   }
 ];
+
+/**
+ * Maps menu action strings to their corresponding CommandIds in the keymap registry.
+ * Used by WebMenuBar to inject dynamic accelerator strings from user overrides.
+ */
+export const ACTION_TO_COMMAND_ID: Partial<Record<string, CommandId>> = {
+  "new-window": "file.newWindow",
+  "open-file": "file.open",
+  "save-file": "file.save",
+  "save-as": "file.saveAs",
+  "close-window": "file.closeTab",
+  "undo": "edit.undo",
+  "redo": "edit.redo",
+  "paste-plaintext": "edit.pasteAsPlaintext",
+  "select-all": "edit.selectAll",
+  "reset-zoom": "view.resetZoom",
+  "zoom-in": "view.zoomIn",
+  "zoom-out": "view.zoomOut",
+  "toggle-compact-mode": "view.compactMode",
+};
 
 /**
  * Format accelerator for display

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -124,6 +124,9 @@ export interface AppState {
 
   // Dockview レイアウトの永続化
   dockviewLayout?: DockviewLayoutState;
+
+  // キーマップオーバーライド
+  keymapOverrides?: Record<string, { modifiers: string[]; key: string } | null>;
 }
 
 /**

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -3,6 +3,7 @@
 import type { StorageSession, AppState, RecentFile, EditorBuffer } from "@/lib/storage/storage-types";
 import type { Token, WordEntry, TokenizeProgress } from "@/lib/nlp-client/types";
 import type { VFSWatchEvent } from "@/lib/vfs/types";
+import type { KeymapOverrides } from "@/lib/keymap/keymap-types";
 
 export {}
 
@@ -43,6 +44,7 @@ declare global {
     onMenuOpenRecentProject?: (callback: (projectId: string) => void) => (() => void) | void;
     rebuildMenu?: () => Promise<boolean>;
     syncMenuUiState?: (state: { compactMode?: boolean; showParagraphNumbers?: boolean; themeMode?: string; autoCharsPerLine?: boolean }) => Promise<boolean>;
+    updateKeymapOverrides?: (overrides: KeymapOverrides) => Promise<boolean>;
     showInFileManager?: (dirPath: string) => Promise<boolean>;
     revealInFileManager?: (filePath: string) => Promise<boolean>;
     openExternal?: (url: string) => Promise<boolean>;


### PR DESCRIPTION
## Summary
- Replace scattered shortcut definitions with centralized `lib/keymap/` registry
- Enable user keymap customization via Settings UI
- Sync customized shortcuts to Electron native menu
- Fix non-functional shortcuts (Ctrl+Shift+E/F/O)

Closes #757, closes #759, closes #760, closes #761, closes #762, closes #763, closes #764, closes #765

## Changes
- **New**: `lib/keymap/` — command IDs, types, registry, utils, storage, listener hook
- **New**: `contexts/KeymapContext.tsx` — centralized keymap state management
- **New**: `components/KeymapSettings.tsx` + `KeybindingInput.tsx` — settings UI
- **Modified**: `use-keyboard-shortcuts.ts` — rewritten with `useKeymapListener`
- **Modified**: `use-global-shortcuts.ts` — registry-based approach
- **Modified**: UI components — read shortcuts from context instead of hardcoding
- **Modified**: Electron IPC — `updateKeymapOverrides` channel for menu sync

## Test plan
- [ ] All keyboard shortcuts work in dev mode (save, search, settings, ruby, tcy)
- [ ] Ctrl+Shift+E/F/O toggle panels correctly
- [ ] KeymapSettings UI shows all commands grouped by category
- [ ] Changing a keybinding persists and takes effect
- [ ] Conflict detection warns when bindings overlap
- [ ] Electron menu accelerators update on override

🤖 Generated with [Claude Code](https://claude.com/claude-code)