### PR TITLE
fix(store): mark existing packages as PendingDelete before uploading new ones

### DIFF
--- a/scripts/submit-store.mjs
+++ b/scripts/submit-store.mjs
@@ -417,12 +417,22 @@ async function main() {
     const appxFiles = DRY_RUN ? ["example.appx"] : findAppxFiles();
     console.log(`\nPackages to submit: ${appxFiles.join(", ")}`);
 
-    submission.applicationPackages = appxFiles.map((fileName) => ({
+    // Mark all existing packages as PendingDelete.
+    // The Store API requires every previously-uploaded package to be present in
+    // the payload; omitting them causes a 400 "missing packages" error.
+    const existingPackages = (submission.applicationPackages ?? []).map((pkg) => ({
+      ...pkg,
+      fileStatus: 'PendingDelete',
+    }));
+
+    const newPackages = appxFiles.map((fileName) => ({
       fileName,
       fileStatus: "PendingUpload",
       minimumDirectXVersion: "None",
       minimumSystemRam: "None",
     }));
+
+    submission.applicationPackages = [...existingPackages, ...newPackages];
   } else {
     console.log("\nSkipping package configuration (listing-only mode).");
   }


### PR DESCRIPTION
## 問題

MS Store Submission API の PUT で既存パッケージが含まれていないと 400 エラー：
```
Please keep all file entries for existing packages. If you wish to remove a package, mark it as PendingDelete.
```

## 修正

既存パッケージを `PendingDelete` でマークしてから新しいパッケージを `PendingUpload` で追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)