### PR TITLE
fix(terminal): add UTF-8 locale and CJK unicode support (#1191, #1125)

### DIFF
--- a/components/TerminalPanel.tsx
+++ b/components/TerminalPanel.tsx
@@ -131,7 +131,7 @@ export default function TerminalPanel({
     // Create terminal instance with user settings
     const terminal = new XTerm({
       theme: buildXtermTheme(terminalAnsiColors, terminalBackground, terminalForeground),
-      fontFamily: terminalFontFamily,
+      fontFamily: `${terminalFontFamily}, "Noto Sans Mono CJK JP", "MS Gothic", "Menlo", monospace`,
       fontSize: terminalFontSize,
       lineHeight: terminalLineHeight,
       cursorStyle: terminalCursorStyle,
@@ -143,6 +143,11 @@ export default function TerminalPanel({
 
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
+
+    // Load Unicode11Addon for correct CJK/full-width character widths
+    const { Unicode11Addon } = await import("@xterm/addon-unicode11");
+    terminal.loadAddon(new Unicode11Addon());
+    terminal.unicode.activeVersion = "11";
 
     // Open terminal in the container element
     terminal.open(containerRef.current);

--- a/electron/ipc/pty-ipc.js
+++ b/electron/ipc/pty-ipc.js
@@ -234,7 +234,10 @@ function registerPtyHandlers() {
         cols,
         rows,
         cwd,
-        env: { ...process.env },
+        env: {
+          ...process.env,
+          ...(process.platform !== "win32" ? { LANG: "en_US.UTF-8", LC_ALL: "en_US.UTF-8" } : {}),
+        },
       });
     } catch (err) {
       console.error("[PTY] Failed to spawn PTY:", err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "illusions",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "illusions",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -18,6 +18,7 @@
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-unicode11": "^0.9.0",
         "@xterm/xterm": "^6.0.0",
         "archiver": "^7.0.1",
         "assert": "^2.1.0",
@@ -6179,6 +6180,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-unicode11": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0.tgz",
+      "integrity": "sha512-FxDnYcyuXhNl+XSqGZL/t0U9eiNb/q3EWT5rYkQT/zuig8Gz/VagnQANKHdDWFM2lTMk9ly0EFQxxxtZUoRetw==",
       "license": "MIT"
     },
     "node_modules/@xterm/xterm": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/xterm": "^6.0.0",
     "archiver": "^7.0.1",
     "assert": "^2.1.0",
@@ -95,6 +96,7 @@
     "esbuild": "^0.27.3",
     "eslint": "^9.18.0",
     "eslint-config-next": "^16.1.6",
+    "husky": "^9.1.7",
     "jsdom": "^28.1.0",
     "license-checker": "^25.0.1",
     "lint-staged": "^15.5.2",
@@ -108,8 +110,7 @@
     "typescript": "^5.7.2",
     "unist-util-visit": "^5.0.0",
     "vitest": "^4.0.18",
-    "wait-on": "^9.0.3",
-    "husky": "^9.1.7"
+    "wait-on": "^9.0.3"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
## Summary

- PTY spawns with `LANG=en_US.UTF-8` / `LC_ALL=en_US.UTF-8` on macOS/Linux, fixing garbled UTF-8 output from shells (closes #1191)
- `@xterm/addon-unicode11` is dynamically loaded and Unicode 11 character widths are activated, so CJK/full-width characters occupy 2 columns as expected (closes #1125)
- CJK fallback fonts (`Noto Sans Mono CJK JP`, `MS Gothic`) appended to `fontFamily` so CJK glyphs render even when the user's chosen font lacks them

## Changes

| File | Change |
|------|--------|
| `electron/ipc/pty-ipc.js` | Inject `LANG` / `LC_ALL` into PTY spawn env on non-Windows |
| `components/TerminalPanel.tsx` | Load `Unicode11Addon`, activate Unicode 11, add CJK fallback fonts |
| `package.json` | Add `@xterm/addon-unicode11 ^0.9.0` dependency |

## Test plan

- [ ] Open terminal panel on macOS — run `echo "日本語テスト"` and verify correct output
- [ ] Open terminal panel on macOS — run a program that outputs CJK characters; verify columns align correctly (no half-width gaps)
- [ ] Verify `locale` command in terminal shows `UTF-8` encoding
- [ ] Run `npx tsc --noEmit` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)