### PR TITLE
fix(electron): show DevTools menu in all builds

### DIFF
--- a/electron/menu.js
+++ b/electron/menu.js
@@ -315,10 +315,10 @@ function buildApplicationMenu(recentProjects = []) {
         ? [
             { role: "reload", label: "再読み込み" },
             { role: "forceReload", label: "強制再読み込み" },
-            { role: "toggleDevTools", label: "開発者ツールを切り替え" },
             { type: "separator" },
           ]
         : []),
+      { role: "toggleDevTools", label: "開発者ツールを切り替え" },
       { role: "resetZoom", label: "実際のサイズ" },
       { role: "zoomIn", label: "拡大" },
       { role: "zoomOut", label: "縮小" },


### PR DESCRIPTION
## Summary

- 開発者ツール（DevTools）のメニュー項目を `isDev` ガードから外し、プロダクションビルドでも常に「表示」メニューから利用可能にした
- 再読み込み・強制再読み込みは引き続き開発モード限定

## Changes

| File | Change |
|------|--------|
| `electron/menu.js` | `toggleDevTools` を `isDev` 条件分岐の外に移動 |

## Test plan

- [ ] 開発モード (`npm run dev`) で「表示」メニューに「開発者ツールを切り替え」が表示されること
- [ ] プロダクションビルドで「表示」メニューに「開発者ツールを切り替え」が表示されること
- [ ] 開発モードでのみ「再読み込み」「強制再読み込み」が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)