### PR TITLE
fix(electron): use queue for pending file paths instead of single slot (#1039)

### DIFF
--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -251,14 +251,15 @@ async function handleMdiFileOpen(filePath) {
 // --- Pull-model pending file handler ---
 // Renderer calls this after hooks are mounted, eliminating the race condition
 // with the old did-finish-load push model.
-let pendingFilePath = null;
+// Use a queue so multiple open requests before window-ready are all preserved.
+let pendingFilePaths = [];
 
 function getPendingFilePath() {
-  return pendingFilePath;
+  return pendingFilePaths.length > 0 ? pendingFilePaths[0] : null;
 }
 
 function setPendingFilePath(p) {
-  pendingFilePath = p;
+  pendingFilePaths.push(p);
 }
 
 function registerFileHandlers() {
@@ -443,36 +444,40 @@ function registerFileHandlers() {
   });
 
   ipcMain.handle("get-pending-file", async (event) => {
-    if (!pendingFilePath) return null;
+    if (pendingFilePaths.length === 0) return [];
 
-    const filePath = pendingFilePath;
-    pendingFilePath = null;
+    // Drain the queue and resolve each path
+    const paths = pendingFilePaths.slice();
+    pendingFilePaths = [];
 
-    try {
-      const dirPath = path.dirname(filePath);
-      const projectRoot = await findProjectRoot(dirPath);
+    const results = [];
+    for (const filePath of paths) {
+      try {
+        const dirPath = path.dirname(filePath);
+        const projectRoot = await findProjectRoot(dirPath);
 
-      if (projectRoot) {
-        const relativePath = path.relative(projectRoot, filePath);
-        return {
-          type: "project",
-          projectPath: projectRoot,
-          initialFile: relativePath,
-        };
+        if (projectRoot) {
+          const relativePath = path.relative(projectRoot, filePath);
+          results.push({
+            type: "project",
+            projectPath: projectRoot,
+            initialFile: relativePath,
+          });
+        } else {
+          // Standalone file: approve path for future saves, scoped to the requesting window
+          approveDialogPath(event.sender.id, path.resolve(filePath));
+          const content = await fs.readFile(filePath, "utf-8");
+          results.push({
+            type: "standalone",
+            path: filePath,
+            content,
+          });
+        }
+      } catch (err) {
+        log.error("get-pending-file failed:", err);
       }
-
-      // Standalone file: approve path for future saves, scoped to the requesting window
-      approveDialogPath(event.sender.id, path.resolve(filePath));
-      const content = await fs.readFile(filePath, "utf-8");
-      return {
-        type: "standalone",
-        path: filePath,
-        content,
-      };
-    } catch (err) {
-      log.error("get-pending-file failed:", err);
-      return null;
     }
+    return results;
   });
 
   // Clean up per-window approved paths when a BrowserWindow is closed/destroyed.

--- a/lib/editor-page/use-editor-lifecycle.ts
+++ b/lib/editor-page/use-editor-lifecycle.ts
@@ -83,14 +83,16 @@ export function useEditorLifecycle({
     const api = window.electronAPI;
     if (!api?.getPendingFile) return;
 
-    void api.getPendingFile().then((result) => {
-      if (!result) return;
+    void api.getPendingFile().then((results) => {
+      if (!results || results.length === 0) return;
 
-      if (result.type === "project") {
-        void handleOpenAsProject(result.projectPath, result.initialFile);
-      } else {
-        tabLoadSystemFile(result.path, result.content);
-        incrementEditorKey();
+      for (const result of results) {
+        if (result.type === "project") {
+          void handleOpenAsProject(result.projectPath, result.initialFile);
+        } else {
+          tabLoadSystemFile(result.path, result.content);
+          incrementEditorKey();
+        }
       }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -38,9 +38,10 @@ declare global {
       callback: (payload: { projectPath: string; initialFile: string }) => void,
     ) => (() => void) | void;
     getPendingFile?: () => Promise<
-      | { type: "project"; projectPath: string; initialFile: string }
-      | { type: "standalone"; path: string; content: string }
-      | null
+      Array<
+        | { type: "project"; projectPath: string; initialFile: string }
+        | { type: "standalone"; path: string; content: string }
+      >
     >;
     onMenuNew?: (callback: () => void) => (() => void) | void;
     onMenuOpen?: (callback: () => void) => (() => void) | void;


### PR DESCRIPTION
## Summary

- Replaces the single `pendingFilePath` variable with a `pendingFilePaths` array queue in `electron/ipc/file-ipc.js`
- `setPendingFilePath` now pushes to the array instead of overwriting, preserving all open requests that arrive before the window is ready
- `get-pending-file` IPC handler drains the entire queue and returns an array of resolved file results
- Updates `use-editor-lifecycle.ts` to iterate over the returned array, opening all queued files
- Updates `types/electron.d.ts` to reflect the new array return type

Closes #1039

## Test plan

- [ ] Open a single `.mdi` file from Finder — verify it opens as before
- [ ] Open multiple `.mdi` files before the window is ready (e.g., double-click several files rapidly at launch) — verify all files open, not just the last one
- [ ] Verify the fix does not interfere with PR #1038 (`isProjectDirectory` changes in same file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)