### PR TITLE
fix(save): sync fileSyncStatus with isDirty after save completes (#1133)

### DIFF
--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -219,20 +219,20 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           suppressFileWatch(tab.file.path);
           await vfs.writeFile(tab.file.path, sanitized);
           setTabs((prev) =>
-            prev.map((t) =>
-              t.id === tabId && isEditorTab(t)
-                ? {
-                    ...t,
-                    lastSavedContent: sanitized,
-                    isDirty: sanitizeMdiContent(t.content) !== sanitized,
-                    lastSavedTime: Date.now(),
-                    lastSaveWasAuto: isAutoSave,
-                    isSaving: false,
-                    fileSyncStatus: "clean",
-                    conflictDiskContent: null,
-                  }
-                : t,
-            ),
+            prev.map((t) => {
+              if (t.id !== tabId || !isEditorTab(t)) return t;
+              const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+              return {
+                ...t,
+                lastSavedContent: sanitized,
+                isDirty: newIsDirty,
+                lastSavedTime: Date.now(),
+                lastSaveWasAuto: isAutoSave,
+                isSaving: false,
+                fileSyncStatus: newIsDirty ? "dirty" : "clean",
+                conflictDiskContent: null,
+              };
+            }),
           );
           await tryAutoSnapshot(tab.file.path, tab.file.name, sanitized);
           return;
@@ -246,21 +246,21 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
         if (result) {
           setTabs((prev) =>
-            prev.map((t) =>
-              t.id === tabId && isEditorTab(t)
-                ? {
-                    ...t,
-                    file: result.descriptor,
-                    lastSavedContent: sanitized,
-                    isDirty: sanitizeMdiContent(t.content) !== sanitized,
-                    lastSavedTime: Date.now(),
-                    lastSaveWasAuto: isAutoSave,
-                    isSaving: false,
-                    fileSyncStatus: "clean",
-                    conflictDiskContent: null,
-                  }
-                : t,
-            ),
+            prev.map((t) => {
+              if (t.id !== tabId || !isEditorTab(t)) return t;
+              const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+              return {
+                ...t,
+                file: result.descriptor,
+                lastSavedContent: sanitized,
+                isDirty: newIsDirty,
+                lastSavedTime: Date.now(),
+                lastSaveWasAuto: isAutoSave,
+                isSaving: false,
+                fileSyncStatus: newIsDirty ? "dirty" : "clean",
+                conflictDiskContent: null,
+              };
+            }),
           );
           if (!(await persistFileReference(result.descriptor, sanitized))) {
             notificationManager.warning(PERSIST_FAILURE_WARNING);


### PR DESCRIPTION
## Summary

- Both project-mode and non-project-mode save complete updaters in `lib/tab-manager/use-file-io.ts` unconditionally set `fileSyncStatus: "clean"` after a save.
- If editor content changes during the async save operation, `isDirty` correctly becomes `true` but `fileSyncStatus` remained `"clean"`, creating an inconsistent state.
- This inconsistency could allow the file-watcher auto-reload to overwrite unsaved edits.
- Fix: compute `newIsDirty` from the post-save content diff and set `fileSyncStatus: newIsDirty ? "dirty" : "clean"` in both updaters.

Closes #1133

## Test plan

- [ ] Save a file normally with no changes during save — `fileSyncStatus` should be `"clean"`, `isDirty` should be `false`
- [ ] Simulate content change during save (e.g., via rapid typing) — `fileSyncStatus` should be `"dirty"`, `isDirty` should be `true`
- [ ] Verify file-watcher does NOT auto-reload when `fileSyncStatus` is `"dirty"` after save
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)