### PR TITLE
fix(export): handle user-gesture DOMException with Japanese error message

### DIFF
--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -41,10 +41,7 @@ async function saveTxtFile(text: string, suggestedName: string): Promise<boolean
       // "Must be handling a user gesture" — the browser requires a direct
       // user interaction (click / key-press) in the active document to open
       // the file picker.  Re-throw with a friendlier Japanese message.
-      if (
-        error instanceof DOMException &&
-        error.message.includes("user gesture")
-      ) {
+      if (error instanceof DOMException && error.message.includes("user gesture")) {
         throw new Error(
           "エクスポートするには、エディタ上をクリックしてフォーカスを合わせてから再度お試しください。",
         );

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -38,6 +38,17 @@ async function saveTxtFile(text: string, suggestedName: string): Promise<boolean
       return true;
     } catch (error) {
       if ((error as { name?: string }).name === "AbortError") return false;
+      // "Must be handling a user gesture" — the browser requires a direct
+      // user interaction (click / key-press) in the active document to open
+      // the file picker.  Re-throw with a friendlier Japanese message.
+      if (
+        error instanceof DOMException &&
+        error.message.includes("user gesture")
+      ) {
+        throw new Error(
+          "エクスポートするには、エディタ上をクリックしてフォーカスを合わせてから再度お試しください。",
+        );
+      }
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- ブラウザの File System Access API は、アクティブなドキュメント上の直接ユーザー操作（クリック/キー入力）がないとファイルピッカーを開けない
- 従来は生の DOMException がスローされていた
- `error.message.includes("user gesture")` でキャッチし、日本語の分かりやすいエラーメッセージに変換するよう修正

## Test plan
- [ ] TXTエクスポートボタンをエディタ外からクリックしてエラーメッセージが日本語で表示されることを確認
- [ ] 通常のエクスポート操作が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)