### PR TITLE
fix(electron): require dialog approval for vfs:set-root (#1043)

### DIFF
--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -292,9 +292,23 @@ function registerVFSHandlers() {
       throw error;
     }
 
-    // 3. Path is allowed — isDeniedPath already blocks sensitive paths,
-    //    and fs.stat above verifies the directory exists.
-    //    No additional restrictions needed for vfs:set-root.
+    // 3. Require prior dialog approval — the path (or an ancestor) must have been
+    //    explicitly selected by the user via the native file-open dialog.
+    //    This prevents a compromised renderer from escalating an arbitrary path to
+    //    an allowed root without explicit user consent (fixes security issue #1043).
+    const isApproved = Array.from(dialogApprovedPaths.keys()).some((approved) => {
+      const normalizedApproved = normalizePath(approved);
+      // Allow exact match or if resolved is a subdirectory of an approved path
+      return (
+        normalizedResolved === normalizedApproved ||
+        normalizedResolved.startsWith(normalizedApproved + "/")
+      );
+    });
+    if (!isApproved) {
+      throw new Error(
+        "このディレクトリはファイルダイアログで承認されていません。ダイアログからディレクトリを開いてください",
+      );
+    }
 
     allowedRoots.set(event.sender.id, resolved);
     return { path: resolved, name: path.basename(resolved) };


### PR DESCRIPTION
## Summary

- `vfs:set-root` previously accepted any arbitrary directory path from the renderer without verifying the user had explicitly approved it via a native file-open dialog.
- A compromised renderer could call `vfs:set-root` with a sensitive path (e.g. `~/.ssh`, `~/Library/Keychains`) to elevate it to an allowed root, bypassing the denylist-only guard.
- Fix: check the requested path (or any ancestor) against the existing `dialogApprovedPaths` LRU map before updating `allowedRoots`. Paths not previously returned by `dialog.showOpenDialog` are rejected with a Japanese error message.

## Changes

- `electron/ipc/vfs-ipc.js` — added approval check in `vfs:set-root` handler (step 3); reuses the existing `dialogApprovedPaths` map already populated by `vfs:open-directory`.

## Test plan

- [ ] Open a directory via the directory picker — confirm the project loads normally (path is now in `dialogApprovedPaths`).
- [ ] Confirm recent-project restore (calls `vfs:set-root` with a previously opened path) still works.
- [ ] Attempt to call `vfs:set-root` with an arbitrary path that was never opened via dialog — confirm an error is thrown and the root is NOT updated.
- [ ] Attempt to call `vfs:set-root` with a path that is a subdirectory of a dialog-approved path — confirm it is accepted.

Closes #1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)