### PR TITLE
fix(electron): allow dev/prod coexistence and include node-pty in build

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -51,8 +51,10 @@ process.on("unhandledRejection", (reason) => {
 // --- Single-instance lock ---
 // Ensure only one instance of the app is running. On Windows/Linux this prevents
 // duplicate windows when a user double-clicks a .mdi file while the app is already open.
-const gotTheLock = app.requestSingleInstanceLock();
-console.log("[DEBUG] Single instance lock:", gotTheLock);
+// In dev mode, skip the lock so dev and production can run side-by-side.
+const { isDev } = require("./app-constants");
+const gotTheLock = isDev || app.requestSingleInstanceLock();
+console.log("[DEBUG] Single instance lock:", gotTheLock, isDev ? "(skipped in dev)" : "");
 if (!gotTheLock) {
   console.log("[DEBUG] Another instance is running, quitting.");
   app.quit();

--- a/lib/editor-page/use-terminal-tabs.ts
+++ b/lib/editor-page/use-terminal-tabs.ts
@@ -59,6 +59,7 @@ export function useTerminalTabs({
         const shell = settings.terminalDefaultShell || undefined;
         const result = await ptyApi.spawn({ cwd, shell });
         if ("error" in result) {
+          console.error("[Terminal] PTY spawn failed:", result.error);
           // PTY spawn failed — remove the stuck "connecting" tab
           const stuckTab = tabsRef.current
             .slice()

--- a/package.json
+++ b/package.json
@@ -138,8 +138,7 @@
       "!www/**/*"
     ],
     "asarUnpack": [
-      "dist-main/node_modules/**",
-      "node_modules/node-pty/**"
+      "dist-main/node_modules/**"
     ],
     "publish": [
       {

--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -113,7 +113,7 @@ function collectDepsRecursive(pkgName, collected) {
 
 // Root external modules that cannot be bundled by esbuild
 // kuromoji: dictionary loading at runtime; better-sqlite3: native addon
-const externalRoots = ["kuromoji", "better-sqlite3"];
+const externalRoots = ["kuromoji", "better-sqlite3", "node-pty"];
 
 // Collect all transitive production dependencies
 const allDeps = new Set();


### PR DESCRIPTION
## Summary

- 開発環境と本番環境の Electron を同時に起動できるように `requestSingleInstanceLock()` を dev モードでスキップ
- 本番ビルドでターミナル機能が無効化される問題を修正（`node-pty` がバンドルに含まれていなかった）

## Changes

| File | Change |
|------|--------|
| `electron/main.js` | dev モード時に `requestSingleInstanceLock()` をスキップ |
| `scripts/bundle-electron.mjs` | `externalRoots` に `node-pty` を追加（dist-main にコピーされるように） |
| `package.json` | `asarUnpack` から冗長な `node_modules/node-pty/**` を削除 |
| `lib/editor-page/use-terminal-tabs.ts` | PTY spawn 失敗時に `console.error` を追加 |

## Test plan

- [ ] `npm run electron:dev` で開発版を起動した状態で、本番ビルド版も同時に起動できることを確認
- [ ] `npm run electron:build` でビルド後、本番版でターミナルタブを開いてシェルが正常に動作することを確認
- [ ] spawn 失敗時に DevTools console にエラーメッセージが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)