### PR TITLE
fix(services): distinguish corrupt vs missing data files (#1054, #1033)

### DIFF
--- a/lib/services/ignored-corrections-service.ts
+++ b/lib/services/ignored-corrections-service.ts
@@ -40,7 +40,8 @@ class IgnoredCorrectionsService {
 
   /**
    * Load ignored corrections from .illusions/ignored-corrections.json.
-   * Returns empty array if the file does not exist.
+   * Returns empty array if the file does not exist (ENOENT).
+   * Re-throws on JSON corruption or permission errors to prevent data loss.
    */
   async loadIgnoredCorrections(): Promise<IgnoredCorrection[]> {
     try {
@@ -50,9 +51,11 @@ class IgnoredCorrectionsService {
       const raw = await fileHandle.read();
       const data: IgnoredCorrectionsFile = JSON.parse(raw);
       return data.ignoredCorrections ?? [];
-    } catch {
+    } catch (err) {
       // File doesn't exist yet — that's fine
-      return [];
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      // JSON corruption or permission error — re-throw to prevent overwriting existing data
+      throw err;
     }
   }
 
@@ -132,6 +135,7 @@ class IgnoredCorrectionsService {
   /**
    * Load ignored corrections from StorageService for a specific file.
    * @param filePath - Full path to the file (used as storage key to avoid basename collisions).
+   * Returns empty array if no entry exists; re-throws on JSON corruption or storage errors.
    */
   async loadIgnoredCorrectionsStandalone(filePath: string): Promise<IgnoredCorrection[]> {
     try {
@@ -140,8 +144,11 @@ class IgnoredCorrectionsService {
       if (!raw) return [];
       const data: IgnoredCorrectionsFile = JSON.parse(raw);
       return data.ignoredCorrections ?? [];
-    } catch {
-      return [];
+    } catch (err) {
+      // No stored entry — that's fine
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      // JSON corruption or storage error — re-throw to prevent overwriting existing data
+      throw err;
     }
   }
 

--- a/lib/services/user-dictionary-service.ts
+++ b/lib/services/user-dictionary-service.ts
@@ -40,7 +40,8 @@ class UserDictionaryService {
 
   /**
    * Load user dictionary entries from .illusions/user-dictionary.json.
-   * Returns empty array if the file does not exist.
+   * Returns empty array if the file does not exist (ENOENT).
+   * Re-throws on JSON corruption or permission errors to prevent data loss.
    */
   async loadEntries(): Promise<UserDictionaryEntry[]> {
     try {
@@ -50,9 +51,11 @@ class UserDictionaryService {
       const raw = await fileHandle.read();
       const data: UserDictionaryFile = JSON.parse(raw);
       return data.entries ?? [];
-    } catch {
+    } catch (err) {
       // File doesn't exist yet — that's fine
-      return [];
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      // JSON corruption or permission error — re-throw to prevent overwriting existing data
+      throw err;
     }
   }
 
@@ -126,6 +129,7 @@ class UserDictionaryService {
   /**
    * Load user dictionary entries from StorageService for a specific file.
    * @param filePath - Full path to the file (used as storage key to avoid basename collisions).
+   * Returns empty array if no entry exists; re-throws on JSON corruption or storage errors.
    */
   async loadEntriesStandalone(filePath: string): Promise<UserDictionaryEntry[]> {
     try {
@@ -134,8 +138,11 @@ class UserDictionaryService {
       if (!raw) return [];
       const data: UserDictionaryFile = JSON.parse(raw);
       return data.entries ?? [];
-    } catch {
-      return [];
+    } catch (err) {
+      // No stored entry — that's fine
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      // JSON corruption or storage error — re-throw to prevent overwriting existing data
+      throw err;
     }
   }
 


### PR DESCRIPTION
## Summary

- **#1054**: All `catch {}` blocks in both `user-dictionary-service.ts` and `ignored-corrections-service.ts` silently swallowed every error (including JSON corruption and permission failures) by returning `[]`, which caused the next `save*` call to overwrite valid data with an empty array. Fixed by checking `err.code === "ENOENT"` — file-not-found returns `[]` safely, all other errors are re-thrown.
- **#1033**: Full-path key scoping (`buildStandaloneKey`) was already shipped to `dev` in a previous PR. This PR adds the complementary ENOENT fix for standalone load paths as well.

## Changes

- `lib/services/user-dictionary-service.ts`: `loadEntries()` and `loadEntriesStandalone()` — ENOENT discrimination in catch blocks
- `lib/services/ignored-corrections-service.ts`: `loadIgnoredCorrections()` and `loadIgnoredCorrectionsStandalone()` — same fix

## Test plan

- [ ] Open a file, add a user dictionary word — confirm it persists across reload
- [ ] Manually corrupt `.illusions/user-dictionary.json` — confirm load now throws instead of silently resetting to `[]`
- [ ] Open two files with the same basename in different directories (standalone mode) — confirm dictionary entries are isolated per full path
- [ ] `npx tsc --noEmit` passes with no errors

Closes #1054

🤖 Generated with [Claude Code](https://claude.com/claude-code)