### PR TITLE
fix(save): address remaining conflict state and fileSyncStatus issues

### DIFF
--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -80,19 +80,19 @@ export function useAutoSave(params: UseAutoSaveParams): void {
               await vfs.writeFile(tab.file.path, sanitized);
               if (!mountedRef.current) return;
               setTabs((prev) =>
-                prev.map((t) =>
-                  t.id === tab.id && isEditorTab(t)
-                    ? {
-                        ...t,
-                        lastSavedContent: sanitized,
-                        isDirty: sanitizeMdiContent(t.content) !== sanitized,
-                        lastSavedTime: Date.now(),
-                        lastSaveWasAuto: true,
-                        fileSyncStatus: "clean",
-                        conflictDiskContent: null,
-                      }
-                    : t,
-                ),
+                prev.map((t) => {
+                  if (t.id !== tab.id || !isEditorTab(t)) return t;
+                  const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+                  return {
+                    ...t,
+                    lastSavedContent: sanitized,
+                    isDirty: newIsDirty,
+                    fileSyncStatus: newIsDirty ? "dirty" : "clean",
+                    conflictDiskContent: null,
+                    lastSavedTime: Date.now(),
+                    lastSaveWasAuto: true,
+                  };
+                }),
               );
             } else if (tab.file?.path || tab.file?.handle) {
               const result = await saveMdiFile({
@@ -103,20 +103,20 @@ export function useAutoSave(params: UseAutoSaveParams): void {
               if (result) {
                 if (!mountedRef.current) return;
                 setTabs((prev) =>
-                  prev.map((t) =>
-                    t.id === tab.id && isEditorTab(t)
-                      ? {
-                          ...t,
-                          file: result.descriptor,
-                          lastSavedContent: sanitized,
-                          isDirty: sanitizeMdiContent(t.content) !== sanitized,
-                          lastSavedTime: Date.now(),
-                          lastSaveWasAuto: true,
-                          fileSyncStatus: "clean",
-                          conflictDiskContent: null,
-                        }
-                      : t,
-                  ),
+                  prev.map((t) => {
+                    if (t.id !== tab.id || !isEditorTab(t)) return t;
+                    const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+                    return {
+                      ...t,
+                      file: result.descriptor,
+                      lastSavedContent: sanitized,
+                      isDirty: newIsDirty,
+                      fileSyncStatus: newIsDirty ? "dirty" : "clean",
+                      conflictDiskContent: null,
+                      lastSavedTime: Date.now(),
+                      lastSaveWasAuto: true,
+                    };
+                  }),
                 );
               }
             }

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -313,15 +313,28 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
       const result = await saveMdiFile({ descriptor, content: sanitized, fileType: tab.fileType });
 
       if (result) {
-        updateTab(tabId, {
-          file: result.descriptor,
-          lastSavedContent: sanitized,
-          isDirty: false,
-          lastSavedTime: Date.now(),
-          isSaving: false,
-          fileSyncStatus: "clean",
-          conflictDiskContent: null,
-        });
+        // Use functional updater to compare against the latest tab content at
+        // completion time, not at dialog-open time. Edits made while the async
+        // Save As dialog was open must not be silently marked as saved.
+        setTabs((prev) =>
+          prev.map((t) =>
+            t.id === tabId && isEditorTab(t)
+              ? (() => {
+                  const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+                  return {
+                    ...t,
+                    file: result.descriptor,
+                    lastSavedContent: sanitized,
+                    isDirty: newIsDirty,
+                    fileSyncStatus: newIsDirty ? "dirty" : "clean",
+                    lastSavedTime: Date.now(),
+                    isSaving: false,
+                    conflictDiskContent: null,
+                  };
+                })()
+              : t,
+          ),
+        );
         if (!(await persistFileReference(result.descriptor, sanitized))) {
           notificationManager.warning(PERSIST_FAILURE_WARNING);
         }
@@ -339,7 +352,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
     } finally {
       isSavingRef.current = false;
     }
-  }, [updateTab, persistFileReference, tryAutoSnapshot, tabsRef, activeTabIdRef]);
+  }, [updateTab, setTabs, persistFileReference, tryAutoSnapshot, tabsRef, activeTabIdRef]);
 
   /** Load a file by path + content into a new tab (or reuse/deduplicate) */
   const loadSystemFile = useCallback(

--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -156,6 +156,10 @@ function buildOnChanged(
                     isDirty: false,
                     fileSyncStatus: "clean",
                     conflictDiskContent: null,
+                    // Trigger live editor update via externalContent prop.
+                    // Without this, the tab state is updated but the active
+                    // editor instance continues to show the stale content.
+                    pendingExternalContent: diskContent,
                   } satisfies EditorTabState;
                 }),
               );


### PR DESCRIPTION
## Summary

- **#1008 / #1132**: `use-auto-save.ts` — compute `fileSyncStatus` conditionally based on recomputed `isDirty` after background tab auto-save. Previously hardcoded to `"clean"` even when content changed during save, which allowed the file watcher to auto-reload and silently overwrite unsaved edits.
- **#1009 / #1135**: `use-file-io.ts` — replace `updateTab` call with `setTabs` functional updater in `saveAsFile()` so `isDirty` and `fileSyncStatus` are computed against the latest tab content at dialog completion time, not at dialog-open time.
- **#1073 / #1071 / #1122**: `use-file-watch-integration.ts` — add `pendingExternalContent: diskContent` to the "ディスクの内容を採用" conflict resolution action so the active editor instance reflects the adopted content immediately via the `externalContent` prop pathway.

## Issues closed

Closes #1008, #1009, #1073, #1071

(#1011 was already fixed by a prior PR targeting dev)

## Test plan

- [ ] Auto-save a background tab while editing it concurrently — verify `fileSyncStatus` stays `"dirty"` if content was modified during save
- [ ] Open Save As dialog, edit content while dialog is open, save — verify the post-save `isDirty` reflects the edits made during the dialog
- [ ] Trigger a file conflict (external edit while editor is dirty), click "ディスクの内容を採用" — verify the editor view immediately shows the disk content without requiring a page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)