### PR TITLE
fix: standalone/upgrade/permission bug batch (#1109, #1110, #1111, #1113, #1114)

### DIFF
--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -24,6 +24,10 @@ interface UseFileOpeningParams {
   loadProjectContent: (project: ProjectMode) => Promise<void>;
   /** Read project.json from a restored directory handle and enter project mode */
   openRestoredProject: (handle: FileSystemDirectoryHandle) => Promise<void>;
+  /** Load a file into the tab manager by path and content */
+  tabLoadSystemFile: (path: string, content: string) => void;
+  /** Increment editor key to force editor remount */
+  incrementEditorKey: () => void;
 }
 
 export interface UseFileOpeningResult {
@@ -53,6 +57,8 @@ export function useFileOpening({
   signalVfsReady,
   loadProjectContent,
   openRestoredProject,
+  tabLoadSystemFile,
+  incrementEditorKey,
 }: UseFileOpeningParams): UseFileOpeningResult {
   const handleOpenProject = useCallback(async () => {
     try {
@@ -82,11 +88,19 @@ export function useFileOpening({
       const projectService = getProjectService();
       const standalone = await projectService.openStandaloneFile();
       setStandaloneMode(standalone);
+
+      // Load file content into the tab manager so the editor shows the file contents
+      const content = await projectService.readStandaloneContent(standalone);
+      const tabPath = standalone.filePath ?? standalone.fileName;
+      tabLoadSystemFile(tabPath, content);
+      incrementEditorKey();
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;
+      if (error instanceof Error && error.message.includes("キャンセル")) return;
       console.error("Failed to open file:", error);
+      notificationManager.error("ファイルを開けませんでした。");
     }
-  }, [setStandaloneMode]);
+  }, [setStandaloneMode, tabLoadSystemFile, incrementEditorKey]);
 
   const handleOpenRecentProject = useCallback(
     async (projectId: string) => {

--- a/lib/editor-page/use-permissions.ts
+++ b/lib/editor-page/use-permissions.ts
@@ -25,10 +25,16 @@ export function usePermissions(
 
   const handlePermissionGranted = useCallback(() => {
     if (permissionPromptData) {
-      void openRestoredProject(permissionPromptData.handle);
+      const handle = permissionPromptData.handle;
+      // Dismiss the prompt immediately so the UI is unblocked, then open the project.
+      // Errors are surfaced inside openRestoredProject via notificationManager.
+      setShowPermissionPrompt(false);
+      setPermissionPromptData(null);
+      void openRestoredProject(handle);
+    } else {
+      setShowPermissionPrompt(false);
+      setPermissionPromptData(null);
     }
-    setShowPermissionPrompt(false);
-    setPermissionPromptData(null);
   }, [permissionPromptData, openRestoredProject]);
 
   const handlePermissionDenied = useCallback(() => {

--- a/lib/editor-page/use-project-initialization.ts
+++ b/lib/editor-page/use-project-initialization.ts
@@ -111,6 +111,7 @@ export function useProjectInitialization({
         }
       } catch (error) {
         console.error("Failed to load restored project:", error);
+        notificationManager.error("プロジェクトを開けませんでした。");
       }
     },
     [setProjectMode, loadProjectContent, isElectron, isAutoRestoringRef],

--- a/lib/editor-page/use-project-lifecycle.ts
+++ b/lib/editor-page/use-project-lifecycle.ts
@@ -214,11 +214,22 @@ export function useProjectLifecycle(params: UseProjectLifecycleParams): UseProje
       const upgradeService = getProjectUpgradeService();
       const project = await upgradeService.upgradeToProject(editorMode, content);
       setProjectMode(project);
+      await loadProjectContent(project);
+
+      if (isElectron && project.rootPath) {
+        const storage = getStorageService();
+        await storage.addRecentProject({
+          id: project.projectId,
+          rootPath: project.rootPath,
+          name: project.name,
+        });
+        void window.electronAPI?.rebuildMenu?.();
+      }
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;
       console.error("Failed to upgrade to project:", error);
     }
-  }, [editorMode, content, setProjectMode]);
+  }, [editorMode, content, setProjectMode, loadProjectContent, isElectron]);
 
   return {
     state: {

--- a/lib/editor-page/use-project-lifecycle.ts
+++ b/lib/editor-page/use-project-lifecycle.ts
@@ -172,6 +172,8 @@ export function useProjectLifecycle(params: UseProjectLifecycleParams): UseProje
     signalVfsReady,
     loadProjectContent,
     openRestoredProject,
+    tabLoadSystemFile,
+    incrementEditorKey,
   });
 
   // Auto-restore the last opened project on startup

--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -379,6 +379,7 @@ export class ProjectService {
         fileName,
         fileExtension,
         editorSettings: getDefaultEditorSettings(fileExtension),
+        filePath: result.path,
       };
     }
 
@@ -468,6 +469,30 @@ export class ProjectService {
     const rootDirHandle = await this.getVFSDirectoryHandle(project);
     const mainFileHandle = await rootDirHandle.getFileHandle(project.metadata.mainFile);
     return mainFileHandle.read();
+  }
+
+  /**
+   * Read file content for a standalone mode file.
+   * スタンドアロンモードのファイル内容を読み込む。
+   *
+   * On Electron, reads via VFS using the absolute file path.
+   * On Web, reads from the FileSystemFileHandle.
+   *
+   * @param standalone - The standalone mode object returned by openStandaloneFile
+   * @returns The file content as text
+   */
+  async readStandaloneContent(standalone: StandaloneMode): Promise<string> {
+    if (isElectronRenderer() && standalone.filePath) {
+      const vfs = getVFS();
+      return vfs.readFile(standalone.filePath);
+    }
+
+    if (standalone.fileHandle) {
+      const file = await standalone.fileHandle.getFile();
+      return file.text();
+    }
+
+    throw new Error("ファイルの内容を読み込めませんでした。");
   }
 
   /**

--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -337,6 +337,19 @@ export class ProjectService {
   }
 
   /**
+   * Save only the project metadata (project.json) without touching the main file.
+   * メインファイルを変更せずに、プロジェクトメタデータ（project.json）だけを保存する。
+   *
+   * @param project - The project whose metadata should be persisted
+   */
+  async saveProjectMetadata(project: ProjectMode): Promise<void> {
+    const rootDirHandle = await this.getVFSDirectoryHandle(project);
+    const illusionsDir = await rootDirHandle.getDirectoryHandle(".illusions", { create: true });
+    const projectJsonHandle = await illusionsDir.getFileHandle("project.json", { create: true });
+    await projectJsonHandle.write(JSON.stringify(project.metadata, null, 2));
+  }
+
+  /**
    * Open a single file in standalone mode.
    * 単一ファイルをスタンドアロンモードで開く。
    *

--- a/lib/project/project-types.ts
+++ b/lib/project/project-types.ts
@@ -90,6 +90,8 @@ export interface StandaloneMode {
   fileName: string;
   fileExtension: SupportedFileExtension;
   editorSettings: EditorSettings;
+  /** Absolute file path (Electron only). Used for VFS read/write operations. */
+  filePath?: string;
 }
 
 /** Current editor mode (null when no file/project is open) */

--- a/lib/project/project-upgrade.ts
+++ b/lib/project/project-upgrade.ts
@@ -51,10 +51,17 @@ export class ProjectUpgradeService {
       editorSettings: standaloneMode.editorSettings,
     };
 
-    return {
+    const updatedProject: ProjectMode = {
       ...project,
       metadata: updatedMetadata,
     };
+
+    // Persist the updated editorSettings to .illusions/project.json so they
+    // survive the next load. Without this call, project.json would still
+    // contain the default editorSettings written by createProject().
+    await this.projectService.saveProjectMetadata(updatedProject);
+
+    return updatedProject;
   }
 }
 


### PR DESCRIPTION
## Summary

standalone → project upgrade フローと WelcomeScreen ファイル開封・権限フローの 5 件のバグをまとめて修正します。

### 修正一覧

| Issue | タイトル | ファイル |
|-------|---------|---------|
| #1109 | upgrade が editorSettings を project.json に保存しない | `lib/project/project-service.ts`, `lib/project/project-upgrade.ts` |
| #1110 | upgrade 後に recent projects へ追加されない | `lib/editor-page/use-project-lifecycle.ts` |
| #1113 | upgrade が project main file を tab へ読み込まない | `lib/editor-page/use-project-lifecycle.ts` |
| #1111 | WelcomeScreen「単一ファイルを開く」が内容を読み込まない | `lib/project/project-service.ts`, `lib/project/project-types.ts`, `lib/editor-page/use-file-opening.ts`, `lib/editor-page/use-project-lifecycle.ts` |
| #1114 | PermissionPrompt 許可後の open 失敗が silent failure | `lib/editor-page/use-permissions.ts`, `lib/editor-page/use-project-initialization.ts` |

### 変更詳細

**#1109** — `ProjectService` に `saveProjectMetadata()` を新設。`upgradeToProject()` 末尾で呼び出し、standaloneMode の `editorSettings` を `project.json` に永続化する。

**#1110 + #1113** — `handleUpgrade()` を `handleProjectCreated()` と同等に更新: `setProjectMode()` の後に `await loadProjectContent(project)` を呼んで main file を tab に反映 (#1113)、かつ Electron では `addRecentProject` + `rebuildMenu()` を実行 (#1110)。

**#1111** — `openStandaloneFile()` が `filePath` を `StandaloneMode` に追加して返すよう変更。`handleOpenStandaloneFile()` がファイル内容を読んで `tabLoadSystemFile()` で tab に流し込む。

**#1114** — `openRestoredProject()` の catch ブロックで `notificationManager.error(「プロジェクトを開けませんでした。」)` を呼び出し、silent failure を解消。`handlePermissionGranted()` は handle 参照を保持してから prompt をクリアするよう修正。

## Test plan
- [ ] #1109: standalone で設定を変更 → upgrade → 再オープン → editorSettings が維持されている
- [ ] #1110: standalone → upgrade → Open Recent に新 project が表示される
- [ ] #1113: standalone → upgrade → editor に project main file がロードされている
- [ ] #1111: WelcomeScreen「単一ファイルを開く」→ファイル選択 → 本文が tab に表示される
- [ ] #1114: 存在しない mainFile を持つ project でPermission grant → エラー通知が日本語で表示される

Closes #1109
Closes #1110
Closes #1111
Closes #1113
Closes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)