### PR TITLE
fix(project): prevent metadata auto-generation on restore, update rootPath only on IPC success (#1036, #1046)

### DIFF
--- a/lib/vfs/electron-vfs.ts
+++ b/lib/vfs/electron-vfs.ts
@@ -373,9 +373,8 @@ export class ElectronVFS implements VirtualFileSystem {
    * @param rootPath - Absolute path to the project root directory
    */
   async setRootPath(rootPath: string): Promise<void> {
-    this.rootPath = rootPath;
-    // Await the main process root update so allowedRoots is set before
-    // any subsequent VFS operation (fixes tab-restoration race condition).
+    // Await the main process root update before updating local state,
+    // so this.rootPath is never set to a value the main process rejected.
     try {
       const bridge = getVFSBridge();
       if ("setRoot" in bridge) {
@@ -389,6 +388,8 @@ export class ElectronVFS implements VirtualFileSystem {
         throw error;
       }
     }
+    // Only update local rootPath after the main process has accepted it.
+    this.rootPath = rootPath;
   }
 
   getRootPath(): string | null {


### PR DESCRIPTION
## Summary

- **#1036**: Add `readProjectJson()` as a read-only helper that throws if `.illusions/project.json` is absent. Switch restore paths (`openRestoredProject`, `handleOpenRecentProject`) to use it instead of `ensureProjectJson()`. The auto-creation logic in `ensureProjectJson()` is now only exercised on the new-project path (`handleOpenAsProject`).
- **#1046**: In `ElectronVFS.setRootPath()`, move `this.rootPath = rootPath` to after the `vfs:set-root` IPC call succeeds, so a rejected or failed root update never pollutes the renderer's `rootPath` state.

## Test plan

- [ ] Open a recent project that has `.illusions/project.json` → loads normally
- [ ] Open a recent project whose `.illusions/` directory is missing → fails gracefully with error, no spurious `.illusions/` created
- [ ] Open As Project (new project creation) → `.illusions/project.json` is still auto-created as before
- [ ] Simulate `vfs:set-root` IPC failure → `rootPath` remains unchanged (null or previous value), subsequent VFS calls use the correct root

🤖 Generated with [Claude Code](https://claude.com/claude-code)