### PR TITLE
fix(auth): wrap sessionStorage access in try/catch for OAuth PKCE (#1072)

### DIFF
--- a/lib/auth/web-auth.ts
+++ b/lib/auth/web-auth.ts
@@ -4,6 +4,30 @@ const OAUTH_PROVIDER_URL = "https://my.illusions.app";
 const OAUTH_CLIENT_ID = "illusions";
 const PENDING_AUTH_KEY = "illusions:oauth_pending";
 
+function safeSessionStorageGet(key: string): string | null {
+  try {
+    return sessionStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function safeSessionStorageSet(key: string, value: string): void {
+  try {
+    sessionStorage.setItem(key, value);
+  } catch {
+    // Ignore errors (e.g. storage quota exceeded, private browsing restrictions)
+  }
+}
+
+function safeSessionStorageRemove(key: string): void {
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // Ignore errors
+  }
+}
+
 function toBase64Url(buffer: ArrayBuffer | Uint8Array): string {
   const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
   let binary = "";
@@ -32,7 +56,7 @@ export async function startWebLogin(): Promise<void> {
   const codeChallenge = await generateCodeChallenge(codeVerifier);
   const redirectUri = `${window.location.origin}/auth/callback/`;
 
-  sessionStorage.setItem(PENDING_AUTH_KEY, JSON.stringify({ state, codeVerifier }));
+  safeSessionStorageSet(PENDING_AUTH_KEY, JSON.stringify({ state, codeVerifier }));
 
   const params = new URLSearchParams({
     response_type: "code",
@@ -49,9 +73,9 @@ export async function startWebLogin(): Promise<void> {
 
 /** Read and consume the pending auth data stored before the redirect. */
 export function consumePendingAuth(): { state: string; codeVerifier: string } | null {
-  const raw = sessionStorage.getItem(PENDING_AUTH_KEY);
+  const raw = safeSessionStorageGet(PENDING_AUTH_KEY);
   if (!raw) return null;
-  sessionStorage.removeItem(PENDING_AUTH_KEY);
+  safeSessionStorageRemove(PENDING_AUTH_KEY);
   try {
     return JSON.parse(raw) as { state: string; codeVerifier: string };
   } catch {


### PR DESCRIPTION
## Summary

- `lib/auth/web-auth.ts` の `sessionStorage` アクセスを全て try/catch でラップする3つのヘルパー関数 (`safeSessionStorageGet`, `safeSessionStorageSet`, `safeSessionStorageRemove`) を追加
- `startWebLogin()` の `sessionStorage.setItem` を `safeSessionStorageSet` に置換
- `consumePendingAuth()` の `sessionStorage.getItem` / `sessionStorage.removeItem` を対応するsafe関数に置換
- `app/auth/callback/page.tsx` はすでに `consumePendingAuth()` の `null` 返却を適切に処理しているため変更不要

Closes #1072

## Test plan

- [ ] プライベートブラウジングモードで OAuth ログインフローを試行 — 例外が発生せずエラーメッセージが表示されること
- [ ] 通常モードで OAuth ログインフローが正常に完了すること
- [ ] `npx tsc --noEmit` がエラーなしで通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)