### PR TITLE
fix(terminal): handle exited PTY status when reattaching panel (#1103)

### DIFF
--- a/components/TerminalPanel.tsx
+++ b/components/TerminalPanel.tsx
@@ -196,14 +196,6 @@ export default function TerminalPanel({
       return;
     }
 
-    // Subscribe to live PTY data events (filter by sessionId)
-    const unsubData = ptyApi.onData((payload) => {
-      if (payload.sessionId !== sessionId) return;
-      terminal.write(payload.data);
-    });
-    cleanupDataRef.current = unsubData;
-
-
     // Subscribe to PTY exit events
     const unsubExit = ptyApi.onExit((payload) => {
       if (payload.sessionId !== sessionId) return;

--- a/components/TerminalPanel.tsx
+++ b/components/TerminalPanel.tsx
@@ -190,6 +190,20 @@ export default function TerminalPanel({
       terminal.write(attachResult.outputBuffer);
     }
 
+    // If the PTY already exited while the panel was unmounted, notify parent immediately
+    if (attachResult.status === "exited" || attachResult.status === "killed") {
+      onExit?.(attachResult.exitCode ?? 0);
+      return;
+    }
+
+    // Subscribe to live PTY data events (filter by sessionId)
+    const unsubData = ptyApi.onData((payload) => {
+      if (payload.sessionId !== sessionId) return;
+      terminal.write(payload.data);
+    });
+    cleanupDataRef.current = unsubData;
+
+
     // Subscribe to PTY exit events
     const unsubExit = ptyApi.onExit((payload) => {
       if (payload.sessionId !== sessionId) return;


### PR DESCRIPTION
## Summary

- `TerminalPanel.tsx` の `ptyApi.attach()` 呼び出し後に `attachResult.status` を検査するよう修正
- `status === 'exited'` または `'killed'` の場合、`onExit()` を即座に呼び出し、tab state を exit 状態に更新する
- panel が unmount されている間に終了した PTY を取り逃す問題を修正

## Test plan

- [ ] ターミナルタブを開き、シェルプロセスを終了させる（`exit` コマンド）
- [ ] タブを別タブに切り替え（TerminalPanel が unmount される）
- [ ] 再度ターミナルタブに戻り（TerminalPanel が remount される）
- [ ] タブが「終了済み」状態として正しく表示されることを確認

Closes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)