### PR TITLE
fix: complete conflict guard across all save paths

### DIFF
--- a/lib/services/__tests__/file-watcher-catchup.test.ts
+++ b/lib/services/__tests__/file-watcher-catchup.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for file watcher catch-up on resume (Fix #1010).
+ *
+ * Verifies that when a watcher is stopped and restarted, it detects
+ * changes that occurred while it was paused (catch-up check).
+ *
+ * Uses real timers with short poll intervals to avoid fake-timer issues
+ * with nested async promise chains.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock VFS and runtime-env before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockLastModified = 1000;
+let mockFileContent = "initial content";
+
+const mockGetFileMetadata = vi.fn(async () => ({
+  lastModified: mockLastModified,
+  size: mockFileContent.length,
+}));
+const mockReadFile = vi.fn(async () => mockFileContent);
+
+vi.mock("@/lib/vfs", () => ({
+  getVFS: () => ({
+    getFileMetadata: mockGetFileMetadata,
+    readFile: mockReadFile,
+  }),
+}));
+
+vi.mock("@/lib/utils/runtime-env", () => ({
+  isElectronRenderer: () => false,
+}));
+
+import { createFileWatcher, suppressFileWatch } from "@/lib/services/file-watcher";
+import type { FileWatcher } from "@/lib/services/file-watcher";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests: WebFileWatcher catch-up
+// ---------------------------------------------------------------------------
+
+describe("WebFileWatcher: catch-up on resume (#1010)", () => {
+  let watcher: FileWatcher;
+  let onChanged: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockLastModified = 1000;
+    mockFileContent = "initial content";
+    mockGetFileMetadata.mockClear();
+    mockReadFile.mockClear();
+    onChanged = vi.fn();
+  });
+
+  afterEach(() => {
+    watcher?.stop();
+    vi.restoreAllMocks();
+  });
+
+  it("detects file change that occurred while watcher was paused", async () => {
+    watcher = createFileWatcher({
+      path: "/test.mdi",
+      onChanged,
+      pollIntervalMs: 5000, // Long interval — we only test the catch-up, not polling
+    });
+
+    // Start watcher — initializes lastModified to 1000
+    watcher.start();
+    await sleep(50); // Let async init complete
+
+    // Stop watcher (simulates tab going to background)
+    watcher.stop();
+    expect(watcher.isActive).toBe(false);
+
+    // Simulate external file change while paused
+    mockLastModified = 2000;
+    mockFileContent = "changed while paused";
+
+    // Resume watcher — should detect the change via catch-up
+    watcher.start();
+    await sleep(50); // Let catch-up complete
+
+    expect(onChanged).toHaveBeenCalledWith("changed while paused", 2000);
+  }, 10000);
+
+  it("does NOT fire catch-up callback when file has not changed", async () => {
+    watcher = createFileWatcher({
+      path: "/test.mdi",
+      onChanged,
+      pollIntervalMs: 5000,
+    });
+
+    // Start and stop
+    watcher.start();
+    await sleep(50);
+    watcher.stop();
+
+    // File unchanged — mockLastModified stays 1000
+
+    // Resume
+    watcher.start();
+    await sleep(50);
+
+    expect(onChanged).not.toHaveBeenCalled();
+  }, 10000);
+
+  it("skips catch-up callback when path is suppressed", async () => {
+    watcher = createFileWatcher({
+      path: "/test-suppressed.mdi",
+      onChanged,
+      pollIntervalMs: 5000,
+    });
+
+    // Start and stop
+    watcher.start();
+    await sleep(50);
+    watcher.stop();
+
+    // Simulate change + suppress (app's own save)
+    mockLastModified = 2000;
+    mockFileContent = "self-saved content";
+    suppressFileWatch("/test-suppressed.mdi");
+
+    // Resume
+    watcher.start();
+    await sleep(50);
+
+    expect(onChanged).not.toHaveBeenCalled();
+  }, 10000);
+
+  it("does NOT fire catch-up on the very first start (no previous baseline)", async () => {
+    mockLastModified = 5000;
+    mockFileContent = "existing file";
+
+    watcher = createFileWatcher({
+      path: "/test.mdi",
+      onChanged,
+      pollIntervalMs: 5000,
+    });
+
+    // First start — lastModified was 0, so previousModified=0, catch-up guard skips
+    watcher.start();
+    await sleep(50);
+
+    expect(onChanged).not.toHaveBeenCalled();
+  }, 10000);
+
+  it("does not fire callback if stopped before catch-up completes", async () => {
+    watcher = createFileWatcher({
+      path: "/test.mdi",
+      onChanged,
+      pollIntervalMs: 5000,
+    });
+
+    // Start, establish baseline
+    watcher.start();
+    await sleep(50);
+    watcher.stop();
+
+    // Change file
+    mockLastModified = 2000;
+    mockFileContent = "changed";
+
+    // Start and immediately stop
+    watcher.start();
+    watcher.stop();
+
+    await sleep(100);
+
+    // Callback should not fire because _isActive was set to false
+    expect(onChanged).not.toHaveBeenCalled();
+  }, 10000);
+});

--- a/lib/services/__tests__/file-watcher-catchup.test.ts
+++ b/lib/services/__tests__/file-watcher-catchup.test.ts
@@ -35,7 +35,7 @@ vi.mock("@/lib/utils/runtime-env", () => ({
 }));
 
 import { createFileWatcher, suppressFileWatch } from "@/lib/services/file-watcher";
-import type { FileWatcher } from "@/lib/services/file-watcher";
+import type { FileChangeCallback, FileWatcher } from "@/lib/services/file-watcher";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -51,14 +51,14 @@ function sleep(ms: number): Promise<void> {
 
 describe("WebFileWatcher: catch-up on resume (#1010)", () => {
   let watcher: FileWatcher;
-  let onChanged: ReturnType<typeof vi.fn>;
+  let onChanged: ReturnType<typeof vi.fn<FileChangeCallback>>;
 
   beforeEach(() => {
     mockLastModified = 1000;
     mockFileContent = "initial content";
     mockGetFileMetadata.mockClear();
     mockReadFile.mockClear();
-    onChanged = vi.fn();
+    onChanged = vi.fn<FileChangeCallback>();
   });
 
   afterEach(() => {

--- a/lib/services/file-watcher.ts
+++ b/lib/services/file-watcher.ts
@@ -190,9 +190,29 @@ class WebFileWatcher implements FileWatcher {
 
     this._isActive = true;
 
+    // Save the previous baseline so we can detect changes that occurred while paused
+    const previousModified = this.lastModified;
+
     // Initialize lastModified before starting to poll
     void this.initializeLastModified().then(() => {
       if (!this._isActive) return;
+
+      // Catch-up check: detect changes that occurred while the watcher was paused
+      if (previousModified > 0 && this.lastModified > previousModified) {
+        if (!isFileSuppressed(this.path)) {
+          void this.vfs
+            .readFile(this.path)
+            .then((content) => {
+              if (this._isActive) {
+                this.onChanged(content, this.lastModified);
+              }
+            })
+            .catch(() => {
+              // File may have been deleted; normal poll cycle will handle it
+            });
+        }
+      }
+
       this.timerId = setInterval(() => {
         void this.checkForChanges();
       }, this.pollIntervalMs);

--- a/lib/services/file-watcher.ts
+++ b/lib/services/file-watcher.ts
@@ -346,10 +346,11 @@ class ElectronFileWatcher implements FileWatcher {
    * 一時停止中に見逃した変更を確認し、ネイティブまたはフォールバックウォッチャーを開始する。
    */
   private async catchUpAndStartWatcher(previousModified: number): Promise<void> {
-    // Detect changes that occurred while the watcher was paused
-    if (previousModified > 0) {
-      try {
-        const metadata = await this.vfs.getFileMetadata(this.path);
+    // Always read current metadata to establish/update the baseline.
+    // When previousModified > 0, also detect changes that occurred while paused.
+    try {
+      const metadata = await this.vfs.getFileMetadata(this.path);
+      if (previousModified > 0) {
         if (
           this._isActive &&
           metadata.lastModified > previousModified &&
@@ -360,10 +361,16 @@ class ElectronFileWatcher implements FileWatcher {
             this.lastKnownModified = metadata.lastModified;
             this.onChanged(content, metadata.lastModified);
           }
+        } else {
+          // Update baseline even when no change detected
+          this.lastKnownModified = metadata.lastModified;
         }
-      } catch {
-        // File may not exist; proceed to start watcher normally
+      } else {
+        // First start: initialize baseline for future catch-up checks
+        this.lastKnownModified = metadata.lastModified;
       }
+    } catch {
+      // File may not exist; proceed to start watcher normally
     }
 
     if (!this._isActive) return;

--- a/lib/services/file-watcher.ts
+++ b/lib/services/file-watcher.ts
@@ -194,29 +194,30 @@ class WebFileWatcher implements FileWatcher {
     const previousModified = this.lastModified;
 
     // Initialize lastModified before starting to poll
-    void this.initializeLastModified().then(() => {
-      if (!this._isActive) return;
+    void this.initializeLastModified()
+      .then(async () => {
+        if (!this._isActive) return;
 
-      // Catch-up check: detect changes that occurred while the watcher was paused
-      if (previousModified > 0 && this.lastModified > previousModified) {
-        if (!isFileSuppressed(this.path)) {
-          void this.vfs
-            .readFile(this.path)
-            .then((content) => {
+        // Catch-up check: detect changes that occurred while the watcher was paused
+        if (previousModified > 0 && this.lastModified > previousModified) {
+          if (!isFileSuppressed(this.path)) {
+            try {
+              const content = await this.vfs.readFile(this.path);
               if (this._isActive) {
                 this.onChanged(content, this.lastModified);
               }
-            })
-            .catch(() => {
+            } catch {
               // File may have been deleted; normal poll cycle will handle it
-            });
+            }
+          }
         }
-      }
-
-      this.timerId = setInterval(() => {
-        void this.checkForChanges();
-      }, this.pollIntervalMs);
-    });
+      })
+      .then(() => {
+        if (!this._isActive) return;
+        this.timerId = setInterval(() => {
+          void this.checkForChanges();
+        }, this.pollIntervalMs);
+      });
   }
 
   /**
@@ -305,6 +306,8 @@ class ElectronFileWatcher implements FileWatcher {
   private nativeWatcher: { stop: () => void } | null = null;
   private fallbackWatcher: WebFileWatcher | null = null;
   private _isActive = false;
+  /** Last known mtime — preserved across stop/start for catch-up detection */
+  private lastKnownModified: number = 0;
 
   constructor(options: FileWatcherOptions) {
     this.vfs = getVFS();
@@ -330,6 +333,40 @@ class ElectronFileWatcher implements FileWatcher {
     }
 
     this._isActive = true;
+
+    const previousModified = this.lastKnownModified;
+
+    // Catch-up check for changes that occurred while the watcher was paused,
+    // then start the actual watcher (native or fallback).
+    void this.catchUpAndStartWatcher(previousModified);
+  }
+
+  /**
+   * Check for missed changes during pause, then start native or fallback watcher.
+   * 一時停止中に見逃した変更を確認し、ネイティブまたはフォールバックウォッチャーを開始する。
+   */
+  private async catchUpAndStartWatcher(previousModified: number): Promise<void> {
+    // Detect changes that occurred while the watcher was paused
+    if (previousModified > 0) {
+      try {
+        const metadata = await this.vfs.getFileMetadata(this.path);
+        if (
+          this._isActive &&
+          metadata.lastModified > previousModified &&
+          !isFileSuppressed(this.path)
+        ) {
+          const content = await this.vfs.readFile(this.path);
+          if (this._isActive) {
+            this.lastKnownModified = metadata.lastModified;
+            this.onChanged(content, metadata.lastModified);
+          }
+        }
+      } catch {
+        // File may not exist; proceed to start watcher normally
+      }
+    }
+
+    if (!this._isActive) return;
 
     // Try native watching first
     if (this.tryStartNativeWatch()) {
@@ -410,6 +447,7 @@ class ElectronFileWatcher implements FileWatcher {
         this.vfs.readFile(this.path),
         this.vfs.getFileMetadata(this.path),
       ]);
+      this.lastKnownModified = metadata.lastModified;
       this.onChanged(content, metadata.lastModified);
     } catch (error) {
       // Check for permission-related errors (DOMException with NotAllowedError)

--- a/lib/tab-manager/__tests__/auto-save-sync-status.test.ts
+++ b/lib/tab-manager/__tests__/auto-save-sync-status.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for auto-save fileSyncStatus reset (Fix #1008).
+ *
+ * Verifies that after a successful auto-save, the tab's fileSyncStatus
+ * is set to "clean" and conflictDiskContent is cleared.
+ *
+ * The production auto-save logic lives in useAutoSave (a React hook).
+ * We extract the pure state-update logic and test it without React.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import type { EditorTabState, TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
+import { createNewTab, generateTabId, sanitizeMdiContent } from "@/lib/tab-manager/types";
+
+// ---------------------------------------------------------------------------
+// Pure logic extracted from useAutoSave's setTabs updater (project mode)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors the setTabs updater in useAutoSave for project-mode saves.
+ * The fix adds fileSyncStatus: "clean" and conflictDiskContent: null.
+ */
+function projectModeAutoSaveUpdater(
+  tabs: TabState[],
+  tabId: string,
+  sanitized: string,
+): TabState[] {
+  return tabs.map((t) =>
+    t.id === tabId && isEditorTab(t)
+      ? {
+          ...t,
+          lastSavedContent: sanitized,
+          isDirty: sanitizeMdiContent(t.content) !== sanitized,
+          lastSavedTime: Date.now(),
+          lastSaveWasAuto: true,
+          fileSyncStatus: "clean" as const,
+          conflictDiskContent: null,
+        }
+      : t,
+  );
+}
+
+/**
+ * Mirrors the setTabs updater in useAutoSave for non-project-mode saves.
+ */
+function nonProjectModeAutoSaveUpdater(
+  tabs: TabState[],
+  tabId: string,
+  sanitized: string,
+  descriptor: EditorTabState["file"],
+): TabState[] {
+  return tabs.map((t) =>
+    t.id === tabId && isEditorTab(t)
+      ? {
+          ...t,
+          file: descriptor,
+          lastSavedContent: sanitized,
+          isDirty: sanitizeMdiContent(t.content) !== sanitized,
+          lastSavedTime: Date.now(),
+          lastSaveWasAuto: true,
+          fileSyncStatus: "clean" as const,
+          conflictDiskContent: null,
+        }
+      : t,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEditorTab(overrides?: Partial<EditorTabState>): EditorTabState {
+  return {
+    ...createNewTab(),
+    id: generateTabId(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Project mode auto-save
+// ---------------------------------------------------------------------------
+
+describe("auto-save: project mode resets fileSyncStatus after save (#1008)", () => {
+  it("sets fileSyncStatus to 'clean' after auto-save", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "saved content",
+      isDirty: true,
+    });
+    const result = projectModeAutoSaveUpdater([tab], tab.id, "saved content");
+    const updated = result.find((t) => t.id === tab.id) as EditorTabState;
+
+    expect(updated.fileSyncStatus).toBe("clean");
+  });
+
+  it("clears conflictDiskContent after auto-save", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "saved content",
+      isDirty: true,
+      conflictDiskContent: "old disk content",
+    });
+    const result = projectModeAutoSaveUpdater([tab], tab.id, "saved content");
+    const updated = result.find((t) => t.id === tab.id) as EditorTabState;
+
+    expect(updated.conflictDiskContent).toBeNull();
+  });
+
+  it("sets lastSaveWasAuto to true", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "content",
+      lastSaveWasAuto: false,
+    });
+    const result = projectModeAutoSaveUpdater([tab], tab.id, "content");
+    const updated = result.find((t) => t.id === tab.id) as EditorTabState;
+
+    expect(updated.lastSaveWasAuto).toBe(true);
+  });
+
+  it("clears isDirty when content matches saved content", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "same content",
+      isDirty: true,
+    });
+    const result = projectModeAutoSaveUpdater([tab], tab.id, "same content");
+    const updated = result.find((t) => t.id === tab.id) as EditorTabState;
+
+    expect(updated.isDirty).toBe(false);
+  });
+
+  it("keeps isDirty true when content diverged during save", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "newer content typed during save",
+      isDirty: true,
+    });
+    const result = projectModeAutoSaveUpdater([tab], tab.id, "older saved content");
+    const updated = result.find((t) => t.id === tab.id) as EditorTabState;
+
+    expect(updated.isDirty).toBe(true);
+  });
+
+  it("does not modify non-matching tabs", () => {
+    const tab = makeEditorTab({ fileSyncStatus: "dirty", content: "a" });
+    const otherTab = makeEditorTab({ fileSyncStatus: "dirty", content: "b" });
+    const result = projectModeAutoSaveUpdater([tab, otherTab], tab.id, "a");
+    const other = result.find((t) => t.id === otherTab.id) as EditorTabState;
+
+    expect(other.fileSyncStatus).toBe("dirty");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Non-project mode auto-save
+// ---------------------------------------------------------------------------
+
+describe("auto-save: non-project mode resets fileSyncStatus after save (#1008)", () => {
+  it("sets fileSyncStatus to 'clean' after auto-save", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "saved content",
+      isDirty: true,
+    });
+    const descriptor = { name: "test.mdi", path: "/test.mdi", handle: null };
+    const result = nonProjectModeAutoSaveUpdater([tab], tab.id, "saved content", descriptor);
+    const updated = result.find((t) => t.id === tab.id) as EditorTabState;
+
+    expect(updated.fileSyncStatus).toBe("clean");
+  });
+
+  it("clears conflictDiskContent after auto-save", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "saved content",
+      isDirty: true,
+      conflictDiskContent: "stale disk",
+    });
+    const descriptor = { name: "test.mdi", path: "/test.mdi", handle: null };
+    const result = nonProjectModeAutoSaveUpdater([tab], tab.id, "saved content", descriptor);
+    const updated = result.find((t) => t.id === tab.id) as EditorTabState;
+
+    expect(updated.conflictDiskContent).toBeNull();
+  });
+
+  it("updates the file descriptor", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "content",
+    });
+    const descriptor = { name: "new-name.mdi", path: "/new-path.mdi", handle: null };
+    const result = nonProjectModeAutoSaveUpdater([tab], tab.id, "content", descriptor);
+    const updated = result.find((t) => t.id === tab.id) as EditorTabState;
+
+    expect(updated.file).toEqual(descriptor);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Auto-save skips conflicted tabs (guard check)
+// ---------------------------------------------------------------------------
+
+describe("auto-save: skips conflicted tabs", () => {
+  it("auto-save guard filters out conflicted tabs", () => {
+    // Mirrors the guard condition in useAutoSave:
+    // if (tab.fileSyncStatus === "conflicted") continue;
+    const conflictedTab = makeEditorTab({
+      fileSyncStatus: "conflicted",
+      isDirty: true,
+      content: "local edits",
+      conflictDiskContent: "disk version",
+      file: { name: "test.mdi", path: "/test.mdi", handle: null },
+      isSaving: false,
+    });
+
+    const shouldAutoSave =
+      isEditorTab(conflictedTab) &&
+      conflictedTab.fileSyncStatus !== "conflicted" &&
+      conflictedTab.isDirty &&
+      conflictedTab.file &&
+      !conflictedTab.isSaving;
+
+    expect(shouldAutoSave).toBe(false);
+  });
+
+  it("auto-save guard allows dirty non-conflicted tabs", () => {
+    const dirtyTab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      isDirty: true,
+      content: "edits",
+      file: { name: "test.mdi", path: "/test.mdi", handle: null },
+      isSaving: false,
+    });
+
+    const shouldAutoSave =
+      isEditorTab(dirtyTab) &&
+      dirtyTab.fileSyncStatus !== "conflicted" &&
+      dirtyTab.isDirty &&
+      dirtyTab.file &&
+      !dirtyTab.isSaving;
+
+    expect(shouldAutoSave).toBe(true);
+  });
+});

--- a/lib/tab-manager/__tests__/close-dialog-conflict-guard.test.ts
+++ b/lib/tab-manager/__tests__/close-dialog-conflict-guard.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for close dialog conflict guard (Fix #1011).
+ *
+ * Verifies that:
+ * 1. handleCloseTabSave blocks saving when tab is conflicted
+ * 2. Non-project save path resets fileSyncStatus after save
+ * 3. Normal (non-conflicted) close-save flow is not blocked
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import type { EditorTabState, TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
+import { createNewTab, generateTabId, sanitizeMdiContent } from "@/lib/tab-manager/types";
+
+// ---------------------------------------------------------------------------
+// Pure logic extracted from useCloseDialog's handleCloseTabSave
+// ---------------------------------------------------------------------------
+
+interface CloseDialogTestContext {
+  tab: EditorTabState;
+  warningMessages: string[];
+  savedContent: string | null;
+  tabClosed: boolean;
+  pendingCloseCleared: boolean;
+  updatedTab: Partial<EditorTabState> | null;
+}
+
+/**
+ * Simulates the handleCloseTabSave logic from use-close-dialog.ts.
+ * Extracts the pure decision logic without React hooks.
+ */
+function simulateCloseTabSave(tab: EditorTabState, isProject: boolean): CloseDialogTestContext {
+  const ctx: CloseDialogTestContext = {
+    tab,
+    warningMessages: [],
+    savedContent: null,
+    tabClosed: false,
+    pendingCloseCleared: false,
+    updatedTab: null,
+  };
+
+  if (!isEditorTab(tab)) return ctx;
+
+  // Fix #1011: Block save if conflicted
+  if (tab.fileSyncStatus === "conflicted") {
+    ctx.warningMessages.push(
+      "ファイルが外部で変更されています。閉じる前にコンフリクトを解決してください。",
+    );
+    ctx.pendingCloseCleared = true;
+    return ctx;
+  }
+
+  const sanitized = sanitizeMdiContent(tab.content);
+
+  if (isProject && tab.file?.path) {
+    ctx.savedContent = sanitized;
+    ctx.tabClosed = true;
+    ctx.pendingCloseCleared = true;
+  } else {
+    // Non-project path: updateTab with conflict state reset
+    ctx.savedContent = sanitized;
+    ctx.updatedTab = {
+      lastSavedContent: sanitized,
+      isDirty: false,
+      fileSyncStatus: "clean",
+      conflictDiskContent: null,
+    };
+    ctx.tabClosed = true;
+    ctx.pendingCloseCleared = true;
+  }
+
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEditorTab(overrides?: Partial<EditorTabState>): EditorTabState {
+  return {
+    ...createNewTab(),
+    id: generateTabId(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Conflict guard
+// ---------------------------------------------------------------------------
+
+describe("close dialog: conflict guard blocks save (#1011)", () => {
+  it("blocks save when tab fileSyncStatus is 'conflicted'", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "conflicted",
+      content: "local edits",
+      isDirty: true,
+      conflictDiskContent: "disk version",
+      file: { name: "test.mdi", path: "/test.mdi", handle: null },
+    });
+
+    const result = simulateCloseTabSave(tab, true);
+
+    expect(result.tabClosed).toBe(false);
+    expect(result.savedContent).toBeNull();
+    expect(result.warningMessages).toHaveLength(1);
+    expect(result.warningMessages[0]).toContain("コンフリクト");
+  });
+
+  it("clears pendingCloseTabId when blocked by conflict", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "conflicted",
+      content: "edits",
+      isDirty: true,
+    });
+
+    const result = simulateCloseTabSave(tab, true);
+
+    expect(result.pendingCloseCleared).toBe(true);
+    expect(result.tabClosed).toBe(false);
+  });
+
+  it("does NOT block save when fileSyncStatus is 'clean'", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "clean",
+      content: "content",
+      isDirty: true,
+      file: { name: "test.mdi", path: "/test.mdi", handle: null },
+    });
+
+    const result = simulateCloseTabSave(tab, true);
+
+    expect(result.tabClosed).toBe(true);
+    expect(result.savedContent).not.toBeNull();
+    expect(result.warningMessages).toHaveLength(0);
+  });
+
+  it("does NOT block save when fileSyncStatus is 'dirty'", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "content",
+      isDirty: true,
+      file: { name: "test.mdi", path: "/test.mdi", handle: null },
+    });
+
+    const result = simulateCloseTabSave(tab, true);
+
+    expect(result.tabClosed).toBe(true);
+    expect(result.warningMessages).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Non-project save resets conflict state
+// ---------------------------------------------------------------------------
+
+describe("close dialog: non-project save resets fileSyncStatus", () => {
+  it("sets fileSyncStatus to 'clean' in updateTab", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "content",
+      isDirty: true,
+      file: { name: "test.mdi", path: null, handle: null },
+    });
+
+    const result = simulateCloseTabSave(tab, false);
+
+    expect(result.updatedTab).not.toBeNull();
+    expect(result.updatedTab!.fileSyncStatus).toBe("clean");
+  });
+
+  it("clears conflictDiskContent in updateTab", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "content",
+      isDirty: true,
+      conflictDiskContent: "old disk",
+      file: { name: "test.mdi", path: null, handle: null },
+    });
+
+    const result = simulateCloseTabSave(tab, false);
+
+    expect(result.updatedTab).not.toBeNull();
+    expect(result.updatedTab!.conflictDiskContent).toBeNull();
+  });
+
+  it("sets isDirty to false in updateTab", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      content: "content",
+      isDirty: true,
+    });
+
+    const result = simulateCloseTabSave(tab, false);
+
+    expect(result.updatedTab!.isDirty).toBe(false);
+  });
+});

--- a/lib/tab-manager/__tests__/save-as-conflict-reset.test.ts
+++ b/lib/tab-manager/__tests__/save-as-conflict-reset.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for Save As conflict state reset (Fix #1009).
+ *
+ * Verifies that saveAsFile clears fileSyncStatus and conflictDiskContent
+ * after a successful save. Save As is an explicit user action via system
+ * dialog, so it does not block on conflict — just clears the state.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import type { EditorTabState, TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
+import { createNewTab, generateTabId } from "@/lib/tab-manager/types";
+
+// ---------------------------------------------------------------------------
+// Pure logic extracted from saveAsFile's updateTab call
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors the updateTab call in saveAsFile after successful save.
+ * The fix adds fileSyncStatus: "clean" and conflictDiskContent: null.
+ */
+function saveAsUpdateTab(
+  tab: EditorTabState,
+  savedContent: string,
+  descriptor: EditorTabState["file"],
+): Partial<EditorTabState> {
+  return {
+    file: descriptor,
+    lastSavedContent: savedContent,
+    isDirty: false,
+    lastSavedTime: Date.now(),
+    isSaving: false,
+    fileSyncStatus: "clean",
+    conflictDiskContent: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEditorTab(overrides?: Partial<EditorTabState>): EditorTabState {
+  return {
+    ...createNewTab(),
+    id: generateTabId(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Save As: clears conflict state after save (#1009)", () => {
+  it("sets fileSyncStatus to 'clean'", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "conflicted",
+      content: "local edits",
+      conflictDiskContent: "disk version",
+    });
+    const descriptor = { name: "saved.mdi", path: "/saved.mdi", handle: null };
+
+    const updates = saveAsUpdateTab(tab, "local edits", descriptor);
+
+    expect(updates.fileSyncStatus).toBe("clean");
+  });
+
+  it("clears conflictDiskContent", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "conflicted",
+      conflictDiskContent: "disk version",
+    });
+    const descriptor = { name: "saved.mdi", path: "/saved.mdi", handle: null };
+
+    const updates = saveAsUpdateTab(tab, "content", descriptor);
+
+    expect(updates.conflictDiskContent).toBeNull();
+  });
+
+  it("sets isDirty to false", () => {
+    const tab = makeEditorTab({ isDirty: true });
+    const descriptor = { name: "saved.mdi", path: "/saved.mdi", handle: null };
+
+    const updates = saveAsUpdateTab(tab, "content", descriptor);
+
+    expect(updates.isDirty).toBe(false);
+  });
+
+  it("updates the file descriptor", () => {
+    const tab = makeEditorTab({
+      file: { name: "old.mdi", path: "/old.mdi", handle: null },
+    });
+    const newDescriptor = { name: "new.mdi", path: "/new.mdi", handle: null };
+
+    const updates = saveAsUpdateTab(tab, "content", newDescriptor);
+
+    expect(updates.file).toEqual(newDescriptor);
+  });
+
+  it("sets isSaving to false", () => {
+    const tab = makeEditorTab({ isSaving: true });
+    const descriptor = { name: "saved.mdi", path: "/saved.mdi", handle: null };
+
+    const updates = saveAsUpdateTab(tab, "content", descriptor);
+
+    expect(updates.isSaving).toBe(false);
+  });
+});
+
+describe("Save As: works correctly for previously clean tab", () => {
+  it("keeps fileSyncStatus as 'clean' after save", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "clean",
+      content: "content",
+    });
+    const descriptor = { name: "saved.mdi", path: "/saved.mdi", handle: null };
+
+    const updates = saveAsUpdateTab(tab, "content", descriptor);
+
+    expect(updates.fileSyncStatus).toBe("clean");
+    expect(updates.conflictDiskContent).toBeNull();
+  });
+});
+
+describe("Save As: works correctly for dirty tab", () => {
+  it("resets fileSyncStatus from 'dirty' to 'clean'", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "dirty",
+      isDirty: true,
+      content: "edited",
+    });
+    const descriptor = { name: "saved.mdi", path: "/saved.mdi", handle: null };
+
+    const updates = saveAsUpdateTab(tab, "edited", descriptor);
+
+    expect(updates.fileSyncStatus).toBe("clean");
+    expect(updates.isDirty).toBe(false);
+  });
+});

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -88,6 +88,8 @@ export function useAutoSave(params: UseAutoSaveParams): void {
                         isDirty: sanitizeMdiContent(t.content) !== sanitized,
                         lastSavedTime: Date.now(),
                         lastSaveWasAuto: true,
+                        fileSyncStatus: "clean",
+                        conflictDiskContent: null,
                       }
                     : t,
                 ),
@@ -110,6 +112,8 @@ export function useAutoSave(params: UseAutoSaveParams): void {
                           isDirty: sanitizeMdiContent(t.content) !== sanitized,
                           lastSavedTime: Date.now(),
                           lastSaveWasAuto: true,
+                          fileSyncStatus: "clean",
+                          conflictDiskContent: null,
                         }
                       : t,
                   ),

--- a/lib/tab-manager/use-close-dialog.ts
+++ b/lib/tab-manager/use-close-dialog.ts
@@ -61,6 +61,15 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
     if (!isEditorTab(rawTab)) return;
     const tab = rawTab;
 
+    // Block save if the file has an unresolved external conflict
+    if (tab.fileSyncStatus === "conflicted") {
+      notificationManager.warning(
+        "ファイルが外部で変更されています。閉じる前にコンフリクトを解決してください。",
+      );
+      setPendingCloseTabId(null);
+      return;
+    }
+
     try {
       const sanitized = sanitizeMdiContent(tab.content);
 
@@ -83,6 +92,8 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
           file: result.descriptor,
           lastSavedContent: sanitized,
           isDirty: false,
+          fileSyncStatus: "clean",
+          conflictDiskContent: null,
         });
       }
     } catch (error) {

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -322,6 +322,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           isDirty: false,
           lastSavedTime: Date.now(),
           isSaving: false,
+          fileSyncStatus: "clean",
+          conflictDiskContent: null,
         });
         if (!(await persistFileReference(result.descriptor, sanitized))) {
           notificationManager.warning(PERSIST_FAILURE_WARNING);


### PR DESCRIPTION
## Summary

Completes the file conflict guard implementation from #1006 by fixing four escape routes that could bypass the protection:

- **#1008**: Auto-save now resets `fileSyncStatus` to `"clean"` after successful save, preventing false conflict warnings on background tabs
- **#1009**: `saveAsFile()` clears conflict state after a successful Save As (explicit user action resolves any conflict)
- **#1010**: File watcher now detects changes that occurred while a background tab's watcher was paused, firing a catch-up callback on resume
- **#1011**: Close-dialog "Save" button now blocks when the tab has an unresolved external conflict, showing a warning instead of silently overwriting

## Test plan

- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes (0 errors)
- [x] Prettier format check passes
- [x] All 402 tests pass
- [ ] Manual: auto-save a dirty tab → verify fileSyncStatus becomes "clean"
- [ ] Manual: edit file externally while tab inactive, switch back → verify change detected
- [ ] Manual: while conflicted, try Save As → verify conflict cleared after save
- [ ] Manual: while conflicted, try closing tab → verify warning, tab stays open

Closes #1008, closes #1009, closes #1010, closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)