### PR TITLE
fix(auth): isolate OAuth PKCE state per window (#1021)

### DIFF
--- a/electron/ipc/auth-ipc.js
+++ b/electron/ipc/auth-ipc.js
@@ -1,11 +1,12 @@
-const { ipcMain, shell, BrowserWindow } = require("electron");
+const { ipcMain, shell, BrowserWindow, app } = require("electron");
 const crypto = require("crypto");
 
 const PROVIDER_URL = "https://my.illusions.app";
 const OAUTH_CLIENT_ID = "illusions";
 const REDIRECT_URI = "illusions://auth/callback";
 
-let pendingAuth = null; // { state, codeVerifier }
+/** @type {Map<string, { codeVerifier: string, windowId: number }>} state → { codeVerifier, windowId } */
+const pendingAuthByState = new Map();
 
 function generateCodeVerifier() {
   return crypto.randomBytes(32).toString("base64url");
@@ -16,12 +17,14 @@ function generateCodeChallenge(verifier) {
 }
 
 function registerAuthHandlers() {
-  ipcMain.handle("auth:start-login", async () => {
+  ipcMain.handle("auth:start-login", async (event) => {
     const state = crypto.randomBytes(16).toString("hex");
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = generateCodeChallenge(codeVerifier);
 
-    pendingAuth = { state, codeVerifier };
+    const win = BrowserWindow.fromWebContents(event.sender);
+    const windowId = win ? win.id : -1;
+    pendingAuthByState.set(state, { codeVerifier, windowId });
 
     const params = new URLSearchParams({
       response_type: "code",
@@ -39,10 +42,12 @@ function registerAuthHandlers() {
   });
 
   ipcMain.handle("auth:exchange-code", async (_event, { code, state }) => {
-    if (!pendingAuth || pendingAuth.state !== state) {
+    const entry = pendingAuthByState.get(state);
+    if (!entry) {
       throw new Error("Invalid state parameter");
     }
-    const { codeVerifier } = pendingAuth;
+    const { codeVerifier } = entry;
+    pendingAuthByState.delete(state);
 
     const response = await fetch(`${PROVIDER_URL}/api/oauth/token`, {
       method: "POST",
@@ -61,7 +66,6 @@ function registerAuthHandlers() {
       throw new Error(err.error_description || "Token exchange failed");
     }
 
-    pendingAuth = null;
     return response.json();
   });
 
@@ -100,9 +104,23 @@ function registerAuthHandlers() {
     return response.json();
   });
 
-  ipcMain.handle("auth:logout", async () => {
-    pendingAuth = null;
+  ipcMain.handle("auth:logout", async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win) {
+      const winId = win.id;
+      for (const [state, entry] of pendingAuthByState) {
+        if (entry.windowId === winId) pendingAuthByState.delete(state);
+      }
+    }
     return { success: true };
+  });
+
+  // Clean up pending auth entries when a window is closed
+  app.on("browser-window-close", (_, win) => {
+    const winId = win.id;
+    for (const [state, entry] of pendingAuthByState) {
+      if (entry.windowId === winId) pendingAuthByState.delete(state);
+    }
   });
 }
 
@@ -116,9 +134,24 @@ function handleAuthCallback(url) {
     const state = parsed.searchParams.get("state");
     const error = parsed.searchParams.get("error");
 
-    // Find the main window (first non-destroyed window)
-    const windows = BrowserWindow.getAllWindows();
-    const targetWindow = windows.find((w) => !w.isDestroyed());
+    let targetWindow = null;
+
+    // Route callback to the specific window that initiated the login flow
+    const entry = state ? pendingAuthByState.get(state) : null;
+    if (entry) {
+      const originWin = BrowserWindow.fromId(entry.windowId);
+      if (originWin && !originWin.isDestroyed()) {
+        targetWindow = originWin;
+      }
+    }
+
+    // Fall back to the focused window or first non-destroyed window
+    if (!targetWindow) {
+      targetWindow =
+        BrowserWindow.getFocusedWindow() ||
+        BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
+    }
+
     if (targetWindow) {
       if (targetWindow.isMinimized()) targetWindow.restore();
       targetWindow.focus();


### PR DESCRIPTION
## Summary

- Replaces the single global `pendingAuth` variable in `electron/ipc/auth-ipc.js` with a `pendingAuthByState` Map keyed by the PKCE `state` string
- Each entry stores `{ codeVerifier, windowId }` so concurrent login flows from multiple windows are fully isolated
- The OS auth callback is routed to the exact window that initiated the login; falls back to the focused window if that window no longer exists
- `auth:logout` now only removes entries belonging to the sender's window
- A `browser-window-close` listener prunes entries when a window closes, preventing unbounded Map growth

Closes #1021

## Test plan

- [ ] Open two windows and start login in both simultaneously — each window receives only its own callback
- [ ] Close a window mid-login — no stale entries remain in the Map (verify via DevTools / logs)
- [ ] Complete a normal login flow in a single window — still works correctly
- [ ] Log out from one window — does not affect any pending auth state in other windows
- [ ] Destroy the originating window before the callback arrives — callback is delivered to the focused/first available window

🤖 Generated with [Claude Code](https://claude.com/claude-code)