### PR TITLE
fix(terminal): register PTY data listener before fetching backlog to prevent output loss (#1104)

### DIFF
--- a/components/TerminalPanel.tsx
+++ b/components/TerminalPanel.tsx
@@ -164,27 +164,31 @@ export default function TerminalPanel({
     fitAddonRef.current = fitAddon;
 
     // --- Attach to PTY session ---
+    // Register the live data listener BEFORE calling attach() to prevent
+    // output loss during the gap between backlog retrieval and listener setup.
+    // Any data arriving while attach() is in-flight is captured immediately.
+    const unsubData = ptyApi.onData((payload) => {
+      if (payload.sessionId !== sessionId) return;
+      terminal.write(payload.data);
+    });
+    cleanupDataRef.current = unsubData;
+
     const attachResult = await ptyApi.attach(sessionId);
 
     if ("error" in attachResult) {
       setInitError(`セッションへの接続に失敗しました: ${attachResult.error}`);
+      unsubData();
+      cleanupDataRef.current = null;
       terminal.dispose();
       terminalRef.current = null;
       fitAddonRef.current = null;
       return;
     }
 
-    // Write buffered output from before attach
+    // Write buffered output first; live events registered above will follow.
     if (attachResult.outputBuffer) {
       terminal.write(attachResult.outputBuffer);
     }
-
-    // Subscribe to live PTY data events (filter by sessionId)
-    const unsubData = ptyApi.onData((payload) => {
-      if (payload.sessionId !== sessionId) return;
-      terminal.write(payload.data);
-    });
-    cleanupDataRef.current = unsubData;
 
     // Subscribe to PTY exit events
     const unsubExit = ptyApi.onExit((payload) => {


### PR DESCRIPTION
## Summary

- `TerminalPanel.tsx` の PTY attach 処理で、`ptyApi.onData()` listener を `ptyApi.attach()` の**前**に登録するよう順序を変更
- これにより、backlog 取得中（IPC round-trip）に main process から push された出力がドロップされなくなる
- エラー時のクリーンアップで早期に登録した listener を解除するよう対応済み

## Root Cause

旧コードは `attach()` で backlog を取得してから `onData()` を登録していたため、IPC 往復中に届いた `pty:data` イベントがレンダラー側で受信されず、ターミナルに表示されない出力が発生していた（issue #1104）。

## Fix

```ts
// 1. listener を先に登録
const unsubData = ptyApi.onData((payload) => { ... });
// 2. backlog を取得
const attachResult = await ptyApi.attach(sessionId);
// 3. backlog を書き込む（live events はその後）
if (attachResult.outputBuffer) terminal.write(attachResult.outputBuffer);
```

## Test plan

- [ ] ターミナルタブを開き、別タブに切り替えてから戻る（remount）
- [ ] remount 中に出力が発生するコマンド（例: `ping localhost`）を実行し、出力が欠落しないことを確認
- [ ] `npx tsc --noEmit` — エラーなし

Closes #1104

🤖 Generated with [Claude Code](https://claude.com/claude-code)