### PR TITLE
fix(save-as): recalculate isDirty after async dialog completes (#1135)

### DIFF
--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -313,15 +313,28 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
       const result = await saveMdiFile({ descriptor, content: sanitized, fileType: tab.fileType });
 
       if (result) {
-        updateTab(tabId, {
-          file: result.descriptor,
-          lastSavedContent: sanitized,
-          isDirty: false,
-          lastSavedTime: Date.now(),
-          isSaving: false,
-          fileSyncStatus: "clean",
-          conflictDiskContent: null,
-        });
+        // Use functional updater to compare against the latest tab content at
+        // completion time, not at dialog-open time. Edits made while the async
+        // Save As dialog was open must not be silently marked as saved.
+        setTabs((prev) =>
+          prev.map((t) =>
+            t.id === tabId && isEditorTab(t)
+              ? (() => {
+                  const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+                  return {
+                    ...t,
+                    file: result.descriptor,
+                    lastSavedContent: sanitized,
+                    isDirty: newIsDirty,
+                    fileSyncStatus: newIsDirty ? "dirty" : "clean",
+                    lastSavedTime: Date.now(),
+                    isSaving: false,
+                    conflictDiskContent: null,
+                  };
+                })()
+              : t,
+          ),
+        );
         if (!(await persistFileReference(result.descriptor, sanitized))) {
           notificationManager.warning(PERSIST_FAILURE_WARNING);
         }
@@ -339,7 +352,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
     } finally {
       isSavingRef.current = false;
     }
-  }, [updateTab, persistFileReference, tryAutoSnapshot, tabsRef, activeTabIdRef]);
+  }, [updateTab, setTabs, persistFileReference, tryAutoSnapshot, tabsRef, activeTabIdRef]);
 
   /** Load a file by path + content into a new tab (or reuse/deduplicate) */
   const loadSystemFile = useCallback(


### PR DESCRIPTION
## Summary

- Fixes #1135: Save As unconditionally cleared dirty state after the async dialog, causing edits made during the dialog to be silently marked as saved.
- Replaced the `updateTab` call (which used stale pre-dialog content) with a `setTabs` functional updater that reads the latest `t.content` at completion time.
- `isDirty` is now recomputed as `sanitizeMdiContent(t.content) !== sanitized`; `fileSyncStatus` follows (`"dirty"` or `"clean"`).
- Same pattern already used in `saveFile` (#1132, #1133).

## Test plan

- [ ] Open a file and trigger Save As
- [ ] While the Save As dialog is open, type additional content
- [ ] Complete the Save As dialog
- [ ] Verify the editor shows the dirty indicator (unsaved changes) for the content typed during the dialog
- [ ] Verify that content typed before opening the dialog is correctly saved and not dirty
- [ ] Verify normal Save As (no edits during dialog) still marks state as clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)