### PR TITLE
refactor: organize use-linting.ts rule registration sections

### DIFF
--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -8,7 +8,9 @@ import { RULE_GUIDELINE_MAP } from "@/lib/linting/lint-presets";
 import type { CorrectionModeId, GuidelineId } from "@/lib/linting/correction-config";
 import { notificationManager } from "@/lib/services/notification-manager";
 
-// Import all lint rules
+// ---------------------------------------------------------------------------
+// L1 rules — Original custom rules (per-paragraph, regex-based)
+// ---------------------------------------------------------------------------
 import { PunctuationRule } from "@/lib/linting/rules/punctuation-rules";
 import { NumberFormatRule } from "@/lib/linting/rules/number-format";
 import { JoyoKanjiRule } from "@/lib/linting/rules/joyo-kanji";
@@ -24,14 +26,11 @@ import { SentenceLengthRule } from "@/lib/linting/rules/sentence-length";
 import { DashFormatRule } from "@/lib/linting/rules/dash-format";
 import { DialoguePunctuationRule } from "@/lib/linting/rules/dialogue-punctuation";
 import { CommaFrequencyRule } from "@/lib/linting/rules/comma-frequency";
-import { DesuMasuConsistencyRule } from "@/lib/linting/rules/desu-masu-consistency";
-import { ConjunctionOveruseRule } from "@/lib/linting/rules/conjunction-overuse";
-import { WordRepetitionRule } from "@/lib/linting/rules/word-repetition";
-import { TaigenDomeOveruseRule } from "@/lib/linting/rules/taigen-dome-overuse";
-import { PassiveOveruseRule } from "@/lib/linting/rules/passive-overuse";
-import { CounterWordMismatchRule } from "@/lib/linting/rules/counter-word-mismatch";
-import { AdverbFormConsistencyRule } from "@/lib/linting/rules/adverb-form-consistency";
-// New rules from official Japanese language standards (#438)
+
+// ---------------------------------------------------------------------------
+// L1 rules — Standards-based rules from PR #438
+// Notation (JTF / JIS X 4051 / 外来語の表記 / 現代仮名遣い)
+// ---------------------------------------------------------------------------
 import { MixedWidthSpacingRule } from "@/lib/linting/rules/mixed-width-spacing-rule";
 import { BracketSpacingRule } from "@/lib/linting/rules/bracket-spacing-rule";
 import { KatakanaWidthRule } from "@/lib/linting/rules/katakana-width-rule";
@@ -51,6 +50,7 @@ import { GairaiKanaTableRule } from "@/lib/linting/rules/gairai-kana-table-rule"
 import { JiZuKanaRule } from "@/lib/linting/rules/ji-zu-kana-rule";
 import { HistoricalKanaDetection } from "@/lib/linting/rules/historical-kana-detection";
 import { LongVowelKanaRule } from "@/lib/linting/rules/long-vowel-kana-rule";
+// Kanji / grammar / style (送り仮名の付け方 / 漢字使用等 / 公用文作成の考え方)
 import { VerbOkuriganaStrictRule } from "@/lib/linting/rules/verb-okurigana-strict-rule";
 import { FixedOkuriganaNounRule } from "@/lib/linting/rules/fixed-okurigana-noun-rule";
 import { FormalNounOpeningRule } from "@/lib/linting/rules/formal-noun-opening-rule";
@@ -72,11 +72,26 @@ import { LiteraryStyleExclusionRule } from "@/lib/linting/rules/literary-style-e
 import { ExcessiveHonorificRule } from "@/lib/linting/rules/excessive-honorific-rule";
 import { ModifierLengthOrderRule } from "@/lib/linting/rules/modifier-length-order-rule";
 import { KanjiVerbOneCharDo } from "@/lib/linting/rules/kanji-verb-one-char-do";
-// Manuscript Editing 2nd Edition rules (#777)
+
+// ---------------------------------------------------------------------------
+// L1 rules — JSON-driven factory rules (additive, different rule IDs)
+// These use data from Japanese-Style-Sheet JSON definitions and have their
+// own unique rule IDs (e.g. jtf-*, me2-*, gk-*, nh-*).
+// ---------------------------------------------------------------------------
 import { createManuscriptL1Rules } from "@/lib/linting/rules/json-l1/manuscript-l1-rules";
-// JSON-driven L1 rules from JTF, gendai-kanazukai, and nihongo-hyouki (#782)
 import { createJtfL1Rules } from "@/lib/linting/rules/json-l1/jtf-l1-rules";
 import { createGendaiKanazukaiL1Rules, createNihongoHyoukiL1Rules } from "@/lib/linting/rules/json-l1";
+
+// ---------------------------------------------------------------------------
+// L2 rules — Morphological analysis (kuromoji-based, require NLP client)
+// ---------------------------------------------------------------------------
+import { DesuMasuConsistencyRule } from "@/lib/linting/rules/desu-masu-consistency";
+import { ConjunctionOveruseRule } from "@/lib/linting/rules/conjunction-overuse";
+import { WordRepetitionRule } from "@/lib/linting/rules/word-repetition";
+import { TaigenDomeOveruseRule } from "@/lib/linting/rules/taigen-dome-overuse";
+import { PassiveOveruseRule } from "@/lib/linting/rules/passive-overuse";
+import { CounterWordMismatchRule } from "@/lib/linting/rules/counter-word-mismatch";
+import { AdverbFormConsistencyRule } from "@/lib/linting/rules/adverb-form-consistency";
 
 export interface UseLintingResult {
   ruleRunner: RuleRunner;
@@ -108,6 +123,8 @@ export function useLinting(
   // Lazily create and register all rules once
   if (!ruleRunnerRef.current) {
     const runner = new RuleRunner();
+
+    // -- L1: Original custom rules (15 rules) --------------------------------
     runner.registerRule(new PunctuationRule());
     runner.registerRule(new NumberFormatRule());
     runner.registerRule(new JoyoKanjiRule());
@@ -123,16 +140,9 @@ export function useLinting(
     runner.registerRule(new DashFormatRule());
     runner.registerRule(new DialoguePunctuationRule());
     runner.registerRule(new CommaFrequencyRule());
-    runner.registerRule(new DesuMasuConsistencyRule());
-    runner.registerRule(new ConjunctionOveruseRule());
-    runner.registerRule(new WordRepetitionRule());
-    runner.registerRule(new TaigenDomeOveruseRule());
-    runner.registerRule(new PassiveOveruseRule());
-    runner.registerRule(new CounterWordMismatchRule());
-    runner.registerRule(new AdverbFormConsistencyRule());
 
-    // New rules from official Japanese language standards (#438)
-    // Notation (約物・表記) — JTF / 公用文 / 外来語の表記 / 現代仮名遣い
+    // -- L1: Standards-based rules (#438) ------------------------------------
+    // Notation (JTF / JIS X 4051 / 外来語の表記 / 現代仮名遣い)
     runner.registerRule(new MixedWidthSpacingRule());
     runner.registerRule(new BracketSpacingRule());
     runner.registerRule(new KatakanaWidthRule());
@@ -152,7 +162,7 @@ export function useLinting(
     runner.registerRule(new JiZuKanaRule());
     runner.registerRule(new HistoricalKanaDetection());
     runner.registerRule(new LongVowelKanaRule());
-    // Kanji / grammar / style — 送り仮名の付け方 / 漢字使用等 / 公用文作成の考え方
+    // Kanji / grammar / style (送り仮名の付け方 / 漢字使用等 / 公用文作成の考え方)
     runner.registerRule(new VerbOkuriganaStrictRule());
     runner.registerRule(new FixedOkuriganaNounRule());
     runner.registerRule(new FormalNounOpeningRule());
@@ -175,23 +185,31 @@ export function useLinting(
     runner.registerRule(new ModifierLengthOrderRule());
     runner.registerRule(new KanjiVerbOneCharDo());
 
-    // Manuscript Editing 2nd Edition rules (#777)
+    // -- L1: JSON-driven factory rules (additive, unique IDs) ----------------
+    // These rules are generated from Japanese-Style-Sheet JSON definitions.
+    // They use distinct rule IDs (jtf-*, me2-*, gk-*, nh-*) and do NOT
+    // replace the hand-written rules above.
     for (const rule of createManuscriptL1Rules()) {
       runner.registerRule(rule);
     }
-
-    // JTF日本語標準スタイルガイド L1 rules (#782)
     for (const rule of createJtfL1Rules()) {
       runner.registerRule(rule);
     }
-    // 現代仮名遣い L1 rules (#782)
     for (const rule of createGendaiKanazukaiL1Rules()) {
       runner.registerRule(rule);
     }
-    // 日本語表記ルールブック L1 rules (#782)
     for (const rule of createNihongoHyoukiL1Rules()) {
       runner.registerRule(rule);
     }
+
+    // -- L2: Morphological rules (require NLP/kuromoji) ----------------------
+    runner.registerRule(new DesuMasuConsistencyRule());
+    runner.registerRule(new ConjunctionOveruseRule());
+    runner.registerRule(new WordRepetitionRule());
+    runner.registerRule(new TaigenDomeOveruseRule());
+    runner.registerRule(new PassiveOveruseRule());
+    runner.registerRule(new CounterWordMismatchRule());
+    runner.registerRule(new AdverbFormConsistencyRule());
 
     // Initialize guideline map for guideline-based filtering
     runner.setGuidelineMap(RULE_GUIDELINE_MAP);


### PR DESCRIPTION
## Summary
- Reorganize imports and rule registrations in `use-linting.ts` into four clearly labeled sections: original L1 rules, standards-based L1 rules (#438), JSON-driven L1 factory rules, and L2 morphological rules
- Add documentation comments explaining that JSON-driven rules (jtf-*, me2-*, gk-*, nh-*) are additive and use different rule IDs from hand-written rules
- No rules removed — this is a documentation and organization improvement only

Closes #780

## Test plan
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Verify linting still works in the editor with all rule categories enabled
- [ ] Verify JSON-driven rules and hand-written rules both appear in lint results

🤖 Generated with [Claude Code](https://claude.com/claude-code)