### PR TITLE
fix(editor): add tab kind guards to editor-specific commands and shortcuts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -200,6 +200,10 @@ export default function EditorPage() {
   const mdiExtensionsEnabled = activeFileType === ".mdi";
   const gfmEnabled = activeFileType !== ".txt";
 
+  // Stable ref so export / shortcut callbacks can read the current value without re-creating
+  const isEditorTabActiveRef = useRef<boolean>(!!activeEditorTab);
+  isEditorTabActiveRef.current = !!activeEditorTab;
+
   const contentRef = useRef<string>(content);
   const editorDomRef = useRef<HTMLDivElement>(null);
   const [showDesktopOnlyDialog, setShowDesktopOnlyDialog] = useState(false);
@@ -289,6 +293,7 @@ export default function EditorPage() {
   const { exportAs } = useExport({
     getContent: getExportContent,
     getTitle: getExportTitle,
+    getIsEditorTabActive: useCallback(() => isEditorTabActiveRef.current, []),
   });
 
   // System file open: tab manager handles loading; we just update editor key
@@ -352,6 +357,7 @@ export default function EditorPage() {
     editorView: editorViewInstance,
     fontScale,
     onFontScaleChange: (scale: number) => fontScaleChangeRef.current(scale),
+    isEditorTabActive: !!activeEditorTab,
   });
 
   // Global shortcuts for Web (only when not in Electron)
@@ -555,6 +561,7 @@ export default function EditorPage() {
     switchToIndex,
     tabs,
     activeTabId,
+    isEditorTabActive: !!activeEditorTab,
     splitEditorRight: useCallback(() => splitEditor("right"), [splitEditor]),
     splitEditorDown: useCallback(() => splitEditor("down"), [splitEditor]),
     toggleExplorer: useCallback(() => setTopView(topView === "explorer" ? "none" : "explorer"), [setTopView, topView]),
@@ -899,41 +906,50 @@ export default function EditorPage() {
             onToggleCollapse={() => setIsRightPanelCollapsed(!isRightPanelCollapsed)}
           >
           <ErrorBoundary sectionName="インスペクタ">
-          <Inspector
-            compactMode={compactMode}
-            charCount={charCount}
-            selectedCharCount={selectedCharCount}
-            paragraphCount={paragraphCount}
-            fileName={fileName}
-            isDirty={isDirty}
-            isSaving={isSaving}
-            lastSavedTime={lastSavedTime}
-            onSaveFile={saveFile}
-            onFileNameChange={updateFileName}
-            sentenceCount={sentenceCount}
-            charTypeAnalysis={charTypeAnalysis}
-            charUsageRates={charUsageRates}
-            readabilityAnalysis={readabilityAnalysis}
-            onOpenPosHighlightSettings={handleOpenPosHighlightSettings}
-            activeFileName={currentFile?.name}
-            currentContent={content}
-            onHistoryRestore={(restoredContent: string) => {
-              setContent(restoredContent);
-              incrementEditorKey();
-            }}
-            onCompareInEditor={setEditorDiff}
-            lintIssues={enrichedLintIssues}
-            onNavigateToIssue={handleNavigateToIssue}
-            onApplyFix={handleApplyFix}
-            onIgnoreCorrection={handleIgnoreCorrection}
-            onRefreshLinting={refreshLinting}
-            isLinting={isLinting}
-            activeLintIssueIndex={activeLintIssueIndex}
-            onOpenLintingSettings={handleOpenLintingSettings}
-            onApplyLintPreset={handleApplyLintPreset}
-            activeLintPresetId={activeLintPresetId}
-            switchToCorrectionsTrigger={switchToCorrectionsTrigger}
-          />
+          {activeEditorTab ? (
+            <Inspector
+              compactMode={compactMode}
+              charCount={charCount}
+              selectedCharCount={selectedCharCount}
+              paragraphCount={paragraphCount}
+              fileName={fileName}
+              isDirty={isDirty}
+              isSaving={isSaving}
+              lastSavedTime={lastSavedTime}
+              onSaveFile={saveFile}
+              onFileNameChange={updateFileName}
+              sentenceCount={sentenceCount}
+              charTypeAnalysis={charTypeAnalysis}
+              charUsageRates={charUsageRates}
+              readabilityAnalysis={readabilityAnalysis}
+              onOpenPosHighlightSettings={handleOpenPosHighlightSettings}
+              activeFileName={currentFile?.name}
+              currentContent={content}
+              onHistoryRestore={(restoredContent: string) => {
+                setContent(restoredContent);
+                incrementEditorKey();
+              }}
+              onCompareInEditor={setEditorDiff}
+              lintIssues={enrichedLintIssues}
+              onNavigateToIssue={handleNavigateToIssue}
+              onApplyFix={handleApplyFix}
+              onIgnoreCorrection={handleIgnoreCorrection}
+              onRefreshLinting={refreshLinting}
+              isLinting={isLinting}
+              activeLintIssueIndex={activeLintIssueIndex}
+              onOpenLintingSettings={handleOpenLintingSettings}
+              onApplyLintPreset={handleApplyLintPreset}
+              activeLintPresetId={activeLintPresetId}
+              switchToCorrectionsTrigger={switchToCorrectionsTrigger}
+            />
+          ) : (
+            // Non-editor tab (terminal / diff): inspector is unavailable
+            <div className="h-full flex items-center justify-center p-4">
+              <p className="text-foreground-secondary text-sm text-center">
+                インスペクタはエディタタブでのみ使用できます
+              </p>
+            </div>
+          )}
           </ErrorBoundary>
         </ResizablePanel>
       </div>

--- a/lib/editor-page/use-keyboard-shortcuts.ts
+++ b/lib/editor-page/use-keyboard-shortcuts.ts
@@ -26,6 +26,9 @@ interface UseKeyboardShortcutsParams {
   switchToIndex: (index: number) => void;
   tabs: TabState[];
   activeTabId: string;
+  /** Whether the currently active tab is an editor tab.
+   *  Editor-only commands (Ruby, TCY, search, paste-as-plaintext) no-op when false. */
+  isEditorTabActive: boolean;
   // Split editor operations
   splitEditorRight?: () => void;
   splitEditorDown?: () => void;
@@ -56,6 +59,7 @@ export function useKeyboardShortcuts({
   switchToIndex,
   tabs,
   activeTabId,
+  isEditorTabActive,
   splitEditorRight,
   splitEditorDown,
   toggleExplorer,
@@ -91,12 +95,13 @@ export function useKeyboardShortcuts({
 
     return {
       "file.save": () => void saveFile(),
-      "edit.pasteAsPlaintext": () => void handlePasteAsPlaintext(),
+      // Editor-only commands: no-op when a terminal or diff tab is active
+      "edit.pasteAsPlaintext": isEditorTabActive ? () => void handlePasteAsPlaintext() : undefined,
       "view.compactMode": handleToggleCompactMode,
-      "format.ruby": handleOpenRubyDialog,
-      "format.tcy": handleToggleTcy,
+      "format.ruby": isEditorTabActive ? handleOpenRubyDialog : undefined,
+      "format.tcy": isEditorTabActive ? handleToggleTcy : undefined,
       "nav.settings": () => setShowSettingsModal(true),
-      "nav.search": () => setSearchOpenTrigger(prev => prev + 1),
+      "nav.search": isEditorTabActive ? () => setSearchOpenTrigger(prev => prev + 1) : undefined,
       "nav.nextTab": () => { nextTab(); incrementEditorKey(); },
       "nav.prevTab": () => { prevTab(); incrementEditorKey(); },
       "file.newTab": isElectron ? undefined : () => { newTab(); incrementEditorKey(); },
@@ -125,6 +130,7 @@ export function useKeyboardShortcuts({
     switchToIndex,
     tabs,
     activeTabId,
+    isEditorTabActive,
     splitEditorRight,
     splitEditorDown,
     toggleExplorer,

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -11,6 +11,9 @@ interface UseExportParams {
   getContent: () => string;
   /** Returns the document title (file name or fallback) */
   getTitle: () => string;
+  /** Returns true when the active tab is an editor tab.
+   *  Export operations no-op when false (e.g. terminal or diff tab is active). */
+  getIsEditorTabActive: () => boolean;
 }
 
 /**
@@ -56,13 +59,16 @@ async function saveTxtFile(text: string, suggestedName: string): Promise<boolean
  * Hook that provides export functionality and registers Electron menu handlers.
  * Handles PDF, EPUB, DOCX, TXT export with progress notifications.
  */
-export function useExport({ getContent, getTitle }: UseExportParams): {
+export function useExport({ getContent, getTitle, getIsEditorTabActive }: UseExportParams): {
   exportAs: (format: ExportFormat) => Promise<void>;
 } {
   const isElectron = typeof window !== "undefined" && isElectronRenderer();
 
   const exportAs = useCallback(
     async (format: ExportFormat) => {
+      // No-op when a non-editor tab (terminal, diff) is active
+      if (!getIsEditorTabActive()) return;
+
       const content = getContent();
       if (!content.trim()) {
         notificationManager.warning("エクスポートするコンテンツがありません");
@@ -172,7 +178,7 @@ export function useExport({ getContent, getTitle }: UseExportParams): {
         );
       }
     },
-    [getContent, getTitle, isElectron]
+    [getContent, getTitle, getIsEditorTabActive, isElectron]
   );
 
   // Register Electron menu event handlers

--- a/lib/menu/use-web-menu-handlers.ts
+++ b/lib/menu/use-web-menu-handlers.ts
@@ -16,6 +16,9 @@ interface UseWebMenuHandlersProps {
   editorView?: EditorView | null;
   fontScale?: number;
   onFontScaleChange?: (scale: number) => void;
+  /** Whether the currently active tab is an editor tab.
+   *  Edit-menu operations (undo/redo/cut/copy/paste) and export are no-ops when false. */
+  isEditorTabActive?: boolean;
 }
 
 export function useWebMenuHandlers({
@@ -31,10 +34,11 @@ export function useWebMenuHandlers({
   editorView,
   fontScale = 100,
   onFontScaleChange,
+  isEditorTabActive = true,
 }: UseWebMenuHandlersProps) {
-  
+
   const handleMenuAction = useCallback((action: string) => {
-    
+
     switch (action) {
       // File menu
       case 'new-window':
@@ -60,70 +64,68 @@ export function useWebMenuHandlers({
         onCloseWindow?.();
         break;
 
-      // Export
+      // Export — disabled when non-editor tab is active
       case 'export-txt':
-        onExport?.('txt');
+        if (isEditorTabActive) onExport?.('txt');
         break;
       case 'export-txt-ruby':
-        onExport?.('txt-ruby');
+        if (isEditorTabActive) onExport?.('txt-ruby');
         break;
       case 'export-pdf':
-        onExport?.('pdf');
+        if (isEditorTabActive) onExport?.('pdf');
         break;
       case 'export-epub':
-        onExport?.('epub');
+        if (isEditorTabActive) onExport?.('epub');
         break;
       case 'export-docx':
-        onExport?.('docx');
+        if (isEditorTabActive) onExport?.('docx');
         break;
 
-      // Edit menu - Using ProseMirror commands
+      // Edit menu — guard with both editorView and isEditorTabActive
       case 'undo':
-        if (editorView) {
-          const { state, dispatch } = editorView;
-          // Use ProseMirror undo command
-          const undoCommand = state.tr;
+        if (editorView && isEditorTabActive) {
+          const { state } = editorView;
           if (state.doc) {
-            // Try to execute undo via history plugin
+            // Execute undo via history plugin
             editorView.focus();
             document.execCommand('undo');
           }
         }
         break;
       case 'redo':
-        if (editorView) {
+        if (editorView && isEditorTabActive) {
           editorView.focus();
           document.execCommand('redo');
         }
         break;
       case 'cut':
-        if (editorView) {
+        if (editorView && isEditorTabActive) {
           editorView.focus();
           document.execCommand('cut');
         }
         break;
       case 'copy':
-        if (editorView) {
+        if (editorView && isEditorTabActive) {
           editorView.focus();
           document.execCommand('copy');
         }
         break;
       case 'paste':
-        if (editorView) {
+        if (editorView && isEditorTabActive) {
           editorView.focus();
           document.execCommand('paste');
         }
         break;
       case 'paste-plaintext':
         // TODO: Implement paste as plaintext
-        if (editorView) {
+        if (editorView && isEditorTabActive) {
           editorView.focus();
           // This will be implemented later with proper Milkdown integration
           console.warn('[Web Menu] Paste as plaintext not yet implemented');
         }
         break;
       case 'select-all':
-        if (editorView) {
+        if (editorView && isEditorTabActive) {
           editorView.focus();
           document.execCommand('selectAll');
         }
@@ -161,7 +163,7 @@ export function useWebMenuHandlers({
         }
         console.warn('[Web Menu] Unknown action:', action);
     }
-  }, [onNew, onOpen, onSave, onSaveAs, onOpenProject, onOpenRecentProject, onCloseWindow, onToggleCompactMode, onExport, editorView, fontScale, onFontScaleChange]);
+  }, [onNew, onOpen, onSave, onSaveAs, onOpenProject, onOpenRecentProject, onCloseWindow, onToggleCompactMode, onExport, editorView, fontScale, onFontScaleChange, isEditorTabActive]);
   
   return { handleMenuAction };
 }


### PR DESCRIPTION
## Summary

- Guards Ruby/TCY dialog, search, and paste-as-plaintext keyboard shortcuts so they no-op when a terminal or diff tab is active (`use-keyboard-shortcuts.ts`, new `isEditorTabActive` param)
- Guards undo/redo/cut/copy/paste/select-all and all export menu actions in `use-web-menu-handlers.ts` via a new `isEditorTabActive` prop
- Guards PDF/EPUB/DOCX Electron IPC export events in `use-export.ts` via a new `getIsEditorTabActive` callback (covers the Electron native menu path that bypasses the web menu handler)
- Replaces the Inspector panel with a Japanese "unavailable" placeholder when the active tab is not an editor tab; restores normally when switching back to an editor tab

## Test plan

- [ ] Terminal tab active + Cmd+S → no-op, no error
- [ ] Terminal tab active + Cmd+Shift+S → no-op, no error
- [ ] Terminal tab active + Ruby shortcut (Cmd+R or equivalent) → no-op
- [ ] Terminal tab active + Search shortcut → no-op
- [ ] Terminal tab active + Web menu Edit > Undo/Redo/Cut/Copy/Paste → no-op
- [ ] Terminal tab active + Export menu items → no-op
- [ ] Terminal tab active → Inspector shows "インスペクタはエディタタブでのみ使用できます"
- [ ] Switch back to editor tab → all features restore normally
- [ ] `npx tsc --noEmit` passes (verified: 0 errors)
- [ ] No console errors on tab switch

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)