### PR TITLE
feat: デスクトップ専用機能ダイアログとダウンロードボタンの共通コンポーネント (closes #822)

### DIFF
--- a/components/DesktopAppDownloadButton.tsx
+++ b/components/DesktopAppDownloadButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Download } from "lucide-react";
+
+interface DesktopAppDownloadButtonProps {
+  className?: string;
+  /** Button label. Defaults to "デスクトップ版をダウンロード" */
+  label?: string;
+}
+
+/**
+ * A styled link button that navigates to the desktop app download page.
+ * デスクトップアプリのダウンロードページへのリンクボタン。
+ */
+export default function DesktopAppDownloadButton({
+  className = "",
+  label = "デスクトップ版をダウンロード",
+}: DesktopAppDownloadButtonProps): React.JSX.Element {
+  return (
+    <a
+      href="https://www.illusions.app/downloads/"
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground hover:bg-accent-hover transition-colors ${className}`}
+    >
+      <Download size={16} />
+      {label}
+    </a>
+  );
+}

--- a/components/DesktopOnlyDialog.tsx
+++ b/components/DesktopOnlyDialog.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Monitor } from "lucide-react";
+import GlassDialog from "@/components/GlassDialog";
+import DesktopAppDownloadButton from "@/components/DesktopAppDownloadButton";
+
+interface DesktopOnlyDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Feature name to display, e.g. "ターミナル" */
+  featureName: string;
+}
+
+/**
+ * Dialog shown to web users when they attempt to use a desktop-only feature.
+ * ウェブユーザーがデスクトップ専用機能を使おうとしたときに表示するダイアログ。
+ */
+export default function DesktopOnlyDialog({
+  isOpen,
+  onClose,
+  featureName,
+}: DesktopOnlyDialogProps): React.JSX.Element {
+  return (
+    <GlassDialog
+      isOpen={isOpen}
+      onBackdropClick={onClose}
+      ariaLabel={`${featureName}はデスクトップ版専用の機能です`}
+    >
+      {/* アイコン */}
+      <div className="flex justify-center text-foreground-secondary mb-4">
+        <Monitor size={40} />
+      </div>
+
+      {/* 見出し */}
+      <h2 className="text-center text-lg font-semibold text-foreground">
+        {featureName}はデスクトップ版専用の機能です
+      </h2>
+
+      {/* 説明文 */}
+      <p className="mt-2 text-center text-sm text-foreground-secondary">
+        この機能をご利用いただくには、デスクトップアプリケーションが必要です。
+      </p>
+
+      {/* アクションボタン */}
+      <div className="mt-6 flex flex-col items-center gap-3">
+        <DesktopAppDownloadButton />
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-sm font-medium text-foreground-secondary hover:text-foreground transition-colors"
+        >
+          閉じる
+        </button>
+      </div>
+    </GlassDialog>
+  );
+}


### PR DESCRIPTION
## Summary

- Add `DesktopAppDownloadButton` component: a reusable anchor button styled with `bg-accent` that links to `https://www.illusions.app/downloads/` with `target="_blank" rel="noopener noreferrer"`. Accepts optional `label` and `className` props.
- Add `DesktopOnlyDialog` component: a `GlassDialog`-based modal that displays a `Monitor` icon, a feature-name-driven heading, a description, the download button, and a "閉じる" secondary action. Backdrop click also closes the dialog.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified — no errors)
- [ ] `DesktopAppDownloadButton` renders with default label "デスクトップ版をダウンロード" and opens download page in new tab
- [ ] `DesktopAppDownloadButton` accepts custom `label` and `className` overrides
- [ ] `DesktopOnlyDialog` displays correct heading with `featureName` interpolated
- [ ] Clicking backdrop calls `onClose`
- [ ] Clicking "閉じる" calls `onClose`
- [ ] Clicking the download button navigates to `https://www.illusions.app/downloads/` in a new tab (no `window.open`)
- [ ] Dialog is not rendered when `isOpen` is `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)