### PR TITLE
fix(ci): add --allow-same-version to npm version commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,7 +296,7 @@ jobs:
 
       - name: Update package.json version
         if: github.event_name != 'pull_request'
-        run: npm version ${{ needs.compute-version.outputs.full }} --no-git-tag-version
+        run: npm version ${{ needs.compute-version.outputs.full }} --no-git-tag-version --allow-same-version
 
       - name: Download local fonts
         if: github.event_name != 'pull_request'
@@ -388,7 +388,7 @@ jobs:
 
       - name: Update package.json version
         if: github.event_name != 'pull_request'
-        run: npm version ${{ needs.compute-version.outputs.full }} --no-git-tag-version
+        run: npm version ${{ needs.compute-version.outputs.full }} --no-git-tag-version --allow-same-version
 
       - name: Download local fonts
         if: github.event_name != 'pull_request'
@@ -468,7 +468,7 @@ jobs:
 
       - name: Update package.json version
         if: github.event_name != 'pull_request'
-        run: npm version ${{ needs.compute-version.outputs.full }} --no-git-tag-version
+        run: npm version ${{ needs.compute-version.outputs.full }} --no-git-tag-version --allow-same-version
 
       - name: Download build output
         if: github.event_name != 'pull_request'
@@ -642,7 +642,7 @@ jobs:
 
       - name: Update package.json version
         if: github.event_name != 'pull_request'
-        run: npm version ${{ needs.compute-version.outputs.full }} --no-git-tag-version
+        run: npm version ${{ needs.compute-version.outputs.full }} --no-git-tag-version --allow-same-version
 
       - name: Download local fonts
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- Add `--allow-same-version` flag to all 4 `npm version` steps in the build workflow
- Fixes "npm error Version not changed" when building on `main` where `package.json` version already matches the computed version

## Root cause
On `main`, the computed `full` version equals the existing `package.json` version (both `0.1.0`). `npm version` errors when the target version is identical to the current one unless `--allow-same-version` is set.

Triggered by: CI failure in run #23741624841 (issue #925)

🤖 Generated with [Claude Code](https://claude.com/claude-code)