### PR TITLE
fix(linux): wrap desktop entry fields in entry key for electron-builder 26.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,10 +211,12 @@
       "icon": "build/icon.png",
       "category": "Office",
       "desktop": {
-        "Name": "illusions",
-        "Comment": "AI搭載日本語小説エディタ",
-        "Keywords": "小説;執筆;日本語;エディタ;AI;novel;writing;japanese;editor;",
-        "MimeType": "application/x-mdi;"
+        "entry": {
+          "Name": "illusions",
+          "Comment": "AI搭載日本語小説エディタ",
+          "Keywords": "小説;執筆;日本語;エディタ;AI;novel;writing;japanese;editor;",
+          "MimeType": "application/x-mdi;"
+        }
       },
       "target": [
         { "target": "AppImage", "arch": ["x64"] },


### PR DESCRIPTION
## Summary
- `linux.desktop` schema changed in electron-builder 26.x — `Name`, `Comment`, `Keywords`, `MimeType` must be nested under `entry` key
- Fixes **all** platform build failures in CI Run #23689829599 (Linux, macOS x64, macOS arm64, Windows Store, Windows NSIS)

## Root Cause
PR #871 added `linux.desktop` with top-level `Name`/`Comment`/`Keywords`/`MimeType` fields, but electron-builder 26.7.0 only accepts `{ desktopActions?, entry? }`.

## Test plan
- [ ] CI "Desktop Build and Release" workflow passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)