### PR TITLE
fix(ci): use tag version directly for tag-triggered builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,22 +101,36 @@ jobs:
           MAJOR=$(echo "$PKG_VERSION" | cut -d. -f1)
           MINOR=$(echo "$PKG_VERSION" | cut -d. -f2)
 
-          # Find the highest patch number from existing tags matching vMAJOR.MINOR.*
-          LATEST_PATCH=$(git tag -l "v${MAJOR}.${MINOR}.*" | sed "s/^v${MAJOR}\.${MINOR}\.//" | grep -E '^[0-9]+$' | sort -n | tail -1)
-
-          if [ -z "$LATEST_PATCH" ]; then
-            NEXT_PATCH=1
-          else
-            NEXT_PATCH=$((LATEST_PATCH + 1))
-          fi
-
-          BASE_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
-
           # Determine effective branch name
           if [ "${{ github.ref_type }}" = "tag" ]; then
             BRANCH_NAME="main"
           else
             BRANCH_NAME="${GITHUB_REF_NAME}"
+          fi
+
+          # For tag pushes: use the tag version directly (strip leading "v")
+          # For branch pushes: auto-increment patch from latest matching tag
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            TAG_VERSION="${GITHUB_REF_NAME#v}"
+            TAG_MAJOR=$(echo "$TAG_VERSION" | cut -d. -f1)
+            TAG_MINOR=$(echo "$TAG_VERSION" | cut -d. -f2)
+
+            if [ "$TAG_MAJOR" != "$MAJOR" ] || [ "$TAG_MINOR" != "$MINOR" ]; then
+              echo "::error::Tag MAJOR.MINOR (${TAG_MAJOR}.${TAG_MINOR}) does not match package.json (${MAJOR}.${MINOR})"
+              exit 1
+            fi
+
+            BASE_VERSION="$TAG_VERSION"
+          else
+            LATEST_PATCH=$(git tag -l "v${MAJOR}.${MINOR}.*" | sed "s/^v${MAJOR}\.${MINOR}\.//" | grep -E '^[0-9]+$' | sort -n | tail -1)
+
+            if [ -z "$LATEST_PATCH" ]; then
+              NEXT_PATCH=1
+            else
+              NEXT_PATCH=$((LATEST_PATCH + 1))
+            fi
+
+            BASE_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
           fi
 
           # main: use computed version as-is


### PR DESCRIPTION
## Summary
- For tag pushes (`v*`): use the tag version as-is instead of auto-incrementing
- For branch pushes: auto-increment patch from latest matching tag (unchanged)
- Validates tag's MAJOR.MINOR matches package.json

Addresses Copilot review on PR #929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)