### PR TITLE
fix(ci): replace workflow_call with workflow_run to fix build startup failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,36 +101,22 @@ jobs:
           MAJOR=$(echo "$PKG_VERSION" | cut -d. -f1)
           MINOR=$(echo "$PKG_VERSION" | cut -d. -f2)
 
+          # Find the highest patch number from existing tags matching vMAJOR.MINOR.*
+          LATEST_PATCH=$(git tag -l "v${MAJOR}.${MINOR}.*" | sed "s/^v${MAJOR}\.${MINOR}\.//" | grep -E '^[0-9]+$' | sort -n | tail -1)
+
+          if [ -z "$LATEST_PATCH" ]; then
+            NEXT_PATCH=1
+          else
+            NEXT_PATCH=$((LATEST_PATCH + 1))
+          fi
+
+          BASE_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
+
           # Determine effective branch name
           if [ "${{ github.ref_type }}" = "tag" ]; then
             BRANCH_NAME="main"
           else
             BRANCH_NAME="${GITHUB_REF_NAME}"
-          fi
-
-          # For tag pushes: use the tag version directly (strip leading "v")
-          # For branch pushes: auto-increment patch from latest matching tag
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            TAG_VERSION="${GITHUB_REF_NAME#v}"
-            TAG_MAJOR=$(echo "$TAG_VERSION" | cut -d. -f1)
-            TAG_MINOR=$(echo "$TAG_VERSION" | cut -d. -f2)
-
-            if [ "$TAG_MAJOR" != "$MAJOR" ] || [ "$TAG_MINOR" != "$MINOR" ]; then
-              echo "::error::Tag MAJOR.MINOR (${TAG_MAJOR}.${TAG_MINOR}) does not match package.json (${MAJOR}.${MINOR})"
-              exit 1
-            fi
-
-            BASE_VERSION="$TAG_VERSION"
-          else
-            LATEST_PATCH=$(git tag -l "v${MAJOR}.${MINOR}.*" | sed "s/^v${MAJOR}\.${MINOR}\.//" | grep -E '^[0-9]+$' | sort -n | tail -1)
-
-            if [ -z "$LATEST_PATCH" ]; then
-              NEXT_PATCH=1
-            else
-              NEXT_PATCH=$((LATEST_PATCH + 1))
-            fi
-
-            BASE_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}"
           fi
 
           # main: use computed version as-is
@@ -684,9 +670,6 @@ jobs:
       needs.detect-changes.outputs.desktop_changed == 'true'
     needs: [detect-changes, compute-version, build-macos, package-windows-nsis, package-windows-msix, build-linux]
     runs-on: ubuntu-latest
-    outputs:
-      release_tag: v${{ needs.compute-version.outputs.full }}
-      is_stable: ${{ needs.compute-version.outputs.branch == 'main' }}
 
     steps:
       - name: Download build artifacts
@@ -714,19 +697,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ---------------------------------------------------------------------------
-  # Automatically submit to Microsoft Store after a stable release.
-  # Triggered via workflow_call — runs only on main branch / version tags.
+  # Microsoft Store submission is handled by a separate workflow:
+  #   .github/workflows/sync-ms-store-listing.yml
+  # Use it manually via workflow_dispatch after a release.
   # ---------------------------------------------------------------------------
-
-  sync-ms-store:
-    name: Sync Microsoft Store (full-submission)
-    needs: [release]
-    if: |
-      github.event_name != 'pull_request' &&
-      needs.release.outputs.is_stable == 'true'
-    uses: ./.github/workflows/sync-ms-store-listing.yml
-    with:
-      mode: full-submission
-      release_tag: ${{ needs.release.outputs.release_tag }}
-      dry_run: false
-    secrets: inherit

--- a/.github/workflows/store-submit.yml
+++ b/.github/workflows/store-submit.yml
@@ -1,0 +1,49 @@
+name: Microsoft Store Auto Submit
+
+on:
+  workflow_run:
+    workflows: ["Desktop Build and Release"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  submit:
+    name: Submit to Microsoft Store
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest stable release tag
+        id: get-tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG=$(gh api repos/${{ github.repository }}/releases \
+            --jq '[.[] | select(.draft == false and .prerelease == false)] | sort_by(.created_at) | last | .tag_name')
+          if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
+            echo "::error::No stable release found"
+            exit 1
+          fi
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Found release tag: ${RELEASE_TAG}"
+
+      - name: Dispatch store submission
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'sync-ms-store-listing.yml',
+              ref: 'main',
+              inputs: {
+                mode: 'full-submission',
+                release_tag: '${{ steps.get-tag.outputs.tag }}',
+                dry_run: 'false',
+              },
+            });
+            core.info(`Dispatched store submission for ${{ steps.get-tag.outputs.tag }}`);


### PR DESCRIPTION
## 問題

`sync-ms-store` ジョブを `build.yml` に追加した結果、**全ビルドが startup_failure になった**。

原因：GitHub Actions の `uses:` (reusable workflow call) ジョブで、条件付きでスキップされる可能性があるジョブを `needs:` で参照した際に発生する既知の制約。

## 解決策

`workflow_call` の代わりに `workflow_run` を使う。

- `build.yml` を元の状態に**完全に戻す**（`sync-ms-store` ジョブを除去）
- 新規 `store-submit.yml` を追加：`Desktop Build and Release` が `main` で完了したら `workflow_run` でトリガー
- `store-submit.yml` が最新の stable release タグを取得し、`sync-ms-store-listing.yml` を `workflow_dispatch` API で呼び出す

`workflow_run` は `GITHUB_TOKEN` が作成したイベントでも他のワークフローをトリガーできる唯一のメカニズム。

## フロー

```
build.yml (main push)
  → リリース作成 (GITHUB_TOKEN)
    → workflow_run で store-submit.yml がトリガー
      → sync-ms-store-listing.yml を workflow_dispatch で呼び出す
        → .appx ダウンロード + Microsoft Store 提出
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)