### PR TITLE
refactor: decompose app/page.tsx and MilkdownEditor into focused units

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useTheme } from "@/contexts/ThemeContext";
-import Explorer, { FilesPanel } from "@/components/Explorer";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Inspector from "@/components/Inspector";
 import NovelEditor from "@/components/Editor";
@@ -12,16 +11,12 @@ import ResizablePanel from "@/components/ResizablePanel";
 import TitleUpdater from "@/components/TitleUpdater";
 import ActivityBar from "@/components/ActivityBar";
 import SidebarSplitter from "@/components/SidebarSplitter";
-import SearchResults from "@/components/SearchResults";
 import UnsavedWarningDialog from "@/components/UnsavedWarningDialog";
 import ConfirmDialog from "@/components/ConfirmDialog";
 import UpgradeToProjectBanner from "@/components/UpgradeToProjectBanner";
-import WordFrequency from "@/components/WordFrequency";
-import Characters from "@/components/Characters";
-import Dictionary from "@/components/Dictionary";
-import Outline from "@/components/Outline";
 import WelcomeScreen from "@/components/WelcomeScreen";
 import PopoutEditorWindow from "@/components/PopoutEditorWindow";
+import SidebarPanel from "@/components/SidebarPanel";
 import CreateProjectWizard from "@/components/CreateProjectWizard";
 import PermissionPrompt from "@/components/PermissionPrompt";
 import SettingsModal from "@/components/SettingsModal";
@@ -57,8 +52,8 @@ import { usePowerSaving } from "@/lib/editor-page/use-power-saving";
 import { useIgnoredCorrections } from "@/lib/editor-page/use-ignored-corrections";
 import { useKeyboardShortcuts } from "@/lib/editor-page/use-keyboard-shortcuts";
 import { usePanelState } from "@/lib/editor-page/use-panel-state";
+import { useSaveToast } from "@/lib/editor-page/use-save-toast";
 
-import type { ActivityBarView } from "@/components/ActivityBar";
 import type { EditorView } from "@milkdown/prose/view";
 import type { SupportedFileExtension } from "@/lib/project/project-types";
 
@@ -196,10 +191,7 @@ export default function EditorPage() {
   const [searchOpenTrigger, setSearchOpenTrigger] = useState(0);
   const [newFileTrigger, setNewFileTrigger] = useState(0);
   const [searchInitialTerm, setSearchInitialTerm] = useState<string | undefined>(undefined);
-  const [showSaveToast, setShowSaveToast] = useState(false);
-  const [saveToastExiting, setSaveToastExiting] = useState(false);
   const [selectedCharCount, setSelectedCharCount] = useState(0);
-  const prevLastSavedTimeRef = useRef<number | null>(null);
   const hasAutoRecoveredRef = useRef(false);
   const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
   const programmaticScrollRef = useRef(false);
@@ -351,34 +343,8 @@ export default function EditorPage() {
     editorDomRef
   );
 
-  // Save toast: show when lastSavedTime updates (skip auto-save / initial load)
-  useEffect(() => {
-    if (lastSavedTime && prevLastSavedTimeRef.current !== lastSavedTime) {
-      if (prevLastSavedTimeRef.current !== null) {
-        // Only show toast for manual saves
-        if (!lastSaveWasAuto) {
-          setShowSaveToast(true);
-          setSaveToastExiting(false);
-
-          let exitTimer: ReturnType<typeof setTimeout> | null = null;
-          const hideTimer = setTimeout(() => {
-            setSaveToastExiting(true);
-            exitTimer = setTimeout(() => {
-              setShowSaveToast(false);
-              setSaveToastExiting(false);
-            }, 150);
-          }, 1200);
-
-          prevLastSavedTimeRef.current = lastSavedTime;
-          return () => {
-            clearTimeout(hideTimer);
-            if (exitTimer) clearTimeout(exitTimer);
-          };
-        }
-      }
-      prevLastSavedTimeRef.current = lastSavedTime;
-    }
-  }, [lastSavedTime, lastSaveWasAuto]);
+  // --- Save toast hook ---
+  const { showSaveToast, saveToastExiting } = useSaveToast({ lastSavedTime, lastSaveWasAuto });
 
   // Recovery notification: fade-out after 5s, then dismiss
   useEffect(() => {
@@ -636,72 +602,27 @@ export default function EditorPage() {
   }
 
   // --- Editor view (project or standalone mode) ---
-  const renderPanel = (view: ActivityBarView) => {
-    switch (view) {
-      case "files":
-        return (
-          <aside className="h-full bg-background border-r border-border flex flex-col">
-            <div className="p-4 flex-1 overflow-y-auto">
-              <FilesPanel
-                projectName={isProjectMode(editorMode) ? editorMode.name : undefined}
-                onFileClick={(vfsPath) => {
-                  void openProjectFile(vfsPath, { preview: true });
-                  incrementEditorKey();
-                }}
-                onFileDoubleClick={(vfsPath) => {
-                  void openProjectFile(vfsPath, { preview: false });
-                  incrementEditorKey();
-                }}
-                onFileMiddleClick={(vfsPath) => {
-                  void openProjectFile(vfsPath, { preview: false });
-                  incrementEditorKey();
-                }}
-                newFileTrigger={newFileTrigger}
-              />
-            </div>
-          </aside>
-        );
-      case "explorer":
-        return (
-          <ErrorBoundary sectionName="エクスプローラ">
-          <Explorer
-            compactMode={compactMode}
-            content={content}
-            onChapterClick={handleChapterClick}
-            onInsertText={handleInsertText}
-          />
-          </ErrorBoundary>
-        );
-      case "search":
-        return (
-          <SearchResults
-            editorView={editorViewInstance}
-            matches={searchResults?.matches}
-            searchTerm={searchResults?.searchTerm}
-            onClose={handleCloseSearchResults}
-            programmaticScrollRef={programmaticScrollRef}
-          />
-        );
-      case "outline":
-        return (
-          <Outline
-            content={content}
-            onHeadingClick={handleChapterClick}
-          />
-        );
-      case "characters":
-        return <Characters content={content} />;
-      case "dictionary":
-        return <Dictionary content={content} initialSearchTerm={dictionarySearchTrigger.term} searchTriggerId={dictionarySearchTrigger.id} editorMode={editorMode} />;
-      case "wordfreq":
-        return <WordFrequency content={content} filePath={currentFile?.path ?? undefined} onWordSearch={(word) => {
-          setSearchInitialTerm(word);
-          setSearchOpenTrigger(prev => prev + 1);
-        }} />;
-      default:
-        return null;
-    }
-  };
+  // Shared props forwarded to every SidebarPanel instance
+  const sidebarPanelProps = {
+    content,
+    editorMode,
+    compactMode,
+    onChapterClick: handleChapterClick,
+    onInsertText: handleInsertText,
+    searchResults,
+    onCloseSearchResults: handleCloseSearchResults,
+    programmaticScrollRef,
+    editorViewInstance,
+    dictionarySearchTrigger,
+    currentFilePath: currentFile?.path ?? undefined,
+    newFileTrigger,
+    openProjectFile,
+    incrementEditorKey,
+    onWordSearch: (word: string) => {
+      setSearchInitialTerm(word);
+      setSearchOpenTrigger(prev => prev + 1);
+    },
+  } as const;
 
     return (
       <EditorSettingsProvider settings={settings} handlers={settingsHandlers}>
@@ -819,8 +740,8 @@ export default function EditorPage() {
           {(topView !== "none" || bottomView !== "none") && (
             <ResizablePanel side="left" defaultWidth={compactMode ? 200 : 256} minWidth={compactMode ? 160 : 200} maxWidth={compactMode ? 320 : 400}>
               {(() => {
-                const topPanel = topView !== "none" ? renderPanel(topView) : null;
-                const bottomPanel = bottomView !== "none" ? renderPanel(bottomView) : null;
+                const topPanel = topView !== "none" ? <SidebarPanel view={topView} {...sidebarPanelProps} /> : null;
+                const bottomPanel = bottomView !== "none" ? <SidebarPanel view={bottomView} {...sidebarPanelProps} /> : null;
 
                 if (topPanel && bottomPanel) {
                   return <SidebarSplitter top={topPanel} bottom={bottomPanel} />;

--- a/components/SidebarPanel.tsx
+++ b/components/SidebarPanel.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { MutableRefObject } from "react";
+
+import Explorer, { FilesPanel } from "@/components/Explorer";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import SearchResults from "@/components/SearchResults";
+import WordFrequency from "@/components/WordFrequency";
+import Characters from "@/components/Characters";
+import Dictionary from "@/components/Dictionary";
+import Outline from "@/components/Outline";
+import { isProjectMode } from "@/lib/project/project-types";
+
+import type { ActivityBarView } from "@/components/ActivityBar";
+import type { EditorMode } from "@/lib/project/project-types";
+import type { EditorView } from "@milkdown/prose/view";
+
+interface SidebarPanelProps {
+  /** Which panel to render. */
+  view: ActivityBarView;
+  /** Current editor content (Markdown string). */
+  content: string;
+  /** Current editor mode (project / standalone / null). */
+  editorMode: EditorMode;
+  /** Whether compact layout is active. */
+  compactMode: boolean;
+  /** Called when a chapter heading in the explorer is clicked. */
+  onChapterClick: (anchorId: string) => void;
+  /** Called when the editor should insert text at the current cursor. */
+  onInsertText: (text: string) => void;
+  /** Current search results for the search panel. */
+  searchResults: { matches: { from: number; to: number }[]; searchTerm: string } | null;
+  /** Called when the search panel should close. */
+  onCloseSearchResults: () => void;
+  /** Ref used to suppress auto-scroll interference during programmatic navigation. */
+  programmaticScrollRef: MutableRefObject<boolean>;
+  /** The active ProseMirror EditorView (required by the search panel). */
+  editorViewInstance: EditorView | null;
+  /** Dictionary search trigger (changes trigger a new search). */
+  dictionarySearchTrigger: { term: string; id: number };
+  /** Path of the currently open file (used by the word frequency panel). */
+  currentFilePath?: string;
+  /** Trigger counter for opening the new-file dialog inside the files panel. */
+  newFileTrigger: number;
+  /** Opens a project file by VFS path. */
+  openProjectFile: (vfsPath: string, options: { preview: boolean }) => Promise<void>;
+  /** Increments the editor key, forcing the editor to remount. */
+  incrementEditorKey: () => void;
+  /** Called when a word in the word-frequency panel should be searched. */
+  onWordSearch: (word: string) => void;
+}
+
+/**
+ * Renders the appropriate sidebar panel for the given ActivityBarView.
+ *
+ * Extracted from `app/page.tsx` to keep the page component focused on layout
+ * orchestration rather than per-panel render logic.
+ */
+export default function SidebarPanel({
+  view,
+  content,
+  editorMode,
+  compactMode,
+  onChapterClick,
+  onInsertText,
+  searchResults,
+  onCloseSearchResults,
+  programmaticScrollRef,
+  editorViewInstance,
+  dictionarySearchTrigger,
+  currentFilePath,
+  newFileTrigger,
+  openProjectFile,
+  incrementEditorKey,
+  onWordSearch,
+}: SidebarPanelProps): React.ReactElement | null {
+  switch (view) {
+    case "files":
+      return (
+        <aside className="h-full bg-background border-r border-border flex flex-col">
+          <div className="p-4 flex-1 overflow-y-auto">
+            <FilesPanel
+              projectName={isProjectMode(editorMode) ? editorMode.name : undefined}
+              onFileClick={(vfsPath) => {
+                void openProjectFile(vfsPath, { preview: true });
+                incrementEditorKey();
+              }}
+              onFileDoubleClick={(vfsPath) => {
+                void openProjectFile(vfsPath, { preview: false });
+                incrementEditorKey();
+              }}
+              onFileMiddleClick={(vfsPath) => {
+                void openProjectFile(vfsPath, { preview: false });
+                incrementEditorKey();
+              }}
+              newFileTrigger={newFileTrigger}
+            />
+          </div>
+        </aside>
+      );
+    case "explorer":
+      return (
+        <ErrorBoundary sectionName="エクスプローラ">
+          <Explorer
+            compactMode={compactMode}
+            content={content}
+            onChapterClick={onChapterClick}
+            onInsertText={onInsertText}
+          />
+        </ErrorBoundary>
+      );
+    case "search":
+      return (
+        <SearchResults
+          editorView={editorViewInstance}
+          matches={searchResults?.matches}
+          searchTerm={searchResults?.searchTerm}
+          onClose={onCloseSearchResults}
+          programmaticScrollRef={programmaticScrollRef}
+        />
+      );
+    case "outline":
+      return (
+        <Outline
+          content={content}
+          onHeadingClick={onChapterClick}
+        />
+      );
+    case "characters":
+      return <Characters content={content} />;
+    case "dictionary":
+      return (
+        <Dictionary
+          content={content}
+          initialSearchTerm={dictionarySearchTrigger.term}
+          searchTriggerId={dictionarySearchTrigger.id}
+          editorMode={editorMode}
+        />
+      );
+    case "wordfreq":
+      return (
+        <WordFrequency
+          content={content}
+          filePath={currentFilePath}
+          onWordSearch={onWordSearch}
+        />
+      );
+    default:
+      return null;
+  }
+}

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -23,6 +23,7 @@ import { $prose } from "@milkdown/utils";
 import BubbleMenu, { type FormatType } from "../BubbleMenu";
 import { searchHighlightPlugin } from "@/lib/editor-page/search-highlight-plugin";
 import { speechHighlightPlugin } from "@/lib/editor-page/speech-highlight-plugin";
+import { useSelectionTracking } from "@/lib/editor-page/use-selection-tracking";
 import EditorContextMenu, { type ContextMenuAction } from "../EditorContextMenu";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
 import type { RuleRunner, LintIssue } from "@/lib/linting";
@@ -87,14 +88,12 @@ export default function MilkdownEditor({
   const { verticalScrollBehavior, scrollSensitivity } = useScrollSettings();
   const editorRef = useRef<HTMLDivElement>(null);
   const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
-  const [hasSelection, setHasSelection] = useState(false);
   const [lintIssueAtCursor, setLintIssueAtCursor] = useState<LintIssue | null>(null);
   const isElectron = typeof window !== "undefined" && isElectronRenderer();
   // 初期内容はマウント時に固定（ファイル切り替えでコンポーネントが再マウントされたときだけ変わる）
   const initialContentRef = useRef<string>(initialContent);
   const onChangeRef = useRef(onChange);
   const onInsertTextRef = useRef(onInsertText);
-  const onSelectionChangeRef = useRef(onSelectionChange);
   const onLintIssuesUpdatedRef = useRef(onLintIssuesUpdated);
   const onNlpErrorRef = useRef(onNlpError);
 
@@ -107,10 +106,6 @@ export default function MilkdownEditor({
   useEffect(() => {
     onInsertTextRef.current = onInsertText;
   }, [onInsertText]);
-
-  useEffect(() => {
-    onSelectionChangeRef.current = onSelectionChange;
-  }, [onSelectionChange]);
 
   useEffect(() => {
     onLintIssuesUpdatedRef.current = onLintIssuesUpdated;
@@ -267,62 +262,11 @@ export default function MilkdownEditor({
     });
   }, [editorViewInstance, lintingEnabled, lintingRuleRunner]);
 
-  // 選択文字数を更新する（editorViewInstance が変わったときだけ再生成）
-  const updateSelectionCount = useCallback(() => {
-    if (!editorViewInstance) return;
-    const { state } = editorViewInstance;
-    const { selection } = state;
-    const { from, to } = selection;
-
-    // 選択がない場合は 0
-    if (from === to) {
-      setHasSelection(false);
-      onSelectionChangeRef.current?.(0);
-      return;
-    }
-
-    // 選択文字列の文字数を数える（空白は除外）
-    const selectedText = state.doc.textBetween(from, to);
-    const count = selectedText.replace(/\s/g, "").length;
-    setHasSelection(count > 0);
-    onSelectionChangeRef.current?.(count);
-  }, [editorViewInstance]);
-
-  // 選択変更のスケジューリング（10ms デバウンス、前回のタイマーをキャンセル）
-  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const scheduleUpdate = useCallback(() => {
-    if (debounceTimerRef.current !== null) {
-      clearTimeout(debounceTimerRef.current);
-    }
-    debounceTimerRef.current = setTimeout(() => {
-      debounceTimerRef.current = null;
-      updateSelectionCount();
-    }, 10);
-  }, [updateSelectionCount]);
-
-  // 選択範囲の変更を追跡する
-  useEffect(() => {
-    if (!editorViewInstance) return;
-
-    const editorDom = editorViewInstance.dom;
-
-    editorDom.addEventListener("mouseup", scheduleUpdate);
-    editorDom.addEventListener("keyup", scheduleUpdate);
-    document.addEventListener("selectionchange", scheduleUpdate);
-
-    // 初期値
-    updateSelectionCount();
-
-    return () => {
-      editorDom.removeEventListener("mouseup", scheduleUpdate);
-      editorDom.removeEventListener("keyup", scheduleUpdate);
-      document.removeEventListener("selectionchange", scheduleUpdate);
-      if (debounceTimerRef.current !== null) {
-        clearTimeout(debounceTimerRef.current);
-        debounceTimerRef.current = null;
-      }
-    };
-  }, [editorViewInstance, scheduleUpdate, updateSelectionCount]);
+  // 選択文字数の追跡
+  const { hasSelection } = useSelectionTracking({
+    editorViewInstance,
+    onSelectionChange: onSelectionChange,
+  });
 
   // 不要なアニメーションを避けるため、直前のスタイル値を保持する
   const prevStyleRef = useRef({ charsPerLine, isVertical, fontFamily, fontScale, lineHeight });

--- a/lib/editor-page/use-save-toast.ts
+++ b/lib/editor-page/use-save-toast.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from "react";
+
+interface UseSaveToastOptions {
+  /** Timestamp of the last successful save, or null if never saved. */
+  lastSavedTime: number | null;
+  /** Whether the last save was triggered automatically (suppresses the toast). */
+  lastSaveWasAuto: boolean;
+}
+
+interface UseSaveToastResult {
+  /** Whether the save-complete toast is currently visible. */
+  showSaveToast: boolean;
+  /** Whether the toast is currently in its exit animation. */
+  saveToastExiting: boolean;
+}
+
+/**
+ * Manages the transient "保存完了" toast notification.
+ *
+ * The toast is shown only after a manual save (not auto-saves and not the
+ * initial load). It auto-dismisses after 1200 ms with a 150 ms fade-out.
+ */
+export function useSaveToast({ lastSavedTime, lastSaveWasAuto }: UseSaveToastOptions): UseSaveToastResult {
+  const [showSaveToast, setShowSaveToast] = useState(false);
+  const [saveToastExiting, setSaveToastExiting] = useState(false);
+  const prevLastSavedTimeRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (lastSavedTime && prevLastSavedTimeRef.current !== lastSavedTime) {
+      if (prevLastSavedTimeRef.current !== null) {
+        // Only show toast for manual saves
+        if (!lastSaveWasAuto) {
+          setShowSaveToast(true);
+          setSaveToastExiting(false);
+
+          let exitTimer: ReturnType<typeof setTimeout> | null = null;
+          const hideTimer = setTimeout(() => {
+            setSaveToastExiting(true);
+            exitTimer = setTimeout(() => {
+              setShowSaveToast(false);
+              setSaveToastExiting(false);
+            }, 150);
+          }, 1200);
+
+          prevLastSavedTimeRef.current = lastSavedTime;
+          return () => {
+            clearTimeout(hideTimer);
+            if (exitTimer) clearTimeout(exitTimer);
+          };
+        }
+      }
+      prevLastSavedTimeRef.current = lastSavedTime;
+    }
+  }, [lastSavedTime, lastSaveWasAuto]);
+
+  return { showSaveToast, saveToastExiting };
+}

--- a/lib/editor-page/use-selection-tracking.ts
+++ b/lib/editor-page/use-selection-tracking.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { EditorView } from "@milkdown/prose/view";
+
+interface UseSelectionTrackingOptions {
+  /** The current ProseMirror EditorView instance. */
+  editorViewInstance: EditorView | null;
+  /** Called with the non-whitespace character count of the current selection (0 when nothing is selected). */
+  onSelectionChange?: (charCount: number) => void;
+}
+
+interface UseSelectionTrackingResult {
+  /** Whether the editor currently has a non-empty text selection. */
+  hasSelection: boolean;
+}
+
+/**
+ * Tracks the editor's text selection and reports the selected character count.
+ *
+ * Attaches mouseup/keyup/selectionchange listeners to the ProseMirror DOM and
+ * debounces updates by 10 ms to avoid excessive re-renders during rapid key events.
+ */
+export function useSelectionTracking({
+  editorViewInstance,
+  onSelectionChange,
+}: UseSelectionTrackingOptions): UseSelectionTrackingResult {
+  const [hasSelection, setHasSelection] = useState(false);
+
+  // コールバック参照（レンダリングのたびにエフェクトを再登録しないように）
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  useEffect(() => {
+    onSelectionChangeRef.current = onSelectionChange;
+  }, [onSelectionChange]);
+
+  // 選択文字数を更新する（editorViewInstance が変わったときだけ再生成）
+  const updateSelectionCount = useCallback(() => {
+    if (!editorViewInstance) return;
+    const { state } = editorViewInstance;
+    const { selection } = state;
+    const { from, to } = selection;
+
+    // 選択がない場合は 0
+    if (from === to) {
+      setHasSelection(false);
+      onSelectionChangeRef.current?.(0);
+      return;
+    }
+
+    // 選択文字列の文字数を数える（空白は除外）
+    const selectedText = state.doc.textBetween(from, to);
+    const count = selectedText.replace(/\s/g, "").length;
+    setHasSelection(count > 0);
+    onSelectionChangeRef.current?.(count);
+  }, [editorViewInstance]);
+
+  // 選択変更のスケジューリング（10ms デバウンス、前回のタイマーをキャンセル）
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleUpdate = useCallback(() => {
+    if (debounceTimerRef.current !== null) {
+      clearTimeout(debounceTimerRef.current);
+    }
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      updateSelectionCount();
+    }, 10);
+  }, [updateSelectionCount]);
+
+  // 選択範囲の変更を追跡する
+  useEffect(() => {
+    if (!editorViewInstance) return;
+
+    const editorDom = editorViewInstance.dom;
+
+    editorDom.addEventListener("mouseup", scheduleUpdate);
+    editorDom.addEventListener("keyup", scheduleUpdate);
+    document.addEventListener("selectionchange", scheduleUpdate);
+
+    // 初期値
+    updateSelectionCount();
+
+    return () => {
+      editorDom.removeEventListener("mouseup", scheduleUpdate);
+      editorDom.removeEventListener("keyup", scheduleUpdate);
+      document.removeEventListener("selectionchange", scheduleUpdate);
+      if (debounceTimerRef.current !== null) {
+        clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
+      }
+    };
+  }, [editorViewInstance, scheduleUpdate, updateSelectionCount]);
+
+  return { hasSelection };
+}


### PR DESCRIPTION
## Summary

Closes #747 — partial decomposition of oversized components.

Previous related work: SettingsModal split (PR #811, 783→218 lines)

This PR extracts three self-contained units from `app/page.tsx` (~994 lines) and `components/editor/MilkdownEditor.tsx` (~984 lines):

- **`lib/editor-page/use-selection-tracking.ts`** — extracted from `MilkdownEditor.tsx`: selection count tracking (debounced event listeners on the ProseMirror DOM, `hasSelection` state) is now isolated in its own hook. `MilkdownEditor` calls `useSelectionTracking({ editorViewInstance, onSelectionChange })`.

- **`lib/editor-page/use-save-toast.ts`** — extracted from `app/page.tsx`: the "保存完了" toast visibility state, timers, and exiting animation flag live in a dedicated hook. `page.tsx` calls `useSaveToast({ lastSavedTime, lastSaveWasAuto })`.

- **`components/SidebarPanel.tsx`** — extracted from `app/page.tsx`: the 65-line `renderPanel` switch statement (files / explorer / search / outline / characters / dictionary / wordfreq) is now a typed React component. `page.tsx` builds a single `sidebarPanelProps` object and renders `<SidebarPanel view={topView} {...sidebarPanelProps} />`.

The remaining bulk of both files is deeply entangled with cross-hook state and was left unchanged as a safe partial extraction.

## Changes
- `app/page.tsx`: removed `renderPanel` function, 7 component imports (Explorer, FilesPanel, SearchResults, WordFrequency, Characters, Dictionary, Outline), save toast state/effect, and `prevLastSavedTimeRef`
- `components/editor/MilkdownEditor.tsx`: removed inline selection tracking (~55 lines), `hasSelection` state, `onSelectionChangeRef`

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Editor loads and functions normally
- [ ] Panels (explorer, search, outline, dictionary, word-freq, characters, files) show correctly
- [ ] Speech TTS works
- [ ] Selection count updates correctly in the inspector
- [ ] Save toast appears on manual save, not on auto-save

🤖 Generated with [Claude Code](https://claude.com/claude-code)