### PR TITLE
fix(popout): sync buffer content to all matching tabs, not just active (#1146)

### DIFF
--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -194,7 +194,7 @@ export function useDockviewAdapter({
   // effect to re-run (which would duplicate addPanel calls).
   const [layoutReadyTick, setLayoutReadyTick] = useState(0);
 
-  const { tabs, activeTabId, switchTab, closeTab, cloneTab } = tabManager;
+  const { tabs, activeTabId, switchTab, closeTab, cloneTab, updateTab } = tabManager;
 
   // -- onReady callback -----------------------------------------------------
 
@@ -428,7 +428,7 @@ export function useDockviewAdapter({
     prevTabsRef.current = tabs;
     prevActiveTabRef.current = activeTabId;
     isSyncingRef.current = false;
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- dockviewApi triggers re-sync after onReady
+     
   }, [tabs, activeTabId, editorKey, searchOpenTrigger, searchInitialTerm, dockviewApi]);
 
   // -- Restore saved layout (separate effect to avoid sync effect interference) --
@@ -536,9 +536,16 @@ export function useDockviewAdapter({
     if (!electronAPI?.editor) return;
 
     const unsubSync = electronAPI.editor.onBufferSync((data) => {
-      // Another window changed a buffer — update if it's our active editor tab
-      const activeTab = tabs.find((t) => t.id === activeTabId);
-      if (data.bufferId === activeTabId && activeTab && isEditorTab(activeTab)) {
+      // Another window changed a buffer — update all matching tabs' state,
+      // and apply to the editor view only for the active tab.
+      for (const tab of tabs) {
+        if (tab.id === data.bufferId && isEditorTab(tab)) {
+          // Update tab state in memory regardless of active/inactive status
+          updateTab(tab.id, { content: data.content });
+        }
+      }
+      // Apply to editor view (ProseMirror) only when the active tab matches
+      if (data.bufferId === activeTabId) {
         tabSetContent(data.content);
       }
     });
@@ -551,7 +558,7 @@ export function useDockviewAdapter({
       if (typeof unsubSync === "function") unsubSync();
       if (typeof unsubClose === "function") unsubClose();
     };
-  }, [activeTabId, tabs, tabSetContent]);
+  }, [activeTabId, tabs, tabSetContent, updateTab]);
 
   // Broadcast content changes to other windows (editor tabs only)
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Root cause**: `onBufferSync` in `use-dockview-adapter.ts` only called `tabSetContent` when `data.bufferId === activeTabId`, so inactive tabs with the same buffer ID were never updated
- **Fix**: Iterate all tabs in `onBufferSync` and call `updateTab(tab.id, { content })` for every tab matching `bufferId`; restrict `tabSetContent` (editor view application) to the active tab only
- **Scope**: Minimal change — 1 file modified, existing `updateTab` helper reused

## Test plan

- [ ] Open the same `.mdi` file in both main window and a popout window
- [ ] Edit in the popout window; verify main window's tab state is updated even while that tab is inactive
- [ ] Switch to the previously inactive tab in main window; verify content is current (not stale)
- [ ] Verify the active tab still receives live editor updates correctly
- [ ] `npx tsc --noEmit` passes with no errors

Fixes #1146

🤖 Generated with [Claude Code](https://claude.com/claude-code)