### PR TITLE
fix(electron): remove terminated PTY sessions from registry (#1025)

### DIFF
--- a/electron/ipc/pty-ipc.js
+++ b/electron/ipc/pty-ipc.js
@@ -21,6 +21,7 @@ const {
   appendToOutputBuffer,
   addSession,
   getSession,
+  removeSession,
   killSession,
 } = require("./terminal-session-registry");
 
@@ -195,6 +196,10 @@ function registerPtyHandlers() {
       entry.status = "exited";
       entry.exitCode = exitCode;
       sendPtyExit(webContentsId, entry.sessionId, exitCode);
+      removeSession(entry.sessionId);
+      console.log(
+        `[PTY] Session ${entry.sessionId} exited (code=${exitCode}), removed from registry`,
+      );
     });
 
     console.log(`[PTY] Spawned session ${entry.sessionId} (shell=${shell}, cwd=${cwd})`);
@@ -312,7 +317,8 @@ function registerPtyHandlers() {
     }
 
     killSession(sessionId);
-    console.log(`[PTY] Killed session ${sessionId}`);
+    removeSession(sessionId);
+    console.log(`[PTY] Killed and removed session ${sessionId}`);
     return { ok: true };
   });
 


### PR DESCRIPTION
## Summary

- Call `removeSession()` in the PTY `onExit` handler so naturally-exited sessions are immediately purged from the registry after the exit notification is sent to the renderer
- Call `removeSession()` in the `pty:kill` IPC handler after `killSession()` succeeds, so explicitly-killed sessions are also pruned

Fixes #1025

## Root Cause

`removeSession()` existed in `terminal-session-registry.js` but was never called anywhere. Dead sessions accumulated in the registry indefinitely until the global limit (`MAX_SESSIONS_GLOBAL = 20`) was hit, preventing any new terminal from being opened.

## Changes

- `electron/ipc/pty-ipc.js`: Import `removeSession` and call it in:
  1. `ptyProcess.onExit()` handler — after marking session as `exited` and sending exit event to renderer
  2. `pty:kill` IPC handler — after `killSession()` completes successfully

## Test plan

- [ ] Open a terminal, run a command that exits (e.g. `exit`), verify the session count drops
- [ ] Repeatedly open and close terminals (>20 times) — new terminals should open successfully without hitting the global limit
- [ ] Use `pty:kill` to terminate a session, verify it is removed from the registry
- [ ] Verify `pty:attach` on a killed/exited session correctly returns `{ error: "セッションが見つかりません: ..." }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)