### PR TITLE
feat(editor): snapshot before external change and preserve scroll position

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -874,6 +874,7 @@ export default function EditorPage() {
         handleShowLintHint,
         handleIgnoreCorrection,
         switchTab,
+        updateTab,
       }}
       inspector={{
         isRightPanelCollapsed,

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -51,6 +51,10 @@ interface EditorProps {
   // Editor mode controls
   mdiExtensionsEnabled?: boolean;
   gfmEnabled?: boolean;
+  /** External content to apply to the editor (from file watcher). Preserves scroll position. */
+  externalContent?: string | null;
+  /** Called after externalContent has been applied to ProseMirror. */
+  onExternalContentApplied?: () => void;
 }
 
 export default function NovelEditor({
@@ -74,6 +78,8 @@ export default function NovelEditor({
   onIgnoreCorrection,
   mdiExtensionsEnabled = true,
   gfmEnabled = true,
+  externalContent,
+  onExternalContentApplied,
 }: EditorProps) {
   const { fontScale, lineHeight, fontFamily, charsPerLine, autoCharsPerLine } =
     useTypographySettings();
@@ -462,6 +468,8 @@ export default function NovelEditor({
               gfmEnabled={gfmEnabled}
               onStartSpeech={startSpeechFromCursor}
               onFind={handleFind}
+              externalContent={externalContent}
+              onExternalContentApplied={onExternalContentApplied}
             />
           </ProsemirrorAdapterProvider>
         </MilkdownProvider>

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -156,6 +156,7 @@ interface EditorLayoutProps {
       React.ComponentProps<typeof NovelEditor>["onIgnoreCorrection"]
     >;
     switchTab: (tabId: string) => void;
+    updateTab: (tabId: string, updates: Partial<EditorTabState>) => void;
   };
   inspector: {
     isRightPanelCollapsed: boolean;
@@ -379,6 +380,8 @@ export default function EditorLayout({
                         const liveEditorTab = liveTab && isEditorTab(liveTab) ? liveTab : undefined;
                         const panelContent = liveEditorTab?.content ?? "";
                         const panelLastSavedContent = liveEditorTab?.lastSavedContent ?? "";
+                        const panelPendingExternalContent =
+                          liveEditorTab?.pendingExternalContent ?? null;
 
                         if (mainArea.editorDiff && isActivePanel) {
                           return (
@@ -419,6 +422,12 @@ export default function EditorLayout({
                                   onIgnoreCorrection={mainArea.handleIgnoreCorrection}
                                   mdiExtensionsEnabled={panelMdiEnabled}
                                   gfmEnabled={panelGfmEnabled}
+                                  externalContent={panelPendingExternalContent}
+                                  onExternalContentApplied={() => {
+                                    mainArea.updateTab(panelBufferId, {
+                                      pendingExternalContent: null,
+                                    });
+                                  }}
                                 />
                               </div>
                             </ErrorBoundary>

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -34,7 +34,7 @@ import { linting } from "@/packages/milkdown-plugin-japanese-novel/linting-plugi
 import clsx from "clsx";
 import { EditorView } from "@milkdown/prose/view";
 import { AllSelection, Plugin, PluginKey } from "@milkdown/prose/state";
-import { $prose } from "@milkdown/utils";
+import { $prose, replaceAll } from "@milkdown/utils";
 import BubbleMenu, { type FormatType } from "../BubbleMenu";
 import { searchHighlightPlugin } from "@/lib/editor-page/search-highlight-plugin";
 import { speechHighlightPlugin } from "@/lib/editor-page/speech-highlight-plugin";
@@ -75,6 +75,10 @@ interface MilkdownEditorProps {
   onFind?: (initialTerm?: string) => void;
   /** Per-pane override for charsPerLine (used by auto mode to avoid global state conflicts in split editors) */
   overrideCharsPerLine?: number;
+  /** External content to apply to the editor (from file watcher). Preserves scroll position. */
+  externalContent?: string | null;
+  /** Called after externalContent has been applied to ProseMirror. */
+  onExternalContentApplied?: () => void;
 }
 
 export default function MilkdownEditor({
@@ -101,6 +105,8 @@ export default function MilkdownEditor({
   onStartSpeech,
   onFind,
   overrideCharsPerLine,
+  externalContent,
+  onExternalContentApplied,
 }: MilkdownEditorProps) {
   const {
     fontScale,
@@ -273,6 +279,22 @@ export default function MilkdownEditor({
 
     return () => clearTimeout(timer);
   }, [get, onEditorViewReady]);
+
+  // 外部ファイル変更時にスクロール位置を保持したまま内容を更新する
+  const onExternalContentAppliedRef = useRef(onExternalContentApplied);
+  onExternalContentAppliedRef.current = onExternalContentApplied;
+
+  useEffect(() => {
+    if (externalContent == null) return;
+    const editor = get();
+    if (!editor) return;
+    try {
+      editor.action(replaceAll(externalContent));
+      onExternalContentAppliedRef.current?.();
+    } catch (error) {
+      console.warn("外部コンテンツの適用に失敗しました:", error);
+    }
+  }, [externalContent, get]);
 
   // posHighlight 設定を動的に更新（Editor を再作成せずに）
   useEffect(() => {

--- a/lib/services/__tests__/file-watch-integration.test.ts
+++ b/lib/services/__tests__/file-watch-integration.test.ts
@@ -66,6 +66,7 @@ function buildOnChangedForTest(
             isDirty: false,
             fileSyncStatus: "clean",
             conflictDiskContent: null,
+            pendingExternalContent: diskContent,
           } as EditorTabState;
         }),
       );
@@ -195,6 +196,15 @@ describe("file-watch: clean tab receives external change", () => {
     onChanged("new disk content", Date.now());
 
     expect(getTab().isDirty).toBe(false);
+  });
+
+  it("sets pendingExternalContent for the editor to apply", () => {
+    const tab = makeEditorTab({ fileSyncStatus: "clean", content: "old", lastSavedContent: "old" });
+    const { onChanged, getTab } = buildContext(tab);
+
+    onChanged("new disk content", Date.now());
+
+    expect(getTab().pendingExternalContent).toBe("new disk content");
   });
 
   it("emits an info notification", () => {

--- a/lib/tab-manager/tab-types.ts
+++ b/lib/tab-manager/tab-types.ts
@@ -31,6 +31,16 @@ export interface EditorTabState {
   fileSyncStatus: FileSyncStatus;
   /** Disk content when status is "conflicted"; null otherwise. */
   conflictDiskContent: string | null;
+  /**
+   * Content from an external file change awaiting application to the editor.
+   * Set by file watcher when disk content changes on a clean tab.
+   * Consumed by the editor component to update ProseMirror without remounting.
+   *
+   * 外部ファイル変更による保留中コンテンツ。
+   * クリーンタブでディスク変更が検知された際にセットされる。
+   * エディタコンポーネントが再マウントなしで ProseMirror を更新するために使用。
+   */
+  pendingExternalContent?: string | null;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -2,7 +2,9 @@
 
 import { useEffect, useRef } from "react";
 import { createFileWatcher } from "../services/file-watcher";
+import { getHistoryService } from "../services/history-service";
 import { notificationManager } from "../services/notification-manager";
+import { getVFS } from "../vfs";
 import { isEditorTab } from "./tab-types";
 import type { FileWatcher } from "../services/file-watcher";
 import type { TabId, TabState, EditorTabState, DiffTabState } from "./tab-types";
@@ -36,6 +38,29 @@ export interface UseFileWatchIntegrationParams extends TabManagerCore {
 // ---------------------------------------------------------------------------
 
 /**
+ * Snapshot the current editor content before an external change overwrites it.
+ * Bypasses the normal 5-minute interval check since external changes are
+ * infrequent and the snapshot preserves user work that might otherwise be lost.
+ *
+ * 外部変更でエディタの内容が上書きされる前にスナップショットを作成する。
+ * 外部変更は頻繁には発生しないため、通常の5分間隔チェックをバイパスする。
+ */
+function snapshotBeforeExternalChange(fileName: string, editorContent: string): void {
+  if (!getVFS().isRootOpen()) return;
+  const historyService = getHistoryService();
+  historyService
+    .createSnapshot({
+      sourceFile: fileName,
+      content: editorContent,
+      type: "auto",
+      label: "外部変更前の自動保存",
+    })
+    .catch((error) => {
+      console.warn("外部変更前のスナップショット作成に失敗しました:", error);
+    });
+}
+
+/**
  * Build the onChanged callback for an editor tab.
  * Implements the state-transition logic described in issue #825.
  *
@@ -56,7 +81,13 @@ function buildOnChanged(
     const fileName = tab.file?.name ?? "ファイル";
 
     if (tab.fileSyncStatus === "clean") {
-      // Clean tab: auto-reload with disk content
+      // Snapshot current content before overwriting with disk content
+      snapshotBeforeExternalChange(fileName, tab.content);
+
+      // Clean tab: update content state AND set pendingExternalContent.
+      // content is updated for state consistency (isDirty, auto-save, etc.).
+      // pendingExternalContent triggers the editor to apply the new content
+      // via ProseMirror transaction (preserves scroll position).
       setTabs((prev) =>
         prev.map((t) => {
           if (t.id !== tabId || !isEditorTab(t)) return t;
@@ -67,11 +98,15 @@ function buildOnChanged(
             isDirty: false,
             fileSyncStatus: "clean",
             conflictDiskContent: null,
+            pendingExternalContent: diskContent,
           } satisfies EditorTabState;
         }),
       );
       notificationManager.info(`「${fileName}」が更新されました`, 3000);
     } else if (tab.fileSyncStatus === "dirty") {
+      // Snapshot current content before entering conflicted state
+      snapshotBeforeExternalChange(fileName, tab.content);
+
       // Dirty tab: do NOT touch buffer; enter conflicted state
       const localContent = tab.content;
 


### PR DESCRIPTION
## Summary

- ディスク上のファイルが外部変更された際（AI ツール等）、エディタの現在のコンテンツを「外部変更前の自動保存」ラベル付きで履歴にスナップショット保存する
- 外部変更の適用を ProseMirror トランザクション（`replaceAll`）経由に変更し、エディタの再マウントを回避することでスクロール位置を保持する

## Changes

| File | Change |
|------|--------|
| `lib/tab-manager/tab-types.ts` | `EditorTabState` に `pendingExternalContent` フィールドを追加 |
| `lib/tab-manager/use-file-watch-integration.ts` | `snapshotBeforeExternalChange` ヘルパー追加、clean/dirty タブ両方で外部変更前にスナップショット作成。clean タブは `pendingExternalContent` 経由で更新 |
| `components/editor/MilkdownEditor.tsx` | `replaceAll` を使用する `useEffect` で `pendingExternalContent` を消費し、スクロール位置を保持したまま ProseMirror を更新 |
| `components/Editor.tsx` | `externalContent` / `onExternalContentApplied` props を追加・受け渡し |
| `components/EditorLayout.tsx` | `pendingExternalContent` を検出してエディタに渡し、適用後にフラグをクリア |
| `app/page.tsx` | `updateTab` を `mainArea` に追加 |
| `lib/services/__tests__/file-watch-integration.test.ts` | `pendingExternalContent` のテストケースを追加 |

## Test plan

- [ ] AI ツール等でファイルをディスク上で変更し、エディタのスクロール位置が保持されることを確認
- [ ] 外部変更前の内容が履歴パネルに「外部変更前の自動保存」として表示されることを確認
- [ ] dirty タブで外部変更が検知された場合、コンフリクト通知が正しく表示されることを確認
- [ ] `vitest run lib/services/__tests__/file-watch-integration.test.ts` が全テストパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)