### PR TITLE
test(web-storage): add kvStore mock table to fix clearAll test

### DIFF
--- a/lib/__tests__/web-storage.test.ts
+++ b/lib/__tests__/web-storage.test.ts
@@ -68,6 +68,7 @@ const mockAppStateTable = createMockTable<any>("id");
 const mockRecentFilesTable = createMockTable<any>("id");
 const mockEditorBufferTable = createMockTable<any>("id");
 const mockProjectHandlesTable = createMockTable<any>("projectId");
+const mockKvStoreTable = createMockTable<any>("key");
 
 const mockDb = {
   open: vi.fn(async () => {}),
@@ -75,6 +76,7 @@ const mockDb = {
   recentFiles: mockRecentFilesTable,
   editorBuffer: mockEditorBufferTable,
   projectHandles: mockProjectHandlesTable,
+  kvStore: mockKvStoreTable,
 };
 
 // -----------------------------------------------------------------------
@@ -93,6 +95,7 @@ vi.mock("dexie", () => {
         recentFiles: mockDb.recentFiles,
         editorBuffer: mockDb.editorBuffer,
         projectHandles: mockDb.projectHandles,
+        kvStore: mockDb.kvStore,
       });
     }
     version() {
@@ -155,6 +158,7 @@ describe("WebStorageProvider", () => {
     mockRecentFilesTable._records.clear();
     mockEditorBufferTable._records.clear();
     mockProjectHandlesTable._records.clear();
+    mockKvStoreTable._records.clear();
 
     // Reset call counts
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary

- Fixes `clearAll` test failure in `lib/__tests__/web-storage.test.ts`
- The `clearAll()` implementation calls `this.db.kvStore.clear()`, but the test's mock database was missing the `kvStore` table (added in schema v3)
- Added `mockKvStoreTable` to `mockDb`, `FakeDexie` constructor, and `beforeEach` reset

## Test plan

- [x] `npx vitest run lib/__tests__/web-storage.test.ts` — 17/17 tests pass

Closes #938

🤖 Generated with [Claude Code](https://claude.com/claude-code)