### PR TITLE
fix(electron): register editor popout IPC handlers (#1032)

### DIFF
--- a/electron/ipc/editor-ipc.js
+++ b/electron/ipc/editor-ipc.js
@@ -1,0 +1,102 @@
+/* eslint-disable no-console */
+// Editor popout IPC handlers — multi-window buffer sync
+
+const { ipcMain, BrowserWindow, app } = require("electron");
+const path = require("path");
+const { isDev } = require("../app-constants");
+
+/**
+ * Register IPC handlers for editor popout windows and cross-window buffer sync.
+ *
+ * Channels handled:
+ *   editor:popout-panel        (handle) — open a new popout editor window
+ *   editor:buffer-sync         (on)     — broadcast buffer content to all other windows
+ *   editor:buffer-close        (on)     — broadcast buffer close to all other windows
+ */
+function registerEditorHandlers() {
+  // Open a new popout editor window for the given buffer
+  ipcMain.handle(
+    "editor:popout-panel",
+    async (event, { bufferId, content, fileName, fileType }) => {
+      // Validate required input
+      if (!bufferId || typeof bufferId !== "string") {
+        console.warn("[editor-ipc] popout-panel: invalid bufferId");
+        return { success: false, error: "invalid bufferId" };
+      }
+
+      const parentWindow = BrowserWindow.fromWebContents(event.sender);
+      const preloadPath = path.join(__dirname, "..", "preload.js");
+
+      const popout = new BrowserWindow({
+        width: 800,
+        height: 600,
+        parent: parentWindow || undefined,
+        show: false,
+        backgroundColor: "#0f172a",
+        webPreferences: {
+          preload: preloadPath,
+          contextIsolation: true,
+          nodeIntegration: false,
+          sandbox: true,
+        },
+      });
+
+      popout.once("ready-to-show", () => {
+        popout.show();
+      });
+
+      // Block navigation away from the app
+      popout.webContents.on("will-navigate", (navEvent, navigationUrl) => {
+        const parsedUrl = new URL(navigationUrl);
+        if (parsedUrl.protocol === "file:") return;
+        if (isDev && parsedUrl.hostname === "localhost") return;
+        navEvent.preventDefault();
+        console.warn("[Security] Blocked popout navigation to:", navigationUrl);
+      });
+
+      // Block new window creation from renderer
+      popout.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+
+      // Build URL with popout query params
+      const params = new URLSearchParams({
+        "popout-buffer": bufferId,
+        fileName: fileName || "",
+        fileType: fileType || "",
+      });
+
+      if (isDev) {
+        await popout.loadURL(`http://localhost:3020?${params}`);
+      } else {
+        const filePath = path.join(app.getAppPath(), "out", "index.html");
+        await popout.loadURL(`file://${filePath}?${params}`);
+      }
+
+      // Send initial content after page has loaded
+      if (content !== undefined && content !== null) {
+        popout.webContents.send("editor:buffer-sync-broadcast", { bufferId, content });
+      }
+
+      return { success: true };
+    },
+  );
+
+  // Broadcast buffer content update to all windows except the sender
+  ipcMain.on("editor:buffer-sync", (event, data) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed() && win.webContents !== event.sender) {
+        win.webContents.send("editor:buffer-sync-broadcast", data);
+      }
+    }
+  });
+
+  // Broadcast buffer close notification to all windows except the sender
+  ipcMain.on("editor:buffer-close", (event, bufferId) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      if (!win.isDestroyed() && win.webContents !== event.sender) {
+        win.webContents.send("editor:buffer-close-broadcast", bufferId);
+      }
+    }
+  });
+}
+
+module.exports = { registerEditorHandlers };

--- a/electron/main.js
+++ b/electron/main.js
@@ -41,6 +41,7 @@ const { registerSystemHandlers } = require("./ipc/system-ipc");
 const { registerPtyHandlers } = require("./ipc/pty-ipc");
 const { killAllSessions, killSessionsForWindow } = require("./ipc/terminal-session-registry");
 const { registerAuthHandlers, handleAuthCallback } = require("./ipc/auth-ipc");
+const { registerEditorHandlers } = require("./ipc/editor-ipc");
 
 process.on("uncaughtException", (err) => {
   console.error("[FATAL] Uncaught exception:", err);
@@ -160,6 +161,7 @@ app.whenReady().then(async () => {
   registerSystemHandlers();
   registerPtyHandlers();
   registerAuthHandlers();
+  registerEditorHandlers();
 
   // Power state monitoring
   powerMonitor.on("on-ac", () => broadcastPowerState("ac"));


### PR DESCRIPTION
## Summary

- Add `electron/ipc/editor-ipc.js` with IPC handlers for the editor popout feature
- Register `registerEditorHandlers()` in `electron/main.js` alongside existing IPC modules
- Closes #1032

## Details

`electron/preload.js` exposed five APIs (`popoutPanel`, `sendBufferSync`, `onBufferSync`, `sendBufferClose`, `onBufferClose`) that invoked IPC channels with no corresponding handlers in the main process. This caused silent failures when calling these APIs from the renderer.

The new `editor-ipc.js` implements:
- `editor:popout-panel` (`ipcMain.handle`) — creates a `BrowserWindow` with the same security settings as the main window (`contextIsolation`, `nodeIntegration: false`, `sandbox: true`), loads the app URL with `?popout-buffer=<id>` query params, and sends initial buffer content via `editor:buffer-sync-broadcast`
- `editor:buffer-sync` (`ipcMain.on`) — re-broadcasts buffer content updates to all windows except the sender
- `editor:buffer-close` (`ipcMain.on`) — re-broadcasts buffer close events to all windows except the sender

## Test plan

- [ ] Open two editor windows and pop out a buffer — verify the popout window opens with the correct content
- [ ] Edit content in the original window — verify the popout receives `editor:buffer-sync-broadcast`
- [ ] Close the buffer in the original window — verify the popout receives `editor:buffer-close-broadcast`
- [ ] Verify no regression for existing IPC channels (storage, file, shell, NLP, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)