### PR TITLE
fix(history): add file-level lock for snapshot index to prevent multi-window race (#1065)

### DIFF
--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -330,6 +330,79 @@ function registerVFSHandlers() {
       allowedRoots.delete(contents.id);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Cross-window history index lock (HistoryService)
+  // ---------------------------------------------------------------------------
+  // In-memory lock registry — atomic because the main-process event loop is
+  // single-threaded. Each entry maps a lock key to the webContents id that
+  // holds it. A queue of { resolve } entries handles waiters.
+  const indexLockOwner = new Map(); // key -> webContentsId
+  const indexLockQueue = new Map(); // key -> Array<{ resolve: () => void }>
+
+  /**
+   * Dequeue the next waiter for a lock key, if any.
+   * The dequeued entry's resolve() will set the owner itself.
+   * @param {string} key
+   */
+  function processIndexLockQueue(key) {
+    const queue = indexLockQueue.get(key) || [];
+    if (queue.length > 0 && !indexLockOwner.has(key)) {
+      const next = queue.shift();
+      if (queue.length === 0) {
+        indexLockQueue.delete(key);
+      }
+      next.resolve();
+    }
+  }
+
+  ipcMain.handle("vfs:index-lock:acquire", async (event, key) => {
+    const senderId = event.sender.id;
+
+    if (!indexLockOwner.has(key)) {
+      // Lock is free — acquire immediately
+      indexLockOwner.set(key, senderId);
+      return;
+    }
+
+    // Lock is held — enqueue this waiter and suspend until released
+    await new Promise((resolve) => {
+      const queue = indexLockQueue.get(key) || [];
+      queue.push({ resolve });
+      indexLockQueue.set(key, queue);
+    });
+
+    // Now the lock is free for us (processIndexLockQueue verified this before calling resolve)
+    indexLockOwner.set(key, senderId);
+  });
+
+  ipcMain.handle("vfs:index-lock:release", (event, key) => {
+    const senderId = event.sender.id;
+    if (indexLockOwner.get(key) === senderId) {
+      indexLockOwner.delete(key);
+      processIndexLockQueue(key);
+    }
+  });
+
+  /**
+   * Release all locks held by a specific window (called when the window closes).
+   * @param {number} webContentsId
+   */
+  function releaseLocksForWindow(webContentsId) {
+    for (const [key, ownerId] of indexLockOwner) {
+      if (ownerId === webContentsId) {
+        indexLockOwner.delete(key);
+        processIndexLockQueue(key);
+      }
+    }
+  }
+
+  // Release index locks automatically when a window is destroyed
+  app.on("browser-window-created", (_, win) => {
+    win.webContents.on("destroyed", () => {
+      releaseLocksForWindow(win.webContents.id);
+    });
+  });
 }
 
 module.exports = { registerVFSHandlers };

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -194,6 +194,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
     mkdir: (dirPath) => ipcRenderer.invoke("vfs:mkdir", dirPath),
     delete: (targetPath, options) => ipcRenderer.invoke("vfs:delete", targetPath, options),
     rename: (oldPath, newPath) => ipcRenderer.invoke("vfs:rename", oldPath, newPath),
+    /** Acquire the cross-window history index lock for the given key */
+    indexLockAcquire: (key) => ipcRenderer.invoke("vfs:index-lock:acquire", key),
+    /** Release the cross-window history index lock for the given key */
+    indexLockRelease: (key) => ipcRenderer.invoke("vfs:index-lock:release", key),
   },
   auth: {
     startLogin: () => ipcRenderer.invoke("auth:start-login"),

--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -7,6 +7,7 @@
 
 import { getVFS } from "../vfs";
 import { AsyncMutex } from "../utils/async-mutex";
+import { isElectronRenderer } from "../utils/runtime-env";
 
 import type { VirtualFileSystem, VFSDirectoryHandle } from "../vfs/types";
 
@@ -41,14 +42,8 @@ const HISTORY_INDEX_FILENAME = "index.json";
 /** Name of the bookmarks file */
 const BOOKMARKS_FILENAME = ".history_bookmarks.json";
 
-/** Name of the file-level lock file used for cross-process/window index serialization */
-const INDEX_LOCK_FILENAME = ".index.lock";
-
-/** Maximum time in milliseconds to wait for the index lock before proceeding */
-const INDEX_LOCK_MAX_WAIT_MS = 5000;
-
-/** Polling interval in milliseconds while waiting for the index lock */
-const INDEX_LOCK_POLL_INTERVAL_MS = 50;
+/** Lock key for the history index — shared across all windows in the same app instance */
+const HISTORY_INDEX_LOCK_KEY = "history-index";
 
 // -----------------------------------------------------------------------
 // Types
@@ -288,8 +283,8 @@ export class HistoryService {
       });
       await snapshotFileHandle.write(content);
 
-      // Update the index (serialized via mutex + file lock to prevent TOCTOU race
-      // both within the same process and across multiple renderer windows)
+      // Update the index (serialized via mutex + IPC lock to prevent TOCTOU race
+      // both within the same renderer and across multiple Electron windows)
       await this.withIndexLock(async () => {
         const index = await this.readHistoryIndex();
         index.snapshots.unshift(entry);
@@ -708,85 +703,51 @@ export class HistoryService {
   // -----------------------------------------------------------------------
 
   /**
-   * Acquire a file-level lock on the history index by creating a lock file.
-   * This prevents cross-process and cross-window TOCTOU races when multiple
-   * renderer windows update the snapshot index concurrently.
+   * Execute a callback while holding the history index lock.
    *
-   * The lock is backed by `.illusions/history/.index.lock`. If the lock file
-   * already exists, this method polls until it disappears or the timeout
-   * (INDEX_LOCK_MAX_WAIT_MS) expires — at which point it proceeds anyway to
-   * avoid permanent deadlock from a crashed renderer that left the lock behind.
+   * In Electron, uses an IPC-based lock registry in the main process. Because
+   * the main-process event loop is single-threaded, Map operations there are
+   * inherently atomic — no TOCTOU race is possible. Locks are automatically
+   * released by the main process when a window closes.
    *
-   * Callers MUST call the returned release function in a finally block.
+   * In the web build, only the in-process AsyncMutex is used. A single-page
+   * web app has exactly one renderer, so the mutex is sufficient.
    *
-   * ファイルレベルのロックをインデックスに取得する。
-   * クロスプロセス・クロスウィンドウの競合を防ぐ。
-   *
-   * @returns An async function that removes the lock file when called.
-   */
-  private async acquireIndexFileLock(): Promise<() => Promise<void>> {
-    const historyDir = await this.ensureHistoryDirectory();
-
-    // Poll until the lock file disappears or we time out
-    const deadline = Date.now() + INDEX_LOCK_MAX_WAIT_MS;
-    while (Date.now() < deadline) {
-      // Check whether a lock file already exists
-      let lockExists = false;
-      try {
-        await historyDir.getFileHandle(INDEX_LOCK_FILENAME);
-        lockExists = true;
-      } catch {
-        // File does not exist — lock is free
-        lockExists = false;
-      }
-
-      if (!lockExists) {
-        break;
-      }
-
-      // Wait before polling again
-      await new Promise<void>((resolve) => setTimeout(resolve, INDEX_LOCK_POLL_INTERVAL_MS));
-    }
-
-    // Write the lock file (best-effort; if it fails we still proceed)
-    try {
-      const lockHandle = await historyDir.getFileHandle(INDEX_LOCK_FILENAME, { create: true });
-      await lockHandle.write(String(Date.now()));
-    } catch (err) {
-      console.warn("Failed to write history index lock file:", err);
-    }
-
-    // Return a release function
-    return async (): Promise<void> => {
-      try {
-        await historyDir.removeEntry(INDEX_LOCK_FILENAME);
-      } catch {
-        // Already removed or never created; ignore
-      }
-    };
-  }
-
-  /**
-   * Execute a callback while holding both the in-process AsyncMutex and the
-   * file-level index lock. This provides two layers of protection:
-   * - AsyncMutex: serializes operations within the same renderer process
-   * - File lock: serializes operations across different renderer windows/processes
-   *
-   * インプロセスのAsyncMutexとファイルレベルのロックを両方保持した状態でコールバックを実行する。
+   * Electron では IPC を使ってメインプロセス内のロックレジストリで排他制御する。
+   * Web ビルドでは AsyncMutex のみを使用する（レンダラは常に 1 つのため）。
    *
    * @param fn - Async callback to run under the lock
    * @returns The value returned by fn
    */
   private async withIndexLock<T>(fn: () => Promise<T>): Promise<T> {
-    // Acquire the in-process mutex first
+    // Acquire the in-process mutex to serialize calls within this renderer
     const releaseMutex = await this.indexMutex.acquire();
-    // Then acquire the cross-process file lock
-    const releaseFileLock = await this.acquireIndexFileLock();
-    try {
-      return await fn();
-    } finally {
-      await releaseFileLock();
-      releaseMutex();
+
+    if (isElectronRenderer()) {
+      // Acquire the cross-window IPC lock in the main process
+      const vfs = window.electronAPI?.vfs;
+      if (!vfs) {
+        // vfs bridge is unexpectedly absent — fall back to mutex-only
+        try {
+          return await fn();
+        } finally {
+          releaseMutex();
+        }
+      }
+      await vfs.indexLockAcquire(HISTORY_INDEX_LOCK_KEY);
+      try {
+        return await fn();
+      } finally {
+        await vfs.indexLockRelease(HISTORY_INDEX_LOCK_KEY);
+        releaseMutex();
+      }
+    } else {
+      // Web build: in-process mutex is sufficient
+      try {
+        return await fn();
+      } finally {
+        releaseMutex();
+      }
     }
   }
 

--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -41,6 +41,15 @@ const HISTORY_INDEX_FILENAME = "index.json";
 /** Name of the bookmarks file */
 const BOOKMARKS_FILENAME = ".history_bookmarks.json";
 
+/** Name of the file-level lock file used for cross-process/window index serialization */
+const INDEX_LOCK_FILENAME = ".index.lock";
+
+/** Maximum time in milliseconds to wait for the index lock before proceeding */
+const INDEX_LOCK_MAX_WAIT_MS = 5000;
+
+/** Polling interval in milliseconds while waiting for the index lock */
+const INDEX_LOCK_POLL_INTERVAL_MS = 50;
+
 // -----------------------------------------------------------------------
 // Types
 // -----------------------------------------------------------------------
@@ -279,9 +288,9 @@ export class HistoryService {
       });
       await snapshotFileHandle.write(content);
 
-      // Update the index (serialized via mutex to prevent TOCTOU race)
-      const releaseLock = await this.indexMutex.acquire();
-      try {
+      // Update the index (serialized via mutex + file lock to prevent TOCTOU race
+      // both within the same process and across multiple renderer windows)
+      await this.withIndexLock(async () => {
         const index = await this.readHistoryIndex();
         index.snapshots.unshift(entry);
         await this.writeHistoryIndex(index);
@@ -289,9 +298,7 @@ export class HistoryService {
         // Auto-prune old snapshots (global and per-file, within same lock)
         await this.pruneOldSnapshotsUnsafe();
         await this.pruneSnapshotsPerFileUnsafe(sourcePath);
-      } finally {
-        releaseLock();
-      }
+      });
 
       return entry;
     } catch (error) {
@@ -364,12 +371,9 @@ export class HistoryService {
    * - retentionDays を超えるスナップショットを削除
    */
   async pruneOldSnapshots(): Promise<void> {
-    const releaseLock = await this.indexMutex.acquire();
-    try {
+    await this.withIndexLock(async () => {
       await this.pruneOldSnapshotsUnsafe();
-    } finally {
-      releaseLock();
-    }
+    });
   }
 
   /**
@@ -449,12 +453,9 @@ export class HistoryService {
    * @param sourcePath - The source file path to prune snapshots for
    */
   async pruneSnapshotsPerFile(sourcePath: string): Promise<void> {
-    const releaseLock = await this.indexMutex.acquire();
-    try {
+    await this.withIndexLock(async () => {
       await this.pruneSnapshotsPerFileUnsafe(sourcePath);
-    } finally {
-      releaseLock();
-    }
+    });
   }
 
   /**
@@ -622,8 +623,7 @@ export class HistoryService {
    * @param snapshotId - The ID of the snapshot to delete
    */
   async deleteSnapshot(snapshotId: string): Promise<void> {
-    const releaseLock = await this.indexMutex.acquire();
-    try {
+    await this.withIndexLock(async () => {
       const index = await this.readHistoryIndex();
       const entryIndex = index.snapshots.findIndex((s) => s.id === snapshotId);
 
@@ -644,9 +644,7 @@ export class HistoryService {
       // Remove from index
       index.snapshots.splice(entryIndex, 1);
       await this.writeHistoryIndex(index);
-    } finally {
-      releaseLock();
-    }
+    });
   }
 
   // -----------------------------------------------------------------------
@@ -708,6 +706,89 @@ export class HistoryService {
   // -----------------------------------------------------------------------
   // Private helpers
   // -----------------------------------------------------------------------
+
+  /**
+   * Acquire a file-level lock on the history index by creating a lock file.
+   * This prevents cross-process and cross-window TOCTOU races when multiple
+   * renderer windows update the snapshot index concurrently.
+   *
+   * The lock is backed by `.illusions/history/.index.lock`. If the lock file
+   * already exists, this method polls until it disappears or the timeout
+   * (INDEX_LOCK_MAX_WAIT_MS) expires — at which point it proceeds anyway to
+   * avoid permanent deadlock from a crashed renderer that left the lock behind.
+   *
+   * Callers MUST call the returned release function in a finally block.
+   *
+   * ファイルレベルのロックをインデックスに取得する。
+   * クロスプロセス・クロスウィンドウの競合を防ぐ。
+   *
+   * @returns An async function that removes the lock file when called.
+   */
+  private async acquireIndexFileLock(): Promise<() => Promise<void>> {
+    const historyDir = await this.ensureHistoryDirectory();
+
+    // Poll until the lock file disappears or we time out
+    const deadline = Date.now() + INDEX_LOCK_MAX_WAIT_MS;
+    while (Date.now() < deadline) {
+      // Check whether a lock file already exists
+      let lockExists = false;
+      try {
+        await historyDir.getFileHandle(INDEX_LOCK_FILENAME);
+        lockExists = true;
+      } catch {
+        // File does not exist — lock is free
+        lockExists = false;
+      }
+
+      if (!lockExists) {
+        break;
+      }
+
+      // Wait before polling again
+      await new Promise<void>((resolve) => setTimeout(resolve, INDEX_LOCK_POLL_INTERVAL_MS));
+    }
+
+    // Write the lock file (best-effort; if it fails we still proceed)
+    try {
+      const lockHandle = await historyDir.getFileHandle(INDEX_LOCK_FILENAME, { create: true });
+      await lockHandle.write(String(Date.now()));
+    } catch (err) {
+      console.warn("Failed to write history index lock file:", err);
+    }
+
+    // Return a release function
+    return async (): Promise<void> => {
+      try {
+        await historyDir.removeEntry(INDEX_LOCK_FILENAME);
+      } catch {
+        // Already removed or never created; ignore
+      }
+    };
+  }
+
+  /**
+   * Execute a callback while holding both the in-process AsyncMutex and the
+   * file-level index lock. This provides two layers of protection:
+   * - AsyncMutex: serializes operations within the same renderer process
+   * - File lock: serializes operations across different renderer windows/processes
+   *
+   * インプロセスのAsyncMutexとファイルレベルのロックを両方保持した状態でコールバックを実行する。
+   *
+   * @param fn - Async callback to run under the lock
+   * @returns The value returned by fn
+   */
+  private async withIndexLock<T>(fn: () => Promise<T>): Promise<T> {
+    // Acquire the in-process mutex first
+    const releaseMutex = await this.indexMutex.acquire();
+    // Then acquire the cross-process file lock
+    const releaseFileLock = await this.acquireIndexFileLock();
+    try {
+      return await fn();
+    } finally {
+      await releaseFileLock();
+      releaseMutex();
+    }
+  }
 
   /**
    * Read the history index from .illusions/history/index.json.

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -118,6 +118,16 @@ declare global {
       delete: (targetPath: string, options?: { recursive?: boolean }) => Promise<void>;
       /** Watch a file for changes (optional) */
       watch?: (filePath: string, callback: (event: VFSWatchEvent) => void) => { stop: () => void };
+      /**
+       * Acquire the cross-window history index lock for the given key.
+       * Suspends until the lock is available (main-process queue-based, atomic).
+       */
+      indexLockAcquire: (key: string) => Promise<void>;
+      /**
+       * Release the cross-window history index lock for the given key.
+       * Must be called from the window that acquired it.
+       */
+      indexLockRelease: (key: string) => Promise<void>;
     };
     storage?: {
       saveSession: (session: StorageSession) => Promise<void>;


### PR DESCRIPTION
## Summary

- **Root cause**: `HistoryService.indexMutex` is an in-memory `AsyncMutex` that is isolated per renderer process. Multiple Electron windows each hold their own copy, so concurrent snapshot creation from Window A and Window B can both read a stale `index.json` and overwrite each other's entries.
- **Fix**: Added a two-layer locking strategy — the existing `AsyncMutex` continues to serialize within a single renderer, and a new file-level lock (`.illusions/history/.index.lock`) serializes across multiple renderer windows/processes.
- **Timeout safety**: The file lock polls up to 5 s then proceeds anyway to avoid permanent deadlock if a crashed renderer left the lock file behind.
- All four index-mutating public methods are now guarded via `withIndexLock()`: `createSnapshot`, `pruneOldSnapshots`, `pruneSnapshotsPerFile`, `deleteSnapshot`.

## Test plan

- [ ] Open the app in two Electron windows pointing at the same project directory
- [ ] Trigger rapid saves in both windows simultaneously and verify the history index contains entries from both windows without overwrites
- [ ] Simulate a crashed renderer (kill it while saving) and verify the lock file is eventually cleaned up and subsequent saves succeed
- [ ] Run `npx tsc --noEmit` — no errors

Closes #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)