### PR TITLE
feat(tab-manager): external file change detection and conflict resolution (#825)

### DIFF
--- a/components/TabBar.tsx
+++ b/components/TabBar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useRef, useEffect } from "react";
-import { X, Terminal, GitCompare } from "lucide-react";
+import { X, Terminal, GitCompare, AlertTriangle } from "lucide-react";
 import type { TabId, TabState } from "@/lib/tab-manager/tab-types";
 import { isEditorTab, isTerminalTab } from "@/lib/tab-manager/tab-types";
 
@@ -68,11 +68,13 @@ export default function TabBar({
           let icon: React.ReactNode = null;
           let isDirty = false;
           let isPreview = false;
+          let isConflicted = false;
 
           if (isEditorTab(tab)) {
             label = tab.file?.name ?? `新規ファイル${tab.fileType}`;
             isDirty = tab.isDirty;
             isPreview = tab.isPreview;
+            isConflicted = tab.fileSyncStatus === "conflicted";
           } else if (isTerminalTab(tab)) {
             label = tab.label;
             icon = <Terminal size={12} className="shrink-0" />;
@@ -104,8 +106,17 @@ export default function TabBar({
               }}
               onMouseDown={(e) => handleMiddleClick(e, tab.id)}
             >
-              {/* Dirty indicator (editor tabs only) */}
-              {isDirty && (
+              {/* Conflict warning icon (editor tabs with external changes) */}
+              {isConflicted && (
+                <AlertTriangle
+                  size={12}
+                  className="shrink-0 text-warning"
+                  aria-label="外部変更との競合"
+                />
+              )}
+
+              {/* Dirty indicator (editor tabs only, hidden when conflicted) */}
+              {isDirty && !isConflicted && (
                 <span className="w-1.5 h-1.5 rounded-full bg-warning shrink-0" />
               )}
 

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -8,6 +8,7 @@ import { useAutoSave } from "./use-auto-save";
 import { useElectronMenuBindings } from "./use-electron-menu-bindings";
 import { useTabPersistence } from "./use-tab-persistence";
 import { useCloseDialog } from "./use-close-dialog";
+import { useFileWatchIntegration } from "./use-file-watch-integration";
 
 // Re-export the return type so consumers can import from this module
 export type { UseTabManagerReturn } from "./types";
@@ -101,6 +102,20 @@ export function useTabManager(options?: {
     loadSystemFile: fileIO.loadSystemFile,
     updateTab: tabState.updateTab,
     systemFileOpenHandlerRef,
+  });
+
+  // --- File watch integration (external change detection) -----------------
+
+  useFileWatchIntegration({
+    tabs: tabState.tabs,
+    setTabs: tabState.setTabs,
+    activeTabId: tabState.activeTabId,
+    setActiveTabId: tabState.setActiveTabId,
+    tabsRef: tabState.tabsRef,
+    activeTabIdRef: tabState.activeTabIdRef,
+    isProjectRef: tabState.isProjectRef,
+    isElectron: tabState.isElectron,
+    openDiffTab: tabState.openDiffTab,
   });
 
   // --- Tab persistence (save/restore to AppState) -------------------------

--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -1,0 +1,272 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { createFileWatcher } from "../services/file-watcher";
+import { notificationManager } from "../services/notification-manager";
+import { isEditorTab } from "./tab-types";
+import type { FileWatcher } from "../services/file-watcher";
+import type { TabId, TabState, EditorTabState, DiffTabState } from "./tab-types";
+import type { TabManagerCore } from "./types";
+
+// ---------------------------------------------------------------------------
+// Params
+// ---------------------------------------------------------------------------
+
+export interface UseFileWatchIntegrationParams extends TabManagerCore {
+  /**
+   * Callback to open a diff tab for conflict visualization.
+   * Called when the user clicks "差分を表示".
+   * Placeholder for Phase 4 implementation.
+   *
+   * 差分タブを開くコールバック（コンフリクト可視化）。
+   * ユーザーが「差分を表示」をクリックした際に呼ばれる。
+   * Phase 4 実装のプレースホルダー。
+   */
+  openDiffTab: (
+    sourceTabId: TabId,
+    sourceFileName: string,
+    localContent: string,
+    remoteContent: string,
+    remoteTimestamp: number,
+  ) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the onChanged callback for an editor tab.
+ * Implements the state-transition logic described in issue #825.
+ *
+ * エディタタブの onChanged コールバックを生成する。
+ * issue #825 で定義された状態遷移ロジックを実装する。
+ */
+function buildOnChanged(
+  tabId: TabId,
+  setTabs: TabManagerCore["setTabs"],
+  tabsRef: TabManagerCore["tabsRef"],
+  openDiffTab: UseFileWatchIntegrationParams["openDiffTab"],
+): (diskContent: string) => void {
+  return (diskContent: string) => {
+    const currentTabs = tabsRef.current;
+    const tab = currentTabs.find((t) => t.id === tabId);
+    if (!tab || !isEditorTab(tab)) return;
+
+    const fileName = tab.file?.name ?? "ファイル";
+
+    if (tab.fileSyncStatus === "clean") {
+      // Clean tab: auto-reload with disk content
+      setTabs((prev) =>
+        prev.map((t) => {
+          if (t.id !== tabId || !isEditorTab(t)) return t;
+          return {
+            ...t,
+            content: diskContent,
+            lastSavedContent: diskContent,
+            isDirty: false,
+            fileSyncStatus: "clean",
+            conflictDiskContent: null,
+          } satisfies EditorTabState;
+        }),
+      );
+      notificationManager.info(`「${fileName}」が更新されました`, 3000);
+    } else if (tab.fileSyncStatus === "dirty") {
+      // Dirty tab: do NOT touch buffer; enter conflicted state
+      const localContent = tab.content;
+
+      setTabs((prev) =>
+        prev.map((t) => {
+          if (t.id !== tabId || !isEditorTab(t)) return t;
+          return {
+            ...t,
+            fileSyncStatus: "conflicted",
+            conflictDiskContent: diskContent,
+          } satisfies EditorTabState;
+        }),
+      );
+
+      // Show persistent notification with conflict resolution actions
+      notificationManager.showMessage(
+        `「${fileName}」が外部で変更されました`,
+        {
+          type: "warning",
+          duration: 0, // Persistent until dismissed or action taken
+          actions: [
+            {
+              label: "差分を表示",
+              onClick: () => {
+                openDiffTab(
+                  tabId,
+                  fileName,
+                  localContent,
+                  diskContent,
+                  Date.now(),
+                );
+                // Do not clear conflict state; user must explicitly resolve
+              },
+            },
+            {
+              label: "ディスクの内容を採用",
+              onClick: () => {
+                setTabs((prev) =>
+                  prev.map((t) => {
+                    if (t.id !== tabId || !isEditorTab(t)) return t;
+                    return {
+                      ...t,
+                      content: diskContent,
+                      lastSavedContent: diskContent,
+                      isDirty: false,
+                      fileSyncStatus: "clean",
+                      conflictDiskContent: null,
+                    } satisfies EditorTabState;
+                  }),
+                );
+              },
+            },
+            {
+              label: "エディタの内容を保持",
+              onClick: () => {
+                setTabs((prev) =>
+                  prev.map((t) => {
+                    if (t.id !== tabId || !isEditorTab(t)) return t;
+                    return {
+                      ...t,
+                      fileSyncStatus: "dirty",
+                      conflictDiskContent: null,
+                    } satisfies EditorTabState;
+                  }),
+                );
+              },
+            },
+          ],
+        },
+      );
+    }
+    // If already "conflicted", ignore further disk changes (user must resolve first)
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages file system watchers for all open editor tabs.
+ * Detects external file modifications and applies state-transition logic:
+ *   - Clean tab  → auto-reload with toast
+ *   - Dirty tab  → enter conflicted state with persistent notification
+ *
+ * 全エディタタブのファイルシステムウォッチャーを管理する。
+ * 外部ファイル変更を検出し、状態遷移ロジックを適用する:
+ *   - clean タブ → 自動リロード + トースト通知
+ *   - dirty タブ → コンフリクト状態に遷移 + 永続通知
+ *
+ * Active-tab watchers run continuously; background-tab watchers are paused
+ * to reduce CPU usage. Watchers are stopped when a tab closes.
+ *
+ * アクティブタブのウォッチャーは継続稼働し、バックグラウンドタブは
+ * CPU 節約のため一時停止する。タブを閉じるとウォッチャーも停止する。
+ */
+export function useFileWatchIntegration(
+  params: UseFileWatchIntegrationParams,
+): void {
+  const {
+    tabs,
+    setTabs,
+    activeTabId,
+    tabsRef,
+    isElectron,
+    openDiffTab,
+  } = params;
+
+  /**
+   * Map from tabId to its FileWatcher instance.
+   * Persists across renders without causing re-renders.
+   *
+   * tabId からウォッチャーインスタンスへのマップ。
+   * 再レンダリングを引き起こさずにレンダー間で保持する。
+   */
+  const watchersRef = useRef<Map<TabId, FileWatcher>>(new Map());
+
+  // ---------------------------------------------------------------------------
+  // Sync watchers when tabs change
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    // File watching only makes sense in Electron (project mode with real paths)
+    if (!isElectron) return;
+
+    const watchers = watchersRef.current;
+    const currentTabIds = new Set(tabs.map((t) => t.id));
+
+    // Stop and remove watchers for tabs that no longer exist
+    for (const [tabId, watcher] of watchers) {
+      if (!currentTabIds.has(tabId)) {
+        watcher.stop();
+        watchers.delete(tabId);
+      }
+    }
+
+    // Create or update watchers for editor tabs with real file paths
+    for (const tab of tabs) {
+      if (!isEditorTab(tab)) continue;
+      const filePath = tab.file?.path;
+      if (!filePath) continue;
+
+      const isActiveTab = tab.id === activeTabId;
+      const existing = watchers.get(tab.id);
+
+      if (!existing) {
+        // Create a new watcher for this tab
+        const onChanged = buildOnChanged(tab.id, setTabs, tabsRef, openDiffTab);
+        const watcher = createFileWatcher({ path: filePath, onChanged });
+
+        if (isActiveTab) {
+          watcher.start();
+        }
+        // Background tabs are not started yet (started when becoming active)
+        watchers.set(tab.id, watcher);
+      }
+    }
+  }, [tabs, activeTabId, isElectron, setTabs, tabsRef, openDiffTab]);
+
+  // ---------------------------------------------------------------------------
+  // Pause/resume watchers based on active tab
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (!isElectron) return;
+
+    const watchers = watchersRef.current;
+    for (const [tabId, watcher] of watchers) {
+      const tab = tabsRef.current.find((t) => t.id === tabId);
+      if (!tab || !isEditorTab(tab) || !tab.file?.path) continue;
+
+      if (tabId === activeTabId) {
+        // Resume active tab watcher
+        if (!watcher.isActive) {
+          watcher.start();
+        }
+      } else {
+        // Pause background tab watchers to save CPU
+        if (watcher.isActive) {
+          watcher.stop();
+        }
+      }
+    }
+  }, [activeTabId, isElectron, tabsRef]);
+
+  // ---------------------------------------------------------------------------
+  // Cleanup all watchers on unmount
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    return () => {
+      for (const watcher of watchersRef.current.values()) {
+        watcher.stop();
+      }
+      watchersRef.current.clear();
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary

- New hook `useFileWatchIntegration` (`lib/tab-manager/use-file-watch-integration.ts`) creates a `FileWatcher` per editor tab using the existing `createFileWatcher()` factory
- **Clean tab** external change → auto-reloads buffer + lightweight toast `「{fileName}」が更新されました`
- **Dirty tab** external change → transitions to `"conflicted"` state, buffer untouched, persistent notification with three actions:
  - 「差分を表示」→ calls `openDiffTab()` (Phase 4 placeholder, does not clear conflict)
  - 「ディスクの内容を採用」→ replaces buffer with disk content, resets to `"clean"`
  - 「エディタの内容を保持」→ clears conflict, remains `"dirty"` (next save overwrites disk)
- Background tab watchers are **paused** (CPU saving); resumed when the tab becomes active
- Watchers stop on tab close and on hook unmount (no leaks)
- Hook is wired into the composed `useTabManager` in `lib/tab-manager/index.ts`
- `components/TabBar.tsx`: shows `AlertTriangle` icon for `fileSyncStatus === "conflicted"` tabs
- Auto-save for conflicted tabs is already skipped in `use-auto-save.ts` (from dev branch)
- App's own saves suppress watcher notifications via existing `suppressFileWatch()` — no false positives
- `npx tsc --noEmit` passes with zero errors

## Test plan

- [ ] Open a project file in Electron; modify it with an external editor → tab auto-reloads, toast appears
- [ ] Edit the file in illusions (dirty), then modify it externally → buffer unchanged, conflict notification with 3 actions appears, `AlertTriangle` shown in tab bar
- [ ] Click 「エディタの内容を保持」→ conflict cleared, tab remains dirty
- [ ] Click 「ディスクの内容を採用」→ buffer replaced, tab becomes clean
- [ ] Click 「差分を表示」→ diff tab opens (Phase 4 stub), conflict notification remains
- [ ] Auto-save timer → conflicted tabs are skipped
- [ ] Closing a tab → watcher stops (no further callbacks after close)
- [ ] Saving a file → no spurious "外部で変更されました" notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)