### PR TITLE
feat(settings): アカウント設定に「アカウントを管理」ボタンを追加

### DIFF
--- a/components/settings/AccountSettingsTab.tsx
+++ b/components/settings/AccountSettingsTab.tsx
@@ -2,6 +2,14 @@
 
 import { useAuth } from "@/contexts/AuthContext";
 
+function openExternal(url: string): void {
+  if (window.electronAPI?.openExternal) {
+    void window.electronAPI.openExternal(url);
+  } else {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+}
+
 function UserInitials({ name }: { name: string }) {
   const initials = name
     .split(/\s+/)
@@ -84,13 +92,22 @@ export default function AccountSettingsTab() {
         </div>
       </div>
 
-      <button
-        type="button"
-        onClick={() => void logout()}
-        className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground-secondary transition-colors hover:bg-hover hover:text-foreground"
-      >
-        ログアウト
-      </button>
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => openExternal("https://my.illusions.app/")}
+          className="inline-flex items-center gap-2 rounded-lg bg-accent px-4 py-2 text-sm font-medium text-accent-foreground transition-colors hover:bg-accent-hover"
+        >
+          アカウントを管理
+        </button>
+        <button
+          type="button"
+          onClick={() => void logout()}
+          className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-foreground-secondary transition-colors hover:bg-hover hover:text-foreground"
+        >
+          ログアウト
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- アカウント設定タブ（ログイン済み状態）に「アカウントを管理」ボタンを追加
- クリックで `https://my.illusions.app/` を外部ブラウザで開く
- Electron: `window.electronAPI.openExternal` IPC 経由 / Web: `window.open`
- ログアウトボタンと横並びに配置

## Test plan
- [ ] ログイン状態で設定 → アカウントタブを開き「アカウントを管理」ボタンが表示される
- [ ] クリックで `https://my.illusions.app/` が外部ブラウザで開く（Electron・Web 両環境）
- [ ] ログアウトボタンが引き続き正常に機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)