### PR TITLE
fix(restore): check return value of handleOpenRecentProject to detect failures (#1139)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,8 +13,7 @@
       "Bash(git -C /Users/iktahana/Repositories/my.illusions.app status --short)",
       "Bash(git -C /Users/iktahana/Repositories/my.illusions.app branch --show-current)",
       "Bash(gh issue:*)",
-      "Bash(gh label:*)",
-      "Bash(gh repo:*)"
+      "Bash(gh label:*)"
     ]
   }
 }

--- a/lib/editor-page/use-auto-restore.ts
+++ b/lib/editor-page/use-auto-restore.ts
@@ -7,7 +7,7 @@ interface UseAutoRestoreParams {
   setIsRestoring: React.Dispatch<React.SetStateAction<boolean>>;
   setRestoreError: React.Dispatch<React.SetStateAction<string | null>>;
   signalVfsReady: () => void;
-  handleOpenRecentProject: (projectId: string) => Promise<void>;
+  handleOpenRecentProject: (projectId: string) => Promise<boolean>;
 }
 
 /**
@@ -35,8 +35,7 @@ export function useAutoRestore({
     void (async () => {
       let success = false;
       try {
-        await handleOpenRecentProject(autoRestoreProjectId);
-        success = true;
+        success = await handleOpenRecentProject(autoRestoreProjectId);
       } catch {
         // handleOpenRecentProject catches its own errors internally
       }

--- a/lib/editor-page/use-electron-events.ts
+++ b/lib/editor-page/use-electron-events.ts
@@ -35,7 +35,7 @@ interface UseElectronEventsParams {
   handleOpenProject: () => Promise<void>;
 
   // Open recent project from menu
-  handleOpenRecentProject: (projectId: string) => Promise<void>;
+  handleOpenRecentProject: (projectId: string) => Promise<boolean>;
 
   // Open as project (double-clicked .mdi in project dir)
   handleOpenAsProject: (projectPath: string, initialFile: string) => Promise<void>;
@@ -228,7 +228,7 @@ export function useElectronEvents(params: UseElectronEventsParams): void {
   useEffect(() => {
     if (!isElectron || typeof window === "undefined") return;
     const cleanup = window.electronAPI?.onMenuOpenRecentProject?.((projectId: string) => {
-      void confirmBeforeAction(() => handleOpenRecentProject(projectId));
+      void confirmBeforeAction(() => void handleOpenRecentProject(projectId));
     });
     return () => {
       cleanup?.();

--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -29,7 +29,7 @@ interface UseFileOpeningParams {
 export interface UseFileOpeningResult {
   handleOpenProject: () => Promise<void>;
   handleOpenStandaloneFile: () => Promise<void>;
-  handleOpenRecentProject: (projectId: string) => Promise<void>;
+  handleOpenRecentProject: (projectId: string) => Promise<boolean>;
   handleOpenAsProject: (projectPath: string, initialFile: string) => Promise<void>;
 }
 
@@ -89,7 +89,7 @@ export function useFileOpening({
   }, [setStandaloneMode]);
 
   const handleOpenRecentProject = useCallback(
-    async (projectId: string) => {
+    async (projectId: string): Promise<boolean> => {
       try {
         if (isElectron) {
           const storage = getStorageService();
@@ -99,7 +99,7 @@ export function useFileOpening({
             if (!isAutoRestoringRef.current) {
               notificationManager.error("このプロジェクトが見つかりませんでした。");
             }
-            return;
+            return false;
           }
 
           try {
@@ -124,7 +124,7 @@ export function useFileOpening({
                   message: `プロジェクトのメタデータが見つかりませんでした。\n\nパス: ${project.rootPath}\n\n最近のプロジェクト一覧から削除しますか?`,
                 });
               }
-              return;
+              return false;
             }
 
             const { metadata, illusionsDir } = projectJsonResult;
@@ -160,6 +160,7 @@ export function useFileOpening({
             if (!isAutoRestoringRef.current || !isElectron) {
               await loadProjectContent(restoredProject);
             }
+            return true;
           } catch (error) {
             signalVfsReady();
             console.error("Failed to load project:", error);
@@ -182,8 +183,8 @@ export function useFileOpening({
                 notificationManager.error(message);
               }
             }
+            return false;
           }
-          return;
         }
 
         // Web: restore from IndexedDB project handles
@@ -198,7 +199,7 @@ export function useFileOpening({
               "このプロジェクトを開けませんでした。「プロジェクトを開く」から再度選択してください。",
             );
           }
-          return;
+          return false;
         }
 
         if (restoreResult.permissionStatus.status === "prompt-required") {
@@ -208,12 +209,15 @@ export function useFileOpening({
             projectId,
           });
           setShowPermissionPrompt(true);
-          return;
+          // Permission prompt shown — outcome depends on user action, not a failure
+          return true;
         }
 
         await openRestoredProject(restoreResult.handle);
+        return true;
       } catch (error) {
         console.error("Failed to open recent project:", error);
+        return false;
       }
     },
     [

--- a/lib/editor-page/use-project-lifecycle.ts
+++ b/lib/editor-page/use-project-lifecycle.ts
@@ -47,7 +47,7 @@ export interface ProjectLifecycleHandlers {
   handleCreateProject: () => void;
   handleOpenProject: () => Promise<void>;
   handleOpenStandaloneFile: () => Promise<void>;
-  handleOpenRecentProject: (projectId: string) => Promise<void>;
+  handleOpenRecentProject: (projectId: string) => Promise<boolean>;
   handleDeleteRecentProject: (projectId: string) => Promise<void>;
   handleOpenAsProject: (projectPath: string, initialFile: string) => Promise<void>;
   handleProjectCreated: (project: ProjectMode) => Promise<void>;


### PR DESCRIPTION
## Summary

- `handleOpenRecentProject` の戻り値を `Promise<void>` から `Promise<boolean>` に変更
- プロジェクトが見つからない・読み込み失敗・Web復元失敗などの全エラー経路で `false` を返す
- 成功時は `true` を返す
- `useAutoRestore` で戻り値を確認して `success` を設定（await完了だけで成功扱いにするバグを修正）
- `use-auto-restore.ts`・`use-project-lifecycle.ts`・`use-electron-events.ts` の型シグネチャを更新

Closes #1139

## Test plan

- [ ] 存在するプロジェクトを最近のプロジェクトから開く → 正常に開ける
- [ ] 削除済みプロジェクトを最近から開く → エラーメッセージが表示される
- [ ] アプリ起動時の自動復元で失敗する場合 → `restoreError` が正しくセットされる
- [ ] アプリ起動時の自動復元で成功する場合 → エラーメッセージが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)