### PR TITLE
fix(services): add write mutex to prevent multi-window race in user-dict/ignored-corrections/bookmarks

### DIFF
--- a/lib/services/ignored-corrections-service.ts
+++ b/lib/services/ignored-corrections-service.ts
@@ -10,6 +10,7 @@
 
 import { getVFS } from "../vfs";
 import { getStorageService } from "../storage/storage-service";
+import { AsyncMutex } from "../utils/async-mutex";
 import type { VirtualFileSystem } from "../vfs/types";
 import type { IStorageService } from "../storage/storage-types";
 import type { IgnoredCorrection, IgnoredCorrectionsFile } from "../project/project-types";
@@ -28,6 +29,8 @@ const STANDALONE_STORAGE_PREFIX = "illusions-ignored-corrections:";
 class IgnoredCorrectionsService {
   private vfs: VirtualFileSystem;
   private storage: IStorageService;
+  /** Serializes all read-modify-write operations to prevent last-writer-wins data loss in multi-window scenarios. */
+  private readonly writeMutex = new AsyncMutex();
 
   constructor() {
     this.vfs = getVFS();
@@ -75,43 +78,55 @@ class IgnoredCorrectionsService {
 
   /**
    * Add an ignored correction. Deduplicates by (ruleId, text, context).
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async addIgnoredCorrection(
     ruleId: string,
     text: string,
     context?: string,
   ): Promise<IgnoredCorrection[]> {
-    const corrections = await this.loadIgnoredCorrections();
-    const exists = corrections.some(
-      (c) => c.ruleId === ruleId && c.text === text && c.context === context,
-    );
-    if (exists) return corrections;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const corrections = await this.loadIgnoredCorrections();
+      const exists = corrections.some(
+        (c) => c.ruleId === ruleId && c.text === text && c.context === context,
+      );
+      if (exists) return corrections;
 
-    const entry: IgnoredCorrection = {
-      ruleId,
-      text,
-      addedAt: Date.now(),
-      ...(context !== undefined ? { context } : {}),
-    };
-    corrections.push(entry);
-    await this.saveIgnoredCorrections(corrections);
-    return corrections;
+      const entry: IgnoredCorrection = {
+        ruleId,
+        text,
+        addedAt: Date.now(),
+        ...(context !== undefined ? { context } : {}),
+      };
+      corrections.push(entry);
+      await this.saveIgnoredCorrections(corrections);
+      return corrections;
+    } finally {
+      releaseLock();
+    }
   }
 
   /**
    * Remove an ignored correction by (ruleId, text, context).
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async removeIgnoredCorrection(
     ruleId: string,
     text: string,
     context?: string,
   ): Promise<IgnoredCorrection[]> {
-    const corrections = await this.loadIgnoredCorrections();
-    const filtered = corrections.filter(
-      (c) => !(c.ruleId === ruleId && c.text === text && c.context === context),
-    );
-    await this.saveIgnoredCorrections(filtered);
-    return filtered;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const corrections = await this.loadIgnoredCorrections();
+      const filtered = corrections.filter(
+        (c) => !(c.ruleId === ruleId && c.text === text && c.context === context),
+      );
+      await this.saveIgnoredCorrections(filtered);
+      return filtered;
+    } finally {
+      releaseLock();
+    }
   }
 
   // -------------------------------------------------------------------
@@ -163,6 +178,7 @@ class IgnoredCorrectionsService {
 
   /**
    * Add an ignored correction in standalone mode.
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async addIgnoredCorrectionStandalone(
     fileName: string,
@@ -170,25 +186,31 @@ class IgnoredCorrectionsService {
     text: string,
     context?: string,
   ): Promise<IgnoredCorrection[]> {
-    const corrections = await this.loadIgnoredCorrectionsStandalone(fileName);
-    const exists = corrections.some(
-      (c) => c.ruleId === ruleId && c.text === text && c.context === context,
-    );
-    if (exists) return corrections;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const corrections = await this.loadIgnoredCorrectionsStandalone(fileName);
+      const exists = corrections.some(
+        (c) => c.ruleId === ruleId && c.text === text && c.context === context,
+      );
+      if (exists) return corrections;
 
-    const entry: IgnoredCorrection = {
-      ruleId,
-      text,
-      addedAt: Date.now(),
-      ...(context !== undefined ? { context } : {}),
-    };
-    corrections.push(entry);
-    await this.saveIgnoredCorrectionsStandalone(fileName, corrections);
-    return corrections;
+      const entry: IgnoredCorrection = {
+        ruleId,
+        text,
+        addedAt: Date.now(),
+        ...(context !== undefined ? { context } : {}),
+      };
+      corrections.push(entry);
+      await this.saveIgnoredCorrectionsStandalone(fileName, corrections);
+      return corrections;
+    } finally {
+      releaseLock();
+    }
   }
 
   /**
    * Remove an ignored correction in standalone mode.
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async removeIgnoredCorrectionStandalone(
     fileName: string,
@@ -196,12 +218,17 @@ class IgnoredCorrectionsService {
     text: string,
     context?: string,
   ): Promise<IgnoredCorrection[]> {
-    const corrections = await this.loadIgnoredCorrectionsStandalone(fileName);
-    const filtered = corrections.filter(
-      (c) => !(c.ruleId === ruleId && c.text === text && c.context === context),
-    );
-    await this.saveIgnoredCorrectionsStandalone(fileName, filtered);
-    return filtered;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const corrections = await this.loadIgnoredCorrectionsStandalone(fileName);
+      const filtered = corrections.filter(
+        (c) => !(c.ruleId === ruleId && c.text === text && c.context === context),
+      );
+      await this.saveIgnoredCorrectionsStandalone(fileName, filtered);
+      return filtered;
+    } finally {
+      releaseLock();
+    }
   }
 }
 

--- a/lib/services/user-dictionary-service.ts
+++ b/lib/services/user-dictionary-service.ts
@@ -10,6 +10,7 @@
 
 import { getVFS } from "../vfs";
 import { getStorageService } from "../storage/storage-service";
+import { AsyncMutex } from "../utils/async-mutex";
 import type { VirtualFileSystem } from "../vfs/types";
 import type { IStorageService } from "../storage/storage-types";
 import type { UserDictionaryEntry, UserDictionaryFile } from "../project/project-types";
@@ -28,6 +29,8 @@ const STANDALONE_STORAGE_PREFIX = "illusions-user-dictionary:";
 class UserDictionaryService {
   private vfs: VirtualFileSystem;
   private storage: IStorageService;
+  /** Serializes all read-modify-write operations to prevent last-writer-wins data loss in multi-window scenarios. */
+  private readonly writeMutex = new AsyncMutex();
 
   constructor() {
     this.vfs = getVFS();
@@ -73,39 +76,57 @@ class UserDictionaryService {
 
   /**
    * Add a new entry. Deduplicates by word.
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async addEntry(entry: UserDictionaryEntry): Promise<UserDictionaryEntry[]> {
-    const entries = await this.loadEntries();
-    const exists = entries.some((e) => e.id === entry.id);
-    if (exists) return entries;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const entries = await this.loadEntries();
+      const exists = entries.some((e) => e.id === entry.id);
+      if (exists) return entries;
 
-    entries.push(entry);
-    entries.sort((a, b) => a.word.localeCompare(b.word));
-    await this.saveEntries(entries);
-    return entries;
+      entries.push(entry);
+      entries.sort((a, b) => a.word.localeCompare(b.word));
+      await this.saveEntries(entries);
+      return entries;
+    } finally {
+      releaseLock();
+    }
   }
 
   /**
    * Update an existing entry by id.
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async updateEntry(
     id: string,
     updates: Partial<UserDictionaryEntry>,
   ): Promise<UserDictionaryEntry[]> {
-    const entries = await this.loadEntries();
-    const updated = entries.map((e) => (e.id === id ? { ...e, ...updates } : e));
-    await this.saveEntries(updated);
-    return updated;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const entries = await this.loadEntries();
+      const updated = entries.map((e) => (e.id === id ? { ...e, ...updates } : e));
+      await this.saveEntries(updated);
+      return updated;
+    } finally {
+      releaseLock();
+    }
   }
 
   /**
    * Remove an entry by id.
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async removeEntry(id: string): Promise<UserDictionaryEntry[]> {
-    const entries = await this.loadEntries();
-    const filtered = entries.filter((e) => e.id !== id);
-    await this.saveEntries(filtered);
-    return filtered;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const entries = await this.loadEntries();
+      const filtered = entries.filter((e) => e.id !== id);
+      await this.saveEntries(filtered);
+      return filtered;
+    } finally {
+      releaseLock();
+    }
   }
 
   // -------------------------------------------------------------------
@@ -154,43 +175,61 @@ class UserDictionaryService {
 
   /**
    * Add an entry in standalone mode.
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async addEntryStandalone(
     fileName: string,
     entry: UserDictionaryEntry,
   ): Promise<UserDictionaryEntry[]> {
-    const entries = await this.loadEntriesStandalone(fileName);
-    const exists = entries.some((e) => e.id === entry.id);
-    if (exists) return entries;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const entries = await this.loadEntriesStandalone(fileName);
+      const exists = entries.some((e) => e.id === entry.id);
+      if (exists) return entries;
 
-    entries.push(entry);
-    entries.sort((a, b) => a.word.localeCompare(b.word));
-    await this.saveEntriesStandalone(fileName, entries);
-    return entries;
+      entries.push(entry);
+      entries.sort((a, b) => a.word.localeCompare(b.word));
+      await this.saveEntriesStandalone(fileName, entries);
+      return entries;
+    } finally {
+      releaseLock();
+    }
   }
 
   /**
    * Update an entry in standalone mode.
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async updateEntryStandalone(
     fileName: string,
     id: string,
     updates: Partial<UserDictionaryEntry>,
   ): Promise<UserDictionaryEntry[]> {
-    const entries = await this.loadEntriesStandalone(fileName);
-    const updated = entries.map((e) => (e.id === id ? { ...e, ...updates } : e));
-    await this.saveEntriesStandalone(fileName, updated);
-    return updated;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const entries = await this.loadEntriesStandalone(fileName);
+      const updated = entries.map((e) => (e.id === id ? { ...e, ...updates } : e));
+      await this.saveEntriesStandalone(fileName, updated);
+      return updated;
+    } finally {
+      releaseLock();
+    }
   }
 
   /**
    * Remove an entry in standalone mode.
+   * Guarded by writeMutex to prevent concurrent read-modify-write races.
    */
   async removeEntryStandalone(fileName: string, id: string): Promise<UserDictionaryEntry[]> {
-    const entries = await this.loadEntriesStandalone(fileName);
-    const filtered = entries.filter((e) => e.id !== id);
-    await this.saveEntriesStandalone(fileName, filtered);
-    return filtered;
+    const releaseLock = await this.writeMutex.acquire();
+    try {
+      const entries = await this.loadEntriesStandalone(fileName);
+      const filtered = entries.filter((e) => e.id !== id);
+      await this.saveEntriesStandalone(fileName, filtered);
+      return filtered;
+    } finally {
+      releaseLock();
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Add `AsyncMutex`-guarded write operations to `UserDictionaryService` (`addEntry`, `updateEntry`, `removeEntry`, and their standalone variants) to prevent last-writer-wins data loss when multiple windows write concurrently (#1062, #1048, #1047)
- Add `AsyncMutex`-guarded write operations to `IgnoredCorrectionsService` (`addIgnoredCorrection`, `removeIgnoredCorrection`, and their standalone variants) for the same reason (#1063, #1058)
- `history-service.ts` already has `bookmarkMutex` wrapping `toggleBookmark` on the `dev` branch (#1044)

## Root cause

All three services perform unguarded read-modify-write: load → mutate → save. When two windows race, both read the same stale data and whichever saves last overwrites the other's change. Wrapping with `AsyncMutex` (already used in `HistoryService.indexMutex`) serializes operations within a single process.

## Test plan

- [ ] Open the same project in two windows simultaneously
- [ ] Add a word to the user dictionary in window 1 and window 2 at the same time — both entries should be preserved
- [ ] Ignore a lint correction in both windows simultaneously — both corrections should be persisted
- [ ] Toggle bookmarks from two windows — both changes should survive
- [ ] `npx tsc --noEmit` passes (verified)

Closes #1062, #1063, #1058, #1048, #1047, #1044

🤖 Generated with [Claude Code](https://claude.com/claude-code)