### PR TITLE
fix(auth): only logout on permanent auth errors, retry on transient failures (#1092)

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -16,12 +16,22 @@ interface UserInfoResponse {
   plan: string;
 }
 
-async function refreshAccessToken(
-  refreshToken: string,
-): Promise<{ access_token: string; refresh_token: string; expires_in: number } | null> {
-  let res: Response;
+/** Result of a token refresh attempt. */
+type RefreshResult =
+  | { ok: true; tokens: { access_token: string; refresh_token: string; expires_in: number } }
+  | { ok: false; permanent: boolean };
+
+/**
+ * Returns whether an HTTP status code represents a permanent auth failure
+ * (token invalid/revoked) vs a transient error (server unavailable, network issue).
+ */
+function isPermanentAuthError(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<RefreshResult> {
   try {
-    res = await fetch(`${OAUTH_PROVIDER_URL}/api/oauth/token`, {
+    const res = await fetch(`${OAUTH_PROVIDER_URL}/api/oauth/token`, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body: new URLSearchParams({
@@ -30,42 +40,45 @@ async function refreshAccessToken(
         client_id: OAUTH_CLIENT_ID,
       }),
     });
-  } catch {
-    return null;
-  }
-  if (!res.ok) return null;
-  try {
-    return (await res.json()) as {
+    if (!res.ok) {
+      return { ok: false, permanent: isPermanentAuthError(res.status) };
+    }
+    const tokens = (await res.json()) as {
       access_token: string;
       refresh_token: string;
       expires_in: number;
     };
+    return { ok: true, tokens };
   } catch {
-    return null;
+    // Network error — transient
+    return { ok: false, permanent: false };
   }
 }
 
-async function fetchUserInfo(accessToken: string): Promise<UserInfoResponse | null> {
-  let res: Response;
+/** Result of a userinfo fetch attempt. */
+type UserInfoResult = { ok: true; userInfo: UserInfoResponse } | { ok: false; permanent: boolean };
+
+async function fetchUserInfo(accessToken: string): Promise<UserInfoResult> {
   try {
-    res = await fetch(`${OAUTH_PROVIDER_URL}/api/oauth/userinfo`, {
+    const res = await fetch(`${OAUTH_PROVIDER_URL}/api/oauth/userinfo`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
+    if (!res.ok) {
+      return { ok: false, permanent: isPermanentAuthError(res.status) };
+    }
+    const userInfo = (await res.json()) as UserInfoResponse;
+    return { ok: true, userInfo };
   } catch {
-    return null;
-  }
-  if (!res.ok) return null;
-  try {
-    return (await res.json()) as UserInfoResponse;
-  } catch {
-    return null;
+    // Network error — transient
+    return { ok: false, permanent: false };
   }
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const cookies = getAuthCookies(request);
   if (!cookies) {
-    return NextResponse.json({ authenticated: false });
+    // No session cookies — permanent (not authenticated)
+    return NextResponse.json({ authenticated: false }, { status: 401 });
   }
 
   let { accessToken } = cookies;
@@ -75,38 +88,54 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
   // Refresh if expired
   if (Date.now() >= expiresAt) {
-    newTokens = await refreshAccessToken(refreshToken);
-    if (!newTokens) {
-      const res = NextResponse.json({ authenticated: false });
-      clearAuthCookies(res);
-      return res;
+    const refreshResult = await refreshAccessToken(refreshToken);
+    if (!refreshResult.ok) {
+      if (refreshResult.permanent) {
+        // Token is invalid/revoked — clear cookies and signal permanent logout
+        const res = NextResponse.json({ authenticated: false }, { status: 401 });
+        clearAuthCookies(res);
+        return res;
+      }
+      // Transient error (5xx / network) — keep cookies, signal retry
+      return NextResponse.json({ authenticated: false }, { status: 503 });
     }
+    newTokens = refreshResult.tokens;
     accessToken = newTokens.access_token;
     tokensRefreshed = true;
   }
 
   // Fetch user info
-  let userInfo = await fetchUserInfo(accessToken);
+  let userInfoResult = await fetchUserInfo(accessToken);
 
   // If userinfo fails with original token, try refreshing once
-  if (!userInfo && !tokensRefreshed) {
-    newTokens = await refreshAccessToken(refreshToken);
-    if (!newTokens) {
-      const res = NextResponse.json({ authenticated: false });
+  if (!userInfoResult.ok && !tokensRefreshed) {
+    const refreshResult = await refreshAccessToken(refreshToken);
+    if (!refreshResult.ok) {
+      if (refreshResult.permanent) {
+        const res = NextResponse.json({ authenticated: false }, { status: 401 });
+        clearAuthCookies(res);
+        return res;
+      }
+      return NextResponse.json({ authenticated: false }, { status: 503 });
+    }
+    newTokens = refreshResult.tokens;
+    accessToken = newTokens.access_token;
+    tokensRefreshed = true;
+    userInfoResult = await fetchUserInfo(accessToken);
+  }
+
+  if (!userInfoResult.ok) {
+    if (userInfoResult.permanent) {
+      // Permanent failure even after refresh — token is invalid
+      const res = NextResponse.json({ authenticated: false }, { status: 401 });
       clearAuthCookies(res);
       return res;
     }
-    accessToken = newTokens.access_token;
-    tokensRefreshed = true;
-    userInfo = await fetchUserInfo(accessToken);
+    // Transient — keep cookies, signal retry
+    return NextResponse.json({ authenticated: false }, { status: 503 });
   }
 
-  if (!userInfo) {
-    const res = NextResponse.json({ authenticated: false });
-    clearAuthCookies(res);
-    return res;
-  }
-
+  const { userInfo } = userInfoResult;
   const res = NextResponse.json({
     authenticated: true,
     user: {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -111,6 +111,12 @@ interface MeResponse {
   authenticated: boolean;
   user?: AuthUser;
   expiresAt?: number;
+  /**
+   * Indicates whether the auth failure is permanent (token invalid/revoked)
+   * or transient (network error, server unavailable).
+   * Only meaningful when authenticated === false.
+   */
+  permanent?: boolean;
 }
 
 async function fetchMe(): Promise<MeResponse> {
@@ -119,11 +125,36 @@ async function fetchMe(): Promise<MeResponse> {
       method: "POST",
       credentials: "same-origin",
     });
-    if (!res.ok) return { authenticated: false };
-    return (await res.json()) as MeResponse;
+    if (res.ok) {
+      return (await res.json()) as MeResponse;
+    }
+    // 401/403 = permanent (token invalid or no session)
+    // 5xx = transient (server error)
+    const permanent = res.status === 401 || res.status === 403;
+    return { authenticated: false, permanent };
   } catch {
-    return { authenticated: false };
+    // Network error — transient
+    return { authenticated: false, permanent: false };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns whether an error thrown by the Electron auth IPC represents a
+ * permanent auth failure (token invalid/revoked) vs a transient error
+ * (server unavailable, network issue).
+ * The IPC handlers attach `error.status` with the upstream HTTP status code.
+ */
+function isElectronAuthErrorPermanent(err: unknown): boolean {
+  if (err instanceof Error && "status" in err) {
+    const status = (err as Error & { status: unknown }).status;
+    return status === 401 || status === 403;
+  }
+  // No status attached (network/IPC error) — treat as transient
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -143,7 +174,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  // --- Electron refresh scheduler (unchanged from original) ---
+  // --- Electron refresh scheduler ---
   const scheduleElectronRefresh = useCallback(
     (expiresAt: number, refreshToken: string) => {
       clearRefreshTimer();
@@ -172,9 +203,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           });
 
           scheduleElectronRefresh(newExpiresAt, tokenResponse.refresh_token);
-        } catch {
-          setUser(null);
-          await clearTokens();
+        } catch (err) {
+          if (isElectronAuthErrorPermanent(err)) {
+            // Permanent failure (401/403): token is invalid — log out
+            setUser(null);
+            await clearTokens();
+          } else {
+            // Transient failure (5xx / network): keep session, retry at next scheduled interval
+            scheduleElectronRefresh(expiresAt, refreshToken);
+          }
         }
       }, refreshIn);
     },
@@ -192,8 +229,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (me.authenticated && me.user) {
           setUser(me.user);
           if (me.expiresAt) scheduleWebRefresh(me.expiresAt);
-        } else {
+        } else if (me.permanent) {
+          // Permanent failure (401/403): token is invalid — log out
           setUser(null);
+        } else {
+          // Transient failure (5xx / network): keep session, retry at next scheduled interval
+          scheduleWebRefresh(expiresAt);
         }
       }, refreshIn);
     },
@@ -242,8 +283,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 plan: userInfo.plan,
               });
               scheduleElectronRefresh(newExpiresAt, tokenResponse.refresh_token);
-            } catch {
-              await clearTokens();
+            } catch (err) {
+              // Only clear tokens on permanent failures (401/403); ignore transient errors on startup
+              if (isElectronAuthErrorPermanent(err)) {
+                await clearTokens();
+              }
             }
           } else {
             if (!api?.auth) {
@@ -280,8 +324,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                   plan: userInfo.plan,
                 });
                 scheduleElectronRefresh(newExpiresAt, tokenResponse.refresh_token);
-              } catch {
-                await clearTokens();
+              } catch (err) {
+                // Only clear tokens on permanent failures (401/403); ignore transient errors on startup
+                if (isElectronAuthErrorPermanent(err)) {
+                  await clearTokens();
+                }
               }
             }
           }

--- a/electron/ipc/auth-ipc.js
+++ b/electron/ipc/auth-ipc.js
@@ -77,7 +77,10 @@ function registerAuthHandlers() {
 
     if (!response.ok) {
       const err = await response.json().catch(() => ({}));
-      throw new Error(err.error_description || "Token refresh failed");
+      const error = new Error(err.error_description || "Token refresh failed");
+      // Attach HTTP status so the renderer can distinguish permanent vs transient errors
+      error.status = response.status;
+      throw error;
     }
     return response.json();
   });
@@ -87,7 +90,12 @@ function registerAuthHandlers() {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
 
-    if (!response.ok) throw new Error("Failed to fetch user info");
+    if (!response.ok) {
+      const error = new Error("Failed to fetch user info");
+      // Attach HTTP status so the renderer can distinguish permanent vs transient errors
+      error.status = response.status;
+      throw error;
+    }
     return response.json();
   });
 


### PR DESCRIPTION
## Summary

- `fetchMe()` now returns a `permanent` flag: `true` for 401/403, `false` for 5xx or network errors
- `scheduleWebRefresh()` only calls `setUser(null)` when `permanent === true`; transient failures reschedule the next retry instead of destroying the session
- `scheduleElectronRefresh()` only clears stored tokens on 401/403; 5xx/network errors retry instead of logging out
- `restoreElectronSession()` applies the same logic on startup refresh failures
- `app/api/auth/me/route.ts` now returns HTTP 401 for invalid/missing tokens and HTTP 503 for transient upstream failures, keeping cookies intact on transient errors
- `electron/ipc/auth-ipc.js` attaches the HTTP status code to thrown errors so the renderer can classify them

Closes #1092

## Test plan

- [ ] Simulate a 5xx response from the OAuth provider during token refresh — confirm the user stays logged in and a retry is scheduled
- [ ] Simulate a network failure during token refresh — confirm the user stays logged in
- [ ] Simulate a 401 response from the OAuth provider — confirm the user is logged out and tokens/cookies are cleared
- [ ] Simulate a 403 response — same as 401 behavior
- [ ] Verify normal auth flow (login, refresh, logout) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)