### PR TITLE
feat(terminal): implement TerminalPanel with xterm.js renderer (#824)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,9 @@
 /* Japanese novel plugin styles (vertical, manuscript, ruby, tcy) */
 @import '../packages/milkdown-plugin-japanese-novel/styles/index.css';
 
+/* xterm.js terminal styles */
+@import '@xterm/xterm/css/xterm.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,10 @@ import { useEditorMode } from "@/contexts/EditorModeContext";
 import { EditorSettingsProvider } from "@/contexts/EditorSettingsContext";
 import { getAvailableFeatures } from "@/lib/utils/feature-detection";
 import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
-import { isEditorTab } from "@/lib/tab-manager/tab-types";
+import { isEditorTab, isTerminalTab } from "@/lib/tab-manager/tab-types";
+import type { TerminalTabState } from "@/lib/tab-manager/tab-types";
+import { TerminalTabContext } from "@/contexts/TerminalTabContext";
+import type { TerminalTabContextValue } from "@/contexts/TerminalTabContext";
 import { useTextStatistics } from "@/lib/editor-page/use-text-statistics";
 import { useEditorSettings } from "@/lib/editor-page/use-editor-settings";
 import { useElectronEvents } from "@/lib/editor-page/use-electron-events";
@@ -170,28 +173,115 @@ export default function EditorPage() {
     newFile: tabNewFile, updateFileName, wasAutoRecovered, onSystemFileOpen,
     _loadSystemFile: tabLoadSystemFile,
     tabs, activeTabId, newTab, closeTab, switchTab, nextTab, prevTab, switchToIndex,
-    openProjectFile, pinTab, newTerminalTab,
+    openProjectFile, pinTab, newTerminalTab, updateTerminalTab,
     pendingCloseTabId, pendingCloseFileName, handleCloseTabSave, handleCloseTabDiscard, handleCloseTabCancel,
   } = tabManager;
+
+  // Ref that always holds the latest tabs array (avoids stale closures in PTY callbacks)
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
+
+  // Ref that always holds the latest updateTerminalTab (avoids re-subscribing)
+  const updateTerminalTabRef = useRef(updateTerminalTab);
+  updateTerminalTabRef.current = updateTerminalTab;
+
+  // --- Tab close wrapper: kill PTY session when a terminal tab closes ---
+  const handleCloseTabWithPtyCleanup = useCallback(
+    (tabId: string) => {
+      // Look up the tab before closing it
+      const tab = tabsRef.current.find((t) => t.id === tabId);
+      if (tab && isTerminalTab(tab) && tab.sessionId) {
+        void window.electronAPI?.pty?.kill(tab.sessionId);
+      }
+      closeTab(tabId);
+    },
+    [closeTab],
+  );
+
+  // Patched tabManager passed to the dockview adapter so that panel close
+  // triggers PTY kill before removing the tab from state.
+  const tabManagerWithPtyCleanup = { ...tabManager, closeTab: handleCloseTabWithPtyCleanup };
 
   // --- Dockview adapter (bridges useTabManager ↔ dockview layout) ---
   const {
     handleDockviewReady,
     dockviewApi,
     splitEditor,
-  } = useDockviewAdapter({ tabManager });
+  } = useDockviewAdapter({ tabManager: tabManagerWithPtyCleanup });
   useDockviewPersistence({ dockviewApi });
 
   // --- New terminal tab callback ---
   const handleNewTerminalTab = useCallback(() => {
     if (isElectronRenderer()) {
-      // Electron: create a real terminal tab via the tab manager
+      const ptyApi = window.electronAPI?.pty;
+      if (!ptyApi) return;
+      // Create the tab first (shows "connecting" state immediately)
       newTerminalTab();
+      // Spawn the PTY session; update the tab's sessionId once we have it
+      void (async () => {
+        const result = await ptyApi.spawn();
+        if ("error" in result) return;
+        const { sessionId } = result;
+        // Update the most recently created terminal tab with an empty sessionId
+        const targetTab = tabsRef.current
+          .slice()
+          .reverse()
+          .find((t) => isTerminalTab(t) && (t as TerminalTabState).sessionId === "");
+        if (targetTab) {
+          updateTerminalTabRef.current(targetTab.id, { sessionId, status: "running" });
+        }
+      })();
     } else {
       // Web: show desktop-only dialog since terminal requires native PTY
       setShowDesktopOnlyDialog(true);
     }
   }, [newTerminalTab]);
+
+  // --- PTY exit event listener: update tab status when process exits ---
+  useEffect(() => {
+    if (!isElectronRenderer()) return;
+    const ptyApi = window.electronAPI?.pty;
+    if (!ptyApi) return;
+
+    const unsubExit = ptyApi.onExit(({ sessionId, exitCode }) => {
+      // Find the terminal tab with this sessionId and mark it as exited
+      const tab = tabsRef.current.find(
+        (t) => isTerminalTab(t) && (t as TerminalTabState).sessionId === sessionId,
+      );
+      if (tab) {
+        updateTerminalTabRef.current(tab.id, { status: "exited", exitCode });
+      }
+    });
+
+    return unsubExit;
+  // Subscribe once on mount; use refs to avoid stale closures
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // --- TerminalTabContext value: exposes terminal tab state to dockview panel components ---
+  const getTerminalTabBySessionId = useCallback(
+    (sessionId: string) =>
+      tabsRef.current.find(
+        (t): t is TerminalTabState => isTerminalTab(t) && t.sessionId === sessionId,
+      ),
+    [],
+  );
+  const setTerminalTabExited = useCallback((sessionId: string, exitCode: number) => {
+    const tab = tabsRef.current.find(
+      (t): t is TerminalTabState => isTerminalTab(t) && t.sessionId === sessionId,
+    );
+    if (tab) {
+      updateTerminalTabRef.current(tab.id, { status: "exited", exitCode });
+    }
+  }, []);
+  const killTerminalSession = useCallback((sessionId: string) => {
+    void window.electronAPI?.pty?.kill(sessionId);
+  }, []);
+  const terminalTabContextValue: TerminalTabContextValue = {
+    getTerminalTabBySessionId,
+    setTerminalTabExited,
+    killTerminalSession,
+  };
 
   // Derive editor mode from active tab's fileType
   const activeTab = tabs.find((t) => t.id === activeTabId);
@@ -642,6 +732,7 @@ export default function EditorPage() {
   } as const;
 
     return (
+      <TerminalTabContext.Provider value={terminalTabContextValue}>
       <EditorSettingsProvider settings={settings} handlers={settingsHandlers}>
       <div className="h-screen flex flex-col overflow-hidden relative">
          {/* Dynamic title update */}
@@ -939,5 +1030,6 @@ export default function EditorPage() {
       </div>
     </div>
       </EditorSettingsProvider>
+      </TerminalTabContext.Provider>
   );
 }

--- a/components/TerminalPanel.tsx
+++ b/components/TerminalPanel.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+/**
+ * TerminalPanel — xterm.js renderer component for embedded terminal tabs.
+ *
+ * Lifecycle:
+ *  - Mount: creates Terminal, attaches FitAddon, connects to PTY session via IPC
+ *  - Unmount: unsubscribes from data events, disposes xterm instance (PTY session is NOT killed)
+ */
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import type { Terminal } from "@xterm/xterm";
+import type { FitAddon } from "@xterm/addon-fit";
+
+import type { TerminalStatus } from "@/lib/tab-manager/tab-types";
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface TerminalPanelProps {
+  /** PTY session ID (empty string while connecting) */
+  sessionId: string;
+  /** Current status of the terminal tab */
+  status: TerminalStatus;
+  /** Exit code reported by the PTY process (null when still running) */
+  exitCode: number | null;
+  /** Called when the PTY process exits so the parent can update tab state */
+  onExit?: (exitCode: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// xterm theme — mirrors app CSS custom properties
+// Dark theme: bg #080808, fg #f2f2f2
+// Light theme: bg #fcfcfc, fg #0c0c0c
+// We derive the appropriate values from the document root at mount time.
+// ---------------------------------------------------------------------------
+
+function resolveThemeColor(property: string, fallback: string): string {
+  if (typeof document === "undefined") return fallback;
+  const raw = getComputedStyle(document.documentElement)
+    .getPropertyValue(property)
+    .trim();
+  if (!raw) return fallback;
+  // CSS values are in "R G B" space-separated format (used with rgb())
+  return `rgb(${raw})`;
+}
+
+function buildXtermTheme(): Record<string, string> {
+  return {
+    background: resolveThemeColor("--background", "#080808"),
+    foreground: resolveThemeColor("--foreground", "#f2f2f2"),
+    cursor: resolveThemeColor("--foreground", "#f2f2f2"),
+    cursorAccent: resolveThemeColor("--background", "#080808"),
+    selectionBackground: resolveThemeColor("--accent-light", "#e6e6e6"),
+    // ANSI colors use sensible defaults for Japanese text legibility
+    black: "#000000",
+    red: "#dc2626",
+    green: "#16a34a",
+    yellow: "#ca8a04",
+    blue: "#2563eb",
+    magenta: "#9333ea",
+    cyan: "#0d9488",
+    white: "#d4d4d4",
+    brightBlack: "#737373",
+    brightRed: "#ef4444",
+    brightGreen: "#22c55e",
+    brightYellow: "#eab308",
+    brightBlue: "#3b82f6",
+    brightMagenta: "#a855f7",
+    brightCyan: "#14b8a6",
+    brightWhite: "#f5f5f5",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// TerminalPanel component
+// ---------------------------------------------------------------------------
+
+export default function TerminalPanel({
+  sessionId,
+  status,
+  exitCode,
+  onExit,
+}: TerminalPanelProps): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const terminalRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const cleanupDataRef = useRef<(() => void) | null>(null);
+  const cleanupExitRef = useRef<(() => void) | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const [initError, setInitError] = useState<string | null>(null);
+
+  // ---------------------------------------------------------------------------
+  // Terminal initialization and PTY attachment
+  // ---------------------------------------------------------------------------
+
+  const initTerminal = useCallback(async () => {
+    if (!containerRef.current || !sessionId) return;
+
+    const ptyApi = window.electronAPI?.pty;
+    if (!ptyApi) {
+      setInitError("PTY APIが利用できません。Electron環境でのみ使用できます。");
+      return;
+    }
+
+    // Dynamic imports to avoid SSR issues
+    const [{ Terminal: XTerm }, { FitAddon }] = await Promise.all([
+      import("@xterm/xterm"),
+      import("@xterm/addon-fit"),
+    ]);
+
+    // Create terminal instance
+    const terminal = new XTerm({
+      theme: buildXtermTheme(),
+      fontFamily: "'JetBrains Mono', 'Menlo', 'Monaco', 'Courier New', monospace",
+      fontSize: 14,
+      lineHeight: 1.4,
+      cursorBlink: true,
+      allowTransparency: false,
+      scrollback: 5000,
+    });
+
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+
+    // Open terminal in the container element
+    terminal.open(containerRef.current);
+    fitAddon.fit();
+
+    terminalRef.current = terminal;
+    fitAddonRef.current = fitAddon;
+
+    // --- Attach to PTY session ---
+    const attachResult = await ptyApi.attach(sessionId);
+
+    if ("error" in attachResult) {
+      setInitError(`セッションへの接続に失敗しました: ${attachResult.error}`);
+      terminal.dispose();
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+      return;
+    }
+
+    // Write buffered output from before attach
+    if (attachResult.outputBuffer) {
+      terminal.write(attachResult.outputBuffer);
+    }
+
+    // Subscribe to live PTY data events (filter by sessionId)
+    const unsubData = ptyApi.onData((payload) => {
+      if (payload.sessionId !== sessionId) return;
+      terminal.write(payload.data);
+    });
+    cleanupDataRef.current = unsubData;
+
+    // Subscribe to PTY exit events
+    const unsubExit = ptyApi.onExit((payload) => {
+      if (payload.sessionId !== sessionId) return;
+      onExit?.(payload.exitCode);
+    });
+    cleanupExitRef.current = unsubExit;
+
+    // Forward keystrokes to PTY
+    terminal.onData((data) => {
+      void ptyApi.write(sessionId, data);
+    });
+
+    // ResizeObserver: fit terminal on container resize
+    const observer = new ResizeObserver(() => {
+      if (!fitAddonRef.current || !terminalRef.current) return;
+      try {
+        fitAddonRef.current.fit();
+        const dims = fitAddonRef.current.proposeDimensions();
+        if (dims) {
+          void ptyApi.resize(sessionId, dims.cols, dims.rows);
+        }
+      } catch {
+        // Ignore resize errors (e.g. terminal disposed)
+      }
+    });
+    observer.observe(containerRef.current);
+    resizeObserverRef.current = observer;
+
+    // Fit once more after layout settles
+    requestAnimationFrame(() => {
+      if (!fitAddonRef.current || !terminalRef.current) return;
+      try {
+        fitAddonRef.current.fit();
+        const dims = fitAddonRef.current.proposeDimensions();
+        if (dims) {
+          void ptyApi.resize(sessionId, dims.cols, dims.rows);
+        }
+      } catch {
+        // Ignore
+      }
+    });
+  }, [sessionId, onExit]);
+
+  useEffect(() => {
+    if (status !== "running" && status !== "connecting") return;
+    if (!sessionId) return;
+
+    void initTerminal();
+
+    return () => {
+      // Cleanup data and exit listeners
+      cleanupDataRef.current?.();
+      cleanupDataRef.current = null;
+      cleanupExitRef.current?.();
+      cleanupExitRef.current = null;
+
+      // Cleanup ResizeObserver
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
+
+      // Dispose xterm (detaches from DOM, releases resources)
+      // Note: do NOT kill the PTY session here — it should survive tab switches
+      terminalRef.current?.dispose();
+      terminalRef.current = null;
+      fitAddonRef.current = null;
+    };
+  }, [sessionId, status, initTerminal]);
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  if (status === "connecting") {
+    return (
+      <div className="flex items-center justify-center h-full gap-3 text-foreground-secondary text-sm">
+        {/* Spinner */}
+        <svg
+          className="animate-spin h-4 w-4"
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+        <span>接続中...</span>
+      </div>
+    );
+  }
+
+  if (status === "exited") {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-2 text-foreground-secondary text-sm">
+        <span>
+          プロセスが終了しました
+          {exitCode !== null ? ` (code: ${exitCode})` : ""}
+        </span>
+      </div>
+    );
+  }
+
+  if (status === "error" || initError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full gap-2 text-error text-sm p-4">
+        <span className="font-medium">エラーが発生しました</span>
+        {initError && (
+          <span className="text-foreground-secondary text-xs text-center max-w-md">
+            {initError}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  // Running state: render xterm container
+  return (
+    <div
+      ref={containerRef}
+      className="h-full w-full overflow-hidden"
+      data-session-id={sessionId}
+      style={{ padding: "4px" }}
+    />
+  );
+}

--- a/contexts/TerminalTabContext.tsx
+++ b/contexts/TerminalTabContext.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+/**
+ * TerminalTabContext — provides terminal tab state lookup and update
+ * to dockview panel components that cannot access the tab manager directly.
+ *
+ * Populated by app/page.tsx; consumed by lib/dockview/dockview-components.tsx.
+ */
+
+import { createContext, useContext } from "react";
+import type { TerminalTabState } from "@/lib/tab-manager/tab-types";
+
+// ---------------------------------------------------------------------------
+// Context value
+// ---------------------------------------------------------------------------
+
+export interface TerminalTabContextValue {
+  /** Look up a terminal tab by sessionId */
+  getTerminalTabBySessionId: (sessionId: string) => TerminalTabState | undefined;
+  /** Update terminal tab status when PTY exits */
+  setTerminalTabExited: (sessionId: string, exitCode: number) => void;
+  /** Kill PTY session when tab is closed */
+  killTerminalSession: (sessionId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const TerminalTabContext = createContext<TerminalTabContextValue | null>(null);
+
+export { TerminalTabContext };
+
+/**
+ * Returns the terminal tab context value.
+ * Throws if used outside of a TerminalTabContext.Provider.
+ */
+export function useTerminalTabContext(): TerminalTabContextValue {
+  const ctx = useContext(TerminalTabContext);
+  if (!ctx) {
+    throw new Error("useTerminalTabContext must be used inside TerminalTabContext.Provider");
+  }
+  return ctx;
+}

--- a/lib/dockview/dockview-components.tsx
+++ b/lib/dockview/dockview-components.tsx
@@ -15,6 +15,8 @@ import {
   useBufferStoreInstance,
   useBuffer,
 } from "./buffer-store";
+import { useTerminalTabContext } from "@/contexts/TerminalTabContext";
+import RealTerminalPanel from "@/components/TerminalPanel";
 
 // ---------------------------------------------------------------------------
 // EditorPanel — content component rendered inside each dockview panel
@@ -213,20 +215,31 @@ export function DockviewTabHeader({
 }
 
 // ---------------------------------------------------------------------------
-// TerminalPanel — placeholder content component for terminal tabs
+// TerminalPanel — xterm.js content component for terminal tabs
 // ---------------------------------------------------------------------------
 
 export function TerminalPanel({
   api,
   params,
 }: IDockviewPanelProps<TerminalPanelParams>) {
+  const { getTerminalTabBySessionId, setTerminalTabExited } = useTerminalTabContext();
+  const tab = getTerminalTabBySessionId(params.sessionId);
+
+  const handleExit = useCallback(
+    (exitCode: number) => {
+      setTerminalTabExited(params.sessionId, exitCode);
+    },
+    [params.sessionId, setTerminalTabExited],
+  );
+
   return (
-    <div
-      className="flex items-center justify-center h-full text-foreground-secondary text-sm"
-      data-panel-id={api.id}
-      data-session-id={params.sessionId}
-    >
-      ターミナル（実装予定）
+    <div className="h-full w-full overflow-hidden" data-panel-id={api.id}>
+      <RealTerminalPanel
+        sessionId={params.sessionId}
+        status={tab?.status ?? "connecting"}
+        exitCode={tab?.exitCode ?? null}
+        onExit={handleExit}
+      />
     </div>
   );
 }

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -163,6 +163,7 @@ export function useTabManager(options?: {
     openProjectFile: fileIO.openProjectFile,
     pinTab: tabState.pinTab,
     newTerminalTab: tabState.newTerminalTab,
+    updateTerminalTab: tabState.updateTerminalTab,
     openDiffTab: tabState.openDiffTab,
 
     // Close-tab dialog

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -3,7 +3,7 @@
 import type { MutableRefObject, Dispatch, SetStateAction } from "react";
 import type { MdiFileDescriptor } from "../project/mdi-file";
 import type { SupportedFileExtension } from "../project/project-types";
-import type { TabId, TabState, EditorTabState } from "./tab-types";
+import type { TabId, TabState, EditorTabState, TerminalTabState } from "./tab-types";
 
 // ---------------------------------------------------------------------------
 // Public return type (must stay identical to the original useTabManager)
@@ -39,6 +39,11 @@ export interface UseTabManagerReturn {
   openProjectFile: (vfsPath: string, options?: { preview?: boolean }) => Promise<void>;
   pinTab: (tabId: TabId) => void;
   newTerminalTab: () => void;
+  /** Update mutable fields on a terminal tab (e.g. status, exitCode after PTY exits). */
+  updateTerminalTab: (
+    tabId: TabId,
+    updates: Partial<Pick<TerminalTabState, "sessionId" | "status" | "exitCode" | "label" | "cwd" | "shell">>,
+  ) => void;
   openDiffTab: (
     sourceTabId: TabId,
     sourceFileName: string,

--- a/lib/tab-manager/use-tab-state.ts
+++ b/lib/tab-manager/use-tab-state.ts
@@ -41,6 +41,8 @@ export interface UseTabStateReturn extends TabManagerCore {
   newTab: (fileType?: SupportedFileExtension) => void;
   /** Open a new terminal tab with placeholder values. */
   newTerminalTab: () => void;
+  /** Update a terminal tab's mutable fields (status, exitCode, sessionId). */
+  updateTerminalTab: (tabId: TabId, updates: Partial<Pick<TerminalTabState, "sessionId" | "status" | "exitCode" | "label" | "cwd" | "shell">>) => void;
   /** Open a diff tab for the given source tab. */
   openDiffTab: (
     sourceTabId: TabId,
@@ -166,6 +168,21 @@ export function useTabState(): UseTabStateReturn {
     setTabs((prev) => [...prev, tab]);
     setActiveTabId(tab.id);
   }, []);
+
+  const updateTerminalTab = useCallback(
+    (
+      tabId: TabId,
+      updates: Partial<Pick<TerminalTabState, "sessionId" | "status" | "exitCode" | "label" | "cwd" | "shell">>,
+    ) => {
+      setTabs((prev) =>
+        prev.map((t) => {
+          if (t.id !== tabId || t.tabKind !== "terminal") return t;
+          return { ...t, ...updates };
+        }),
+      );
+    },
+    [],
+  );
 
   const openDiffTab = useCallback(
     (
@@ -343,6 +360,7 @@ export function useTabState(): UseTabStateReturn {
     // Tab CRUD
     newTab,
     newTerminalTab,
+    updateTerminalTab,
     openDiffTab,
     switchTab,
     nextTab: nextTabFn,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "@serwist/next": "^9.5.5",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "archiver": "^7.0.1",
         "assert": "^2.1.0",
         "better-sqlite3": "^12.6.2",
@@ -30,6 +32,7 @@
         "kuromoji": "^0.1.2",
         "markdown-it": "^14.1.1",
         "next": "^16.1.6",
+        "node-pty": "^1.0.0",
         "pako": "^2.1.0",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
@@ -6168,6 +6171,21 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -14129,6 +14147,22 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
+      }
+    },
+    "node_modules/node-pty/node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.27",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "@serwist/next": "^9.5.5",
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "archiver": "^7.0.1",
     "assert": "^2.1.0",
     "better-sqlite3": "^12.6.2",
@@ -48,12 +50,12 @@
     "kuromoji": "^0.1.2",
     "markdown-it": "^14.1.1",
     "next": "^16.1.6",
+    "node-pty": "^1.0.0",
     "pako": "^2.1.0",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
-    "util": "^0.12.5",
-    "node-pty": "^1.0.0"
+    "util": "^0.12.5"
   },
   "devDependencies": {
     "@electron/notarize": "^2.5.0",


### PR DESCRIPTION
## Summary

- Add `components/TerminalPanel.tsx` — xterm.js renderer component with FitAddon for PTY sessions
- Add `contexts/TerminalTabContext.tsx` — context providing terminal tab state to dockview panel components
- Replace placeholder `TerminalPanel` in `lib/dockview/dockview-components.tsx` with real xterm renderer
- Add `updateTerminalTab` method to `lib/tab-manager/` for updating mutable terminal tab fields
- Wire PTY spawn/kill/exit in `app/page.tsx` and update tab status accordingly

## Key design decisions

- `TerminalTabContext` bridges the gap between dockview panel components (which cannot access the tab manager directly) and the tab state managed by `useTabManager`
- PTY `closeTab` is wrapped to call `pty.kill(sessionId)` before removing the tab from state
- xterm CSS is imported via `app/globals.css` (not dynamic JS import) to follow project conventions
- `tabsRef` and `updateTerminalTabRef` are used to avoid stale closures in PTY event callbacks
- Terminal instance is disposed on unmount but PTY session is NOT killed (session survives tab switches)

## Test plan

- [ ] Open illusions in Electron, click "ターミナル" in the new tab menu → shell prompt appears
- [ ] Type commands (`echo hello`, `ls`) → output displays correctly
- [ ] Type Japanese characters → renders correctly (CJK support)
- [ ] Resize the window → terminal follows the resize
- [ ] Switch to another tab and back → session preserved, output still visible
- [ ] Close the terminal tab → PTY session killed (verify with `ps` that shell process is gone)
- [ ] Type `exit` in shell → tab shows "プロセスが終了しました (code: 0)"
- [ ] Open illusions on web → clicking "ターミナル" shows `DesktopOnlyDialog`
- [ ] `npx tsc --noEmit` passes

Closes #824

🤖 Generated with [Claude Code](https://claude.com/claude-code)