### PR TITLE
fix(www): use stale-while-revalidate for release cache

### DIFF
--- a/www/src/downloads.ts
+++ b/www/src/downloads.ts
@@ -538,27 +538,27 @@ function saveCache(data: GitHubRelease): void {
   }
 }
 
-// Serve from cache immediately if available, otherwise show loading
+// Stale-while-revalidate: render cached data immediately, then refresh in background
 const cached = loadCache()
-if (cached) {
-  renderPage(cached, null)
-} else {
-  renderPage(null, null)
+renderPage(cached, null)
 
-  fetch(API_URL, { headers: { Accept: 'application/vnd.github.v3+json' } })
-    .then(async (res) => {
-      if (res.status === 403 || res.status === 429) {
+fetch(API_URL, { headers: { Accept: 'application/vnd.github.v3+json' } })
+  .then(async (res) => {
+    if (res.status === 403 || res.status === 429) {
+      if (!cached) {
         window.location.href = 'https://github.com/Iktahana/illusions/blob/main/README.md'
-        return
       }
-      if (!res.ok) {
-        throw new Error(`GitHub API returned ${res.status}`)
-      }
-      const data = (await res.json()) as GitHubRelease
-      saveCache(data)
-      renderPage(data, null)
-    })
-    .catch((err: Error) => {
+      return
+    }
+    if (!res.ok) {
+      throw new Error(`GitHub API returned ${res.status}`)
+    }
+    const data = (await res.json()) as GitHubRelease
+    saveCache(data)
+    renderPage(data, null)
+  })
+  .catch((err: Error) => {
+    if (!cached) {
       renderPage(null, err.message)
-    })
-}
+    }
+  })


### PR DESCRIPTION
## Summary
- Cached release data was suppressing all revalidation for up to 1 hour, serving outdated installers after a new release
- Changed to stale-while-revalidate: render cached data immediately, always fetch in background to refresh

## Test plan
- [ ] Visit /downloads with cached data, verify background fetch updates the page
- [ ] Clear cache, verify loading state then fetch works
- [ ] Rate-limited with cache → silent fallback to cached data
- [ ] Rate-limited without cache → redirect to GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)