### PR TITLE
fix(history): key snapshots by source path

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -771,6 +771,7 @@ export default function EditorPage() {
     readabilityAnalysis,
     onOpenPosHighlightSettings: handleOpenPosHighlightSettings,
     activeFileName: currentFile?.name,
+    activeFilePath: currentFile?.path ?? undefined,
     currentContent: content,
     onHistoryRestore: (restoredContent: string) => {
       setContent(restoredContent);

--- a/components/HistoryPanel.tsx
+++ b/components/HistoryPanel.tsx
@@ -36,7 +36,8 @@ const SNAPSHOTS_PER_PAGE = 20;
 
 interface HistoryPanelProps {
   projectId: string;
-  mainFileName: string;
+  sourcePath: string;
+  displayName: string;
   onRestore: (content: string) => void;
   /** Current editor content for diff comparison */
   currentContent?: string;
@@ -85,7 +86,8 @@ function groupSnapshotsByDate(items: SnapshotEntry[]): DateGroup[] {
 
 export default function HistoryPanel({
   projectId: _projectId,
-  mainFileName,
+  sourcePath,
+  displayName,
   onRestore,
   currentContent = "",
   onCompareInEditor,
@@ -108,7 +110,7 @@ export default function HistoryPanel({
       setIsLoading(true);
       setError(null);
       const historyService = getHistoryService();
-      const loaded = await historyService.getSnapshots(mainFileName);
+      const loaded = await historyService.getSnapshots(sourcePath);
       setSnapshots(loaded);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -116,9 +118,9 @@ export default function HistoryPanel({
     } finally {
       setIsLoading(false);
     }
-  }, [mainFileName]);
+  }, [sourcePath]);
 
-  // Load snapshots on mount and when mainFileName changes
+  // Load snapshots on mount and when sourcePath changes
   useEffect(() => {
     void loadSnapshots();
     // Reset pagination when file changes
@@ -352,7 +354,8 @@ export default function HistoryPanel({
       setError(null);
       const historyService = getHistoryService();
       await historyService.createSnapshot({
-        sourceFile: mainFileName,
+        sourcePath,
+        displayName,
         content: currentContent,
         type: "manual",
       });
@@ -363,7 +366,7 @@ export default function HistoryPanel({
     } finally {
       setCreatingSnapshot(false);
     }
-  }, [mainFileName, loadSnapshots, currentContent]);
+  }, [sourcePath, displayName, loadSnapshots, currentContent]);
 
   /**
    * Handle comparing a snapshot with current content.

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -388,7 +388,11 @@ export default function Inspector({
           <HistoryPanel
             projectId={projectMode.projectId}
             sourcePath={activeFilePath || projectMode.metadata.mainFile}
-            displayName={activeFileName || (activeFilePath || projectMode.metadata.mainFile).split("/").pop() || projectMode.metadata.mainFile}
+            displayName={
+              activeFileName ||
+              (activeFilePath || projectMode.metadata.mainFile).split("/").pop() ||
+              projectMode.metadata.mainFile
+            }
             onRestore={onHistoryRestore}
             currentContent={currentContent}
             onCompareInEditor={onCompareInEditor}

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -48,6 +48,7 @@ export default function Inspector({
   onOpenPosHighlightSettings,
   onHistoryRestore,
   activeFileName,
+  activeFilePath,
   currentContent = "",
   onCompareInEditor,
   lintIssues,
@@ -386,7 +387,8 @@ export default function Inspector({
         {activeTab === "history" && projectMode && onHistoryRestore && (
           <HistoryPanel
             projectId={projectMode.projectId}
-            mainFileName={activeFileName || projectMode.metadata.mainFile}
+            sourcePath={activeFilePath || projectMode.metadata.mainFile}
+            displayName={activeFileName || (activeFilePath || projectMode.metadata.mainFile).split("/").pop() || projectMode.metadata.mainFile}
             onRestore={onHistoryRestore}
             currentContent={currentContent}
             onCompareInEditor={onCompareInEditor}

--- a/components/inspector/types.ts
+++ b/components/inspector/types.ts
@@ -65,6 +65,7 @@ export interface InspectorProps {
   onOpenPosHighlightSettings?: () => void;
   onHistoryRestore?: (content: string) => void;
   activeFileName?: string;
+  activeFilePath?: string;
   currentContent?: string;
   onCompareInEditor?: (data: {
     snapshotContent: string;

--- a/lib/services/__tests__/history-service.test.ts
+++ b/lib/services/__tests__/history-service.test.ts
@@ -3,7 +3,7 @@
  *
  * Tests cover:
  * - Snapshot creation (auto, manual, milestone)
- * - Snapshot retrieval and filtering by source file
+ * - Snapshot retrieval and filtering by source path
  * - Snapshot restoration with checksum verification
  * - Snapshot deletion
  * - Pruning by max count, retention period, and per-file limit
@@ -175,11 +175,12 @@ describe("HistoryService", () => {
   describe("createSnapshot", () => {
     it("should create an auto snapshot with correct metadata", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Hello, world!",
       });
 
-      expect(entry.sourceFile).toBe("main.mdi");
+      expect(entry.sourcePath).toBe("main.mdi");
+      expect(entry.displayName).toBe("main.mdi");
       expect(entry.type).toBe("auto");
       expect(entry.characterCount).toBe(13);
       expect(entry.fileSize).toBeGreaterThan(0);
@@ -193,7 +194,7 @@ describe("HistoryService", () => {
 
     it("should create a manual snapshot without __auto__ marker", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "chapter1.mdi",
+        sourcePath: "chapter1.mdi",
         content: "Manual save",
         type: "manual",
       });
@@ -205,7 +206,7 @@ describe("HistoryService", () => {
 
     it("should create a milestone snapshot with label", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "novel.mdi",
+        sourcePath: "novel.mdi",
         content: "Milestone content",
         type: "milestone",
         label: "Draft v1.0",
@@ -219,7 +220,7 @@ describe("HistoryService", () => {
     it("should store the snapshot content in VFS", async () => {
       const content = "Stored content for verification";
       await service.createSnapshot({
-        sourceFile: "test.mdi",
+        sourcePath: "test.mdi",
         content,
       });
 
@@ -231,11 +232,11 @@ describe("HistoryService", () => {
 
     it("should update the history index", async () => {
       await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "First snapshot",
       });
       await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Second snapshot",
       });
 
@@ -251,7 +252,7 @@ describe("HistoryService", () => {
 
     it("should handle empty content", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "empty.mdi",
+        sourcePath: "empty.mdi",
         content: "",
       });
 
@@ -263,7 +264,7 @@ describe("HistoryService", () => {
     it("should handle Japanese content correctly", async () => {
       const japaneseContent = "私は{雪女|ゆき.おんな}を見た。";
       const entry = await service.createSnapshot({
-        sourceFile: "japanese.mdi",
+        sourcePath: "japanese.mdi",
         content: japaneseContent,
       });
 
@@ -285,13 +286,13 @@ describe("HistoryService", () => {
 
     it("should return all snapshots sorted by timestamp descending", async () => {
       await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "First",
       });
       // Small delay to ensure different timestamps
       await new Promise((r) => setTimeout(r, 10));
       await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Second",
       });
 
@@ -300,32 +301,32 @@ describe("HistoryService", () => {
       expect(snapshots[0].timestamp).toBeGreaterThanOrEqual(snapshots[1].timestamp);
     });
 
-    it("should filter snapshots by source file", async () => {
+    it("should filter snapshots by source path", async () => {
       await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Main content",
       });
       await service.createSnapshot({
-        sourceFile: "chapter1.mdi",
+        sourcePath: "chapter1.mdi",
         content: "Chapter 1 content",
       });
       await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Main content v2",
       });
 
       const mainSnapshots = await service.getSnapshots("main.mdi");
       expect(mainSnapshots.length).toBe(2);
-      expect(mainSnapshots.every((s) => s.sourceFile === "main.mdi")).toBe(true);
+      expect(mainSnapshots.every((s) => s.sourcePath === "main.mdi")).toBe(true);
 
       const ch1Snapshots = await service.getSnapshots("chapter1.mdi");
       expect(ch1Snapshots.length).toBe(1);
-      expect(ch1Snapshots[0].sourceFile).toBe("chapter1.mdi");
+      expect(ch1Snapshots[0].sourcePath).toBe("chapter1.mdi");
     });
 
-    it("should return empty array for a non-existent source file", async () => {
+    it("should return empty array for a non-existent source path", async () => {
       await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "content",
       });
 
@@ -342,7 +343,7 @@ describe("HistoryService", () => {
     it("should restore snapshot content successfully", async () => {
       const content = "Content to restore";
       const entry = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content,
       });
 
@@ -363,7 +364,7 @@ describe("HistoryService", () => {
 
     it("should detect corrupted snapshots via checksum mismatch", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Original content",
       });
 
@@ -387,7 +388,7 @@ describe("HistoryService", () => {
   describe("getSnapshotContent", () => {
     it("should return content for valid snapshot", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Read-only peek",
       });
 
@@ -408,7 +409,7 @@ describe("HistoryService", () => {
   describe("deleteSnapshot", () => {
     it("should delete a snapshot by ID", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "To be deleted",
       });
 
@@ -424,7 +425,7 @@ describe("HistoryService", () => {
 
     it("should allow deleting milestone snapshots", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Milestone to delete",
         type: "milestone",
         label: "Test Milestone",
@@ -449,7 +450,7 @@ describe("HistoryService", () => {
 
     it("should return false when a recent snapshot exists (within 5 min)", async () => {
       await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Recent snapshot",
       });
 
@@ -459,7 +460,7 @@ describe("HistoryService", () => {
 
     it("should return true for a different source file", async () => {
       await service.createSnapshot({
-        sourceFile: "chapter1.mdi",
+        sourcePath: "chapter1.mdi",
         content: "Chapter 1",
       });
 
@@ -476,7 +477,7 @@ describe("HistoryService", () => {
     it("should not prune milestones", async () => {
       // Create a milestone
       const milestone = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Milestone",
         type: "milestone",
         label: "Keep me",
@@ -484,8 +485,8 @@ describe("HistoryService", () => {
 
       // Create some auto snapshots
       for (let i = 0; i < 3; i++) {
-        await service.createSnapshot({
-          sourceFile: "main.mdi",
+          await service.createSnapshot({
+          sourcePath: "main.mdi",
           content: `Auto ${i}`,
         });
       }
@@ -501,7 +502,7 @@ describe("HistoryService", () => {
       // Create fewer snapshots than the default max (100)
       for (let i = 0; i < 5; i++) {
         await service.createSnapshot({
-          sourceFile: "main.mdi",
+          sourcePath: "main.mdi",
           content: `Snapshot ${i}`,
         });
       }
@@ -525,7 +526,7 @@ describe("HistoryService", () => {
 
     it("should toggle bookmark on", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Bookmarked snapshot",
       });
 
@@ -538,7 +539,7 @@ describe("HistoryService", () => {
 
     it("should toggle bookmark off", async () => {
       const entry = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Toggle test",
       });
 
@@ -580,32 +581,32 @@ describe("HistoryService", () => {
   // -----------------------------------------------------------------------
 
   describe("edge cases", () => {
-    it("should handle creating snapshots for multiple source files", async () => {
+    it("should handle creating snapshots for multiple source paths", async () => {
       await service.createSnapshot({
-        sourceFile: "file-a.mdi",
+        sourcePath: "file-a.mdi",
         content: "Content A",
       });
       await service.createSnapshot({
-        sourceFile: "file-b.mdi",
+        sourcePath: "file-b.mdi",
         content: "Content B",
       });
       await service.createSnapshot({
-        sourceFile: "file-c.mdi",
+        sourcePath: "file-c.mdi",
         content: "Content C",
       });
 
       const allSnapshots = await service.getSnapshots();
       expect(allSnapshots.length).toBe(3);
 
-      const sourceFiles = new Set(allSnapshots.map((s) => s.sourceFile));
-      expect(sourceFiles.size).toBe(3);
+      const sourcePaths = new Set(allSnapshots.map((s) => s.sourcePath));
+      expect(sourcePaths.size).toBe(3);
     });
 
     it("should generate unique IDs for each snapshot", async () => {
       const entries: SnapshotEntry[] = [];
       for (let i = 0; i < 5; i++) {
         const entry = await service.createSnapshot({
-          sourceFile: "main.mdi",
+          sourcePath: "main.mdi",
           content: `Snapshot ${i}`,
         });
         entries.push(entry);
@@ -617,11 +618,11 @@ describe("HistoryService", () => {
 
     it("should produce different checksums for different content", async () => {
       const entry1 = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Content version 1",
       });
       const entry2 = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Content version 2",
       });
 
@@ -631,11 +632,11 @@ describe("HistoryService", () => {
     it("should produce the same checksum for identical content", async () => {
       const content = "Identical content for both snapshots";
       const entry1 = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content,
       });
       const entry2 = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content,
       });
 
@@ -645,7 +646,7 @@ describe("HistoryService", () => {
     it("should set correct timestamp on snapshot entries", async () => {
       const before = Date.now();
       const entry = await service.createSnapshot({
-        sourceFile: "main.mdi",
+        sourcePath: "main.mdi",
         content: "Timestamp test",
       });
       const after = Date.now();
@@ -658,13 +659,64 @@ describe("HistoryService", () => {
       // Each CJK character is 3 bytes in UTF-8
       const cjkContent = "漢字";
       const entry = await service.createSnapshot({
-        sourceFile: "cjk.mdi",
+        sourcePath: "cjk.mdi",
         content: cjkContent,
       });
 
       expect(entry.characterCount).toBe(2);
       // 2 CJK chars * 3 bytes each = 6 bytes
       expect(entry.fileSize).toBe(6);
+    });
+
+    it("keeps histories separate for duplicate basenames in different paths", async () => {
+      await service.createSnapshot({
+        sourcePath: "chapters/intro.mdi",
+        displayName: "intro.mdi",
+        content: "Chapter intro",
+      });
+      await service.createSnapshot({
+        sourcePath: "notes/intro.mdi",
+        displayName: "intro.mdi",
+        content: "Notes intro",
+      });
+
+      const chapterSnapshots = await service.getSnapshots("chapters/intro.mdi");
+      const noteSnapshots = await service.getSnapshots("notes/intro.mdi");
+
+      expect(chapterSnapshots).toHaveLength(1);
+      expect(noteSnapshots).toHaveLength(1);
+      expect(chapterSnapshots[0].sourcePath).toBe("chapters/intro.mdi");
+      expect(noteSnapshots[0].sourcePath).toBe("notes/intro.mdi");
+      expect(chapterSnapshots[0].displayName).toBe("intro.mdi");
+      expect(noteSnapshots[0].displayName).toBe("intro.mdi");
+    });
+
+    it("reads legacy entries that only stored sourceFile", async () => {
+      const legacyIndex: HistoryIndex = {
+        snapshots: [
+          {
+            id: "legacy-1",
+            timestamp: Date.now(),
+            filename: "main.mdi.[202604010101].__auto__.history",
+            sourcePath: "",
+            displayName: "",
+            sourceFile: "main.mdi",
+            type: "auto",
+            characterCount: 4,
+            fileSize: 4,
+            checksum: "abcd",
+          } as SnapshotEntry,
+        ],
+        maxSnapshots: 100,
+        retentionDays: 90,
+      };
+      fileStore.set(".illusions/history/index.json", JSON.stringify(legacyIndex));
+
+      const snapshots = await service.getSnapshots("main.mdi");
+
+      expect(snapshots).toHaveLength(1);
+      expect(snapshots[0].sourcePath).toBe("main.mdi");
+      expect(snapshots[0].displayName).toBe("main.mdi");
     });
   });
 });

--- a/lib/services/__tests__/history-service.test.ts
+++ b/lib/services/__tests__/history-service.test.ts
@@ -485,7 +485,7 @@ describe("HistoryService", () => {
 
       // Create some auto snapshots
       for (let i = 0; i < 3; i++) {
-          await service.createSnapshot({
+        await service.createSnapshot({
           sourcePath: "main.mdi",
           content: `Auto ${i}`,
         });

--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -167,7 +167,9 @@ function isAutoSnapshotFilename(filename: string): boolean {
   return filename.includes(".__auto__.");
 }
 
-function getSnapshotSourceKey(snapshot: Partial<Pick<SnapshotEntry, "sourcePath" | "sourceFile">>): string {
+function getSnapshotSourceKey(
+  snapshot: Partial<Pick<SnapshotEntry, "sourcePath" | "sourceFile">>,
+): string {
   return snapshot.sourcePath || snapshot.sourceFile || "";
 }
 

--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -59,8 +59,12 @@ export interface SnapshotEntry {
   timestamp: number;
   /** History file name (e.g. "main.mdi.[202602061430].history") */
   filename: string;
-  /** Source file that was snapshotted (e.g. "main.mdi") */
-  sourceFile: string;
+  /** Stable document identity within the project (prefer project-relative path). */
+  sourcePath: string;
+  /** Human-readable file name for UI display. */
+  displayName: string;
+  /** Legacy basename-only identity retained for backward compatibility reads. */
+  sourceFile?: string;
   /** Type of snapshot */
   type: SnapshotType;
   /** User-defined label (primarily for milestones) */
@@ -91,8 +95,10 @@ export interface HistoryIndex {
  * スナップショット作成時のオプション。
  */
 export interface CreateSnapshotOptions {
-  /** Source file name (e.g. "main.mdi") */
-  sourceFile: string;
+  /** Stable document identity within the project (prefer project-relative path). */
+  sourcePath: string;
+  /** Human-readable file name for UI display. */
+  displayName?: string;
   /** Content to snapshot */
   content: string;
   /** Snapshot type (defaults to "auto") */
@@ -161,6 +167,26 @@ function isAutoSnapshotFilename(filename: string): boolean {
   return filename.includes(".__auto__.");
 }
 
+function getSnapshotSourceKey(snapshot: Partial<Pick<SnapshotEntry, "sourcePath" | "sourceFile">>): string {
+  return snapshot.sourcePath || snapshot.sourceFile || "";
+}
+
+function getSnapshotDisplayName(
+  snapshot: Partial<Pick<SnapshotEntry, "displayName" | "sourcePath" | "sourceFile">>,
+): string {
+  if (snapshot.displayName) return snapshot.displayName;
+  const source = getSnapshotSourceKey(snapshot);
+  const normalized = source.replace(/\\/g, "/");
+  const lastSegment = normalized.split("/").pop();
+  return lastSegment || source;
+}
+
+function makeSnapshotStorageLabel(sourcePath: string, displayName: string): string {
+  const normalizedPath = sourcePath.replace(/\\/g, "/");
+  const pathLabel = normalizedPath.replace(/[\\/]/g, "__");
+  return pathLabel || displayName;
+}
+
 /**
  * Create a default (empty) history index.
  * デフォルトの空の履歴インデックスを作成する。
@@ -203,13 +229,15 @@ export class HistoryService {
    * @returns The created SnapshotEntry
    */
   async createSnapshot(options: CreateSnapshotOptions): Promise<SnapshotEntry> {
-    const { sourceFile, content, type = "auto", label } = options;
+    const { sourcePath, displayName: displayNameOption, content, type = "auto", label } = options;
 
     try {
       const timestamp = Date.now();
       const formattedTime = formatTimestamp(timestamp);
       const autoMarker = type === "auto" ? ".__auto__" : "";
-      const filename = `${sourceFile}.[${formattedTime}]${autoMarker}.history`;
+      const displayName = displayNameOption ?? getSnapshotDisplayName({ sourcePath });
+      const storageLabel = makeSnapshotStorageLabel(sourcePath, displayName);
+      const filename = `${storageLabel}.[${formattedTime}]${autoMarker}.history`;
       const checksum = await calculateChecksum(content);
       const fileSize = calculateByteSize(content);
       const characterCount = content.length;
@@ -218,7 +246,8 @@ export class HistoryService {
         id: crypto.randomUUID(),
         timestamp,
         filename,
-        sourceFile,
+        sourcePath,
+        displayName,
         type,
         characterCount,
         fileSize,
@@ -247,7 +276,7 @@ export class HistoryService {
 
         // Auto-prune old snapshots (global and per-file, within same lock)
         await this.pruneOldSnapshotsUnsafe();
-        await this.pruneSnapshotsPerFileUnsafe(sourceFile);
+        await this.pruneSnapshotsPerFileUnsafe(sourcePath);
       } finally {
         releaseLock();
       }
@@ -405,12 +434,12 @@ export class HistoryService {
    * 特定ソースファイルのスナップショットがファイルあたりの上限を超えた場合に削除する。
    * 削除対象は自動スナップショットのみ。マイルストーンと手動スナップショットは保持する。
    *
-   * @param sourceFile - The source file name to prune snapshots for
+   * @param sourcePath - The source file path to prune snapshots for
    */
-  async pruneSnapshotsPerFile(sourceFile: string): Promise<void> {
+  async pruneSnapshotsPerFile(sourcePath: string): Promise<void> {
     const releaseLock = await this.indexMutex.acquire();
     try {
-      await this.pruneSnapshotsPerFileUnsafe(sourceFile);
+      await this.pruneSnapshotsPerFileUnsafe(sourcePath);
     } finally {
       releaseLock();
     }
@@ -423,14 +452,14 @@ export class HistoryService {
    * ロックを取得しないファイルごとの内部削減ロジック。
    * 呼び出し元は事前に indexMutex を保持していなければならない。
    *
-   * @param sourceFile - The source file name to prune snapshots for
+   * @param sourcePath - The source file path to prune snapshots for
    */
-  private async pruneSnapshotsPerFileUnsafe(sourceFile: string): Promise<void> {
+  private async pruneSnapshotsPerFileUnsafe(sourcePath: string): Promise<void> {
     try {
       const index = await this.readHistoryIndex();
 
       // Get all snapshots for this file
-      const fileSnapshots = index.snapshots.filter((s) => s.sourceFile === sourceFile);
+      const fileSnapshots = index.snapshots.filter((s) => getSnapshotSourceKey(s) === sourcePath);
 
       const autoCount = fileSnapshots.filter((s) => s.type === "auto").length;
       if (autoCount <= MAX_SNAPSHOTS_PER_FILE) {
@@ -505,15 +534,15 @@ export class HistoryService {
    * 新しい自動スナップショットを作成すべきか判定する。
    * 最後のスナップショットが最小間隔内に作成されていた場合は false を返す。
    *
-   * @param sourceFile - The source file name to check against
+   * @param sourcePath - The source file path to check against
    * @returns true if a new snapshot should be created
    */
-  async shouldCreateSnapshot(sourceFile: string): Promise<boolean> {
+  async shouldCreateSnapshot(sourcePath: string): Promise<boolean> {
     try {
       const index = await this.readHistoryIndex();
 
       // Find the most recent snapshot for this source file
-      const lastSnapshot = index.snapshots.find((s) => s.sourceFile === sourceFile);
+      const lastSnapshot = index.snapshots.find((s) => getSnapshotSourceKey(s) === sourcePath);
 
       if (!lastSnapshot) {
         return true;
@@ -536,23 +565,29 @@ export class HistoryService {
    * タイムスタンプ降順（新しい順）でソートされる。
    * メタデータが不足している場合、ファイル名から型を検出する。
    *
-   * @param sourceFile - Optional source file filter
+   * @param sourcePath - Optional source file filter
    * @returns Array of snapshot entries
    */
-  async getSnapshots(sourceFile?: string): Promise<SnapshotEntry[]> {
+  async getSnapshots(sourcePath?: string): Promise<SnapshotEntry[]> {
     try {
       const index = await this.readHistoryIndex();
 
       let { snapshots } = index;
 
-      if (sourceFile !== undefined) {
-        snapshots = snapshots.filter((s) => s.sourceFile === sourceFile);
+      if (sourcePath !== undefined) {
+        snapshots = snapshots.filter((s) => getSnapshotSourceKey(s) === sourcePath);
       }
 
-      // Add type fallback for entries missing type metadata
+      // Add fallbacks for older entries missing newer metadata.
       for (const entry of snapshots) {
         if (!entry.type) {
           entry.type = isAutoSnapshotFilename(entry.filename) ? "auto" : "manual";
+        }
+        if (!entry.sourcePath) {
+          entry.sourcePath = entry.sourceFile ?? "";
+        }
+        if (!entry.displayName) {
+          entry.displayName = getSnapshotDisplayName(entry);
         }
       }
 

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -104,15 +104,16 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
   // --- Auto-snapshot (project mode) ---------------------------------------
 
   const tryAutoSnapshot = useCallback(
-    async (sourceFileName: string, savedContent: string) => {
+    async (sourcePath: string, displayName: string, savedContent: string) => {
       if (!isProjectRef.current) return;
       if (!getVFS().isRootOpen()) return;
       try {
         const historyService = getHistoryService();
-        const shouldCreate = await historyService.shouldCreateSnapshot(sourceFileName);
+        const shouldCreate = await historyService.shouldCreateSnapshot(sourcePath);
         if (shouldCreate) {
           await historyService.createSnapshot({
-            sourceFile: sourceFileName,
+            sourcePath,
+            displayName,
             content: savedContent,
             type: "auto",
           });
@@ -225,7 +226,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
                 : t,
             ),
           );
-          await tryAutoSnapshot(tab.file.name, sanitized);
+          await tryAutoSnapshot(tab.file.path, tab.file.name, sanitized);
           return;
         }
 
@@ -254,7 +255,9 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           if (!(await persistFileReference(result.descriptor, sanitized))) {
             notificationManager.warning(PERSIST_FAILURE_WARNING);
           }
-          await tryAutoSnapshot(result.descriptor.name, sanitized);
+          if (result.descriptor.path) {
+            await tryAutoSnapshot(result.descriptor.path, result.descriptor.name, sanitized);
+          }
         } else {
           updateTab(tabId, { isSaving: false });
         }
@@ -310,7 +313,9 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         if (!(await persistFileReference(result.descriptor, sanitized))) {
           notificationManager.warning(PERSIST_FAILURE_WARNING);
         }
-        await tryAutoSnapshot(result.descriptor.name, sanitized);
+        if (result.descriptor.path) {
+          await tryAutoSnapshot(result.descriptor.path, result.descriptor.name, sanitized);
+        }
       } else {
         updateTab(tabId, { isSaving: false });
       }

--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -45,12 +45,17 @@ export interface UseFileWatchIntegrationParams extends TabManagerCore {
  * 外部変更でエディタの内容が上書きされる前にスナップショットを作成する。
  * 外部変更は頻繁には発生しないため、通常の5分間隔チェックをバイパスする。
  */
-function snapshotBeforeExternalChange(fileName: string, editorContent: string): void {
+function snapshotBeforeExternalChange(
+  sourcePath: string,
+  displayName: string,
+  editorContent: string,
+): void {
   if (!getVFS().isRootOpen()) return;
   const historyService = getHistoryService();
   historyService
     .createSnapshot({
-      sourceFile: fileName,
+      sourcePath,
+      displayName,
       content: editorContent,
       type: "auto",
       label: "外部変更前の自動保存",
@@ -79,10 +84,13 @@ function buildOnChanged(
     if (!tab || !isEditorTab(tab)) return;
 
     const fileName = tab.file?.name ?? "ファイル";
+    const filePath = tab.file?.path;
 
     if (tab.fileSyncStatus === "clean") {
       // Snapshot current content before overwriting with disk content
-      snapshotBeforeExternalChange(fileName, tab.content);
+      if (filePath) {
+        snapshotBeforeExternalChange(filePath, fileName, tab.content);
+      }
 
       // Clean tab: update content state AND set pendingExternalContent.
       // content is updated for state consistency (isDirty, auto-save, etc.).
@@ -105,7 +113,9 @@ function buildOnChanged(
       notificationManager.info(`「${fileName}」が更新されました`, 3000);
     } else if (tab.fileSyncStatus === "dirty") {
       // Snapshot current content before entering conflicted state
-      snapshotBeforeExternalChange(fileName, tab.content);
+      if (filePath) {
+        snapshotBeforeExternalChange(filePath, fileName, tab.content);
+      }
 
       // Dirty tab: do NOT touch buffer; enter conflicted state
       const localContent = tab.content;


### PR DESCRIPTION
## Summary
History snapshots were keyed by basename, which merged files like `chapters/intro.mdi` and `notes/intro.mdi` into the same history bucket. This PR switches the history / auto-snapshot identity to `sourcePath` while keeping `displayName` for UI rendering.

## What Changed
- add `sourcePath` + `displayName` to `SnapshotEntry`
- key snapshot filtering, rate limiting, and per-file pruning by `sourcePath`
- update save / manual snapshot / external-change snapshot call sites to pass path identity
- update HistoryPanel / Inspector to load history by active file path instead of basename
- keep fallback reads for legacy entries that only stored `sourceFile`
- add regression tests for duplicate basenames in different paths and legacy-entry compatibility

## Compatibility
- old snapshot entries remain readable/restorable
- old basename-collided history is not auto-split, because the old data does not contain enough information to do that losslessly
- new snapshots are written with path-based identity, so new collisions stop happening

## Verification
- `tsc --noEmit`
- `vitest run lib/services/__tests__/history-service.test.ts lib/services/__tests__/file-watch-integration.test.ts lib/tab-manager/__tests__/tab-model.test.ts`

Closes #1012