### PR TITLE
fix: batch bug fixes (#1061, #1069, #1076, #1077)

### DIFF
--- a/lib/editor-page/use-power-saving.ts
+++ b/lib/editor-page/use-power-saving.ts
@@ -44,7 +44,8 @@ export function usePowerSaving({
     return () => {
       unsubscribe();
     };
-    // Re-run when the user toggles autoPowerSaveOnBattery in settings.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [autoPowerSaveOnBattery]);
+    // Re-run when autoPowerSaveOnBattery changes or when the callback identity
+    // changes (i.e. when the caller's useCallback deps — lintingEnabled,
+    // lintingRuleConfigs, llmEnabled — are updated).
+  }, [autoPowerSaveOnBattery, onPowerSaveModeChange]);
 }

--- a/lib/hooks/use-speech.ts
+++ b/lib/hooks/use-speech.ts
@@ -75,6 +75,9 @@ export function useSpeech(config?: SpeechConfig): {
   const onBoundaryRef = useRef<SpeechCallbacks["onBoundary"]>(undefined);
   const onEndRef = useRef<SpeechCallbacks["onEnd"]>(undefined);
   const onSegmentStartRef = useRef<SegmentCallbacks["onSegmentStart"]>(undefined);
+  // Flag set during stop() so cancel-triggered onend/onerror events are ignored.
+  // This prevents stop() from being mistaken for natural completion by continuation logic.
+  const isStoppingRef = useRef(false);
 
   // Detect support on the client after mount (window is not available during SSR).
   useEffect(() => {
@@ -117,12 +120,16 @@ export function useSpeech(config?: SpeechConfig): {
 
     utterance.onend = () => {
       setState({ isPlaying: false, isPaused: false, isSupported: true });
-      onEndRef.current?.();
+      if (!isStoppingRef.current) {
+        onEndRef.current?.();
+      }
     };
 
     utterance.onerror = () => {
       setState({ isPlaying: false, isPaused: false, isSupported: true });
-      onEndRef.current?.();
+      if (!isStoppingRef.current) {
+        onEndRef.current?.();
+      }
     };
 
     utterance.onpause = () => {
@@ -173,7 +180,9 @@ export function useSpeech(config?: SpeechConfig): {
       u.onerror = () => {
         window.speechSynthesis.cancel();
         setState({ isPlaying: false, isPaused: false, isSupported: true });
-        onEndRef.current?.();
+        if (!isStoppingRef.current) {
+          onEndRef.current?.();
+        }
       };
       return u;
     });
@@ -181,7 +190,9 @@ export function useSpeech(config?: SpeechConfig): {
     // Only the last utterance's onend resets state and fires callback
     utterances[utterances.length - 1].onend = () => {
       setState({ isPlaying: false, isPaused: false, isSupported: true });
-      onEndRef.current?.();
+      if (!isStoppingRef.current) {
+        onEndRef.current?.();
+      }
     };
 
     // Queue all utterances — speechSynthesis plays them in order
@@ -202,9 +213,15 @@ export function useSpeech(config?: SpeechConfig): {
 
   const stop = useCallback(() => {
     if (typeof window !== "undefined" && "speechSynthesis" in window) {
+      // Set the flag BEFORE cancel() so any synchronously-fired onend/onerror
+      // events know this was a user stop, not natural completion.
+      isStoppingRef.current = true;
       window.speechSynthesis.cancel();
       setState((prev) => ({ ...prev, isPlaying: false, isPaused: false }));
-      onEndRef.current?.();
+      // Reset the flag after a microtask so async event handlers are also covered.
+      Promise.resolve().then(() => {
+        isStoppingRef.current = false;
+      });
     }
   }, []);
 

--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -354,7 +354,7 @@ export class ProjectService {
         throw new Error("ファイル選択がキャンセルされました。");
       }
 
-      const fileName = result.path.split("/").pop() ?? result.path;
+      const fileName = result.path.split(/[/\\]/).pop() ?? result.path;
       const fileExtension = this.getFileExtension(fileName);
 
       // Electron does not have FileSystemFileHandle, so we create a minimal shim.

--- a/lib/storage/local-preferences.ts
+++ b/lib/storage/local-preferences.ts
@@ -28,13 +28,18 @@ function migrateOldKeys(): void {
     // "illusions:sidebar-top-order" === KEYS.sidebarTopOrder
     // "illusions:sidebar-bottom-order" === KEYS.sidebarBottomOrder
   ];
-  for (const [oldKey, newKey] of migrations) {
-    if (oldKey === newKey) continue;
-    const value = localStorage.getItem(oldKey);
-    if (value !== null && localStorage.getItem(newKey) === null) {
-      localStorage.setItem(newKey, value);
-      localStorage.removeItem(oldKey);
+  try {
+    for (const [oldKey, newKey] of migrations) {
+      if (oldKey === newKey) continue;
+      const value = localStorage.getItem(oldKey);
+      if (value !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, value);
+        localStorage.removeItem(oldKey);
+      }
     }
+  } catch {
+    // localStorage may throw SecurityError in private browsing or sandboxed contexts;
+    // silently skip migration rather than crashing the module.
   }
 }
 
@@ -43,12 +48,20 @@ migrateOldKeys();
 
 function get(key: string): string | null {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem(key);
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
 }
 
 function set(key: string, value: string): void {
   if (typeof window === "undefined") return;
-  localStorage.setItem(key, value);
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Silently ignore write failures (e.g. SecurityError, QuotaExceededError).
+  }
 }
 
 export type ThemeMode = "light" | "dark" | "auto";


### PR DESCRIPTION
## Summary

4つの独立したバグを並列サブエージェントで修正し、まとめて1つの PR にしています。

### 修正一覧

| Issue | タイトル | ファイル |
|-------|---------|---------|
| #1061 | Windows standalone open の fileName にフルパスが残る | `lib/project/project-service.ts` |
| #1069 | `local-preferences` の import 時 localStorage migration が Web で startup crash | `lib/storage/local-preferences.ts` |
| #1076 | `usePowerSaving()` が stale callback で古い AI 設定に巻き戻す | `lib/editor-page/use-power-saving.ts` |
| #1077 | TTS の `stop()` が `onEnd` を誤発火し continuation が暴走 | `lib/hooks/use-speech.ts` |

### 変更詳細

**#1061** — `split("/")` を `split(/[/\\]/)` に変更。Windows のバックスラッシュ区切りパスにも対応。

**#1069** — `localStorage` への全アクセスを try/catch で保護。`SecurityError` などが発生してもモジュール評価が失敗しないよう修正。

**#1076** — `usePowerSaving` の `useEffect` 依存配列に `onPowerSaveModeChange` を追加。`eslint-disable` コメントを削除し、常に最新の callback で再購読するよう修正。

**#1077** — `stop()` に `isStoppingRef` フラグを追加。`cancel()` 後の `onend`/`onerror` ハンドラはこのフラグを確認し、ユーザー停止時は `onEnd` を呼ばないよう修正。

## Test plan
- [ ] #1061: Windows で standalone open し、タブタイトルに basename のみ表示されることを確認
- [ ] #1069: プライベートモード / storage 無効環境でアプリが起動することを確認
- [ ] #1076: バッテリー→AC 切替後、AI 設定が正しく復帰することを確認
- [ ] #1077: 読み上げ中に停止しても次 chunk が開始しないことを確認

Closes #1061
Closes #1069
Closes #1076
Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)