### PR TITLE
fix(history): create snapshot in save-before-close and close-tab save flows (#1137, #1138)

### DIFF
--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -65,6 +65,7 @@ export function useTabManager(options?: {
     setPendingCloseTabId: tabState.setPendingCloseTabId,
     updateTab: tabState.updateTab,
     forceCloseTab: tabState.forceCloseTab,
+    tryAutoSnapshot: fileIO.tryAutoSnapshot,
   });
 
   // --- Auto-save ----------------------------------------------------------
@@ -109,6 +110,7 @@ export function useTabManager(options?: {
     systemFileOpenHandlerRef,
     flushTabState: flushTabStateRef.current,
     flushLayoutState: options?.flushLayoutState,
+    tryAutoSnapshot: fileIO.tryAutoSnapshot,
   });
 
   // --- File watch integration (external change detection) -----------------

--- a/lib/tab-manager/use-close-dialog.ts
+++ b/lib/tab-manager/use-close-dialog.ts
@@ -23,6 +23,11 @@ export interface UseCloseDialogParams extends TabManagerCore {
   updateTab: (tabId: TabId, updates: Partial<EditorTabState>) => void;
   /** Force-close a tab without dirty check. */
   forceCloseTab: (tabId: TabId) => void;
+  /**
+   * Attempt to create a history snapshot after saving (project mode only).
+   * Provided by useFileIO.
+   */
+  tryAutoSnapshot: (sourcePath: string, displayName: string, savedContent: string) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -51,6 +56,7 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
     setPendingCloseTabId,
     updateTab,
     forceCloseTab,
+    tryAutoSnapshot,
   } = params;
 
   const handleCloseTabSave = useCallback(async () => {
@@ -77,6 +83,7 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
         const vfs = getVFS();
         suppressFileWatch(tab.file.path);
         await vfs.writeFile(tab.file.path, sanitized);
+        await tryAutoSnapshot(tab.file.path, tab.file.name, sanitized);
       } else {
         const result = await saveMdiFile({
           descriptor: tab.file,
@@ -95,6 +102,11 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
           fileSyncStatus: "clean",
           conflictDiskContent: null,
         });
+        await tryAutoSnapshot(
+          result.descriptor.path ?? result.descriptor.name,
+          result.descriptor.name,
+          sanitized,
+        );
       }
     } catch (error) {
       console.error("保存に失敗しました:", error);
@@ -106,7 +118,15 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
 
     forceCloseTab(pendingCloseTabId);
     setPendingCloseTabId(null);
-  }, [pendingCloseTabId, updateTab, forceCloseTab, tabsRef, isProjectRef, setPendingCloseTabId]);
+  }, [
+    pendingCloseTabId,
+    updateTab,
+    forceCloseTab,
+    tabsRef,
+    isProjectRef,
+    setPendingCloseTabId,
+    tryAutoSnapshot,
+  ]);
 
   const handleCloseTabDiscard = useCallback(() => {
     if (pendingCloseTabId) {

--- a/lib/tab-manager/use-electron-menu-bindings.ts
+++ b/lib/tab-manager/use-electron-menu-bindings.ts
@@ -36,6 +36,15 @@ export interface UseElectronMenuBindingsParams extends TabManagerCore {
   flushTabState?: () => Promise<void>;
   /** Immediately flush pending dockview layout to storage. */
   flushLayoutState?: () => Promise<void>;
+  /**
+   * Attempt to create a history snapshot after saving (project mode only).
+   * Provided by useFileIO.
+   */
+  tryAutoSnapshot?: (
+    sourcePath: string,
+    displayName: string,
+    savedContent: string,
+  ) => Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -67,6 +76,7 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
     systemFileOpenHandlerRef,
     flushTabState,
     flushLayoutState,
+    tryAutoSnapshot,
   } = params;
 
   // Stable refs for callbacks that change frequently
@@ -87,6 +97,8 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
   flushTabStateRef.current = flushTabState;
   const flushLayoutStateRef = useRef(flushLayoutState);
   flushLayoutStateRef.current = flushLayoutState;
+  const tryAutoSnapshotRef = useRef(tryAutoSnapshot);
+  tryAutoSnapshotRef.current = tryAutoSnapshot;
 
   // Save all dirty tabs before Electron window close
   useEffect(() => {
@@ -149,11 +161,17 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
             const vfs = getVFS();
             suppressFileWatch(tab.file.path);
             await vfs.writeFile(tab.file.path, sanitized);
+            await tryAutoSnapshotRef.current?.(tab.file.path, tab.file.name, sanitized);
           } else {
             await saveMdiFile({
               descriptor: tab.file,
               content: sanitized,
             });
+            await tryAutoSnapshotRef.current?.(
+              tab.file.path ?? tab.file.name,
+              tab.file.name,
+              sanitized,
+            );
           }
         } catch (error) {
           console.error(`保存に失敗しました (${tab.file.name}):`, error);


### PR DESCRIPTION
## Summary

- **#1137**: `onSaveBeforeClose` in `use-electron-menu-bindings.ts` now calls `tryAutoSnapshot` after each dirty tab is successfully saved before window close
- **#1138**: `handleCloseTabSave` in `use-close-dialog.ts` now calls `tryAutoSnapshot` after successfully saving before closing the tab
- `tryAutoSnapshot` is exported from `useFileIO` via `UseFileIOReturn` and passed down to both hooks through `useTabManager`

## Changes

- `lib/tab-manager/use-file-io.ts` — add `tryAutoSnapshot` to `UseFileIOReturn` and return it from the hook
- `lib/tab-manager/use-close-dialog.ts` — add `tryAutoSnapshot` param to `UseCloseDialogParams`; call it after each successful save path in `handleCloseTabSave`
- `lib/tab-manager/use-electron-menu-bindings.ts` — add optional `tryAutoSnapshot` param; store in a stable ref; call it after each save in `onSaveBeforeClose`
- `lib/tab-manager/index.ts` — pass `fileIO.tryAutoSnapshot` to both `useCloseDialog` and `useElectronMenuBindings`

## Test plan

- [ ] Open project, edit a file, then close the window — confirm a history snapshot is created
- [ ] Open project, edit a tab, then close the tab via the close button and click "保存" in the dialog — confirm a history snapshot is created
- [ ] Verify `npx tsc --noEmit` passes (confirmed clean)
- [ ] Non-project (single-file) mode: close flows should behave identically (snapshot is skipped since `isProjectRef.current === false`)

Closes #1137
Closes #1138

🤖 Generated with [Claude Code](https://claude.com/claude-code)