### PR TITLE
fix(conflict): set pendingExternalContent when adopting disk content from notification (#1122)

### DIFF
--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -156,6 +156,10 @@ function buildOnChanged(
                     isDirty: false,
                     fileSyncStatus: "clean",
                     conflictDiskContent: null,
+                    // Trigger live editor update via externalContent prop.
+                    // Without this, the tab state is updated but the active
+                    // editor instance continues to show the stale content.
+                    pendingExternalContent: diskContent,
                   } satisfies EditorTabState;
                 }),
               );


### PR DESCRIPTION
## Summary

- `use-file-watch-integration.ts` の「ディスクの内容を採用」アクションが `pendingExternalContent` をセットしていなかったため、タブの状態は更新されてもアクティブなエディタインスタンスには古い内容が残り続けるバグを修正
- `pendingExternalContent: diskContent` を追加し、clean タブの自動リロードパスと同様に `externalContent` prop 経由でライブエディタを更新するようにした
- 変更は1行追加（コメント含め4行）の最小限の修正

## Changes

- `lib/tab-manager/use-file-watch-integration.ts`: 「ディスクの内容を採用」の `setTabs` 呼び出しに `pendingExternalContent: diskContent` を追加

## Test plan

- [ ] ファイルをエディタで開き、内容を編集する（dirty 状態にする）
- [ ] 外部エディタでそのファイルを変更して保存する
- [ ] コンフリクト通知が表示されることを確認
- [ ] 「ディスクの内容を採用」をクリックする
- [ ] エディタがディスクの内容に更新されることを確認（修正前は古い内容のままだった）

Closes #1122

🤖 Generated with [Claude Code](https://claude.com/claude-code)