### PR TITLE
fix(project): make openProject read-only, don't create missing metadata (#1023)

### DIFF
--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -233,12 +233,30 @@ export class ProjectService {
   async openProject(): Promise<ProjectMode> {
     const rootDirHandle = await this.vfs.openDirectory();
 
-    // Read .illusions/project.json (create if missing)
-    const illusionsDir = await rootDirHandle.getDirectoryHandle(".illusions", { create: true });
-    const projectJsonHandle = await illusionsDir.getFileHandle("project.json", { create: true });
+    // Read .illusions/project.json — do NOT create; fail clearly if not found.
+    let illusionsDir: Awaited<ReturnType<typeof rootDirHandle.getDirectoryHandle>>;
+    try {
+      illusionsDir = await rootDirHandle.getDirectoryHandle(".illusions", { create: false });
+    } catch {
+      throw new Error(
+        "選択したフォルダはプロジェクトフォルダではありません。.illusions フォルダが見つかりません。",
+      );
+    }
+
+    let projectJsonHandle: Awaited<ReturnType<typeof illusionsDir.getFileHandle>>;
+    try {
+      projectJsonHandle = await illusionsDir.getFileHandle("project.json");
+    } catch {
+      throw new Error(
+        "プロジェクトの設定ファイル (.illusions/project.json) が見つかりません。プロジェクトが破損している可能性があります。",
+      );
+    }
+
     const metadataText = await projectJsonHandle.read();
     if (!metadataText.trim()) {
-      throw new Error(".illusions/project.json is empty — project may need to be re-created.");
+      throw new Error(
+        "プロジェクトの設定ファイル (.illusions/project.json) が空です。プロジェクトが破損している可能性があります。",
+      );
     }
     const metadata: ProjectConfig = JSON.parse(metadataText) as ProjectConfig;
 


### PR DESCRIPTION
## Summary

- Fixes #1023: `openProject()` was using `{ create: true }` when opening the `.illusions` directory and `project.json`, which silently created empty files in any non-project folder the user selected.
- Changed to `{ create: false }` (and no `create` option for `getFileHandle`) so that `openProject()` is strictly read-only.
- Added clear Japanese error messages for two failure cases: (1) `.illusions` directory missing → not a project folder, (2) `project.json` missing or empty → project may be corrupted.

## Changes

- `lib/project/project-service.ts` — `openProject()` lines 236-243: replaced `create: true` with existence checks wrapped in try/catch, throwing descriptive Japanese errors on failure.

## Test plan

- [ ] Open a regular non-project folder → should show Japanese error, no `.illusions/` directory created
- [ ] Open a project folder missing `project.json` → should show "設定ファイルが見つかりません" error
- [ ] Open a valid project folder → should open normally as before
- [ ] `npx tsc --noEmit` passes (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)