### PR TITLE
feat(diff): implement read-only DiffView with conflict resolution (closes #826)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,10 +46,12 @@ import { useEditorMode } from "@/contexts/EditorModeContext";
 import { EditorSettingsProvider } from "@/contexts/EditorSettingsContext";
 import { getAvailableFeatures } from "@/lib/utils/feature-detection";
 import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
-import { isEditorTab, isTerminalTab } from "@/lib/tab-manager/tab-types";
-import type { TerminalTabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab, isTerminalTab, isDiffTab } from "@/lib/tab-manager/tab-types";
+import type { TerminalTabState, DiffTabState } from "@/lib/tab-manager/tab-types";
 import { TerminalTabContext } from "@/contexts/TerminalTabContext";
 import type { TerminalTabContextValue } from "@/contexts/TerminalTabContext";
+import { DiffTabContext } from "@/contexts/DiffTabContext";
+import type { DiffTabContextValue } from "@/contexts/DiffTabContext";
 import { useTextStatistics } from "@/lib/editor-page/use-text-statistics";
 import { useEditorSettings } from "@/lib/editor-page/use-editor-settings";
 import { useElectronEvents } from "@/lib/editor-page/use-electron-events";
@@ -173,7 +175,8 @@ export default function EditorPage() {
     newFile: tabNewFile, updateFileName, wasAutoRecovered, onSystemFileOpen,
     _loadSystemFile: tabLoadSystemFile,
     tabs, activeTabId, newTab, closeTab, switchTab, nextTab, prevTab, switchToIndex,
-    openProjectFile, pinTab, newTerminalTab, updateTerminalTab,
+    openProjectFile, pinTab, newTerminalTab, updateTerminalTab, openDiffTab,
+    forceCloseTab, updateTab,
     pendingCloseTabId, pendingCloseFileName, handleCloseTabSave, handleCloseTabDiscard, handleCloseTabCancel,
   } = tabManager;
 
@@ -283,6 +286,93 @@ export default function EditorPage() {
     killTerminalSession,
   };
 
+  // --- DiffTabContext value: exposes diff tab state and conflict resolution to panel components ---
+
+  const getDiffTabById = useCallback(
+    (tabId: string) =>
+      tabsRef.current.find((t): t is DiffTabState => isDiffTab(t) && t.id === tabId),
+    [],
+  );
+
+  const getDiffTabBySourceTabId = useCallback(
+    (sourceTabId: string) =>
+      tabsRef.current.find(
+        (t): t is DiffTabState => isDiffTab(t) && t.sourceTabId === sourceTabId,
+      ),
+    [],
+  );
+
+  /**
+   * Accept disk content: update the source editor tab with the remote content,
+   * clear its conflict state, then force-close the diff tab.
+   */
+  const acceptDiskContent = useCallback(
+    (diffTabId: string) => {
+      const diffTab = tabsRef.current.find(
+        (t): t is DiffTabState => isDiffTab(t) && t.id === diffTabId,
+      );
+      if (!diffTab) return;
+
+      const sourceTab = tabsRef.current.find(
+        (t) => isEditorTab(t) && t.id === diffTab.sourceTabId,
+      );
+      if (sourceTab && isEditorTab(sourceTab)) {
+        updateTab(sourceTab.id, {
+          content: diffTab.remoteContent,
+          lastSavedContent: diffTab.remoteContent,
+          isDirty: false,
+          fileSyncStatus: "clean",
+          conflictDiskContent: null,
+        });
+      }
+      forceCloseTab(diffTabId);
+    },
+    [updateTab, forceCloseTab],
+  );
+
+  /**
+   * Keep editor content: clear the conflict state on the source tab,
+   * then force-close the diff tab.
+   */
+  const keepEditorContent = useCallback(
+    (diffTabId: string) => {
+      const diffTab = tabsRef.current.find(
+        (t): t is DiffTabState => isDiffTab(t) && t.id === diffTabId,
+      );
+      if (!diffTab) return;
+
+      const sourceTab = tabsRef.current.find(
+        (t) => isEditorTab(t) && t.id === diffTab.sourceTabId,
+      );
+      if (sourceTab && isEditorTab(sourceTab)) {
+        updateTab(sourceTab.id, {
+          fileSyncStatus: "clean",
+          conflictDiskContent: null,
+        });
+      }
+      forceCloseTab(diffTabId);
+    },
+    [updateTab, forceCloseTab],
+  );
+
+  /**
+   * Close only the diff tab; source tab conflict state is preserved.
+   */
+  const closeDiffTab = useCallback(
+    (diffTabId: string) => {
+      forceCloseTab(diffTabId);
+    },
+    [forceCloseTab],
+  );
+
+  const diffTabContextValue: DiffTabContextValue = {
+    getDiffTabById,
+    getDiffTabBySourceTabId,
+    acceptDiskContent,
+    keepEditorContent,
+    closeDiffTab,
+  };
+
   // Derive editor mode from active tab's fileType
   const activeTab = tabs.find((t) => t.id === activeTabId);
   const activeEditorTab = activeTab && isEditorTab(activeTab) ? activeTab : undefined;
@@ -357,6 +447,32 @@ export default function EditorPage() {
       incrementEditorKey();
     }
   }, [wasAutoRecovered, incrementEditorKey]);
+
+  // --- Auto-close diff tabs when their source editor tab is closed ---
+  // Tracks the previous tab id set to detect removals.
+  const prevTabIdsRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const currentTabIds = new Set(tabs.map((t) => t.id));
+    const removedTabIds = new Set(
+      [...prevTabIdsRef.current].filter((id) => !currentTabIds.has(id)),
+    );
+
+    if (removedTabIds.size > 0) {
+      // For each removed tab, find any diff tab that references it as sourceTabId
+      const orphanedDiffTabIds = tabs
+        .filter(
+          (t): t is DiffTabState =>
+            isDiffTab(t) && removedTabIds.has(t.sourceTabId),
+        )
+        .map((t) => t.id);
+
+      for (const diffTabId of orphanedDiffTabIds) {
+        forceCloseTab(diffTabId);
+      }
+    }
+
+    prevTabIdsRef.current = currentTabIds;
+  }, [tabs, forceCloseTab]);
 
   // With tabs, open/new don't need unsaved warnings (they create new tabs)
   const openFile = useCallback(async () => {
@@ -739,6 +855,7 @@ export default function EditorPage() {
   } as const;
 
     return (
+      <DiffTabContext.Provider value={diffTabContextValue}>
       <TerminalTabContext.Provider value={terminalTabContextValue}>
       <EditorSettingsProvider settings={settings} handlers={settingsHandlers}>
       <div className="h-screen flex flex-col overflow-hidden relative">
@@ -1047,5 +1164,6 @@ export default function EditorPage() {
     </div>
       </EditorSettingsProvider>
       </TerminalTabContext.Provider>
+      </DiffTabContext.Provider>
   );
 }

--- a/components/DiffView.tsx
+++ b/components/DiffView.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+/**
+ * DiffView — read-only inline diff viewer for the illusions editor.
+ *
+ * Displays character-level differences between the editor buffer (local) and
+ * the on-disk content (remote) with conflict resolution action buttons.
+ *
+ * Uses computeDiff() from lib/services/diff-service for diff calculation.
+ */
+
+import { useMemo } from "react";
+import { HardDrive, FileText } from "lucide-react";
+import type { DiffTabState } from "@/lib/tab-manager/tab-types";
+import { computeDiff, getDiffStats } from "@/lib/services/diff-service";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Threshold in bytes above which the inline diff is replaced by a fallback message. */
+const DIFF_SIZE_LIMIT = 50_000;
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface DiffViewProps {
+  /** The diff tab state containing both content versions and metadata. */
+  tab: DiffTabState;
+  /** Called when the user clicks "ディスクの内容を採用". */
+  onAcceptDisk: () => void;
+  /** Called when the user clicks "エディタの内容を保持". */
+  onKeepEditor: () => void;
+  /** Called when the user clicks "閉じる". */
+  onClose: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Read-only diff viewer showing character-level additions/deletions.
+ * Renders a toolbar with filename, timestamp, stats, and action buttons.
+ * For very large diffs (> 50 KB combined), shows a simplified fallback.
+ */
+export default function DiffView({
+  tab,
+  onAcceptDisk,
+  onKeepEditor,
+  onClose,
+}: DiffViewProps) {
+  const { sourceFileName, localContent, remoteContent, remoteTimestamp } = tab;
+
+  // Format timestamp for display
+  const formattedTimestamp = new Date(remoteTimestamp).toLocaleString("ja-JP");
+
+  // Compute diff (memoized to avoid re-running on every render)
+  const { chunks, stats, isTooLarge } = useMemo(() => {
+    const combinedSize = localContent.length + remoteContent.length;
+    if (combinedSize > DIFF_SIZE_LIMIT) {
+      return { chunks: [], stats: null, isTooLarge: true };
+    }
+    const diffChunks = computeDiff(localContent, remoteContent);
+    const diffStats = getDiffStats(diffChunks);
+    return { chunks: diffChunks, stats: diffStats, isTooLarge: false };
+  }, [localContent, remoteContent]);
+
+  return (
+    <div className="flex flex-col h-full w-full bg-background overflow-hidden">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border bg-background-secondary shrink-0 flex-wrap">
+        {/* File info */}
+        <div className="flex items-center gap-2 min-w-0 shrink">
+          <FileText size={14} className="text-foreground-tertiary shrink-0" />
+          <span className="text-sm font-medium text-foreground truncate">
+            {sourceFileName}
+          </span>
+          <span className="text-xs text-foreground-tertiary whitespace-nowrap">
+            （ディスク最終更新: {formattedTimestamp}）
+          </span>
+        </div>
+
+        {/* Diff stats */}
+        {stats && (stats.addedChars > 0 || stats.removedChars > 0) && (
+          <div className="flex items-center gap-2 text-xs ml-2">
+            {stats.addedChars > 0 && (
+              <span className="text-success">
+                +{stats.addedChars.toLocaleString()} 文字追加
+              </span>
+            )}
+            {stats.removedChars > 0 && (
+              <span className="text-error">
+                −{stats.removedChars.toLocaleString()} 文字削除
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Spacer */}
+        <div className="flex-1" />
+
+        {/* Action buttons */}
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            onClick={onKeepEditor}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-foreground-secondary bg-white/8 hover:bg-white/12 border border-border transition-colors"
+            title="エディタの内容をそのまま保持し、競合状態を解消します"
+          >
+            <FileText size={12} />
+            エディタの内容を保持
+          </button>
+          <button
+            type="button"
+            onClick={onAcceptDisk}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium text-foreground bg-accent hover:bg-accent/90 transition-colors"
+            title="ディスクの内容でエディタの内容を上書きします"
+          >
+            <HardDrive size={12} />
+            ディスクの内容を採用
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 rounded-md text-xs font-medium text-foreground-secondary bg-white/8 hover:bg-white/12 border border-border transition-colors"
+            title="差分タブを閉じます（競合状態は保持されます）"
+          >
+            閉じる
+          </button>
+        </div>
+      </div>
+
+      {/* Diff content area */}
+      <div className="flex-1 overflow-auto p-4">
+        {isTooLarge ? (
+          // Fallback for large files
+          <LargeDiffFallback
+            onAcceptDisk={onAcceptDisk}
+            onKeepEditor={onKeepEditor}
+          />
+        ) : chunks.length === 0 ? (
+          // No changes
+          <div className="flex items-center justify-center h-full text-foreground-muted text-sm">
+            差分なし — 両方の内容は同一です
+          </div>
+        ) : (
+          // Inline diff display
+          <InlineDiff chunks={chunks} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// InlineDiff — renders the character-level diff inline
+// ---------------------------------------------------------------------------
+
+import type { DiffChunk } from "@/lib/services/diff-service";
+
+interface InlineDiffProps {
+  chunks: DiffChunk[];
+}
+
+/**
+ * Renders character-level diff chunks inline.
+ * Added text: green background. Removed text: red strikethrough background.
+ * Unchanged text: normal foreground color.
+ */
+function InlineDiff({ chunks }: InlineDiffProps) {
+  return (
+    <div
+      className="font-mono text-sm leading-relaxed whitespace-pre-wrap break-words text-foreground"
+      aria-label="差分表示"
+      aria-readonly="true"
+    >
+      {chunks.map((chunk, index) => {
+        if (chunk.type === "added") {
+          return (
+            <span
+              key={index}
+              className="bg-success/20 text-success rounded-sm"
+            >
+              {chunk.value}
+            </span>
+          );
+        }
+        if (chunk.type === "removed") {
+          return (
+            <span
+              key={index}
+              className="bg-error/20 text-error line-through rounded-sm"
+            >
+              {chunk.value}
+            </span>
+          );
+        }
+        // unchanged
+        return (
+          <span key={index} className="text-foreground">
+            {chunk.value}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LargeDiffFallback — shown when diff exceeds the 50 KB threshold
+// ---------------------------------------------------------------------------
+
+interface LargeDiffFallbackProps {
+  onAcceptDisk: () => void;
+  onKeepEditor: () => void;
+}
+
+/**
+ * Fallback shown for large files where inline diff computation is skipped.
+ * Still provides accept/reject action buttons so the conflict can be resolved.
+ */
+function LargeDiffFallback({ onAcceptDisk, onKeepEditor }: LargeDiffFallbackProps) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-6 text-center">
+      <p className="text-foreground-secondary text-sm">
+        ファイルが大きすぎるため差分の詳細を表示できません
+      </p>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onKeepEditor}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-md text-sm font-medium text-foreground-secondary bg-white/8 hover:bg-white/12 border border-border transition-colors"
+        >
+          <FileText size={14} />
+          エディタの内容を保持
+        </button>
+        <button
+          type="button"
+          onClick={onAcceptDisk}
+          className="flex items-center gap-1.5 px-4 py-2 rounded-md text-sm font-medium text-foreground bg-accent hover:bg-accent/90 transition-colors"
+        >
+          <HardDrive size={14} />
+          ディスクの内容を採用
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/contexts/DiffTabContext.tsx
+++ b/contexts/DiffTabContext.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * DiffTabContext — provides diff tab state lookup and conflict resolution actions
+ * to dockview panel components that cannot access the tab manager directly.
+ *
+ * Populated by app/page.tsx; consumed by lib/dockview/dockview-components.tsx.
+ */
+
+import { createContext, useContext } from "react";
+import type { DiffTabState } from "@/lib/tab-manager/tab-types";
+
+// ---------------------------------------------------------------------------
+// Context value
+// ---------------------------------------------------------------------------
+
+export interface DiffTabContextValue {
+  /** Look up a diff tab by its own tab id */
+  getDiffTabById: (tabId: string) => DiffTabState | undefined;
+  /** Look up a diff tab by the source (editor) tab id */
+  getDiffTabBySourceTabId: (sourceTabId: string) => DiffTabState | undefined;
+  /**
+   * Accept disk content: update the source editor tab buffer with the remote
+   * content and clear its conflict state, then close the diff tab.
+   */
+  acceptDiskContent: (diffTabId: string) => void;
+  /**
+   * Keep editor content: clear the conflict state on the source tab
+   * (mark it no longer conflicted) and close the diff tab.
+   */
+  keepEditorContent: (diffTabId: string) => void;
+  /** Close only the diff tab, leaving the source tab conflict state intact. */
+  closeDiffTab: (diffTabId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const DiffTabContext = createContext<DiffTabContextValue | null>(null);
+
+export { DiffTabContext };
+
+/**
+ * Returns the diff tab context value.
+ * Throws if used outside of a DiffTabContext.Provider.
+ */
+export function useDiffTabContext(): DiffTabContextValue {
+  const ctx = useContext(DiffTabContext);
+  if (!ctx) {
+    throw new Error("useDiffTabContext must be used inside DiffTabContext.Provider");
+  }
+  return ctx;
+}

--- a/lib/dockview/dockview-components.tsx
+++ b/lib/dockview/dockview-components.tsx
@@ -16,7 +16,9 @@ import {
   useBuffer,
 } from "./buffer-store";
 import { useTerminalTabContext } from "@/contexts/TerminalTabContext";
+import { useDiffTabContext } from "@/contexts/DiffTabContext";
 import RealTerminalPanel from "@/components/TerminalPanel";
+import DiffView from "@/components/DiffView";
 
 // ---------------------------------------------------------------------------
 // EditorPanel — content component rendered inside each dockview panel
@@ -308,21 +310,45 @@ export function TerminalTabHeader({
 }
 
 // ---------------------------------------------------------------------------
-// DiffPanel — placeholder content component for diff tabs
+// DiffPanel — real diff content component using DiffView
 // ---------------------------------------------------------------------------
 
 export function DiffPanel({
   api,
   params,
 }: IDockviewPanelProps<DiffPanelParams>) {
+  const { getDiffTabBySourceTabId, acceptDiskContent, keepEditorContent, closeDiffTab } =
+    useDiffTabContext();
+
+  const tab = getDiffTabBySourceTabId(params.sourceTabId);
+
+  const handleAcceptDisk = useCallback(() => {
+    acceptDiskContent(api.id);
+  }, [acceptDiskContent, api.id]);
+
+  const handleKeepEditor = useCallback(() => {
+    keepEditorContent(api.id);
+  }, [keepEditorContent, api.id]);
+
+  const handleClose = useCallback(() => {
+    closeDiffTab(api.id);
+  }, [closeDiffTab, api.id]);
+
+  if (!tab) {
+    return (
+      <div className="flex items-center justify-center h-full text-foreground-muted text-sm">
+        差分データが見つかりません
+      </div>
+    );
+  }
+
   return (
-    <div
-      className="flex items-center justify-center h-full text-foreground-secondary text-sm"
-      data-panel-id={api.id}
-      data-source-tab-id={params.sourceTabId}
-    >
-      差分表示（実装予定）
-    </div>
+    <DiffView
+      tab={tab}
+      onAcceptDisk={handleAcceptDisk}
+      onKeepEditor={handleKeepEditor}
+      onClose={handleClose}
+    />
   );
 }
 

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -180,6 +180,8 @@ export function useTabManager(options?: {
     newTerminalTab: tabState.newTerminalTab,
     updateTerminalTab: tabState.updateTerminalTab,
     openDiffTab: tabState.openDiffTab,
+    forceCloseTab: tabState.forceCloseTab,
+    updateTab: tabState.updateTab,
 
     // Close-tab dialog
     pendingCloseTabId: tabState.pendingCloseTabId,

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -51,6 +51,16 @@ export interface UseTabManagerReturn {
     remoteContent: string,
     remoteTimestamp: number,
   ) => void;
+  /**
+   * Force-close a tab without dirty check.
+   * Used by diff tab conflict resolution to close tabs programmatically.
+   */
+  forceCloseTab: (tabId: TabId) => void;
+  /**
+   * Update a single editor tab by id.
+   * Used by diff tab conflict resolution to update source tab content.
+   */
+  updateTab: (tabId: TabId, updates: Partial<EditorTabState>) => void;
 
   // Close-tab unsaved warning flow
   pendingCloseTabId: TabId | null;

--- a/lib/tab-manager/use-tab-state.ts
+++ b/lib/tab-manager/use-tab-state.ts
@@ -192,6 +192,15 @@ export function useTabState(): UseTabStateReturn {
       remoteContent: string,
       remoteTimestamp: number,
     ) => {
+      // Prevent duplicate: if a diff tab for this source already exists, switch to it.
+      const existing = tabsRef.current.find(
+        (t): t is DiffTabState => t.tabKind === "diff" && t.sourceTabId === sourceTabId,
+      );
+      if (existing) {
+        setActiveTabId(existing.id);
+        return;
+      }
+
       const tab: DiffTabState = {
         tabKind: "diff",
         id: generateTabId(),
@@ -204,7 +213,7 @@ export function useTabState(): UseTabStateReturn {
       setTabs((prev) => [...prev, tab]);
       setActiveTabId(tab.id);
     },
-    [],
+    [tabsRef],
   );
 
   const switchTab = useCallback((tabId: TabId) => {


### PR DESCRIPTION
## Summary

- Add `DiffView` component with character-level inline diff display (green additions, red strikethrough deletions), toolbar with filename/timestamp/diff stats, three action buttons, and a 50 KB large-file fallback
- Add `DiffTabContext` providing conflict resolution callbacks (`acceptDiskContent`, `keepEditorContent`, `closeDiffTab`) to dockview panel components — follows the same pattern as `TerminalTabContext`
- Replace placeholder `DiffPanel` in `dockview-components.tsx` with the real `DiffView` wired to `DiffTabContext`
- Source tab close → related diff tab auto-closes (via `useEffect` watching tab removals)
- Duplicate diff tab prevention: `openDiffTab()` now switches to an existing diff tab for the same source instead of opening a second one
- Expose `forceCloseTab` and `updateTab` through `UseTabManagerReturn` for programmatic conflict resolution

## Test plan

- [ ] Trigger an external file change on an open editor tab (e.g. edit the file from another editor)
- [ ] Verify the conflict notification appears with a "差分を表示" button
- [ ] Click "差分を表示" — confirm a diff tab opens showing green/red character-level diffs
- [ ] Verify Japanese text diffs display correctly
- [ ] Click "ディスクの内容を採用" — confirm the source tab updates to disk content and diff tab closes
- [ ] Repeat, click "エディタの内容を保持" — confirm the source tab's conflict state clears and diff tab closes
- [ ] Repeat, click "閉じる" — confirm only the diff tab closes and the source tab retains its conflict (triangle icon in tab)
- [ ] Close the source editor tab — confirm the diff tab auto-closes
- [ ] Click "差分を表示" twice in rapid succession — confirm only one diff tab opens (second click switches to existing)
- [ ] Test with a file > 50 KB — confirm the fallback message appears with only accept/reject buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)