### PR TITLE
fix: address Copilot review issues from PR #919

### DIFF
--- a/components/explorer/FilesPanel.tsx
+++ b/components/explorer/FilesPanel.tsx
@@ -618,7 +618,7 @@ export function FilesPanel({
       { label: "新規フォルダ", action: "new-folder" },
       ...(isElectronRenderer() ? [
         { label: "", action: "_separator" },
-        { label: "Finder で開く", action: "open-in-finder" },
+        { label: `${getFileManagerName()} で開く`, action: "open-in-finder" },
       ] : []),
     ];
     const result = await showContextMenu(e, items);

--- a/components/inspector/IssueCard.tsx
+++ b/components/inspector/IssueCard.tsx
@@ -89,6 +89,7 @@ export default function IssueCard({
             }}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
                 e.stopPropagation();
                 onApplyFix?.(issue);
               }

--- a/lib/dockview/use-dockview-persistence.ts
+++ b/lib/dockview/use-dockview-persistence.ts
@@ -63,7 +63,7 @@ function extractSimplifiedLayout(
     const activePanel = group.activePanel;
     const activeTabPath = activePanel ? (pathByPanelId.get(activePanel.id) ?? null) : null;
     simplifiedGroups.push({ tabPaths, activeTabPath });
-    sizes.push(group.api.height > 0 ? group.api.width : group.api.width);
+    sizes.push(orientation === "HORIZONTAL" ? group.api.width : group.api.height);
   }
 
   // Normalize sizes to proportional values


### PR DESCRIPTION
## Summary
- fix dockview persistence sizing to use width for horizontal groups and height for vertical groups
- use getFileManagerName() for the FilesPanel empty-area context menu label
- prevent Space key from scrolling the page when applying an issue fix via keyboard

## Verification
- ./node_modules/.bin/tsc --noEmit