### PR TITLE
fix(nlp): scope word frequency cache by full path, add generation guard, fix NLP progress listener (#1027, #1078, #1028)

### DIFF
--- a/components/WordFrequency.tsx
+++ b/components/WordFrequency.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useCallback, memo } from "react";
+import { useState, useEffect, useMemo, useCallback, memo, useRef } from "react";
 import { RefreshCw, LoaderCircle } from "lucide-react";
 import clsx from "clsx";
 
@@ -76,6 +76,9 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
   const [lastAnalyzedContent, setLastAnalyzedContent] = useState<string>("");
   const [cacheTimestamp, setCacheTimestamp] = useState<number>(0);
 
+  /** Generation counter — incremented on each analysis start; stale async results are discarded (#1078) */
+  const genRef = useRef(0);
+
   const contextMenu = useContextMenu();
 
   const openDictionary = useCallback((word: string, url: string, title: string) => {
@@ -132,6 +135,9 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
       return;
     }
 
+    // Increment generation counter so any previously in-flight analysis is considered stale (#1078)
+    const myGen = ++genRef.current;
+
     setIsLoading(true);
     setError(null);
 
@@ -148,6 +154,8 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
           const meta = await vfs.getFileMetadata(filePath);
 
           if (cache.lastModified === meta.lastModified && cache.fileSize === meta.size) {
+            // Discard stale result if a newer analysis was started (#1078)
+            if (genRef.current !== myGen) return;
             setWords(cache.words);
             setLastAnalyzedContent(content);
             setCacheTimestamp(cache.analyzedAt);
@@ -162,6 +170,10 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
       // Run NLP analysis
       const nlpClient = getNlpClient();
       const wordEntries = await nlpClient.analyzeWordFrequency(content);
+
+      // Discard stale result if a newer analysis was started (#1078)
+      if (genRef.current !== myGen) return;
+
       setWords(wordEntries);
       setLastAnalyzedContent(content);
       const now = Date.now();
@@ -191,7 +203,10 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
       console.error("[WordFrequency] Analysis error:", err);
       setError("解析に失敗しました");
     } finally {
-      setIsLoading(false);
+      // Only clear the loading spinner for the current generation (#1078)
+      if (genRef.current === myGen) {
+        setIsLoading(false);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

- **#1027**: `getCachePath()` now appends a djb2 hash of the full file path to the cache filename, preventing files with the same basename in different directories from sharing a cache entry
- **#1078**: `analyzeContent()` uses a `genRef` generation counter; stale async results (from NLP analysis and cache reads) are discarded when a newer analysis has already started, preventing UI and cache pollution
- **#1028**: `tokenizeDocument()` generates a unique `requestId` per call and filters `nlp:tokenize-progress` events by that id instead of calling `removeAllListeners()`, allowing concurrent tokenize calls to coexist safely

## Files Changed

- `components/WordFrequency.tsx` — generation guard (#1078) + full-path cache key already on dev (#1027)
- `electron/preload.js` — requestId-based listener isolation already on dev (#1028)

## Test Plan

- [ ] Open two files with the same filename in different directories; verify each has its own cache entry in `.illusions/word_count/`
- [ ] Rapidly switch between files or trigger multiple re-analyses; confirm UI shows the result for the latest content only (no stale result flash)
- [ ] Run two concurrent `tokenizeDocument` calls; confirm both receive correct progress events without interference

Closes #1027, #1078, #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)