### PR TITLE
fix(storage): make WebStorageProvider.saveSession atomic using Dexie transaction (#1100)

### DIFF
--- a/lib/storage/web-storage.ts
+++ b/lib/storage/web-storage.ts
@@ -130,14 +130,38 @@ export class WebStorageProvider implements IStorageService {
     await this.initialize();
 
     try {
-      // すべてを並列で保存
-      await Promise.all([
-        this.saveAppState(session.appState),
-        this.saveRecentFiles(session.recentFiles),
-        session.editorBuffer
-          ? this.saveEditorBuffer(session.editorBuffer)
-          : this.clearEditorBuffer(),
-      ]);
+      // Dexie transaction で atomic に保存する（partial write を防ぐ）
+      await this.db.transaction(
+        "rw",
+        [this.db.appState, this.db.recentFiles, this.db.editorBuffer],
+        async () => {
+          // appState
+          await this.db.appState.put({
+            id: "app_state",
+            data: session.appState,
+          });
+
+          // recentFiles: 既存を全削除してから一括追加
+          await this.db.recentFiles.clear();
+          const recentRecords = session.recentFiles.map((file) => ({
+            id: `recent_${file.path}`,
+            path: file.path,
+            data: file,
+          }));
+          await this.db.recentFiles.bulkPut(recentRecords);
+
+          // editorBuffer
+          if (session.editorBuffer) {
+            await this.db.editorBuffer.put({
+              id: "editor_buffer",
+              data: session.editorBuffer,
+              fileHandle: session.editorBuffer.fileHandle,
+            });
+          } else {
+            await this.db.editorBuffer.delete("editor_buffer");
+          }
+        },
+      );
     } catch (error) {
       console.error("セッションの保存に失敗しました:", error);
       throw error;


### PR DESCRIPTION
## Summary

- `WebStorageProvider.saveSession()` の `Promise.all()` による並列書き込みを Dexie transaction に置き換え
- `appState`、`recentFiles`、`editorBuffer` の 3 テーブルをひとつの `rw` トランザクション内で書き込む
- いずれかの書き込みが失敗した場合、IndexedDB がトランザクション全体をロールバックし、セッションが半壊した状態にならない
- Electron 側（`ElectronStorageManager`）の BEGIN/COMMIT/ROLLBACK パターンを Web 側にも適用

Closes #1100

## Test plan

- [ ] Web 環境でセッション保存が正常に動作することを確認
- [ ] 保存途中に意図的に例外を投げた場合、DB が元の状態を保つことを確認
- [ ] `npx tsc --noEmit` がエラーなしで通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)