### PR TITLE
fix(electron): isolate menu UI state and keymap overrides per window (#1041)

### DIFF
--- a/electron/ipc/system-ipc.js
+++ b/electron/ipc/system-ipc.js
@@ -41,18 +41,24 @@ function registerSystemHandlers() {
     return true;
   });
 
-  // Sync UI state from renderer to update menu checked states
-  ipcMain.handle("menu:sync-ui-state", async (_event, state) => {
+  // Sync UI state from renderer to update menu checked states (per-window)
+  ipcMain.handle("menu:sync-ui-state", async (event, state) => {
     const { setMenuUiState, rebuildApplicationMenu } = require("../menu");
-    setMenuUiState(state);
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win) {
+      setMenuUiState(state, win.id);
+    }
     await rebuildApplicationMenu();
     return true;
   });
 
-  // Sync keymap overrides from renderer to update menu accelerators
-  ipcMain.handle("menu:update-keymap-overrides", async (_event, overrides) => {
+  // Sync keymap overrides from renderer to update menu accelerators (per-window)
+  ipcMain.handle("menu:update-keymap-overrides", async (event, overrides) => {
     const { setKeymapOverrides, rebuildApplicationMenu } = require("../menu");
-    setKeymapOverrides(overrides);
+    const win = BrowserWindow.fromWebContents(event.sender);
+    if (win) {
+      setKeymapOverrides(overrides, win.id);
+    }
     await rebuildApplicationMenu();
     return true;
   });

--- a/electron/main.js
+++ b/electron/main.js
@@ -185,12 +185,22 @@ app.on("before-quit", () => {
   killAllSessions();
 });
 
+// Per-window menu state lifecycle: focus → swap active state; closed → cleanup
+app.on("browser-window-focus", (_event, win) => {
+  const { setActiveWindowId, rebuildApplicationMenu } = require("./menu");
+  setActiveWindowId(win.id);
+  void rebuildApplicationMenu();
+});
+
 // Kill PTY sessions for a window when it is closed
 app.on("browser-window-created", (_event, win) => {
   const wcId = win.webContents.id;
 
   win.on("closed", () => {
     killSessionsForWindow(wcId);
+    // Remove per-window menu state to prevent memory leak
+    const { removeWindowState } = require("./menu");
+    removeWindowState(win.id);
   });
 
   // Kill orphaned PTYs if the renderer crashes

--- a/electron/menu.js
+++ b/electron/menu.js
@@ -5,16 +5,23 @@ const { app, BrowserWindow, Menu, shell } = require("electron");
 const { APP_NAME, isDev } = require("./app-constants");
 const { getStorageManager } = require("./ipc/storage-ipc");
 
-// UI state synced from renderer for menu checked states
-let menuUiState = {
+// Default UI state for menu checked states
+const DEFAULT_MENU_UI_STATE = {
   compactMode: false,
   showParagraphNumbers: true,
   themeMode: "auto", // 'auto' | 'light' | 'dark'
   autoCharsPerLine: true,
 };
 
-// Keymap overrides synced from renderer (only differences from defaults)
-let keymapOverrides = {};
+// Per-window UI state (BrowserWindow.id → menuUiState object)
+const windowMenuStates = new Map();
+
+// Per-window keymap overrides (BrowserWindow.id → overrides object)
+const windowKeymapOverrides = new Map();
+
+// The ID of the currently focused window; used to select the correct per-window state
+// when building the application menu.
+let activeWindowId = null;
 
 /**
  * Default Electron accelerator strings keyed by CommandId.
@@ -35,12 +42,75 @@ const DEFAULT_ACCELERATORS = {
 };
 
 /**
+ * Returns the UI state for the currently active window.
+ * Falls back to the default state if no window state has been registered yet.
+ * @returns {typeof DEFAULT_MENU_UI_STATE}
+ */
+function getMenuUiState() {
+  if (activeWindowId !== null && windowMenuStates.has(activeWindowId)) {
+    return windowMenuStates.get(activeWindowId);
+  }
+  return { ...DEFAULT_MENU_UI_STATE };
+}
+
+/**
+ * Stores the UI state for a specific window.
+ * @param {Partial<typeof DEFAULT_MENU_UI_STATE>} state
+ * @param {number} windowId - BrowserWindow.id
+ */
+function setMenuUiState(state, windowId) {
+  const existing = windowMenuStates.get(windowId) ?? { ...DEFAULT_MENU_UI_STATE };
+  windowMenuStates.set(windowId, { ...existing, ...state });
+}
+
+/**
+ * Returns the keymap overrides for the currently active window.
+ * @returns {Record<string, unknown>}
+ */
+function getKeymapOverrides() {
+  if (activeWindowId !== null && windowKeymapOverrides.has(activeWindowId)) {
+    return windowKeymapOverrides.get(activeWindowId);
+  }
+  return {};
+}
+
+/**
+ * Stores keymap overrides for a specific window.
+ * @param {Record<string, unknown>} overrides
+ * @param {number} windowId - BrowserWindow.id
+ */
+function setKeymapOverrides(overrides, windowId) {
+  windowKeymapOverrides.set(windowId, overrides ?? {});
+}
+
+/**
+ * Sets the active window ID so that subsequent menu builds reflect that window's state.
+ * @param {number | null} windowId - BrowserWindow.id, or null to clear
+ */
+function setActiveWindowId(windowId) {
+  activeWindowId = windowId;
+}
+
+/**
+ * Removes all per-window state for a closed window.
+ * @param {number} windowId - BrowserWindow.id
+ */
+function removeWindowState(windowId) {
+  windowMenuStates.delete(windowId);
+  windowKeymapOverrides.delete(windowId);
+  if (activeWindowId === windowId) {
+    activeWindowId = null;
+  }
+}
+
+/**
  * Resolves the Electron accelerator for a command, applying user overrides.
  * @param {string} commandId
  * @returns {string | undefined}
  */
 function resolveAccelerator(commandId) {
-  const override = keymapOverrides[commandId];
+  const overrides = getKeymapOverrides();
+  const override = overrides[commandId];
   if (override === null) return undefined; // intentionally unbound
   if (override) {
     // Convert KeyBinding { modifiers: [...], key: "s" } to "CmdOrCtrl+Shift+S"
@@ -61,24 +131,10 @@ function resolveAccelerator(commandId) {
   return DEFAULT_ACCELERATORS[commandId];
 }
 
-function getMenuUiState() {
-  return menuUiState;
-}
-
-function setMenuUiState(state) {
-  menuUiState = { ...menuUiState, ...state };
-}
-
-function getKeymapOverrides() {
-  return keymapOverrides;
-}
-
-function setKeymapOverrides(overrides) {
-  keymapOverrides = overrides ?? {};
-}
-
 function buildApplicationMenu(recentProjects = []) {
   const isMac = process.platform === "darwin";
+  // Snapshot the active window's UI state once for this build
+  const menuUiState = getMenuUiState();
 
   /** Send an IPC message to the focused window instead of mainWindow */
   const sendToFocused = (channel, ...args) => {
@@ -435,4 +491,6 @@ module.exports = {
   setMenuUiState,
   getKeymapOverrides,
   setKeymapOverrides,
+  setActiveWindowId,
+  removeWindowState,
 };


### PR DESCRIPTION
## Summary

- Replaces the process-global `menuUiState` and `keymapOverrides` variables in `electron/menu.js` with per-window `Map`s keyed by `BrowserWindow.id`
- The active window's state is selected on focus change via a new `browser-window-focus` listener in `electron/main.js`, which calls `setActiveWindowId()` + `rebuildApplicationMenu()`
- IPC handlers `menu:sync-ui-state` and `menu:update-keymap-overrides` now extract the sender window's ID and write only to that window's slot in the maps
- On window close, `removeWindowState()` is called to free the per-window entries and prevent memory leaks

Closes #1041

## Test plan

- [ ] Open two windows; set compact mode ON in window A — confirm window B's menu still shows compact mode OFF
- [ ] Set a theme (dark/light) in window B — confirm window A keeps its previous theme checked state
- [ ] Customize a keymap shortcut in window A — confirm window B shows its own (default) accelerator
- [ ] Focus window A → menu reflects A's state; focus window B → menu reflects B's state
- [ ] Close window A → no crash; remaining window's menu state is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)