### PR TITLE
ci(store): auto-submit to MS Store after stable release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -700,7 +700,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ---------------------------------------------------------------------------
-  # Microsoft Store submission is handled by a separate workflow:
-  #   .github/workflows/sync-ms-store-listing.yml
-  # Use it manually via workflow_dispatch after a release.
+  # Automatically submit to Microsoft Store after a stable release.
+  # Triggered via workflow_call — runs only on main branch / version tags.
   # ---------------------------------------------------------------------------
+
+  sync-ms-store:
+    name: Sync Microsoft Store (full-submission)
+    needs: [release, compute-version]
+    if: |
+      github.event_name != 'pull_request' &&
+      needs.compute-version.outputs.branch == 'main'
+    uses: ./.github/workflows/sync-ms-store-listing.yml
+    with:
+      mode: full-submission
+      release_tag: v${{ needs.compute-version.outputs.full }}
+      dry_run: false
+    secrets: inherit

--- a/.github/workflows/sync-ms-store-listing.yml
+++ b/.github/workflows/sync-ms-store-listing.yml
@@ -21,6 +21,22 @@ on:
         type: boolean
         default: false
 
+  workflow_call:
+    inputs:
+      mode:
+        description: "Submission mode (listing-only | full-submission)"
+        required: true
+        type: string
+      release_tag:
+        description: "GitHub Release tag to download .appx from (required for full-submission)"
+        required: false
+        type: string
+      dry_run:
+        description: "Dry run — log actions without mutating"
+        required: false
+        type: boolean
+        default: false
+
 permissions:
   contents: read
   pull-requests: read
@@ -39,11 +55,11 @@ jobs:
       DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
 
     steps:
-      - name: Verify running from main branch
+      - name: Verify running from main branch or tag
         shell: bash
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ]; then
-            echo "::error::This workflow may only be run from main. Current ref: ${{ github.ref }}"
+          if [ "${{ github.ref }}" != "refs/heads/main" ] && [ "${{ github.ref_type }}" != "tag" ]; then
+            echo "::error::This workflow may only be run from main or a version tag. Current ref: ${{ github.ref }}"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- `sync-ms-store-listing.yml` に `workflow_call` トリガーを追加（`workflow_dispatch` と同じ inputs）
- ブランチチェックを `main` に加えてバージョンタグ (`refs/tags/v*`) も許可するよう修正
- `build.yml` に `sync-ms-store` ジョブを追加 — `release` ジョブ完了後、`main` ブランチのみ自動実行

## 背景

`GITHUB_TOKEN` で作成された GitHub Release は `on: release` イベントを他のワークフローに伝搬しない（GitHub の仕様）。  
そのため `workflow_call` で直接連鎖させる方式を採用。PAT 不要。

## 実行フロー

```
build.yml (main push / tag push)
  └── release job (GITHUB_TOKEN でリリース作成)
       └── sync-ms-store job (workflow_call)
            └── sync-ms-store-listing.yml
                 ├── generate-release-notes
                 ├── download .appx from GitHub Release
                 └── submit to Microsoft Store
```

**alpha/beta/dev ブランチでは `sync-ms-store` は実行されない**（`branch == 'main'` 条件）

## Test plan

- [ ] このPRを `dev` にマージ後、次の `main` リリース時に `sync-ms-store` ジョブが自動起動することを確認
- [ ] `workflow_dispatch` からの手動実行も引き続き動作することを確認
- [ ] 初回は `dry_run: true` で動作確認推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)