### PR TITLE
fix: Cmd+F検索ショートカットが機能しない問題を修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -277,6 +277,10 @@ export default function EditorPage() {
   // triggers PTY kill before removing the tab from state.
   const tabManagerWithPtyCleanup = { ...tabManager, closeTab: handleCloseTabWithPtyCleanup };
 
+  // Search state — declared before useDockviewAdapter so it can be passed as options
+  const [searchOpenTrigger, setSearchOpenTrigger] = useState(0);
+  const [searchInitialTerm, setSearchInitialTerm] = useState<string | undefined>(undefined);
+
   // --- Dockview adapter (bridges useTabManager ↔ dockview layout) ---
   const { handleDockviewReady, dockviewApi, splitEditor } = useDockviewAdapter({
     tabManager: tabManagerWithPtyCleanup,
@@ -329,9 +333,7 @@ export default function EditorPage() {
   const editorDomRef = useRef<HTMLDivElement>(null);
   const [dismissedRecovery, setDismissedRecovery] = useState(false);
   const [recoveryExiting, setRecoveryExiting] = useState(false);
-  const [searchOpenTrigger, setSearchOpenTrigger] = useState(0);
   const [newFileTrigger, setNewFileTrigger] = useState(0);
-  const [searchInitialTerm, setSearchInitialTerm] = useState<string | undefined>(undefined);
   const [selectedCharCount, setSelectedCharCount] = useState(0);
   const { menu: tabBarMenu, show: showTabBarMenu, close: closeTabBarMenu } = useContextMenu();
   const hasAutoRecoveredRef = useRef(false);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -281,6 +281,8 @@ export default function EditorPage() {
   const { handleDockviewReady, dockviewApi, splitEditor } = useDockviewAdapter({
     tabManager: tabManagerWithPtyCleanup,
     editorKey,
+    searchOpenTrigger,
+    searchInitialTerm,
   });
   const { flushLayoutState } = useDockviewPersistence({
     dockviewApi,

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -369,6 +369,10 @@ export default function EditorLayout({
                         const panelFileType = (panelParams?.fileType ?? ".mdi") as string;
                         const panelEditorKey = panelParams?.editorKey ?? 0;
                         const panelActiveTabId = panelParams?.activeTabId ?? "";
+                        const panelSearchOpenTrigger = panelParams?.searchOpenTrigger ?? 0;
+                        const panelSearchInitialTerm = panelParams?.searchInitialTerm as
+                          | string
+                          | undefined;
                         const isActivePanel = panelBufferId === panelActiveTabId;
                         const panelMdiEnabled = panelFileType === ".mdi";
                         const panelGfmEnabled = panelFileType !== ".txt";
@@ -404,8 +408,8 @@ export default function EditorLayout({
                                   onChange={mainArea.handleChange}
                                   onInsertText={mainArea.handleInsertText}
                                   onSelectionChange={mainArea.setSelectedCharCount}
-                                  searchOpenTrigger={mainArea.searchOpenTrigger}
-                                  searchInitialTerm={mainArea.searchInitialTerm}
+                                  searchOpenTrigger={panelSearchOpenTrigger}
+                                  searchInitialTerm={panelSearchInitialTerm}
                                   onEditorViewReady={mainArea.setEditorViewInstance}
                                   programmaticScrollRef={mainArea.programmaticScrollRef}
                                   onShowAllSearchResults={mainArea.handleShowAllSearchResults}

--- a/lib/dockview/types.ts
+++ b/lib/dockview/types.ts
@@ -48,6 +48,10 @@ export interface EditorPanelParams {
   editorKey: number;
   /** Currently active tab ID for isActivePanel check */
   activeTabId: string;
+  /** Monotonic counter to trigger search dialog open */
+  searchOpenTrigger: number;
+  /** Initial search term to pre-fill when search dialog opens */
+  searchInitialTerm?: string;
 }
 
 /** Params for a terminal panel */

--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -32,6 +32,10 @@ export interface UseDockviewAdapterOptions {
   tabManager: UseTabManagerReturn;
   /** Monotonic counter to force editor remount (e.g. after settings change) */
   editorKey: number;
+  /** Monotonic counter to trigger search dialog open in the active editor panel */
+  searchOpenTrigger: number;
+  /** Initial search term to pre-fill when search dialog opens */
+  searchInitialTerm?: string;
 }
 
 export interface UseDockviewAdapterReturn {
@@ -170,6 +174,8 @@ function applySimplifiedLayout(
 export function useDockviewAdapter({
   tabManager,
   editorKey,
+  searchOpenTrigger,
+  searchInitialTerm,
 }: UseDockviewAdapterOptions): UseDockviewAdapterReturn {
   const [dockviewApi, setDockviewApi] = useState<DockviewApi | null>(null);
   const apiRef = useRef<DockviewApi | null>(null);
@@ -372,6 +378,8 @@ export function useDockviewAdapter({
           fileType: tab.fileType,
           editorKey,
           activeTabId,
+          searchOpenTrigger,
+          searchInitialTerm,
         });
       } else if (isTerminalTab(tab)) {
         if (panel.title !== tab.label) {
@@ -417,7 +425,7 @@ export function useDockviewAdapter({
     prevActiveTabRef.current = activeTabId;
     isSyncingRef.current = false;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- dockviewApi triggers re-sync after onReady
-  }, [tabs, activeTabId, editorKey, dockviewApi]);
+  }, [tabs, activeTabId, editorKey, searchOpenTrigger, searchInitialTerm, dockviewApi]);
 
   // -- Restore saved layout (separate effect to avoid sync effect interference) --
   // Using a dedicated effect prevents savedLayout changes from re-triggering

--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -218,6 +218,8 @@ export function useDockviewAdapter({
               fileType: tab.fileType,
               editorKey,
               activeTabId,
+              searchOpenTrigger,
+              searchInitialTerm,
             },
           });
         } else if (isTerminalTab(tab)) {
@@ -323,6 +325,8 @@ export function useDockviewAdapter({
               fileType: tab.fileType,
               editorKey,
               activeTabId,
+              searchOpenTrigger,
+              searchInitialTerm,
             },
           });
         } else if (isTerminalTab(tab)) {


### PR DESCRIPTION
## 問題の原因

dockview-react はパネルコンポーネント関数を**初回作成時のクロージャで固定する**。
`DockviewReact` の `components` prop は初期マウント時の `useEffect` 内で一度だけ参照される（`React.useEffect(..., [])`）。

そのため、親コンポーネント（`EditorLayout`）が再レンダリングされて `searchOpenTrigger` が変化しても、dockview パネル内の `NovelEditor` には値が届かず、検索ダイアログが開かなかった。

## 修正内容

dockview パネルへ値を確実に届けるには `panel.api.updateParameters()` を使う必要がある（dockview 内部の `ReactComponentBridge` がこれをサポートしている）。

- `EditorPanelParams` に `searchOpenTrigger` / `searchInitialTerm` を追加
- `useDockviewAdapter` の `updateParameters` 呼び出しに両フィールドを含める
- `EditorLayout` でクロージャ経由でなく `panelParams` から読み取る
- `page.tsx` で `useDockviewAdapter` に `searchOpenTrigger` / `searchInitialTerm` を渡す

## Test plan
- [ ] Cmd+F を押すと右上に検索ダイアログが表示されることを確認
- [ ] 複数タブを開いた状態でも、アクティブなタブで検索が開くことを確認
- [ ] コンテキストメニューの「検索」で初期検索語が入力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)