### PR TITLE
fix(persistence): resolve tab and layout state not persisting on quit

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -116,6 +116,13 @@ export default function EditorPage() {
     setEditorKey(prev => prev + 1);
   }, []);
 
+  // Ref for dockview layout flush — populated after useDockviewPersistence,
+  // consumed by useTabManager's close handler via stable callback.
+  const flushLayoutStateRef = useRef<(() => Promise<void>) | undefined>(undefined);
+  const stableFlushLayoutState = useCallback(async () => {
+    await flushLayoutStateRef.current?.();
+  }, []);
+
   // Deferred promise gate: tab restoration waits until VFS root is set
   const [vfsGate] = useState(() => {
     let resolve!: () => void;
@@ -170,7 +177,7 @@ export default function EditorPage() {
     handleOpenLintingSettings, handleOpenPosHighlightSettings, triggerSwitchToCorrections,
   } = panelHandlers;
 
-  const tabManager = useTabManager({ skipAutoRestore, autoSave, vfsReadyPromise: vfsGate.promise });
+  const tabManager = useTabManager({ skipAutoRestore, autoSave, vfsReadyPromise: vfsGate.promise, flushLayoutState: stableFlushLayoutState });
   const {
     content, setContent, currentFile, isDirty, isSaving, lastSavedTime, lastSaveWasAuto,
     openFile: tabOpenFile, saveFile, saveAsFile,
@@ -213,7 +220,8 @@ export default function EditorPage() {
     dockviewApi,
     splitEditor,
   } = useDockviewAdapter({ tabManager: tabManagerWithPtyCleanup, editorKey });
-  useDockviewPersistence({ dockviewApi });
+  const { flushLayoutState } = useDockviewPersistence({ dockviewApi, tabs: tabManagerWithPtyCleanup.tabs });
+  flushLayoutStateRef.current = flushLayoutState;
 
   // --- New terminal tab callback ---
   const handleNewTerminalTab = useCallback(() => {

--- a/lib/dockview/index.ts
+++ b/lib/dockview/index.ts
@@ -10,6 +10,7 @@ export type {
   BufferState,
   EditorPanelParams,
   DockviewLayoutState,
+  SimplifiedGroupLayout,
   SerializedBuffer,
   BufferChangeEvent,
 } from "./types";

--- a/lib/dockview/types.ts
+++ b/lib/dockview/types.ts
@@ -73,12 +73,30 @@ export interface SerializedBuffer {
   isPreview: boolean;
 }
 
+/**
+ * Simplified, ID-independent layout descriptor.
+ * Uses file paths as stable keys so layout survives tab ID regeneration on restart.
+ */
+export interface SimplifiedGroupLayout {
+  /** Each group and its tab file paths in order */
+  groups: Array<{
+    tabPaths: (string | null)[];
+    activeTabPath: string | null;
+  }>;
+  /** Root grid orientation */
+  orientation: "HORIZONTAL" | "VERTICAL";
+  /** Relative sizes of each group (proportional) */
+  sizes: number[];
+}
+
 /** Full layout state persisted to AppState */
 export interface DockviewLayoutState {
   /** Dockview's own serialized layout (groups, panels, orientations) */
   dockviewJson: SerializedDockview;
   /** Buffer metadata for each open document */
   buffers: SerializedBuffer[];
+  /** Simplified layout for ID-independent restoration */
+  simplifiedLayout?: SimplifiedGroupLayout;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -16,7 +16,8 @@ import type { DockviewApi, IDockviewPanel } from "dockview-react";
 import type { TabId, TabState } from "@/lib/tab-manager/tab-types";
 import { isEditorTab, isTerminalTab, isDiffTab } from "@/lib/tab-manager/tab-types";
 import type { UseTabManagerReturn } from "@/lib/tab-manager/types";
-import type { EditorPanelParams, TerminalPanelParams, DiffPanelParams } from "./types";
+import type { EditorPanelParams, TerminalPanelParams, DiffPanelParams, SimplifiedGroupLayout } from "./types";
+import { loadDockviewLayout } from "./use-dockview-persistence";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -87,6 +88,81 @@ function positionTerminalPanel(
 }
 
 // ---------------------------------------------------------------------------
+// Layout restoration helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply a saved simplified layout to the current dockview state.
+ * Matches panels to saved groups by file path and uses moveTo() to redistribute.
+ */
+function applySimplifiedLayout(
+  api: DockviewApi,
+  layout: SimplifiedGroupLayout,
+  tabs: TabState[],
+): void {
+  // Build filePath → panelId lookup from current tabs
+  const panelIdByPath = new Map<string, string>();
+  for (const tab of tabs) {
+    if (isEditorTab(tab) && tab.file?.path) {
+      panelIdByPath.set(tab.file.path, tab.id);
+    }
+  }
+
+  // Skip if only one group (default layout, nothing to do)
+  if (layout.groups.length <= 1) return;
+
+  // All panels start in the first group (default). We need to move panels
+  // from groups[1..n] to new split groups.
+  // Strategy: for each subsequent saved group, pick a reference panel from
+  // the first group, then move the target panels to create new groups.
+
+  for (let i = 1; i < layout.groups.length; i++) {
+    const savedGroup = layout.groups[i];
+    const direction = layout.orientation === "HORIZONTAL" ? "right" : "bottom";
+
+    let firstPanelInGroup: IDockviewPanel | null = null;
+
+    for (const filePath of savedGroup.tabPaths) {
+      if (!filePath) continue;
+      const panelId = panelIdByPath.get(filePath);
+      if (!panelId) continue;
+      const panel = api.getPanel(panelId);
+      if (!panel) continue;
+
+      if (!firstPanelInGroup) {
+        // First panel in this group: split to create a new group
+        try {
+          // Find a reference panel that's still in the default group
+          const refPanel = api.panels.find(
+            (p) => p.id !== panelId && p.group !== panel.group,
+          ) ?? api.panels[0];
+          if (refPanel && refPanel.id !== panelId) {
+            panel.api.moveTo({
+              group: refPanel.group,
+              position: direction,
+            });
+          }
+          firstPanelInGroup = panel;
+        } catch {
+          // Move failed; skip this group
+          break;
+        }
+      } else {
+        // Subsequent panels: move into the same group as the first panel
+        try {
+          panel.api.moveTo({
+            group: firstPanelInGroup.group,
+            position: "center",
+          });
+        } catch {
+          // Move failed; panel stays where it is
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
@@ -102,6 +178,10 @@ export function useDockviewAdapter({
   // Track previous tab state for diffing
   const prevTabsRef = useRef<TabState[]>([]);
   const prevActiveTabRef = useRef<TabId>("");
+
+  // Layout restoration state
+  const savedLayoutRef = useRef<SimplifiedGroupLayout | null>(null);
+  const layoutAppliedRef = useRef(false);
 
   const { tabs, activeTabId, switchTab, closeTab, newTab } = tabManager;
 
@@ -174,6 +254,19 @@ export function useDockviewAdapter({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only run once on mount
     [],
   );
+
+  // -- Pre-load saved layout for restoration --------------------------------
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadDockviewLayout().then((state) => {
+      if (cancelled) return;
+      if (state?.simplifiedLayout) {
+        savedLayoutRef.current = state.simplifiedLayout;
+      }
+    });
+    return () => { cancelled = true; };
+  }, []);
 
   // -- Pending split tracking -----------------------------------------------
 
@@ -278,6 +371,21 @@ export function useDockviewAdapter({
         if (panel.title !== tab.sourceFileName) {
           panel.api.setTitle(tab.sourceFileName);
         }
+      }
+    }
+
+    // Apply saved layout after initial tab restoration (only once)
+    if (
+      !layoutAppliedRef.current &&
+      savedLayoutRef.current &&
+      prevTabs.length === 0 &&
+      tabs.length > 0
+    ) {
+      layoutAppliedRef.current = true;
+      try {
+        applySimplifiedLayout(api, savedLayoutRef.current, tabs);
+      } catch (err) {
+        console.warn("[dockview-adapter] Failed to restore layout:", err);
       }
     }
 

--- a/lib/dockview/use-dockview-persistence.ts
+++ b/lib/dockview/use-dockview-persistence.ts
@@ -5,12 +5,15 @@
  *
  * Uses the existing StorageService AppState for persistence.
  * Layout is serialized via dockview's toJSON() and stored alongside
- * the existing openTabs field for backward compatibility.
+ * a simplified layout descriptor for ID-independent restoration.
  */
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { DockviewApi } from "dockview-react";
-import type { DockviewLayoutState } from "./types";
+import type { DockviewLayoutState, SimplifiedGroupLayout } from "./types";
+import type { TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
+import { persistAppState } from "@/lib/storage/app-state-manager";
 import { getStorageService } from "@/lib/storage/storage-service";
 
 // ---------------------------------------------------------------------------
@@ -20,19 +23,113 @@ import { getStorageService } from "@/lib/storage/storage-service";
 const LAYOUT_PERSIST_DEBOUNCE = 2000;
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a simplified, ID-independent layout from the current dockview state.
+ * Uses file paths as stable keys so the layout survives tab ID regeneration.
+ */
+function extractSimplifiedLayout(
+  api: DockviewApi,
+  tabs: TabState[],
+): SimplifiedGroupLayout | undefined {
+  const groups = api.groups;
+  if (groups.length <= 1) return undefined; // Single group = default layout, no need to save
+
+  // Build panelId → filePath lookup
+  const pathByPanelId = new Map<string, string | null>();
+  for (const tab of tabs) {
+    if (isEditorTab(tab)) {
+      pathByPanelId.set(tab.id, tab.file?.path ?? null);
+    }
+  }
+
+  // Extract orientation from serialized JSON (the API doesn't expose it directly)
+  let orientation: "HORIZONTAL" | "VERTICAL" = "HORIZONTAL";
+  try {
+    const json = api.toJSON();
+    const rawOrientation = String(json.grid.orientation);
+    orientation = rawOrientation === "VERTICAL" ? "VERTICAL" : "HORIZONTAL";
+  } catch {
+    // Fall back to default
+  }
+
+  const simplifiedGroups: SimplifiedGroupLayout["groups"] = [];
+  const sizes: number[] = [];
+
+  for (const group of groups) {
+    const tabPaths = group.panels.map((p) => pathByPanelId.get(p.id) ?? null);
+    const activePanel = group.activePanel;
+    const activeTabPath = activePanel ? (pathByPanelId.get(activePanel.id) ?? null) : null;
+    simplifiedGroups.push({ tabPaths, activeTabPath });
+    sizes.push(group.api.height > 0 ? group.api.width : group.api.width);
+  }
+
+  // Normalize sizes to proportional values
+  const totalSize = sizes.reduce((sum, s) => sum + s, 0);
+  const normalizedSizes = totalSize > 0 ? sizes.map((s) => s / totalSize) : sizes;
+
+  return {
+    groups: simplifiedGroups,
+    orientation,
+    sizes: normalizedSizes,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
 export interface UseDockviewPersistenceOptions {
   dockviewApi: DockviewApi | null;
+  /** Current tab state for extracting file paths */
+  tabs?: TabState[];
   enabled?: boolean;
+}
+
+export interface UseDockviewPersistenceReturn {
+  /** Immediately flush pending layout state to storage (cancels debounce). */
+  flushLayoutState: () => Promise<void>;
 }
 
 export function useDockviewPersistence({
   dockviewApi,
+  tabs = [],
   enabled = true,
-}: UseDockviewPersistenceOptions): void {
+}: UseDockviewPersistenceOptions): UseDockviewPersistenceReturn {
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const apiRef = useRef<DockviewApi | null>(null);
+  apiRef.current = dockviewApi;
+  const tabsRef = useRef<TabState[]>(tabs);
+  tabsRef.current = tabs;
+
+  /** Serialize and persist the current layout immediately. */
+  const persistLayoutNow = useCallback(async () => {
+    const api = apiRef.current;
+    if (!api) return;
+    try {
+      const layoutJson = api.toJSON();
+      const simplified = extractSimplifiedLayout(api, tabsRef.current);
+      const layoutState: DockviewLayoutState = {
+        dockviewJson: layoutJson,
+        buffers: [],
+        simplifiedLayout: simplified,
+      };
+      await persistAppState({ dockviewLayout: layoutState });
+    } catch (err) {
+      console.warn("[dockview-persistence] Failed to serialize layout:", err);
+    }
+  }, []);
+
+  /** Flush pending layout state: cancel debounce and persist immediately. */
+  const flushLayoutState = useCallback(async () => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+    await persistLayoutNow();
+  }, [persistLayoutNow]);
 
   // Save layout on changes (debounced)
   useEffect(() => {
@@ -43,20 +140,9 @@ export function useDockviewPersistence({
         clearTimeout(debounceTimerRef.current);
       }
       debounceTimerRef.current = setTimeout(() => {
-        try {
-          const layoutJson = dockviewApi.toJSON();
-          const layoutState: DockviewLayoutState = {
-            dockviewJson: layoutJson,
-            buffers: [], // Buffer metadata managed by tab persistence
-          };
-          void getStorageService()
-            .saveAppState({ dockviewLayout: layoutState })
-            .catch((err) => {
-              console.warn("[dockview-persistence] Failed to save layout:", err);
-            });
-        } catch (err) {
-          console.warn("[dockview-persistence] Failed to serialize layout:", err);
-        }
+        void persistLayoutNow().catch((err) => {
+          console.warn("[dockview-persistence] Failed to save layout:", err);
+        });
       }, LAYOUT_PERSIST_DEBOUNCE);
     });
 
@@ -66,7 +152,9 @@ export function useDockviewPersistence({
         clearTimeout(debounceTimerRef.current);
       }
     };
-  }, [dockviewApi, enabled]);
+  }, [dockviewApi, enabled, persistLayoutNow]);
+
+  return { flushLayoutState };
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/keymap/keymap-storage.ts
+++ b/lib/keymap/keymap-storage.ts
@@ -1,4 +1,5 @@
 import { getStorageService } from "@/lib/storage/storage-service";
+import { persistAppState } from "@/lib/storage/app-state-manager";
 import type { KeymapOverrides } from "./keymap-types";
 
 /**
@@ -6,9 +7,7 @@ import type { KeymapOverrides } from "./keymap-types";
  * Overrides are stored as part of AppState.keymapOverrides.
  */
 export async function saveKeymapOverrides(overrides: KeymapOverrides): Promise<void> {
-  const storage = getStorageService();
-  const appState = await storage.loadAppState() ?? {};
-  await storage.saveAppState({ ...appState, keymapOverrides: overrides });
+  await persistAppState({ keymapOverrides: overrides });
 }
 
 /**

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -25,6 +25,8 @@ export function useTabManager(options?: {
   skipAutoRestore?: boolean;
   autoSave?: boolean;
   vfsReadyPromise?: Promise<void>;
+  /** External flush callback for dockview layout persistence. */
+  flushLayoutState?: () => Promise<void>;
 }): UseTabManagerReturn {
   const skipAutoRestore = options?.skipAutoRestore ?? false;
   const autoSaveEnabled = options?.autoSave ?? true;
@@ -86,6 +88,10 @@ export function useTabManager(options?: {
     ((path: string, content: string) => void) | null
   >(null);
 
+  // flushTabState is provided by useTabPersistence below; use a ref so the
+  // menu bindings can call it in the async onSaveBeforeClose handler.
+  const flushTabStateRef = useRef<(() => Promise<void>) | undefined>(undefined);
+
   useElectronMenuBindings({
     tabs: tabState.tabs,
     setTabs: tabState.setTabs,
@@ -102,6 +108,8 @@ export function useTabManager(options?: {
     loadSystemFile: fileIO.loadSystemFile,
     updateTab: tabState.updateTab,
     systemFileOpenHandlerRef,
+    flushTabState: flushTabStateRef.current,
+    flushLayoutState: options?.flushLayoutState,
   });
 
   // --- File watch integration (external change detection) -----------------
@@ -120,7 +128,7 @@ export function useTabManager(options?: {
 
   // --- Tab persistence (save/restore to AppState) -------------------------
 
-  const { wasAutoRecovered } = useTabPersistence({
+  const { wasAutoRecovered, flushTabState: _flushTabState } = useTabPersistence({
     tabs: tabState.tabs,
     setTabs: tabState.setTabs,
     activeTabId: tabState.activeTabId,
@@ -132,6 +140,9 @@ export function useTabManager(options?: {
     skipAutoRestore,
     vfsReadyPromise: options?.vfsReadyPromise,
   });
+
+  // Update the ref so useElectronMenuBindings can access flushTabState
+  flushTabStateRef.current = _flushTabState;
 
   // --- Backward compat alias: newFile === newTab --------------------------
   const newFile = tabState.newTab;
@@ -189,5 +200,8 @@ export function useTabManager(options?: {
     handleCloseTabSave: closeDialog.handleCloseTabSave,
     handleCloseTabDiscard: closeDialog.handleCloseTabDiscard,
     handleCloseTabCancel: tabState.handleCloseTabCancel,
+
+    // Persistence flush
+    flushTabState: _flushTabState,
   };
 }

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -68,6 +68,10 @@ export interface UseTabManagerReturn {
   handleCloseTabSave: () => Promise<void>;
   handleCloseTabDiscard: () => void;
   handleCloseTabCancel: () => void;
+
+  // Persistence flush (for save-before-close)
+  /** Immediately flush pending tab state to storage. */
+  flushTabState: () => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/tab-manager/use-electron-menu-bindings.ts
+++ b/lib/tab-manager/use-electron-menu-bindings.ts
@@ -31,6 +31,10 @@ export interface UseElectronMenuBindingsParams extends TabManagerCore {
   systemFileOpenHandlerRef: React.MutableRefObject<
     ((path: string, content: string) => void) | null
   >;
+  /** Immediately flush pending tab state to storage. */
+  flushTabState?: () => Promise<void>;
+  /** Immediately flush pending dockview layout to storage. */
+  flushLayoutState?: () => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -60,6 +64,8 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
     loadSystemFile,
     updateTab,
     systemFileOpenHandlerRef,
+    flushTabState,
+    flushLayoutState,
   } = params;
 
   // Stable refs for callbacks that change frequently
@@ -75,11 +81,23 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
     window.electronAPI.setDirty(anyDirty);
   }, [tabs, isElectron]);
 
+  // Stable refs for flush callbacks
+  const flushTabStateRef = useRef(flushTabState);
+  flushTabStateRef.current = flushTabState;
+  const flushLayoutStateRef = useRef(flushLayoutState);
+  flushLayoutStateRef.current = flushLayoutState;
+
   // Save all dirty tabs before Electron window close
   useEffect(() => {
     if (!isElectron || !window.electronAPI?.onSaveBeforeClose) return;
 
     const cleanup = window.electronAPI.onSaveBeforeClose(async () => {
+      // Flush debounced persistence state before saving files
+      await Promise.all([
+        flushTabStateRef.current?.(),
+        flushLayoutStateRef.current?.(),
+      ]);
+
       for (const tab of tabsRef.current) {
         if (!isEditorTab(tab)) continue;
         if (!tab.isDirty || !tab.file) continue;

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getStorageService } from "../storage/storage-service";
 import { fetchAppState, persistAppState } from "../storage/app-state-manager";
 import type { TabState, SerializedTab, TabPersistenceState, EditorTabState } from "./tab-types";
@@ -12,6 +12,7 @@ import {
   generateTabId,
   inferFileType,
 } from "./types";
+import { getVFS } from "../vfs";
 
 // ---------------------------------------------------------------------------
 // Params
@@ -31,6 +32,8 @@ export interface UseTabPersistenceParams extends TabManagerCore {
 export interface UseTabPersistenceReturn {
   /** Whether the session was auto-recovered from a saved buffer. */
   wasAutoRecovered: boolean;
+  /** Immediately flush pending tab state to storage (cancels debounce). */
+  flushTabState: () => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -52,6 +55,8 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     setTabs,
     activeTabId,
     setActiveTabId,
+    tabsRef,
+    activeTabIdRef,
     isElectron,
     skipAutoRestore,
     vfsReadyPromise,
@@ -68,6 +73,34 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
 
   const tabPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  /** Build and persist the current tab state immediately. */
+  const persistTabStateNow = useCallback(async () => {
+    const currentTabs = tabsRef.current;
+    const currentActiveId = activeTabIdRef.current;
+    const editorTabs = currentTabs.filter(isEditorTab);
+    const serializedTabs: SerializedTab[] = editorTabs.map((t) => ({
+      filePath: t.file?.path ?? null,
+      fileName: t.file?.name ?? "新規ファイル",
+      isPreview: t.isPreview || undefined,
+      fileType: t.fileType,
+    }));
+    const activeEditorIndex = editorTabs.findIndex((t) => t.id === currentActiveId);
+    const state: TabPersistenceState = {
+      tabs: serializedTabs,
+      activeIndex: Math.max(0, activeEditorIndex),
+    };
+    await persistAppState({ openTabs: state });
+  }, [tabsRef, activeTabIdRef]);
+
+  /** Flush pending tab state: cancel debounce and persist immediately. */
+  const flushTabState = useCallback(async () => {
+    if (tabPersistTimerRef.current) {
+      clearTimeout(tabPersistTimerRef.current);
+      tabPersistTimerRef.current = null;
+    }
+    await persistTabStateNow();
+  }, [persistTabStateNow]);
+
   useEffect(() => {
     // Skip persisting empty state until after storage has been initialized.
     // This prevents a race on Electron where the 1s debounce fires before
@@ -80,20 +113,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     }
 
     tabPersistTimerRef.current = setTimeout(() => {
-      // Only persist editor tabs; terminal and diff tabs are transient
-      const editorTabs = tabs.filter(isEditorTab);
-      const serializedTabs: SerializedTab[] = editorTabs.map((t) => ({
-        filePath: t.file?.path ?? null,
-        fileName: t.file?.name ?? "新規ファイル",
-        isPreview: t.isPreview || undefined,
-        fileType: t.fileType,
-      }));
-      const activeEditorIndex = editorTabs.findIndex((t) => t.id === activeTabId);
-      const state: TabPersistenceState = {
-        tabs: serializedTabs,
-        activeIndex: Math.max(0, activeEditorIndex),
-      };
-      void persistAppState({ openTabs: state }).catch((error) => {
+      void persistTabStateNow().catch((error) => {
         console.error("タブ状態の保存に失敗しました:", error);
       });
     }, TAB_PERSIST_DEBOUNCE);
@@ -103,7 +123,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
         clearTimeout(tabPersistTimerRef.current);
       }
     };
-  }, [tabs, activeTabId]);
+  }, [tabs, activeTabId, persistTabStateNow]);
 
   // --- Storage initialization & Web file restore --------------------------
   //
@@ -222,8 +242,8 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
         for (const serialized of openTabs.tabs) {
           if (serialized.filePath) {
             try {
-              const fileContent =
-                await window.electronAPI!.vfs!.readFile(serialized.filePath);
+              const vfs = getVFS();
+              const fileContent = await vfs.readFile(serialized.filePath);
               restoredTabs.push({
                 tabKind: "editor",
                 id: generateTabId(),
@@ -276,5 +296,5 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     void restoreTabs();
   }, [isElectron, skipAutoRestore, setTabs, setActiveTabId, vfsReadyPromise]);
 
-  return { wasAutoRecovered };
+  return { wasAutoRecovered, flushTabState };
 }


### PR DESCRIPTION
## Summary

- **Fix storage race condition**: `dockview-persistence` and `keymap-storage` now use `persistAppState()` (mutex-protected read-merge-write) instead of direct `saveAppState()` which could overwrite other AppState fields
- **Add flush-on-quit**: both tab persistence and dockview layout persistence expose `flushNow()` callbacks called in `onSaveBeforeClose` before `window.destroy()`, preventing debounced state loss
- **Implement layout restoration**: save a simplified, ID-independent layout descriptor (groups + file paths) alongside dockview's `toJSON()`, and restore split-pane arrangement on restart using `moveTo()`
- **Fix VFS path bug**: tab restore now uses `getVFS().readFile()` instead of direct IPC, so relative file paths are resolved against project root

## Test plan

- [ ] Open 2+ tabs, split into side-by-side layout, close window, reopen → verify tabs AND layout restored
- [ ] Close window within 1s of editing → verify tab state persisted (flush-on-quit)
- [ ] Change display settings while layout changes debounce → verify no data loss (race condition fix)
- [ ] Close all tabs → reopen → should get empty state, not previous tabs
- [ ] Open project A → close → open project B → verify project A tabs don't leak

🤖 Generated with [Claude Code](https://claude.com/claude-code)