### PR TITLE
fix(services): add seconds to history snapshot filename format (#1031)

### DIFF
--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -125,8 +125,8 @@ export interface RestoreResult {
 // -----------------------------------------------------------------------
 
 /**
- * Format a timestamp as YYYYMMDDHHmm.
- * タイムスタンプを YYYYMMDDHHmm 形式に変換する。
+ * Format a timestamp as YYYYMMDDHHmmss.
+ * タイムスタンプを YYYYMMDDHHmmss 形式に変換する。
  */
 function formatTimestamp(timestamp: number): string {
   const d = new Date(timestamp);
@@ -135,7 +135,8 @@ function formatTimestamp(timestamp: number): string {
   const day = String(d.getDate()).padStart(2, "0");
   const hours = String(d.getHours()).padStart(2, "0");
   const minutes = String(d.getMinutes()).padStart(2, "0");
-  return `${year}${month}${day}${hours}${minutes}`;
+  const seconds = String(d.getSeconds()).padStart(2, "0");
+  return `${year}${month}${day}${hours}${minutes}${seconds}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes #1031: history snapshot filenames used `YYYYMMDDHHmm` (minute-level precision), causing overwrite collisions when multiple saves occurred within the same minute.
- Changed `formatTimestamp` in `lib/services/history-service.ts` to output `YYYYMMDDHHmmss`, adding second-level precision.
- No API or interface changes — purely internal filename format update.

## Test plan

- [ ] Save a file multiple times within the same minute and verify distinct snapshot files are created (no overwrites).
- [ ] Verify existing snapshots with the old format remain readable in the history panel.
- [ ] Run `npx tsc --noEmit` — passes with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)