### PR TITLE
fix(project): fix Web project permission classification and prompt-required handling (#1049, #1057, #1068)

### DIFF
--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -192,17 +192,11 @@ export function useFileOpening({
         const projectManager = getProjectManager();
         const restoreResult = await projectManager.restoreProjectHandle(projectId);
 
-        if (!restoreResult.success || !restoreResult.handle) {
-          console.error("Failed to restore project handle:", restoreResult.error);
-          if (!isAutoRestoringRef.current) {
-            notificationManager.error(
-              "このプロジェクトを開けませんでした。「プロジェクトを開く」から再度選択してください。",
-            );
-          }
-          return false;
-        }
-
-        if (restoreResult.permissionStatus.status === "prompt-required") {
+        // #1049/#1057: needsPermission indicates the handle is valid but requires
+        // a user-gesture permission prompt (covers prompt-required and read-only states).
+        // Must be checked before the general failure guard below, because needsPermission
+        // results have success:false but should route to the permission UI, not an error.
+        if (restoreResult.needsPermission && restoreResult.handle) {
           setPermissionPromptData({
             projectName: projectId,
             handle: restoreResult.handle,
@@ -211,6 +205,16 @@ export function useFileOpening({
           setShowPermissionPrompt(true);
           // Permission prompt shown — outcome depends on user action, not a failure
           return true;
+        }
+
+        if (!restoreResult.success || !restoreResult.handle) {
+          console.error("Failed to restore project handle:", restoreResult.error);
+          if (!isAutoRestoringRef.current) {
+            notificationManager.error(
+              "このプロジェクトを開けませんでした。「プロジェクトを開く」から再度選択してください。",
+            );
+          }
+          return false;
         }
 
         await openRestoredProject(restoreResult.handle);

--- a/lib/project/project-manager.ts
+++ b/lib/project/project-manager.ts
@@ -29,6 +29,15 @@ export interface RestoreResult {
   success: boolean;
   handle: FileSystemDirectoryHandle | null;
   permissionStatus: PermissionStatus;
+  /**
+   * True when the handle is valid but requires a user-gesture permission prompt
+   * before the project can be opened (prompt-required or read-only states).
+   * The caller must show a permission request UI before proceeding.
+   *
+   * ハンドルは有効だが、権限プロンプトが必要な場合に true。
+   * 呼び出し元は権限リクエスト UI を表示する必要がある。
+   */
+  needsPermission?: boolean;
   error?: string;
 }
 
@@ -187,8 +196,27 @@ export class ProjectManager {
         permissionState,
       });
 
+      // #1049: prompt-required means the handle is valid but needs a user-gesture
+      // permission prompt before opening. Return success:false with needsPermission:true
+      // so the caller can show the permission request UI instead of treating it as an error.
+      //
+      // #1057: read-only means write permission was explicitly denied. We also surface
+      // needsPermission:true so the caller can prompt the user to grant write access
+      // or explicitly open in read-only mode.
+      if (
+        permissionStatus.status === "prompt-required" ||
+        permissionStatus.status === "read-only"
+      ) {
+        return {
+          success: false,
+          needsPermission: true,
+          handle: stored.rootHandle,
+          permissionStatus,
+        };
+      }
+
       return {
-        success: permissionStatus.canRead,
+        success: permissionStatus.canRead && permissionStatus.canWrite,
         handle: stored.rootHandle,
         permissionStatus,
       };

--- a/lib/services/permission-manager.ts
+++ b/lib/services/permission-manager.ts
@@ -100,7 +100,14 @@ export class PermissionManager {
         return { status: "granted", canWrite: true, canRead: true };
       }
 
-      if (readState === "granted") {
+      // #1068: If read is granted but write is not yet granted (prompt),
+      // return prompt-required so the caller can request write permission.
+      // Returning read-only here would incorrectly skip the permission request flow.
+      if (readState === "granted" && writeState === "prompt") {
+        return { status: "prompt-required", canWrite: false, canRead: true };
+      }
+
+      if (readState === "granted" && writeState === "denied") {
         return { status: "read-only", canWrite: false, canRead: true };
       }
 
@@ -203,7 +210,14 @@ export class PermissionManager {
         return { status: "granted", canWrite: true, canRead: true };
       }
 
-      if (readState === "granted") {
+      // #1068: If read is granted but write is not yet granted (prompt),
+      // return prompt-required so the caller can request write permission.
+      // Returning read-only here would incorrectly skip the permission request flow.
+      if (readState === "granted" && writeState === "prompt") {
+        return { status: "prompt-required", canWrite: false, canRead: true };
+      }
+
+      if (readState === "granted" && writeState === "denied") {
         return { status: "read-only", canWrite: false, canRead: true };
       }
 


### PR DESCRIPTION
## Summary

- **#1068**: `checkDirectoryPermission` / `checkFilePermission` now correctly return `"prompt-required"` when `read=granted` but `write=prompt`, instead of incorrectly returning `"read-only"`. The `"read-only"` status is reserved for the case where write is explicitly `denied`.
- **#1057**: `restoreProjectHandle()` returns `needsPermission: true` for both `"prompt-required"` and `"read-only"` states, so the caller can prompt the user to grant write access in either case instead of silently opening as a fully editable project.
- **#1049**: `handleOpenRecentProject` checks `restoreResult.needsPermission` _before_ the general failure guard, so a valid handle with pending permissions routes to the permission request UI rather than being swallowed as an error.

## Files Changed

- `lib/services/permission-manager.ts` — fixed permission classification logic in `checkDirectoryPermission` and `checkFilePermission`
- `lib/project/project-manager.ts` — added `needsPermission` field to `RestoreResult`; updated `restoreProjectHandle` to set it for `prompt-required` and `read-only` states
- `lib/editor-page/use-file-opening.ts` — reordered checks to handle `needsPermission` before general failure, covering both `prompt-required` and `read-only`

## Test Plan

- [ ] Web: Open a project, restart browser — on restore, permission prompt dialog appears (previously silently failed — #1049)
- [ ] Web: With `read=granted, write=prompt` directory handle — `checkDirectoryPermission` returns `"prompt-required"` not `"read-only"` (verifiable via DevTools) — #1068
- [ ] Web: Stored project with read-only handle — restore triggers permission request UI, not silent editable open — #1057
- [ ] `npx tsc --noEmit` passes with no errors

Closes #1049, #1057, #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)