### PR TITLE
fix(electron): reduce power state broadcast debounce to 300ms (#1045)

### DIFF
--- a/electron/window-manager.js
+++ b/electron/window-manager.js
@@ -10,16 +10,26 @@ const allWindows = new Set();
 
 // --- Power state monitoring ---
 let powerDebounceTimer = null;
+let lastBroadcastedPowerState = null;
 
+/**
+ * Broadcast a power state change to all renderer windows.
+ * Uses a short debounce (300ms) to coalesce rapid OS events,
+ * and skips dispatch if the state has not changed since the last broadcast.
+ */
 function broadcastPowerState(state) {
   clearTimeout(powerDebounceTimer);
   powerDebounceTimer = setTimeout(() => {
+    if (state === lastBroadcastedPowerState) {
+      return;
+    }
+    lastBroadcastedPowerState = state;
     for (const win of allWindows) {
       if (!win.isDestroyed()) {
         win.webContents.send("power:state-changed", state);
       }
     }
-  }, 60_000); // 1-minute debounce
+  }, 300); // 300ms debounce — coalesces rapid OS events without noticeable delay
 }
 
 function getMainWindow() {


### PR DESCRIPTION
## Summary

- Reduces the `powerMonitor` broadcast debounce in `electron/window-manager.js` from **60 000ms (1 minute)** to **300ms**, so AC/battery state changes propagate to the renderer almost immediately.
- Adds state deduplication via `lastBroadcastedPowerState` — rapid OS events that resolve to the same state are skipped, preventing unnecessary IPC traffic.

Closes #1045

## Changes

- `electron/window-manager.js`: reduced debounce from `60_000` → `300`, added `lastBroadcastedPowerState` dedup guard.

## Test plan

- [ ] Unplug power adapter → power-save mode activates within ~300ms (not 60s)
- [ ] Plug power adapter back in → power-save mode deactivates promptly
- [ ] Rapidly toggle AC/battery multiple times → only the final state is sent (no duplicate IPC events)
- [ ] No regression in editor performance or window management

🤖 Generated with [Claude Code](https://claude.com/claude-code)