### PR TITLE
fix: ウィンドウタイトルをプロジェクトディレクトリ名に変更

### DIFF
--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -182,7 +182,7 @@ export default function EditorLayout({
       <TerminalTabContext.Provider value={providers.terminalTabContextValue}>
         <EditorSettingsProvider settings={providers.settings} handlers={providers.settingsHandlers}>
           <div className="h-screen flex flex-col overflow-hidden relative">
-            <TitleUpdater currentFile={chrome.currentFile} isDirty={chrome.isDirty} />
+            <TitleUpdater editorMode={upgrade.editorMode} isDirty={chrome.isDirty} />
 
             {!chrome.isElectron && (
               <WebMenuBar

--- a/components/TitleUpdater.tsx
+++ b/components/TitleUpdater.tsx
@@ -1,19 +1,22 @@
 "use client";
 
 import { useEffect } from "react";
-import type { MdiFileDescriptor } from "@/lib/project/mdi-file";
+import { isProjectMode, type EditorMode } from "@/lib/project/project-types";
 
 interface TitleUpdaterProps {
-  currentFile: MdiFileDescriptor | null;
+  editorMode: EditorMode;
   isDirty: boolean;
 }
 
-export default function TitleUpdater({ currentFile, isDirty }: TitleUpdaterProps) {
+export default function TitleUpdater({ editorMode, isDirty }: TitleUpdaterProps) {
   useEffect(() => {
-    const fileName = currentFile?.name ?? (isDirty ? "新規ファイル *" : "新規ファイル");
-    const title = `${fileName} - illusions`;
-    document.title = title;
-  }, [currentFile?.name, isDirty]);
+    const name = isProjectMode(editorMode)
+      ? editorMode.name
+      : isDirty
+        ? "新規ファイル *"
+        : "新規ファイル";
+    document.title = `${name} - illusions`;
+  }, [editorMode, isDirty]);
 
   return null;
 }

--- a/components/TitleUpdater.tsx
+++ b/components/TitleUpdater.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { isProjectMode, type EditorMode } from "@/lib/project/project-types";
+import { isProjectMode, isStandaloneMode, type EditorMode } from "@/lib/project/project-types";
 
 interface TitleUpdaterProps {
   editorMode: EditorMode;
@@ -10,11 +10,14 @@ interface TitleUpdaterProps {
 
 export default function TitleUpdater({ editorMode, isDirty }: TitleUpdaterProps) {
   useEffect(() => {
-    const name = isProjectMode(editorMode)
-      ? editorMode.name
-      : isDirty
-        ? "新規ファイル *"
-        : "新規ファイル";
+    let name: string;
+    if (isProjectMode(editorMode)) {
+      name = editorMode.name;
+    } else if (isStandaloneMode(editorMode) && editorMode.fileHandle) {
+      name = isDirty ? `${editorMode.fileName} *` : editorMode.fileName;
+    } else {
+      name = isDirty ? "新規ファイル *" : "新規ファイル";
+    }
     document.title = `${name} - illusions`;
   }, [editorMode, isDirty]);
 


### PR DESCRIPTION
## Summary
- `TitleUpdater` の props を `currentFile` から `editorMode` に変更
- プロジェクトモード時は `editorMode.name`（ディレクトリ名）をタイトルに使用
- スタンドアロンモード・未開封時は従来通り「新規ファイル」を表示

## Test plan
- [ ] プロジェクトを開いた状態でウィンドウタイトルがプロジェクト名になることを確認
- [ ] スタンドアロンモード（単一ファイル）でタイトルが「新規ファイル」になることを確認
- [ ] 未保存変更がある場合のタイトル表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)