### PR TITLE
fix(storage): scope characters by project ID to prevent cross-contamination (#1030)

### DIFF
--- a/components/Characters.tsx
+++ b/components/Characters.tsx
@@ -31,12 +31,25 @@ function Characters({ content }: CharactersProps) {
     relationships: "",
   });
 
-  // Restore characters from persistent storage on mount
+  // Cache the project ID resolved during restore so the persist effect uses the same key.
+  const projectIdRef = useRef<string>("__standalone__");
+
+  // Restore characters from persistent storage on mount.
+  // Reads from charactersByProject[projectId] and falls back to the legacy
+  // characters field for one-time migration.
   useEffect(() => {
     const restore = async () => {
       try {
         const appState = await fetchAppState();
-        if (appState?.characters && appState.characters.length > 0) {
+        const projectId = appState?.currentProjectId ?? "__standalone__";
+        projectIdRef.current = projectId;
+
+        const perProject = appState?.charactersByProject?.[projectId];
+        if (perProject && perProject.length > 0) {
+          // Use the per-project data if it already exists.
+          setCharacters(perProject);
+        } else if (appState?.characters && appState.characters.length > 0) {
+          // One-time migration: move legacy flat array into per-project bucket.
           setCharacters(appState.characters);
         }
       } catch (err) {
@@ -48,14 +61,25 @@ function Characters({ content }: CharactersProps) {
     void restore();
   }, []);
 
-  // Persist characters to storage on change (debounced)
+  // Persist characters to per-project storage on change (debounced).
   useEffect(() => {
     if (!isLoaded) return; // skip initial empty state
 
     const timer = setTimeout(() => {
-      void persistAppState({ characters }).catch((err) => {
-        console.error("Failed to persist characters:", err);
-      });
+      const projectId = projectIdRef.current;
+      void (async () => {
+        try {
+          const appState = await fetchAppState();
+          await persistAppState({
+            charactersByProject: {
+              ...appState?.charactersByProject,
+              [projectId]: characters,
+            },
+          });
+        } catch (err) {
+          console.error("Failed to persist characters:", err);
+        }
+      })();
     }, 500);
 
     return () => clearTimeout(timer);

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -92,7 +92,7 @@ export interface AppState {
   characterExtractionBatchSize?: number;
   characterExtractionConcurrency?: number;
 
-  // Persisted character data
+  // Persisted character data (legacy: shared across all projects)
   characters?: Array<{
     id: string;
     name: string;
@@ -102,6 +102,22 @@ export interface AppState {
     personality: string;
     relationships: string;
   }>;
+
+  // Per-project character data keyed by project ID.
+  // Falls back to `characters` for migration.
+  // "__standalone__" is used when no project is open.
+  charactersByProject?: Record<
+    string,
+    Array<{
+      id: string;
+      name: string;
+      aliases: string[];
+      description: string;
+      appearance: string;
+      personality: string;
+      relationships: string;
+    }>
+  >;
 
   // 校正モード設定
   correctionMode?: CorrectionModeId;


### PR DESCRIPTION
## Summary

- Characters were stored in a single flat `AppState.characters` array shared across all projects and standalone files, causing cross-contamination
- Add `charactersByProject?: Record<string, CharacterShape[]>` to `AppState` in `storage-types.ts`, keeping the old `characters` field for backward compatibility
- Update `Characters.tsx` restore logic to read from `charactersByProject[projectId]`, with a one-time migration fallback to the legacy `characters` field
- Update `Characters.tsx` persist logic to write per-project by merging into `charactersByProject`
- Use `"__standalone__"` as the bucket key when no project is open

## Test plan

- [ ] Open a project, add characters → confirm they appear only under that project
- [ ] Open a different project → confirm it starts with an empty character list (not the first project's characters)
- [ ] Existing users: on first load, legacy `characters` data is migrated into the current project's bucket transparently
- [ ] Standalone mode (no project open): characters stored under `"__standalone__"` key, isolated from project data

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)