### PR TITLE
fix(ci): MSIX 4-part version write fix (#913)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -548,7 +548,7 @@ jobs:
 
       - name: Update package.json version (4-part for MSIX)
         if: github.event_name != 'pull_request'
-        run: npm version ${{ needs.compute-version.outputs.msix }} --no-git-tag-version
+        run: node -e "const p=require('./package.json');p.version='${{ needs.compute-version.outputs.msix }}';require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
 
       - name: Download build output
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
Fix CI failure in Windows Store build where `npm version 0.1.0.0` fails because npm rejects 4-part versions as invalid semver.

Replace `npm version` with a node one-liner that writes the version directly to package.json.

## Changes
- `.github/workflows/build.yml`: Replace `npm version` with `node -e` script for MSIX version

Fixes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)