### PR TITLE
fix: resolve Electron static export build failure for auth routes

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -40,7 +40,7 @@ async function fetchUserInfo(accessToken: string): Promise<UserInfoResponse | nu
   return res.json() as Promise<UserInfoResponse>;
 }
 
-export async function GET(request: NextRequest): Promise<NextResponse> {
+export async function POST(request: NextRequest): Promise<NextResponse> {
   const cookies = getAuthCookies(request);
   if (!cookies) {
     return NextResponse.json({ authenticated: false });

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { consumePendingAuth } from "@/lib/auth/web-auth";
 
-export default function AuthCallbackPage() {
+function AuthCallbackContent() {
   const searchParams = useSearchParams();
   const [error, setError] = useState<string | null>(null);
   const exchanged = useRef(false);
@@ -84,5 +84,22 @@ export default function AuthCallbackPage() {
         <span className="text-sm">ログイン中...</span>
       </div>
     </div>
+  );
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-screen items-center justify-center bg-background">
+          <div className="flex items-center gap-3 text-foreground-secondary">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-foreground-tertiary border-t-accent" />
+            <span className="text-sm">ログイン中...</span>
+          </div>
+        </div>
+      }
+    >
+      <AuthCallbackContent />
+    </Suspense>
   );
 }

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -115,7 +115,10 @@ interface MeResponse {
 
 async function fetchMe(): Promise<MeResponse> {
   try {
-    const res = await fetch("/api/auth/me/", { credentials: "same-origin" });
+    const res = await fetch("/api/auth/me/", {
+      method: "POST",
+      credentials: "same-origin",
+    });
     if (!res.ok) return { authenticated: false };
     return (await res.json()) as MeResponse;
   } catch {


### PR DESCRIPTION
## Summary
- `/api/auth/me` の GET ハンドラーを POST に変更 — Next.js の `output: "export"` (静的エクスポート) では GET ハンドラーに `force-static` 設定が必要だが、動的な認証ルートには適用不可
- `/auth/callback` ページの `useSearchParams()` を `<Suspense>` で囲む — 静的エクスポート時の SSR プリレンダリングに必要
- `AuthContext` の fetch 呼び出しを POST メソッドに更新

Closes #968

## Test plan
- [x] `ELECTRON_BUILD=1 next build` がローカルで成功することを確認
- [ ] CI Desktop Build and Release が全プラットフォームで通ることを確認
- [ ] Web 版のログイン・ログアウトフローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)