### PR TITLE
fix(auth): clear pending OAuth state only after successful token exchange (#1087)

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { consumePendingAuth } from "@/lib/auth/web-auth";
+import { getPendingAuth, clearPendingAuth } from "@/lib/auth/web-auth";
 
 function AuthCallbackContent() {
   const searchParams = useSearchParams();
@@ -28,7 +28,7 @@ function AuthCallbackContent() {
       return;
     }
 
-    const pending = consumePendingAuth();
+    const pending = getPendingAuth();
     if (!pending || pending.state !== state) {
       queueMicrotask(() => setError("認証セッションが無効です。もう一度ログインしてください。"));
       return;
@@ -52,6 +52,7 @@ function AuthCallbackContent() {
           return;
         }
 
+        clearPendingAuth();
         window.location.href = "/";
       } catch {
         setError("ログイン処理中にエラーが発生しました。");

--- a/electron/ipc/auth-ipc.js
+++ b/electron/ipc/auth-ipc.js
@@ -43,7 +43,6 @@ function registerAuthHandlers() {
       throw new Error("Invalid state parameter");
     }
     const { codeVerifier } = pendingAuth;
-    pendingAuth = null;
 
     const response = await fetch(`${PROVIDER_URL}/api/oauth/token`, {
       method: "POST",
@@ -61,6 +60,8 @@ function registerAuthHandlers() {
       const err = await response.json().catch(() => ({}));
       throw new Error(err.error_description || "Token exchange failed");
     }
+
+    pendingAuth = null;
     return response.json();
   });
 

--- a/lib/auth/web-auth.ts
+++ b/lib/auth/web-auth.ts
@@ -71,14 +71,18 @@ export async function startWebLogin(): Promise<void> {
   window.location.href = `${OAUTH_PROVIDER_URL}/api/oauth/authorize?${params}`;
 }
 
-/** Read and consume the pending auth data stored before the redirect. */
-export function consumePendingAuth(): { state: string; codeVerifier: string } | null {
+/** Read the pending auth data stored before the redirect without removing it. */
+export function getPendingAuth(): { state: string; codeVerifier: string } | null {
   const raw = safeSessionStorageGet(PENDING_AUTH_KEY);
   if (!raw) return null;
-  safeSessionStorageRemove(PENDING_AUTH_KEY);
   try {
     return JSON.parse(raw) as { state: string; codeVerifier: string };
   } catch {
     return null;
   }
+}
+
+/** Remove the pending auth data after a successful token exchange. */
+export function clearPendingAuth(): void {
+  sessionStorage.removeItem(PENDING_AUTH_KEY);
 }


### PR DESCRIPTION
## Summary

- `consumePendingAuth()` を `getPendingAuth()`（読み取り専用）と `clearPendingAuth()`（明示的削除）に分割
- Web コールバックページでは、トークン交換成功後にのみ `clearPendingAuth()` を呼び出すよう変更
- Electron IPC ハンドラでは、`response.ok` 確認後に `pendingAuth = null` を移動
- 一時的なネットワーク/サーバーエラー発生時にリトライできるよう `codeVerifier` を保持

## Root Cause

`consumePendingAuth()` は sessionStorage からデータを即削除していた。token exchange が一時的に失敗すると、リトライに必要な `codeVerifier` が失われ、再認証が必要になっていた。同様に Electron 側では fetch 前に `pendingAuth = null` していた。

## Fix

delete-after-success パターンを採用:
- `lib/auth/web-auth.ts`: `consumePendingAuth` → `getPendingAuth` + `clearPendingAuth` に分割
- `app/auth/callback/page.tsx`: exchange 成功後に `clearPendingAuth()` を呼び出す
- `electron/ipc/auth-ipc.js`: `response.ok` 確認後に `pendingAuth = null`

Closes #1087

## Test plan

- [ ] Web OAuth フローで正常ログインできることを確認
- [ ] token exchange が一時失敗した場合、リトライで成功できることを確認
- [ ] Electron OAuth フローで正常ログインできることを確認
- [ ] Electron で exchange 失敗後にリトライできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)