### PR TITLE
feat(ui): add usage menu item to user avatar menu

### DIFF
--- a/components/ActivityBar.tsx
+++ b/components/ActivityBar.tsx
@@ -475,6 +475,18 @@ export default function ActivityBar({
                     type="button"
                     onClick={() => {
                       setShowUserMenu(false);
+                      window.open("https://my.illusions.app/dashboard/usage", "_blank");
+                    }}
+                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-hover transition-colors"
+                  >
+                    <BarChart3 className="w-4 h-4" />
+                    使用状況
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowUserMenu(false);
                       onOpenAccountSettings?.();
                     }}
                     className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-hover transition-colors"

--- a/components/WelcomeScreen.tsx
+++ b/components/WelcomeScreen.tsx
@@ -10,6 +10,7 @@ import {
   User,
   Settings,
   LogOut,
+  BarChart3,
 } from "lucide-react";
 import clsx from "clsx";
 import { useEffect, useState, useRef } from "react";
@@ -167,6 +168,18 @@ export default function WelcomeScreen({
                 >
                   <User className="w-4 h-4" />
                   マイページ
+                </button>
+
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowUserMenu(false);
+                    window.open("https://my.illusions.app/dashboard/usage", "_blank");
+                  }}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-hover transition-colors"
+                >
+                  <BarChart3 className="w-4 h-4" />
+                  使用状況
                 </button>
 
                 <button


### PR DESCRIPTION
## Summary

- ユーザーアバターメニューに「使用状況」リンクを追加
- クリックで https://my.illusions.app/dashboard/usage を新しいタブで開く

## Changes

| File | Change |
|------|--------|
| `components/ActivityBar.tsx` | サイドバーのアバターメニューに「使用状況」項目を追加 |
| `components/WelcomeScreen.tsx` | ウェルカム画面のアバターメニューに「使用状況」項目を追加（`BarChart3` アイコンを import） |

## Test plan

- [ ] サイドバーのユーザーアバターをクリックし、「使用状況」メニュー項目が表示されることを確認
- [ ] ウェルカム画面のユーザーアバターをクリックし、「使用状況」メニュー項目が表示されることを確認
- [ ] 「使用状況」をクリックすると新しいタブで正しい URL が開くことを確認
- [ ] メニュー項目の順序が「マイページ → 使用状況 → 設定 → ログアウト」であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)