### PR TITLE
fix(storage): scope Web editor buffer key by file path to prevent cross-tab collision (#1064)

### DIFF
--- a/lib/storage/electron-storage.ts
+++ b/lib/storage/electron-storage.ts
@@ -96,19 +96,22 @@ export class ElectronStorageProvider implements IStorageService {
     return api.clearRecent();
   }
 
-  async saveEditorBuffer(buffer: EditorBuffer): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async saveEditorBuffer(buffer: EditorBuffer, _fileKey?: string): Promise<void> {
     await this.initialize();
     const api = this.getElectronAPI();
     return api.saveEditorBuffer(buffer);
   }
 
-  async loadEditorBuffer(): Promise<EditorBuffer | null> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async loadEditorBuffer(_fileKey?: string): Promise<EditorBuffer | null> {
     await this.initialize();
     const api = this.getElectronAPI();
     return api.loadEditorBuffer();
   }
 
-  async clearEditorBuffer(): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async clearEditorBuffer(_fileKey?: string): Promise<void> {
     await this.initialize();
     const api = this.getElectronAPI();
     return api.clearEditorBuffer();

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -247,18 +247,22 @@ export interface IStorageService {
 
   /**
    * エディタバッファ（未保存下書き）を保存する。
+   * @param buffer - 保存するバッファデータ
+   * @param fileKey - ファイルを識別するキー（省略時は "editor_buffer"）。Web 環境でのタブ間衝突を防ぐために使用する。
    */
-  saveEditorBuffer(buffer: EditorBuffer): Promise<void>;
+  saveEditorBuffer(buffer: EditorBuffer, fileKey?: string): Promise<void>;
 
   /**
    * エディタバッファを読み込む。
+   * @param fileKey - ファイルを識別するキー（省略時は "editor_buffer"）。saveEditorBuffer と同じ値を渡す。
    */
-  loadEditorBuffer(): Promise<EditorBuffer | null>;
+  loadEditorBuffer(fileKey?: string): Promise<EditorBuffer | null>;
 
   /**
    * エディタバッファを削除する。
+   * @param fileKey - ファイルを識別するキー（省略時は "editor_buffer"）。saveEditorBuffer と同じ値を渡す。
    */
-  clearEditorBuffer(): Promise<void>;
+  clearEditorBuffer(fileKey?: string): Promise<void>;
 
   /**
    * Add a project to the recent projects list.

--- a/lib/storage/web-storage.ts
+++ b/lib/storage/web-storage.ts
@@ -282,12 +282,13 @@ export class WebStorageProvider implements IStorageService {
     }
   }
 
-  async saveEditorBuffer(buffer: EditorBuffer): Promise<void> {
+  async saveEditorBuffer(buffer: EditorBuffer, fileKey?: string): Promise<void> {
     await this.initialize();
 
+    const id = fileKey ? `editor_buffer:${fileKey}` : "editor_buffer";
     try {
       await this.db.editorBuffer.put({
-        id: "editor_buffer",
+        id,
         data: buffer,
         fileHandle: buffer.fileHandle,
       });
@@ -297,11 +298,12 @@ export class WebStorageProvider implements IStorageService {
     }
   }
 
-  async loadEditorBuffer(): Promise<EditorBuffer | null> {
+  async loadEditorBuffer(fileKey?: string): Promise<EditorBuffer | null> {
     await this.initialize();
 
+    const id = fileKey ? `editor_buffer:${fileKey}` : "editor_buffer";
     try {
-      const stored = await this.db.editorBuffer.get("editor_buffer");
+      const stored = await this.db.editorBuffer.get(id);
       if (!stored?.data) return null;
 
       // fileHandle があれば復元する
@@ -316,11 +318,12 @@ export class WebStorageProvider implements IStorageService {
     }
   }
 
-  async clearEditorBuffer(): Promise<void> {
+  async clearEditorBuffer(fileKey?: string): Promise<void> {
     await this.initialize();
 
+    const id = fileKey ? `editor_buffer:${fileKey}` : "editor_buffer";
     try {
-      await this.db.editorBuffer.delete("editor_buffer");
+      await this.db.editorBuffer.delete(id);
     } catch (error) {
       console.error("エディタバッファの削除に失敗しました:", error);
       throw error;

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -84,11 +84,19 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         } else if (!isElectron && descriptor.handle) {
           const storage = getStorageService();
           await storage.initialize();
-          await storage.saveEditorBuffer({
-            content: fileContent,
-            timestamp: Date.now(),
-            fileHandle: descriptor.handle,
-          });
+          // Use the file name as the key to prevent cross-tab collisions when
+          // multiple browser tabs open different files simultaneously.
+          const fileKey = descriptor.handle.name;
+          await storage.saveEditorBuffer(
+            {
+              content: fileContent,
+              timestamp: Date.now(),
+              fileHandle: descriptor.handle,
+            },
+            fileKey,
+          );
+          // Record which fileKey this tab last used so restore can look it up.
+          await storage.setItem("last_editor_buffer_key", fileKey);
         }
         return true;
       } catch (error) {

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -152,8 +152,11 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
         let initialTab: EditorTabState | null = null;
 
         if (!skipAutoRestore && !isElectron && !savedEmpty) {
-          // Web: restore file handle from editor buffer
-          const buffer = await storage.loadEditorBuffer();
+          // Web: restore file handle from editor buffer.
+          // Look up the file key this tab last saved with to avoid loading
+          // another tab's buffer (cross-tab collision fix for #1064).
+          const lastFileKey = await storage.getItem("last_editor_buffer_key");
+          const buffer = await storage.loadEditorBuffer(lastFileKey ?? undefined);
           if (buffer?.fileHandle) {
             try {
               const file = await buffer.fileHandle.getFile();
@@ -176,7 +179,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
               setWasAutoRecovered(true);
             } catch (error) {
               console.warn("前回のファイルを復元できませんでした:", error);
-              await storage.clearEditorBuffer();
+              await storage.clearEditorBuffer(lastFileKey ?? undefined);
             }
           }
         }


### PR DESCRIPTION
## Summary

- `IStorageService` の `saveEditorBuffer` / `loadEditorBuffer` / `clearEditorBuffer` に optional `fileKey` パラメータを追加
- `WebStorageProvider`: `fileKey` 指定時は Dexie のレコード ID を `"editor_buffer:<fileKey>"` にすることで、別ブラウザタブが書き込んだバッファを上書きしないようにする
- `ElectronStorageProvider`: シグネチャを合わせつつ `fileKey` は無視（Electron は単一プロセスのためタブ間衝突が起きない）
- `use-file-io.ts`: `persistFileReference` で `fileHandle.name` を `fileKey` として渡し、同時に `"last_editor_buffer_key"` を KV ストアに記録する
- `use-tab-persistence.ts`: 復元時に `"last_editor_buffer_key"` を読み取ってから `loadEditorBuffer(key)` を呼ぶことで、自タブが最後に保存したバッファのみ復元する

Closes #1064

## Test plan

- [ ] Web standalone で 2 つのブラウザタブを開き、それぞれ別のファイルを開く
- [ ] 両タブでファイルを保存し、IndexedDB に `editor_buffer:<filename>` の形式でレコードが作成されていることを確認
- [ ] 各タブをリロードし、それぞれ正しいファイルが復元されることを確認（相互上書きがないこと）
- [ ] 新規ファイル（ハンドルなし）ではバッファ保存が行われないことを確認（既存の動作を維持）
- [ ] Electron でのファイル保存・復元が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)