### PR TITLE
fix(electron): allow saving files with any extension if path was dialog-approved (#1059)

### DIFF
--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -154,27 +154,33 @@ function validateSaveFilePath(filePath, { skipApproval = false, webContentsId } 
     };
   }
 
-  // Validate file extension
-  const ext = path.extname(resolved).toLowerCase();
-  if (!VALID_SAVE_FILE_TYPES.includes(ext)) {
-    log.warn(`save-file path rejected (invalid extension "${ext}"): ${filePath}`);
-    return { success: false, error: `無効なファイル拡張子: ${ext}`, code: "INVALID_EXTENSION" };
+  // Check if this path was previously approved via dialog or system file open.
+  // Approval is scoped to the requesting window to prevent cross-window reuse.
+  // Dialog-approved paths bypass the extension check because the user already
+  // consented to the file (e.g. they opened a .json or .log file via the open dialog).
+  const windowPaths = webContentsId != null ? dialogApprovedPaths.get(webContentsId) : undefined;
+  const isApproved = skipApproval || (windowPaths != null && windowPaths.has(resolved));
+
+  // Validate file extension — skip for dialog-approved paths
+  if (!isApproved) {
+    const ext = path.extname(resolved).toLowerCase();
+    if (!VALID_SAVE_FILE_TYPES.includes(ext)) {
+      log.warn(`save-file path rejected (invalid extension "${ext}"): ${filePath}`);
+      return { success: false, error: `無効なファイル拡張子: ${ext}`, code: "INVALID_EXTENSION" };
+    }
   }
 
   // Reject paths not previously approved via dialog or system file open.
   // Approval is scoped to the requesting window to prevent cross-window reuse.
-  if (!skipApproval) {
-    const windowPaths = webContentsId != null ? dialogApprovedPaths.get(webContentsId) : undefined;
-    if (!windowPaths || !windowPaths.has(resolved)) {
-      log.warn(
-        `save-file path rejected (not dialog-approved for window ${webContentsId}): ${filePath}`,
-      );
-      return {
-        success: false,
-        error: "ダイアログで承認されていないファイルパスです",
-        code: "PATH_NOT_APPROVED",
-      };
-    }
+  if (!isApproved) {
+    log.warn(
+      `save-file path rejected (not dialog-approved for window ${webContentsId}): ${filePath}`,
+    );
+    return {
+      success: false,
+      error: "ダイアログで承認されていないファイルパスです",
+      code: "PATH_NOT_APPROVED",
+    };
   }
 
   return null;


### PR DESCRIPTION
## Summary

- Fixes #1059: Electron の open dialog でサポート外拡張子（`.json`, `.log` 等）を開いた後、同じパスに保存しようとすると `INVALID_EXTENSION` エラーで拒否されていた問題を修正。
- `validateSaveFilePath` 内で、拡張子チェックより前に `dialogApprovedPaths` の確認を行うよう順序を変更。ダイアログ承認済みパスは拡張子チェックをスキップする。
- セキュリティ境界は維持：未承認パスへの書き込みは引き続き拒否される。

## Root Cause

`validateSaveFilePath` の処理順序が原因：

1. ディレクトリトラバーサルチェック
2. **拡張子チェック** ← ここで `.json` 等を拒否（`dialogApprovedPaths` 確認前）
3. `dialogApprovedPaths` 確認

open dialog で承認されたパスでも、拡張子チェックが先に実行されるため保存できなかった。

## Fix

`isApproved = skipApproval || dialogApprovedPaths.has(resolved)` を先に計算し、承認済みの場合は拡張子チェックと未承認チェックの両方をスキップする。

## Test plan

- [ ] `.json` ファイルを open dialog で開く → 保存できることを確認
- [ ] `.log` ファイルを open dialog で開く → 保存できることを確認
- [ ] 未承認パスへの `.json` 保存は引き続き拒否されることを確認
- [ ] `.mdi`/`.md`/`.txt` の通常の保存フローが変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)