### PR TITLE
fix(tabs): reload disk content on reopen, restore new tabs without filePath (#1134, #1108)

### DIFF
--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -142,10 +142,17 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
     const { descriptor, content: fileContent } = result;
 
-    // Deduplicate: switch to existing tab if same path
+    // Deduplicate: if the same path is already open, reload from disk and activate
     if (descriptor.path) {
       const existing = findTabByPath(descriptor.path);
       if (existing) {
+        // Force-refresh tab content so stale in-memory state is replaced with the
+        // latest content that was just read from disk by openMdiFile().
+        updateTab(existing.id, {
+          content: fileContent,
+          lastSavedContent: fileContent,
+          isDirty: false,
+        });
         setActiveTabId(existing.id);
         return;
       }

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -251,32 +251,35 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
 
         const restoredTabs: EditorTabState[] = [];
         for (const serialized of openTabs.tabs) {
-          if (serialized.filePath) {
-            try {
-              const vfs = getVFS();
-              const fileContent = await vfs.readFile(serialized.filePath);
-              restoredTabs.push({
-                tabKind: "editor",
-                id: generateTabId(),
-                file: {
-                  path: serialized.filePath,
-                  handle: null,
-                  name: serialized.fileName,
-                },
-                content: fileContent,
-                lastSavedContent: fileContent,
-                isDirty: false,
-                lastSavedTime: Date.now(),
-                lastSaveWasAuto: false,
-                isSaving: false,
-                isPreview: serialized.isPreview ?? false,
-                fileType: serialized.fileType ?? inferFileType(serialized.fileName),
-                fileSyncStatus: "clean",
-                conflictDiskContent: null,
-              });
-            } catch (error) {
-              console.warn(`タブの復元に失敗しました (${serialized.filePath}):`, error);
-            }
+          if (!serialized.filePath) {
+            // Restore unsaved (new) tabs as blank tabs so they are not silently dropped.
+            restoredTabs.push(createNewTab(undefined, serialized.fileType ?? ".mdi"));
+            continue;
+          }
+          try {
+            const vfs = getVFS();
+            const fileContent = await vfs.readFile(serialized.filePath);
+            restoredTabs.push({
+              tabKind: "editor",
+              id: generateTabId(),
+              file: {
+                path: serialized.filePath,
+                handle: null,
+                name: serialized.fileName,
+              },
+              content: fileContent,
+              lastSavedContent: fileContent,
+              isDirty: false,
+              lastSavedTime: Date.now(),
+              lastSaveWasAuto: false,
+              isSaving: false,
+              isPreview: serialized.isPreview ?? false,
+              fileType: serialized.fileType ?? inferFileType(serialized.fileName),
+              fileSyncStatus: "clean",
+              conflictDiskContent: null,
+            });
+          } catch (error) {
+            console.warn(`タブの復元に失敗しました (${serialized.filePath}):`, error);
           }
         }
 


### PR DESCRIPTION
## Summary

- **#1134**: `openFile()` previously just activated the existing tab when the same path was already open, leaving stale in-memory content. Now calls `updateTab()` with the freshly-read disk content before activating, so the editor always shows the latest file state.
- **#1108**: The Electron tab restore loop silently dropped serialized tabs with no `filePath` (unsaved/new tabs). They are now restored as blank tabs via `createNewTab()`, preserving the user's tab session across restarts.

## Test plan

- [ ] Open a `.mdi` file, edit it externally, then use File > Open to re-open the same path → editor should reflect the new content (not the old in-memory version)
- [ ] Open a new unsaved tab, close and reopen the app → the blank tab should be restored alongside any file-backed tabs
- [ ] Verify `npx tsc --noEmit` passes (confirmed clean)

Closes #1134
Closes #1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)