### PR TITLE
fix(project): prevent openProject mutation, fix await race, workspace.json ENOENT, lastModified bypass (#1023, #1022, #1050, #1055)

### DIFF
--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -206,7 +206,9 @@ export class ProjectService {
       if (parentPath) {
         projectRootPath = `${parentPath}/${name}`;
         if ("setRootPath" in this.vfs) {
-          (this.vfs as { setRootPath: (p: string) => void }).setRootPath(projectRootPath);
+          await (this.vfs as { setRootPath: (p: string) => Promise<void> }).setRootPath(
+            projectRootPath,
+          );
         }
       }
     }
@@ -499,7 +501,9 @@ export class ProjectService {
     if (isElectronRenderer() && project.rootPath) {
       // Re-set the VFS root using the stored absolute path
       if ("setRootPath" in this.vfs) {
-        (this.vfs as { setRootPath: (p: string) => void }).setRootPath(project.rootPath);
+        await (this.vfs as { setRootPath: (p: string) => Promise<void> }).setRootPath(
+          project.rootPath,
+        );
       }
       return await this.vfs.getDirectoryHandle("");
     }

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -218,6 +218,20 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           const vfs = getVFS();
           suppressFileWatch(tab.file.path);
           await vfs.writeFile(tab.file.path, sanitized);
+
+          // Update project.json lastModified so workspace metadata stays in sync.
+          // This mirrors what ProjectService.saveProject() does for the full save path.
+          try {
+            const projectJsonPath = ".illusions/project.json";
+            const projectJsonText = await vfs.readFile(projectJsonPath);
+            const projectJson = JSON.parse(projectJsonText) as Record<string, unknown>;
+            projectJson["lastModified"] = Date.now();
+            await vfs.writeFile(projectJsonPath, JSON.stringify(projectJson, null, 2));
+          } catch {
+            // Non-fatal: project.json update failure should not block the save
+            console.warn("project.json の lastModified 更新に失敗しました");
+          }
+
           setTabs((prev) =>
             prev.map((t) =>
               t.id === tabId && isEditorTab(t)


### PR DESCRIPTION
## Summary

- **#1023**: `openProject()` no longer creates `.illusions/` or `project.json` when they are absent. It now throws a descriptive Japanese error, preventing silent mutation of non-project directories.
- **#1022**: `saveProject()` now uses `create: true` when obtaining the `workspace.json` file handle, fixing `ENOENT` on the first save of legacy projects missing the file.
- **#1050**: Both `setRootPath()` call-sites in `createProject()` and `getVFSDirectoryHandle()` are now properly `await`ed, eliminating the VFS root restore race condition.
- **#1055**: Project-mode saves in `useFileIO.saveFile()` now update `project.json`'s `lastModified` field via VFS after writing the main file, keeping workspace metadata in sync when saves bypass `ProjectService.saveProject()`.

## Files Changed

- `lib/project/project-service.ts` — #1050 await fixes
- `lib/tab-manager/use-file-io.ts` — #1055 lastModified update

Note: #1023 and #1022 fixes were already present on `dev`; this PR adds #1050 and #1055 fixes on top.

## Test plan

- [ ] Open a regular (non-project) folder via "Open Project" — verify error dialog appears instead of `.illusions/` being created
- [ ] Open an old project without `workspace.json` and save — verify no ENOENT error
- [ ] Reload while a project is open (Electron) — verify editor loads correctly without VFS root race
- [ ] Save in project mode — verify `project.json`'s `lastModified` timestamp is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)