### PR TITLE
fix(pdf-export): use isolated session partition to prevent CSP hook leak (#1034)

### DIFF
--- a/lib/export/pdf-exporter.ts
+++ b/lib/export/pdf-exporter.ts
@@ -105,9 +105,11 @@ export async function generatePdf(content: string, options: PdfExportOptions): P
     typesetting,
   });
 
-  // Use an isolated partition so the CSP webRequest hook does not affect
-  // the shared default session. Each export gets a fresh in-memory session
-  // that is automatically cleaned up when the BrowserWindow is destroyed.
+  // Use a unique in-memory partition (no "persist:" prefix) per export so
+  // that the CSP webRequest hook is registered on a fresh, isolated session.
+  // The session is automatically GC'd when the BrowserWindow is destroyed,
+  // preventing hook accumulation on the shared default session (#1034).
+  const partition = `pdf-export-${Date.now()}`;
   const hiddenWin = new BrowserWindow({
     show: false,
     width: 800,
@@ -117,14 +119,14 @@ export async function generatePdf(content: string, options: PdfExportOptions): P
       nodeIntegration: false,
       contextIsolation: true,
       sandbox: true,
-      partition: "pdf-export",
+      partition,
     },
   });
 
   // Set a strict CSP header to block all script execution and data: URLs.
   // This is a defense-in-depth measure alongside html:false in markdown-it
   // and the CSP meta tag in the HTML document.
-  // The hook is registered on the isolated "pdf-export" partition session,
+  // The hook is registered on the isolated per-export partition session,
   // so it never leaks into the shared default session (#1034).
   hiddenWin.webContents.session.webRequest.onHeadersReceived((details, callback) => {
     callback({


### PR DESCRIPTION
## Summary

- Fixes #1034: `generatePdf()` was registering `onHeadersReceived` on the shared default session (or a shared named partition) each time it was called, causing CSP hooks to accumulate and leak to other requests
- Replaced static `partition: "pdf-export"` with a unique per-export in-memory partition: `pdf-export-${Date.now()}`
- Each export now gets a completely fresh, isolated session; the `onHeadersReceived` CSP hook is scoped to that session only
- Session is automatically GC'd when the `BrowserWindow` is destroyed — no explicit cleanup required

## Root Cause

`hiddenWin.webContents.session` was a shared session (previously the default session, then a shared named partition). Calling `onHeadersReceived` multiple times on the same session stacks listeners, leaking the PDF export CSP policy to all other requests.

## Fix

```ts
const partition = `pdf-export-${Date.now()}`;
const hiddenWin = new BrowserWindow({
  webPreferences: { ..., partition },
});
```

Using a timestamp-unique partition (without `persist:` prefix) creates an isolated in-memory session per export.

## Test plan

- [ ] Export a PDF — verify it generates successfully
- [ ] Export multiple PDFs in the same session — verify no CSP errors in the main window or other windows
- [ ] Verify the hidden window session does not persist after the window is destroyed

🤖 Generated with [Claude Code](https://claude.com/claude-code)