### PR TITLE
fix(restore): do not create blank tab when all file-backed tabs fail to restore (#1140)

### DIFF
--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { getStorageService } from "../storage/storage-service";
 import { fetchAppState, persistAppState } from "../storage/app-state-manager";
 import type { TabState, SerializedTab, TabPersistenceState, EditorTabState } from "./tab-types";
@@ -18,6 +19,12 @@ export interface UseTabPersistenceParams extends TabManagerCore {
   skipAutoRestore: boolean;
   /** Promise that resolves once the VFS root is set (Electron only). */
   vfsReadyPromise?: Promise<void>;
+  /**
+   * Optional setter for surfacing a restore error to parent UI.
+   * Called when all file-backed tabs fail to restore so the session is not
+   * silently overwritten with a blank default tab.
+   */
+  setRestoreError?: Dispatch<SetStateAction<string | null>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,6 +62,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     isElectron,
     skipAutoRestore,
     vfsReadyPromise,
+    setRestoreError,
   } = params;
 
   const [wasAutoRecovered, setWasAutoRecovered] = useState(false);
@@ -274,6 +282,18 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
           const activeIdx = Math.min(openTabs.activeIndex, restoredTabs.length - 1);
           setActiveTabId(restoredTabs[activeIdx].id);
         } else {
+          // Check whether any of the saved tabs had a file path.
+          const hadFileBacked = openTabs.tabs.some((t) => Boolean(t.filePath));
+          if (hadFileBacked) {
+            // All file-backed tabs failed to restore — do NOT create a blank
+            // default tab, as that would overwrite the saved session on the
+            // next debounced persist. Surface an error instead so the UI can
+            // inform the user.
+            setRestoreError?.(
+              "前回開いていたファイルを復元できませんでした。ファイルが移動または削除された可能性があります。",
+            );
+            return;
+          }
           // Saved tabs were all untitled (no file path) — create a default tab.
           const defaultTab = createNewTab();
           setTabs((prev) => (prev.length > 0 ? prev : [defaultTab]));
@@ -288,7 +308,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     };
 
     void restoreTabs();
-  }, [isElectron, skipAutoRestore, setTabs, setActiveTabId, vfsReadyPromise]);
+  }, [isElectron, skipAutoRestore, setTabs, setActiveTabId, vfsReadyPromise, setRestoreError]);
 
   return { wasAutoRecovered, flushTabState };
 }


### PR DESCRIPTION
## Summary

- 全 file-backed tab の復元が失敗した場合、空のデフォルトタブを作成しないように修正
- 代わりに `setRestoreError` (optional callback) でエラーを通知し、早期 return でセッション保存を防止
- `restoredTabs.length === 0 && hadFileBacked` の条件分岐を追加

## Root Cause

`lib/tab-manager/use-tab-persistence.ts` の `restoreTabs` 関数で、保存済みの file-backed tabs が全て復元失敗した場合でも blank tab を作成していた。その blank tab が debounce 保存で元のセッションを上書きしてしまっていた。

## Fix

- `hadFileBacked` チェックを追加: 保存済み tabs に `filePath` を持つものがあるか判定
- 全て失敗 + file-backed だった場合は `setRestoreError` を呼び `return` して persist をスキップ
- `UseTabPersistenceParams` に optional な `setRestoreError` フィールドを追加

## Test plan

- [ ] Electron でファイルを開いた状態でアプリを終了
- [ ] そのファイルを削除/移動してからアプリを再起動
- [ ] 空タブが作られず、エラー通知が表示されること
- [ ] 再起動後のセッション保存に元の `openTabs` が残っていること

Closes #1140

🤖 Generated with [Claude Code](https://claude.com/claude-code)