### PR TITLE
fix(diff-tab): apply disk content to editor view when accepting from diff tab (#1123)

### DIFF
--- a/lib/editor-page/use-diff-tabs.ts
+++ b/lib/editor-page/use-diff-tabs.ts
@@ -77,6 +77,10 @@ export function useDiffTabs({
           isDirty: false,
           fileSyncStatus: "clean",
           conflictDiskContent: null,
+          // Set pendingExternalContent so the live editor instance reflects the new content.
+          // EditorLayout passes this as externalContent prop to NovelEditor, which applies
+          // it via ProseMirror replaceAll and then clears it via onExternalContentApplied.
+          pendingExternalContent: diffTab.remoteContent,
         });
       }
 


### PR DESCRIPTION
## Summary

- `acceptDiskContent()` in `lib/editor-page/use-diff-tabs.ts` updated the tab state (`content`, `lastSavedContent`, `isDirty`, `fileSyncStatus`, `conflictDiskContent`) but never set `pendingExternalContent`
- Without `pendingExternalContent`, the live ProseMirror editor instance was not notified, leaving the editor stale while state appeared resolved
- Added `pendingExternalContent: diffTab.remoteContent` to the `updateTab` call so `EditorLayout` passes the value as `externalContent` to `NovelEditor`, which applies it via `replaceAll` and clears it via `onExternalContentApplied`

Closes #1123

## Test plan
- [ ] Open a file in an editor tab
- [ ] Trigger an external disk change to create a conflict diff tab
- [ ] In the diff tab, choose "ディスクの内容を採用"
- [ ] Verify the source editor tab now displays the disk content (not the old stale content)
- [ ] Verify `isDirty` is false and the tab is no longer in conflict state

🤖 Generated with [Claude Code](https://claude.com/claude-code)