### PR TITLE
fix(tab-manager): add conflict guard to window-close save path (#1011)

### DIFF
--- a/lib/tab-manager/use-electron-menu-bindings.ts
+++ b/lib/tab-manager/use-electron-menu-bindings.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { saveMdiFile } from "../project/mdi-file";
 import { getVFS } from "../vfs";
 import { suppressFileWatch } from "../services/file-watcher";
+import { notificationManager } from "../services/notification-manager";
 import type { SupportedFileExtension } from "../project/project-types";
 import type { TabId, TabState, EditorTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
@@ -100,6 +101,15 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
       for (const tab of tabsRef.current) {
         if (!isEditorTab(tab)) continue;
         if (!tab.isDirty) continue;
+
+        // Block save if tab has unresolved external conflict
+        if (tab.fileSyncStatus === "conflicted") {
+          notificationManager.warning(
+            `「${tab.file?.name ?? "無題"}」のファイルが外部で変更されています。コンフリクトを解決してから保存してください。`,
+          );
+          anyFailed = true;
+          continue;
+        }
 
         const sanitized = sanitizeMdiContent(tab.content);
 


### PR DESCRIPTION
## Summary

- Adds `fileSyncStatus === "conflicted"` guard to the Electron window-close save path in `use-electron-menu-bindings.ts`
- Imports `notificationManager` (was missing from this file)
- When a conflicted tab is encountered during save-before-close, a warning notification is shown and the window close is aborted (`anyFailed = true`) so the user can resolve the conflict first
- The close-tab dialog path (`use-close-dialog.ts`) was already guarded in a prior commit

Closes #1011

## Test plan

- [ ] Open a file in Electron, trigger an external file change while the tab is dirty to enter conflicted state
- [ ] Try to close the window — verify it stays open and shows a warning notification
- [ ] Resolve the conflict, then close the window — verify it saves and closes normally
- [ ] Verify close-tab "Save" button also blocks conflicted tabs (existing guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)