### PR TITLE
refactor: タブモデルを判別共用体（discriminated union）に改造する (closes #819)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -43,6 +43,7 @@ import { useEditorMode } from "@/contexts/EditorModeContext";
 import { EditorSettingsProvider } from "@/contexts/EditorSettingsContext";
 import { getAvailableFeatures } from "@/lib/utils/feature-detection";
 import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
 import { useTextStatistics } from "@/lib/editor-page/use-text-statistics";
 import { useEditorSettings } from "@/lib/editor-page/use-editor-settings";
 import { useElectronEvents } from "@/lib/editor-page/use-electron-events";
@@ -180,7 +181,8 @@ export default function EditorPage() {
 
   // Derive editor mode from active tab's fileType
   const activeTab = tabs.find((t) => t.id === activeTabId);
-  const activeFileType = activeTab?.fileType ?? ".mdi";
+  const activeEditorTab = activeTab && isEditorTab(activeTab) ? activeTab : undefined;
+  const activeFileType = activeEditorTab?.fileType ?? ".mdi";
   const mdiExtensionsEnabled = activeFileType === ".mdi";
   const gfmEnabled = activeFileType !== ".txt";
 
@@ -232,7 +234,7 @@ export default function EditorPage() {
   } = projectLifecycle;
 
   // Unsaved warning hook (project mode transitions only; tabs handle per-tab dirty checks)
-  const anyDirty = tabs.some((t) => t.isDirty);
+  const anyDirty = tabs.some((t) => isEditorTab(t) && t.isDirty);
   const unsavedWarning = useUnsavedWarning(
     anyDirty,
     saveFile,
@@ -265,7 +267,7 @@ export default function EditorPage() {
   const getExportContent = useCallback(() => content, [content]);
   const getExportTitle = useCallback(() => {
     const tab = tabs.find((t) => t.id === activeTabId);
-    const name = tab?.file?.name ?? "untitled";
+    const name = (tab && isEditorTab(tab) ? tab.file?.name : undefined) ?? "untitled";
     return name.replace(/\.[^.]+$/, "");
   }, [tabs, activeTabId]);
 
@@ -822,7 +824,8 @@ export default function EditorPage() {
                 // Non-active panel: render a lightweight read-only editor
                 // that activates the tab when clicked
                 const panelTab = tabs.find((t) => t.id === panelBufferId);
-                const panelFileType = panelTab?.fileType ?? ".mdi";
+                const panelEditorTab = panelTab && isEditorTab(panelTab) ? panelTab : undefined;
+                const panelFileType = panelEditorTab?.fileType ?? ".mdi";
                 return (
                   <div
                     className="h-full cursor-pointer"
@@ -834,7 +837,7 @@ export default function EditorPage() {
                     <ErrorBoundary sectionName="エディタ">
                       <NovelEditor
                         key={`tab-${panelBufferId}-inactive`}
-                        initialContent={panelTab?.lastSavedContent ?? ""}
+                        initialContent={panelEditorTab?.lastSavedContent ?? ""}
                         mdiExtensionsEnabled={panelFileType === ".mdi"}
                         gfmEnabled={panelFileType !== ".txt"}
                       />

--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useEffect } from "react";
 import { X } from "lucide-react";
 import type { TabId, TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
 
 interface TabBarProps {
   tabs: TabState[];
@@ -43,7 +44,9 @@ export default function TabBar({
     [onCloseTab],
   );
 
-  if (tabs.length <= 1 && !tabs[0]?.file && !tabs[0]?.isDirty) {
+  const firstTab = tabs[0];
+  const firstEditorTab = firstTab && isEditorTab(firstTab) ? firstTab : undefined;
+  if (tabs.length <= 1 && !firstEditorTab?.file && !firstEditorTab?.isDirty) {
     // Single untitled clean tab → hide tab bar
     return null;
   }
@@ -59,7 +62,8 @@ export default function TabBar({
       >
         {tabs.map((tab) => {
           const isActive = tab.id === activeTabId;
-          const label = tab.file?.name ?? `新規ファイル${tab.fileType}`;
+          const editorTab = isEditorTab(tab) ? tab : undefined;
+          const label = editorTab?.file?.name ?? `新規ファイル${editorTab?.fileType ?? ""}`;
 
           return (
             <button
@@ -79,17 +83,17 @@ export default function TabBar({
               `}
               onClick={() => onSwitchTab(tab.id)}
               onDoubleClick={() => {
-                if (tab.isPreview) onPinTab?.(tab.id);
+                if (editorTab?.isPreview) onPinTab?.(tab.id);
               }}
               onMouseDown={(e) => handleMiddleClick(e, tab.id)}
             >
               {/* Dirty indicator */}
-              {tab.isDirty && (
+              {editorTab?.isDirty && (
                 <span className="w-1.5 h-1.5 rounded-full bg-warning shrink-0" />
               )}
 
               {/* Tab label */}
-              <span className={`truncate flex-1 text-left${tab.isPreview ? " italic opacity-75" : ""}`}>{label}</span>
+              <span className={`truncate flex-1 text-left${editorTab?.isPreview ? " italic opacity-75" : ""}`}>{label}</span>
 
               {/* Close button */}
               <span

--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -14,6 +14,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { DockviewApi } from "dockview-react";
 import type { TabId, TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
 import type { UseTabManagerReturn } from "@/lib/tab-manager/types";
 import type { EditorPanelParams } from "./types";
 
@@ -64,8 +65,9 @@ export function useDockviewAdapter({
       apiRef.current = api;
       setDockviewApi(api);
 
-      // Initialize dockview with current tabs
+      // Initialize dockview with current tabs (editor tabs only for now)
       for (const tab of tabs) {
+        if (!isEditorTab(tab)) continue;
         api.addPanel<EditorPanelParams>({
           id: tab.id,
           component: "editor",
@@ -128,8 +130,9 @@ export function useDockviewAdapter({
     // Detect newly added tabs (before updating prevTabsRef)
     const newlyAddedTabs = tabs.filter((t) => !prevTabIds.has(t.id));
 
-    // Add new tabs
+    // Add new tabs (editor tabs only for now)
     for (const tab of tabs) {
+      if (!isEditorTab(tab)) continue;
       if (!prevTabIds.has(tab.id)) {
         try {
           api.addPanel<EditorPanelParams>({
@@ -161,8 +164,9 @@ export function useDockviewAdapter({
       }
     }
 
-    // Update titles for changed tabs
+    // Update titles for changed editor tabs
     for (const tab of tabs) {
+      if (!isEditorTab(tab)) continue;
       const panel = api.getPanel(tab.id);
       if (panel) {
         const title = tab.file?.name ?? `新規ファイル${tab.fileType}`;
@@ -226,7 +230,7 @@ export function useDockviewAdapter({
       // Create a new empty tab with the same file type.
       // The new panel will be positioned in the split direction
       // by the sync effect above (via pendingSplitRef).
-      newTab(activeTab.fileType);
+      newTab(isEditorTab(activeTab) ? activeTab.fileType : undefined);
 
       pendingSplitRef.current = {
         direction,
@@ -257,7 +261,7 @@ export function useDockviewAdapter({
 
   const popoutPanel = useCallback(() => {
     const activeTab = tabs.find((t) => t.id === activeTabId);
-    if (!activeTab) return;
+    if (!activeTab || !isEditorTab(activeTab)) return;
 
     const electronAPI = window.electronAPI;
     const content = tabManager.content ?? "";

--- a/lib/editor-page/use-keyboard-shortcuts.ts
+++ b/lib/editor-page/use-keyboard-shortcuts.ts
@@ -1,17 +1,12 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useMemo } from "react";
 
-import type { MdiFileDescriptor } from "@/lib/project/mdi-file";
 import type { SupportedFileExtension } from "@/lib/project/project-types";
 import type { CommandId } from "@/lib/keymap/command-ids";
 import { useKeymapListener } from "@/lib/keymap/use-keymap-listener";
 import { useKeymap } from "@/contexts/KeymapContext";
-
-interface TabInfo {
-  id: string;
-  file: MdiFileDescriptor | null;
-  isDirty: boolean;
-}
+import type { TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
 
 interface UseKeyboardShortcutsParams {
   isElectron: boolean;
@@ -29,7 +24,7 @@ interface UseKeyboardShortcutsParams {
   newTab: (fileType?: SupportedFileExtension) => void;
   closeTab: (tabId: string) => void;
   switchToIndex: (index: number) => void;
-  tabs: TabInfo[];
+  tabs: TabState[];
   activeTabId: string;
   // Split editor operations
   splitEditorRight?: () => void;
@@ -85,7 +80,9 @@ export function useKeyboardShortcuts({
     const closeTabHandler = isElectron
       ? undefined
       : () => {
-          if (tabs.length === 1 && !tabs[0]?.file && !tabs[0]?.isDirty) {
+          if (tabs.length === 0) return;
+          const firstTab = tabs[0];
+          if (tabs.length === 1 && firstTab && isEditorTab(firstTab) && !firstTab.file && !firstTab.isDirty) {
             window.close();
             return;
           }

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -162,6 +162,8 @@ export function useTabManager(options?: {
     switchToIndex: tabState.switchToIndex,
     openProjectFile: fileIO.openProjectFile,
     pinTab: tabState.pinTab,
+    newTerminalTab: tabState.newTerminalTab,
+    openDiffTab: tabState.openDiffTab,
 
     // Close-tab dialog
     pendingCloseTabId: tabState.pendingCloseTabId,

--- a/lib/tab-manager/tab-types.ts
+++ b/lib/tab-manager/tab-types.ts
@@ -4,8 +4,19 @@ import type { SupportedFileExtension } from "../project/project-types";
 /** Unique identifier for a tab */
 export type TabId = string;
 
+/** Discriminant literal for each tab variant */
+export type TabKind = "editor" | "terminal" | "diff";
+
+// ---------------------------------------------------------------------------
+// Editor tab
+// ---------------------------------------------------------------------------
+
+/** Sync status between the in-memory content and the on-disk file */
+export type FileSyncStatus = "clean" | "dirty" | "staleOnDisk" | "conflicted";
+
 /** Runtime state of a single editor tab */
-export interface TabState {
+export interface EditorTabState {
+  tabKind: "editor";
   id: TabId;
   file: MdiFileDescriptor | null;
   content: string;
@@ -17,7 +28,74 @@ export interface TabState {
   isSaving: boolean;
   isPreview: boolean;
   fileType: SupportedFileExtension;
+  fileSyncStatus: FileSyncStatus;
+  /** Disk content when status is "conflicted"; null otherwise. */
+  conflictDiskContent: string | null;
 }
+
+// ---------------------------------------------------------------------------
+// Terminal tab
+// ---------------------------------------------------------------------------
+
+export type TerminalStatus = "connecting" | "running" | "exited" | "error";
+export type TerminalSource = "user" | "agent" | "system";
+
+export interface TerminalTabState {
+  tabKind: "terminal";
+  id: TabId;
+  sessionId: string;
+  label: string;
+  cwd: string;
+  shell: string;
+  status: TerminalStatus;
+  exitCode: number | null;
+  createdAt: number;
+  source: TerminalSource;
+}
+
+// ---------------------------------------------------------------------------
+// Diff tab
+// ---------------------------------------------------------------------------
+
+export interface DiffTabState {
+  tabKind: "diff";
+  id: TabId;
+  sourceTabId: TabId;
+  sourceFileName: string;
+  localContent: string;
+  remoteContent: string;
+  remoteTimestamp: number;
+}
+
+// ---------------------------------------------------------------------------
+// Union
+// ---------------------------------------------------------------------------
+
+/** Discriminated union of all tab variants */
+export type TabState = EditorTabState | TerminalTabState | DiffTabState;
+
+// ---------------------------------------------------------------------------
+// Type guards
+// ---------------------------------------------------------------------------
+
+/** Returns true if the tab is an editor tab */
+export function isEditorTab(tab: TabState): tab is EditorTabState {
+  return tab.tabKind === "editor";
+}
+
+/** Returns true if the tab is a terminal tab */
+export function isTerminalTab(tab: TabState): tab is TerminalTabState {
+  return tab.tabKind === "terminal";
+}
+
+/** Returns true if the tab is a diff tab */
+export function isDiffTab(tab: TabState): tab is DiffTabState {
+  return tab.tabKind === "diff";
+}
+
+// ---------------------------------------------------------------------------
+// Serialized / persisted forms (editor tabs only)
+// ---------------------------------------------------------------------------
 
 /** Serialized tab for persistence (file path only, no handles) */
 export interface SerializedTab {

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -3,7 +3,7 @@
 import type { MutableRefObject, Dispatch, SetStateAction } from "react";
 import type { MdiFileDescriptor } from "../project/mdi-file";
 import type { SupportedFileExtension } from "../project/project-types";
-import type { TabId, TabState } from "./tab-types";
+import type { TabId, TabState, EditorTabState } from "./tab-types";
 
 // ---------------------------------------------------------------------------
 // Public return type (must stay identical to the original useTabManager)
@@ -38,6 +38,14 @@ export interface UseTabManagerReturn {
   switchToIndex: (index: number) => void;
   openProjectFile: (vfsPath: string, options?: { preview?: boolean }) => Promise<void>;
   pinTab: (tabId: TabId) => void;
+  newTerminalTab: () => void;
+  openDiffTab: (
+    sourceTabId: TabId,
+    sourceFileName: string,
+    localContent: string,
+    remoteContent: string,
+    remoteTimestamp: number,
+  ) => void;
 
   // Close-tab unsaved warning flow
   pendingCloseTabId: TabId | null;
@@ -253,9 +261,10 @@ export function getErrorMessage(error: unknown): string {
   return message;
 }
 
-export function createNewTab(content?: string, fileType: SupportedFileExtension = ".mdi"): TabState {
+export function createNewTab(content?: string, fileType: SupportedFileExtension = ".mdi"): EditorTabState {
   const c = content ?? "";
   return {
+    tabKind: "editor",
     id: generateTabId(),
     file: null,
     content: c,
@@ -266,6 +275,8 @@ export function createNewTab(content?: string, fileType: SupportedFileExtension 
     isSaving: false,
     isPreview: false,
     fileType,
+    fileSyncStatus: "clean",
+    conflictDiskContent: null,
   };
 }
 

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -5,6 +5,7 @@ import { saveMdiFile } from "../project/mdi-file";
 import { getVFS } from "../vfs";
 import { suppressFileWatch } from "../services/file-watcher";
 import { notificationManager } from "../services/notification-manager";
+import { isEditorTab } from "./tab-types";
 import type { TabManagerCore } from "./types";
 import { AUTO_SAVE_INTERVAL, sanitizeMdiContent } from "./types";
 
@@ -55,6 +56,9 @@ export function useAutoSave(params: UseAutoSaveParams): void {
     autoSaveTimerRef.current = setInterval(() => {
       const currentTabs = tabsRef.current;
       for (const tab of currentTabs) {
+        // Skip non-editor tabs (terminal, diff) and conflicted editor tabs
+        if (!isEditorTab(tab)) continue;
+        if (tab.fileSyncStatus === "conflicted") continue;
         if (!tab.isDirty || !tab.file || tab.isSaving) continue;
 
         // Active tab: use the normal saveFile path
@@ -83,7 +87,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
               if (!mountedRef.current) return;
               setTabs((prev) =>
                 prev.map((t) =>
-                  t.id === tab.id
+                  t.id === tab.id && isEditorTab(t)
                     ? {
                         ...t,
                         lastSavedContent: sanitized,
@@ -104,7 +108,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
                 if (!mountedRef.current) return;
                 setTabs((prev) =>
                   prev.map((t) =>
-                    t.id === tab.id
+                    t.id === tab.id && isEditorTab(t)
                       ? {
                           ...t,
                           file: result.descriptor,

--- a/lib/tab-manager/use-close-dialog.ts
+++ b/lib/tab-manager/use-close-dialog.ts
@@ -5,7 +5,8 @@ import { saveMdiFile } from "../project/mdi-file";
 import { getVFS } from "../vfs";
 import { suppressFileWatch } from "../services/file-watcher";
 import { notificationManager } from "../services/notification-manager";
-import type { TabId, TabState } from "./tab-types";
+import type { TabId, TabState, EditorTabState } from "./tab-types";
+import { isEditorTab } from "./tab-types";
 import { sanitizeMdiContent, getErrorMessage } from "./types";
 import type { TabManagerCore } from "./types";
 
@@ -19,7 +20,7 @@ export interface UseCloseDialogParams extends TabManagerCore {
   /** Clear the pending close tab id. */
   setPendingCloseTabId: React.Dispatch<React.SetStateAction<TabId | null>>;
   /** Update a single tab by id. */
-  updateTab: (tabId: TabId, updates: Partial<TabState>) => void;
+  updateTab: (tabId: TabId, updates: Partial<EditorTabState>) => void;
   /** Force-close a tab without dirty check. */
   forceCloseTab: (tabId: TabId) => void;
 }
@@ -54,8 +55,11 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
 
   const handleCloseTabSave = useCallback(async () => {
     if (!pendingCloseTabId) return;
-    const tab = tabsRef.current.find((t) => t.id === pendingCloseTabId);
-    if (!tab) return;
+    const rawTab = tabsRef.current.find((t) => t.id === pendingCloseTabId);
+    if (!rawTab) return;
+    // pendingCloseTabId is only set for editor tabs (see closeTab guard in useTabState)
+    if (!isEditorTab(rawTab)) return;
+    const tab = rawTab;
 
     try {
       const sanitized = sanitizeMdiContent(tab.content);

--- a/lib/tab-manager/use-electron-menu-bindings.ts
+++ b/lib/tab-manager/use-electron-menu-bindings.ts
@@ -5,7 +5,8 @@ import { saveMdiFile } from "../project/mdi-file";
 import { getVFS } from "../vfs";
 import { suppressFileWatch } from "../services/file-watcher";
 import type { SupportedFileExtension } from "../project/project-types";
-import type { TabId, TabState } from "./tab-types";
+import type { TabId, TabState, EditorTabState } from "./tab-types";
+import { isEditorTab } from "./tab-types";
 import { sanitizeMdiContent } from "./types";
 import type { TabManagerCore } from "./types";
 
@@ -25,7 +26,7 @@ export interface UseElectronMenuBindingsParams extends TabManagerCore {
   /** Load a system file into a tab. */
   loadSystemFile: (path: string, content: string) => void;
   /** Update a single tab by id. */
-  updateTab: (tabId: TabId, updates: Partial<TabState>) => void;
+  updateTab: (tabId: TabId, updates: Partial<EditorTabState>) => void;
   /** Register a handler for system file open events. */
   systemFileOpenHandlerRef: React.MutableRefObject<
     ((path: string, content: string) => void) | null
@@ -70,7 +71,7 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
   // Dirty state → Electron title dot
   useEffect(() => {
     if (!isElectron || !window.electronAPI?.setDirty) return;
-    const anyDirty = tabs.some((t) => t.isDirty);
+    const anyDirty = tabs.some((t) => isEditorTab(t) && t.isDirty);
     window.electronAPI.setDirty(anyDirty);
   }, [tabs, isElectron]);
 
@@ -80,6 +81,7 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
 
     const cleanup = window.electronAPI.onSaveBeforeClose(async () => {
       for (const tab of tabsRef.current) {
+        if (!isEditorTab(tab)) continue;
         if (!tab.isDirty || !tab.file) continue;
         try {
           const sanitized = sanitizeMdiContent(tab.content);
@@ -131,6 +133,7 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
       if (!vfs.isRootOpen()) return;
 
       for (const tab of tabsRef.current) {
+        if (!isEditorTab(tab)) continue;
         if (!tab.file?.path || tab.isSaving) continue;
         if (tab.isDirty) continue;
         try {
@@ -178,10 +181,11 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
       const activeId = activeTabIdRef.current;
       const active = current.find((t) => t.id === activeId);
 
-      // Single empty clean tab → close window
+      // Single empty clean editor tab → close window
       if (
         current.length === 1 &&
         active &&
+        isEditorTab(active) &&
         !active.file &&
         !active.isDirty
       ) {
@@ -207,7 +211,7 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
   useEffect(() => {
     if (isElectron) return;
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      const anyDirty = tabsRef.current.some((t) => t.isDirty);
+      const anyDirty = tabsRef.current.some((t) => isEditorTab(t) && t.isDirty);
       if (anyDirty) {
         event.preventDefault();
         event.returnValue = "";

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -15,7 +15,8 @@ import { getHistoryService } from "../services/history-service";
 import { getVFS } from "../vfs";
 import { suppressFileWatch } from "../services/file-watcher";
 import type { SupportedFileExtension } from "../project/project-types";
-import type { TabId, TabState } from "./tab-types";
+import type { TabId, TabState, EditorTabState } from "./tab-types";
+import { isEditorTab } from "./tab-types";
 import {
   generateTabId,
   inferFileType,
@@ -29,8 +30,8 @@ import type { TabManagerCore } from "./types";
 // ---------------------------------------------------------------------------
 
 export interface UseFileIOParams extends TabManagerCore {
-  updateTab: (tabId: TabId, updates: Partial<TabState>) => void;
-  findTabByPath: (path: string) => TabState | undefined;
+  updateTab: (tabId: TabId, updates: Partial<EditorTabState>) => void;
+  findTabByPath: (path: string) => EditorTabState | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -156,7 +157,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
     const cur = tabsRef.current.find(
       (t) => t.id === activeTabIdRef.current,
     );
-    if (cur && !cur.file && !cur.isDirty) {
+    if (cur && isEditorTab(cur) && !cur.file && !cur.isDirty) {
       updateTab(cur.id, {
         file: descriptor,
         content: fileContent,
@@ -166,7 +167,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         fileType: detectedFileType,
       });
     } else {
-      const tab: TabState = {
+      const tab: EditorTabState = {
+        tabKind: "editor",
         id: generateTabId(),
         file: descriptor,
         content: fileContent,
@@ -177,6 +179,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         isSaving: false,
         isPreview: false,
         fileType: detectedFileType,
+        fileSyncStatus: "clean",
+        conflictDiskContent: null,
       };
       setTabs((prev) => [...prev, tab]);
       setActiveTabId(tab.id);
@@ -196,6 +200,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
       const tabId = activeTabIdRef.current;
       const tab = tabsRef.current.find((t) => t.id === tabId);
       if (!tab) return;
+      // Only editor tabs can be saved
+      if (!isEditorTab(tab)) return;
 
       isSavingRef.current = true;
       updateTab(tabId, { isSaving: true });
@@ -210,7 +216,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           await vfs.writeFile(tab.file.path, sanitized);
           setTabs((prev) =>
             prev.map((t) =>
-              t.id === tabId
+              t.id === tabId && isEditorTab(t)
                 ? {
                     ...t,
                     lastSavedContent: sanitized,
@@ -235,7 +241,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         if (result) {
           setTabs((prev) =>
             prev.map((t) =>
-              t.id === tabId
+              t.id === tabId && isEditorTab(t)
                 ? {
                     ...t,
                     file: result.descriptor,
@@ -274,6 +280,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
     const tabId = activeTabIdRef.current;
     const tab = tabsRef.current.find((t) => t.id === tabId);
     if (!tab) return;
+    // Only editor tabs can be saved
+    if (!isEditorTab(tab)) return;
 
     isSavingRef.current = true;
     updateTab(tabId, { isSaving: true });
@@ -334,7 +342,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
       const cur = tabsRef.current.find(
         (t) => t.id === activeTabIdRef.current,
       );
-      if (cur && !cur.file && !cur.isDirty) {
+      if (cur && isEditorTab(cur) && !cur.file && !cur.isDirty) {
         updateTab(cur.id, {
           file: {
             path,
@@ -351,7 +359,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
       }
 
       // New tab
-      const tab: TabState = {
+      const tab: EditorTabState = {
+        tabKind: "editor",
         id: generateTabId(),
         file: {
           path,
@@ -366,6 +375,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         isSaving: false,
         isPreview: false,
         fileType: sysFileType,
+        fileSyncStatus: "clean",
+        conflictDiskContent: null,
       };
       setTabs((prev) => [...prev, tab]);
       setActiveTabId(tab.id);
@@ -380,9 +391,9 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
       // Deduplicate: if already open, switch to it
       const existing = tabsRef.current.find(
-        (t) => t.file?.path === vfsPath,
+        (t) => isEditorTab(t) && t.file?.path === vfsPath,
       );
-      if (existing) {
+      if (existing && isEditorTab(existing)) {
         setActiveTabId(existing.id);
         // If double-click on existing preview tab, pin it
         if (!preview && existing.isPreview) {
@@ -422,8 +433,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
         if (effectivePreview) {
           // Replace existing preview tab, or create new preview tab
-          const existingPreview = tabsRef.current.find((t) => t.isPreview);
-          if (existingPreview) {
+          const existingPreview = tabsRef.current.find((t) => isEditorTab(t) && t.isPreview);
+          if (existingPreview && isEditorTab(existingPreview)) {
             updateTab(existingPreview.id, {
               file: { path: vfsPath, handle: null, name: fileName },
               content: fileContent,
@@ -442,7 +453,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         const cur = tabsRef.current.find(
           (t) => t.id === activeTabIdRef.current,
         );
-        if (cur && !cur.file && !cur.isDirty) {
+        if (cur && isEditorTab(cur) && !cur.file && !cur.isDirty) {
           updateTab(cur.id, {
             file: { path: vfsPath, handle: null, name: fileName },
             content: fileContent,
@@ -456,7 +467,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         }
 
         // New tab — with atomic dedup guard inside the updater
-        const tab: TabState = {
+        const tab: EditorTabState = {
+          tabKind: "editor",
           id: generateTabId(),
           file: { path: vfsPath, handle: null, name: fileName },
           content: fileContent,
@@ -467,11 +479,13 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           isSaving: false,
           isPreview: effectivePreview,
           fileType: vfsFileType,
+          fileSyncStatus: "clean",
+          conflictDiskContent: null,
         };
         let existingTabId: TabId | null = null;
         setTabs((prev) => {
-          const dup = prev.find((t) => t.file?.path === vfsPath);
-          if (dup) {
+          const dup = prev.find((t) => isEditorTab(t) && t.file?.path === vfsPath);
+          if (dup && isEditorTab(dup)) {
             existingTabId = dup.id;
             if (!preview && dup.isPreview) {
               return prev.map((t) =>

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -3,7 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { getStorageService } from "../storage/storage-service";
 import { fetchAppState, persistAppState } from "../storage/app-state-manager";
-import type { TabState, SerializedTab, TabPersistenceState } from "./tab-types";
+import type { TabState, SerializedTab, TabPersistenceState, EditorTabState } from "./tab-types";
+import { isEditorTab } from "./tab-types";
 import type { TabManagerCore } from "./types";
 import {
   TAB_PERSIST_DEBOUNCE,
@@ -79,16 +80,18 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     }
 
     tabPersistTimerRef.current = setTimeout(() => {
-      const serializedTabs: SerializedTab[] = tabs.map((t) => ({
+      // Only persist editor tabs; terminal and diff tabs are transient
+      const editorTabs = tabs.filter(isEditorTab);
+      const serializedTabs: SerializedTab[] = editorTabs.map((t) => ({
         filePath: t.file?.path ?? null,
         fileName: t.file?.name ?? "新規ファイル",
         isPreview: t.isPreview || undefined,
         fileType: t.fileType,
       }));
-      const activeIndex = tabs.findIndex((t) => t.id === activeTabId);
+      const activeEditorIndex = editorTabs.findIndex((t) => t.id === activeTabId);
       const state: TabPersistenceState = {
         tabs: serializedTabs,
-        activeIndex: Math.max(0, activeIndex),
+        activeIndex: Math.max(0, activeEditorIndex),
       };
       void persistAppState({ openTabs: state }).catch((error) => {
         console.error("タブ状態の保存に失敗しました:", error);
@@ -123,7 +126,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
 
         // Determine the initial tab using a local variable to make the
         // fallback logic explicit and avoid multiple setTabs calls.
-        let initialTab: TabState | null = null;
+        let initialTab: EditorTabState | null = null;
 
         if (!skipAutoRestore && !isElectron && !savedEmpty) {
           // Web: restore file handle from editor buffer
@@ -133,6 +136,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
               const file = await buffer.fileHandle.getFile();
               const fileContent = await file.text();
               initialTab = {
+                tabKind: "editor",
                 id: generateTabId(),
                 file: { path: null, handle: buffer.fileHandle, name: file.name },
                 content: fileContent,
@@ -143,6 +147,8 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
                 isSaving: false,
                 isPreview: false,
                 fileType: inferFileType(file.name),
+                fileSyncStatus: "clean",
+                conflictDiskContent: null,
               };
               setWasAutoRecovered(true);
             } catch (error) {
@@ -212,13 +218,14 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
         // Saved state is explicitly empty (user closed all tabs last session).
         if (openTabs.tabs.length === 0) return;
 
-        const restoredTabs: TabState[] = [];
+        const restoredTabs: EditorTabState[] = [];
         for (const serialized of openTabs.tabs) {
           if (serialized.filePath) {
             try {
               const fileContent =
                 await window.electronAPI!.vfs!.readFile(serialized.filePath);
               restoredTabs.push({
+                tabKind: "editor",
                 id: generateTabId(),
                 file: {
                   path: serialized.filePath,
@@ -233,6 +240,8 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
                 isSaving: false,
                 isPreview: serialized.isPreview ?? false,
                 fileType: serialized.fileType ?? inferFileType(serialized.fileName),
+                fileSyncStatus: "clean",
+                conflictDiskContent: null,
               });
             } catch (error) {
               console.warn(

--- a/lib/tab-manager/use-tab-state.ts
+++ b/lib/tab-manager/use-tab-state.ts
@@ -3,8 +3,9 @@
 import { useCallback, useRef, useState } from "react";
 import type { MdiFileDescriptor } from "../project/mdi-file";
 import type { SupportedFileExtension } from "../project/project-types";
-import type { TabId, TabState } from "./tab-types";
-import { createNewTab } from "./types";
+import type { TabId, TabState, EditorTabState, TerminalTabState, DiffTabState } from "./tab-types";
+import { isEditorTab } from "./tab-types";
+import { createNewTab, generateTabId } from "./types";
 import type { TabManagerCore } from "./types";
 import { useEditorMode } from "@/contexts/EditorModeContext";
 import { isElectronRenderer } from "../utils/runtime-env";
@@ -31,13 +32,23 @@ export interface UseTabStateReturn extends TabManagerCore {
   /** Derived: whether the most recent save on the active tab was an auto-save. */
   lastSaveWasAuto: boolean;
   /** Update a single tab by id. */
-  updateTab: (tabId: TabId, updates: Partial<TabState>) => void;
+  updateTab: (tabId: TabId, updates: Partial<EditorTabState>) => void;
   /** Find a tab by its file path. */
-  findTabByPath: (path: string) => TabState | undefined;
+  findTabByPath: (path: string) => EditorTabState | undefined;
 
   // Tab CRUD operations
-  /** Create a new empty tab. */
+  /** Create a new empty editor tab. */
   newTab: (fileType?: SupportedFileExtension) => void;
+  /** Open a new terminal tab with placeholder values. */
+  newTerminalTab: () => void;
+  /** Open a diff tab for the given source tab. */
+  openDiffTab: (
+    sourceTabId: TabId,
+    sourceFileName: string,
+    localContent: string,
+    remoteContent: string,
+    remoteTimestamp: number,
+  ) => void;
   /** Switch to an existing tab by id. */
   switchTab: (tabId: TabId) => void;
   /** Switch to the next tab. */
@@ -95,12 +106,14 @@ export function useTabState(): UseTabStateReturn {
   // --- Derived state from active tab --------------------------------------
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0];
-  const currentFile = activeTab?.file ?? null;
-  const content = activeTab?.content ?? "";
-  const isDirty = activeTab?.isDirty ?? false;
-  const isSaving = activeTab?.isSaving ?? false;
-  const lastSavedTime = activeTab?.lastSavedTime ?? null;
-  const lastSaveWasAuto = activeTab?.lastSaveWasAuto ?? false;
+  // Editor-tab specific fields — fall back safely for non-editor tabs
+  const editorActiveTab = activeTab && isEditorTab(activeTab) ? activeTab : undefined;
+  const currentFile = editorActiveTab?.file ?? null;
+  const content = editorActiveTab?.content ?? "";
+  const isDirty = editorActiveTab?.isDirty ?? false;
+  const isSaving = editorActiveTab?.isSaving ?? false;
+  const lastSavedTime = editorActiveTab?.lastSavedTime ?? null;
+  const lastSaveWasAuto = editorActiveTab?.lastSaveWasAuto ?? false;
 
   const contentRef = useRef(content);
   contentRef.current = content;
@@ -108,19 +121,24 @@ export function useTabState(): UseTabStateReturn {
   // --- Helpers ------------------------------------------------------------
 
   const updateTab = useCallback(
-    (tabId: TabId, updates: Partial<TabState>) => {
+    (tabId: TabId, updates: Partial<EditorTabState>) => {
       setTabs((prev) =>
-        prev.map((tab) =>
-          tab.id === tabId ? { ...tab, ...updates } : tab,
-        ),
+        prev.map((tab): TabState => {
+          if (tab.id !== tabId || !isEditorTab(tab)) return tab;
+          return { ...tab, ...updates };
+        }),
       );
     },
     [],
   );
 
   const findTabByPath = useCallback(
-    (path: string): TabState | undefined =>
-      tabsRef.current.find((t) => t.file?.path === path),
+    (path: string): EditorTabState | undefined => {
+      const tab = tabsRef.current.find(
+        (t) => isEditorTab(t) && t.file?.path === path,
+      );
+      return tab && isEditorTab(tab) ? tab : undefined;
+    },
     [],
   );
 
@@ -131,6 +149,46 @@ export function useTabState(): UseTabStateReturn {
     setTabs((prev) => [...prev, tab]);
     setActiveTabId(tab.id);
   }, []);
+
+  const newTerminalTab = useCallback(() => {
+    const tab: TerminalTabState = {
+      tabKind: "terminal",
+      id: generateTabId(),
+      sessionId: "",
+      label: "ターミナル",
+      cwd: "",
+      shell: "",
+      status: "connecting",
+      exitCode: null,
+      createdAt: Date.now(),
+      source: "user",
+    };
+    setTabs((prev) => [...prev, tab]);
+    setActiveTabId(tab.id);
+  }, []);
+
+  const openDiffTab = useCallback(
+    (
+      sourceTabId: TabId,
+      sourceFileName: string,
+      localContent: string,
+      remoteContent: string,
+      remoteTimestamp: number,
+    ) => {
+      const tab: DiffTabState = {
+        tabKind: "diff",
+        id: generateTabId(),
+        sourceTabId,
+        sourceFileName,
+        localContent,
+        remoteContent,
+        remoteTimestamp,
+      };
+      setTabs((prev) => [...prev, tab]);
+      setActiveTabId(tab.id);
+    },
+    [],
+  );
 
   const switchTab = useCallback((tabId: TabId) => {
     if (tabsRef.current.some((t) => t.id === tabId)) {
@@ -188,7 +246,8 @@ export function useTabState(): UseTabStateReturn {
     (tabId: TabId) => {
       const tab = tabsRef.current.find((t) => t.id === tabId);
       if (!tab) return;
-      if (tab.isDirty) {
+      // Only editor tabs can have unsaved changes
+      if (isEditorTab(tab) && tab.isDirty) {
         setPendingCloseTabId(tabId);
         return;
       }
@@ -200,7 +259,7 @@ export function useTabState(): UseTabStateReturn {
   const pinTab = useCallback(
     (tabId: TabId) => {
       const tab = tabsRef.current.find((t) => t.id === tabId);
-      if (tab?.isPreview) {
+      if (tab && isEditorTab(tab) && tab.isPreview) {
         updateTab(tabId, { isPreview: false });
       }
     },
@@ -213,6 +272,7 @@ export function useTabState(): UseTabStateReturn {
     setTabs((prev) =>
       prev.map((tab) => {
         if (tab.id !== activeTabIdRef.current) return tab;
+        if (!isEditorTab(tab)) return tab;
         const dirty = newContent !== tab.lastSavedContent;
         return {
           ...tab,
@@ -229,6 +289,7 @@ export function useTabState(): UseTabStateReturn {
     setTabs((prev) =>
       prev.map((tab) => {
         if (tab.id !== activeTabIdRef.current) return tab;
+        if (!isEditorTab(tab)) return tab;
         const file: MdiFileDescriptor = tab.file
           ? { ...tab.file, name: newName }
           : { path: null, handle: null, name: newName };
@@ -242,8 +303,11 @@ export function useTabState(): UseTabStateReturn {
   const pendingCloseTab = pendingCloseTabId
     ? tabs.find((t) => t.id === pendingCloseTabId)
     : null;
+  const pendingCloseEditorTab =
+    pendingCloseTab && isEditorTab(pendingCloseTab) ? pendingCloseTab : null;
   const pendingCloseFileName =
-    pendingCloseTab?.file?.name ?? `新規ファイル${pendingCloseTab?.fileType ?? ".mdi"}`;
+    pendingCloseEditorTab?.file?.name ??
+    `新規ファイル${pendingCloseEditorTab?.fileType ?? ".mdi"}`;
 
   const handleCloseTabCancel = useCallback(() => {
     setPendingCloseTabId(null);
@@ -278,6 +342,8 @@ export function useTabState(): UseTabStateReturn {
 
     // Tab CRUD
     newTab,
+    newTerminalTab,
+    openDiffTab,
     switchTab,
     nextTab: nextTabFn,
     prevTab: prevTabFn,


### PR DESCRIPTION
## Summary

- Converts the flat `TabState` interface into a discriminated union `EditorTabState | TerminalTabState | DiffTabState` with a `tabKind` discriminant field
- Adds `fileSyncStatus` and `conflictDiskContent` fields to `EditorTabState` for future conflict resolution UI
- Adds type guards `isEditorTab()`, `isTerminalTab()`, `isDiffTab()` exported from `tab-types.ts`
- Adds `newTerminalTab()` and `openDiffTab()` functions to `useTabState` and wires them through `useTabManager` / `index.ts`
- Guards all editor-specific logic (dirty checks, auto-save, persistence, file I/O) with `isEditorTab()` narrowing
- Adds minimal `isEditorTab` narrowing in the Dockview adapter, `TabBar`, `use-keyboard-shortcuts`, and `app/page.tsx` to satisfy the compiler (full adapter refactor is in #820)

## Test plan

- [ ] `npx tsc --noEmit` passes with exit code 0 (verified)
- [ ] Open multiple editor tabs, edit, save, close with dirty warning — all work as before
- [ ] Auto-save fires only for editor tabs (terminal/diff tabs are skipped)
- [ ] Tab persistence (Electron): only editor tabs are serialized to AppState
- [ ] Restored tabs on Electron startup include `tabKind: "editor"`, `fileSyncStatus: "clean"`, `conflictDiskContent: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)