### PR TITLE
fix(ci): use base semver for Windows Store MSIX build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -546,9 +546,9 @@ jobs:
 
       # --- Full packaging steps (push to main/alpha/beta/dev only) ---
 
-      - name: Update package.json version (4-part for MSIX)
+      - name: Update package.json version for MSIX build
         if: github.event_name != 'pull_request'
-        run: node -e "const p=require('./package.json');p.version='${{ needs.compute-version.outputs.msix }}';require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+        run: node -e "const p=require('./package.json');p.version='${{ needs.compute-version.outputs.base }}';require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
 
       - name: Download build output
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- Use `outputs.base` (3-part semver `0.1.0`) instead of `outputs.msix` (4-part `0.1.0.0`) when writing `package.json` version for the Windows Store build step
- electron-builder automatically converts `X.Y.Z` to `X.Y.Z.0` for APPX packaging — no need to do it manually
- Fixes the recurring "Invalid version: 0.1.0.0" error in `Desktop Build and Release / Build (Windows Store)`

## Root cause
`electron-builder`'s `normalizePackageData` validates `package.json` version as strict semver. The 4-part `0.1.0.0` format is not valid semver, causing the build to fail every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)