### PR TITLE
fix(ci): add Dexie transaction mock and fix formatting

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -388,7 +388,7 @@ export default function NovelEditor({
         setLocalAutoCharsPerLine(clamped);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- charsPerLine & callback read via refs to break recalc loop
+     
   }, [fontFamily, fontScale, lineHeight, isVertical, scrollContainerRef]);
 
   // Add window resize listener to auto-adjust chars per line
@@ -476,7 +476,11 @@ export default function NovelEditor({
 
         {/* 選択文字数（エディタ基準で配置） */}
         {editorViewInstance && (
-          <SelectionCounter editorView={editorViewInstance} isVertical={isVertical} containerRef={scrollContainerRef} />
+          <SelectionCounter
+            editorView={editorViewInstance}
+            isVertical={isVertical}
+            containerRef={scrollContainerRef}
+          />
         )}
       </div>
 

--- a/components/SelectionCounter.tsx
+++ b/components/SelectionCounter.tsx
@@ -38,20 +38,25 @@ export default function SelectionCounter({
         const rect = container.getBoundingClientRect();
 
         // キーボード選択時は選択末尾の座標をフォールバックに使う
-        const fallbackCoords = !(event instanceof MouseEvent) && from !== to
-          ? editorView.coordsAtPos(to)
-          : null;
+        const fallbackCoords =
+          !(event instanceof MouseEvent) && from !== to ? editorView.coordsAtPos(to) : null;
 
         if (isVertical) {
           // 縦書き: エディタの一番下に配置
-          const xPos = event instanceof MouseEvent ? event.clientX : (fallbackCoords?.left ?? rect.left + rect.width / 2);
+          const xPos =
+            event instanceof MouseEvent
+              ? event.clientX
+              : (fallbackCoords?.left ?? rect.left + rect.width / 2);
           setPosition({
             bottom: window.innerHeight - rect.bottom + 16,
             left: xPos,
           });
         } else {
           // 横書き: エディタの一番右に配置
-          const yPos = event instanceof MouseEvent ? event.clientY : (fallbackCoords?.top ?? rect.top + rect.height / 2);
+          const yPos =
+            event instanceof MouseEvent
+              ? event.clientY
+              : (fallbackCoords?.top ?? rect.top + rect.height / 2);
           setPosition({
             top: yPos,
             right: window.innerWidth - rect.right + 16,

--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -355,7 +355,6 @@ export function useDockviewAdapter({
     return () => {
       cancelled = true;
     };
-     
   }, [windowKey]);
 
   // -- Pending split tracking -----------------------------------------------

--- a/lib/storage/__tests__/web-storage.test.ts
+++ b/lib/storage/__tests__/web-storage.test.ts
@@ -70,6 +70,9 @@ const mockKvStoreTable = createMockTable<any>("key");
 
 const mockDb = {
   open: vi.fn(async () => {}),
+  transaction: vi.fn(async (_mode: string, _tables: unknown[], fn: () => Promise<void>) => {
+    await fn();
+  }),
   appState: mockAppStateTable,
   recentFiles: mockRecentFilesTable,
   editorBuffer: mockEditorBufferTable,
@@ -89,6 +92,7 @@ vi.mock("dexie", () => {
       // can reference them through the instance.
       Object.assign(this, {
         open: mockDb.open,
+        transaction: mockDb.transaction,
         appState: mockDb.appState,
         recentFiles: mockDb.recentFiles,
         editorBuffer: mockDb.editorBuffer,


### PR DESCRIPTION
## Summary

- Add `transaction` method to `FakeDexie` mock in `web-storage.test.ts` — the atomic `Dexie.transaction()` call in `saveSession()` (from PR #1162) needs this mock to work in tests
- Fix Prettier formatting in 3 files (`Editor.tsx`, `SelectionCounter.tsx`, `use-dockview-adapter.ts`)

## Test plan

- [ ] `npm run format:check` passes
- [ ] `npx vitest run lib/storage/__tests__/web-storage.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)