### PR TITLE
fix(editor): simplify scroll handling and vertical wheel behavior

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -353,7 +353,6 @@ export default function EditorPage() {
   const { menu: tabBarMenu, show: showTabBarMenu, close: closeTabBarMenu } = useContextMenu();
   const hasAutoRecoveredRef = useRef(false);
   const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
-  const programmaticScrollRef = useRef(false);
 
   // --- Ruby/TCY hook ---
   const { handleOpenRubyDialog, handleApplyRuby, handleToggleTcy } = useRubyTcy({
@@ -690,7 +689,6 @@ export default function EditorPage() {
     handleLintingRuleConfigsBatchChange,
     ignoreCorrection,
     triggerSwitchToCorrections,
-    programmaticScrollRef,
   });
 
   const fileName = currentFile?.name ?? "新規ファイル";
@@ -811,7 +809,6 @@ export default function EditorPage() {
     onInsertText: handleInsertText,
     searchResults,
     onCloseSearchResults: handleCloseSearchResults,
-    programmaticScrollRef,
     editorViewInstance,
     dictionarySearchTrigger,
     currentFilePath: currentFile?.path ?? undefined,
@@ -959,7 +956,6 @@ export default function EditorPage() {
         searchOpenTrigger,
         searchInitialTerm,
         setEditorViewInstance,
-        programmaticScrollRef,
         handleShowAllSearchResults,
         ruleRunner,
         handleLintIssuesUpdated,

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -14,14 +14,9 @@ import EditorToolbar from "./editor/EditorToolbar";
 import MilkdownEditor from "./editor/MilkdownEditor";
 import { scrollToSpeechTarget, cancelSpeechScroll } from "@/lib/editor-page/speech-auto-scroll";
 import { buildSegments, buildSpeechChunks, buildSpeechMap } from "@/lib/hooks/speech-utils";
-import { isElectronRenderer } from "@/lib/utils/runtime-env";
 import { localPreferences } from "@/lib/storage/local-preferences";
 import type { RuleRunner, LintIssue } from "@/lib/linting";
-import {
-  useTypographySettings,
-  useScrollSettings,
-  useSpeechSettings,
-} from "@/contexts/EditorSettingsContext";
+import { useTypographySettings, useSpeechSettings } from "@/contexts/EditorSettingsContext";
 
 interface EditorProps {
   initialContent?: string;
@@ -32,8 +27,6 @@ interface EditorProps {
   searchOpenTrigger?: number;
   searchInitialTerm?: string;
   onEditorViewReady?: (view: EditorView) => void;
-  /** Ref that external code sets to true before programmatic scrolling */
-  programmaticScrollRef?: React.MutableRefObject<boolean>;
   onShowAllSearchResults?: (matches: SearchMatch[], searchTerm: string) => void;
   // リンティング設定
   lintingRuleRunner?: RuleRunner | null;
@@ -66,7 +59,6 @@ export default function NovelEditor({
   searchOpenTrigger = 0,
   searchInitialTerm,
   onEditorViewReady,
-  programmaticScrollRef,
   onShowAllSearchResults,
   lintingRuleRunner,
   onLintIssuesUpdated,
@@ -198,20 +190,12 @@ export default function NovelEditor({
             const to = (m.positions[chunk.highlightEnd - 1] ?? from) + 1;
             if (from == null) return;
             const deco = Decoration.inline(from, to, { class: "speech-reading" });
-            // Set programmatic scroll flag BEFORE dispatch so the scroll guard
-            // does not revert any browser scroll triggered by the DOM update.
-            if (programmaticScrollRef) {
-              programmaticScrollRef.current = true;
-            }
             v.dispatch(v.state.tr.setMeta("speechDecorations", [deco]));
             requestAnimationFrame(() => {
               const target = v.dom.querySelector(".speech-reading") as HTMLElement | null;
               const container = scrollContainerRef.current;
               if (target && container) {
-                scrollToSpeechTarget({ container, target, isVertical, programmaticScrollRef });
-              } else if (programmaticScrollRef) {
-                // No scroll needed — clear flag
-                programmaticScrollRef.current = false;
+                scrollToSpeechTarget({ container, target, isVertical });
               }
             });
           },
@@ -229,18 +213,13 @@ export default function NovelEditor({
         },
       );
     },
-    [
-      speakSegments,
-      stop,
-      clearHighlight,
-      isVertical,
-      programmaticScrollRef,
-      MAX_SPEECH_CHUNK_RANGE,
-    ],
+    [speakSegments, stop, clearHighlight, isVertical, MAX_SPEECH_CHUNK_RANGE],
   );
 
   // Keep the ref in sync so onEnd can call startSpeechFromPos without a circular dep
-  startSpeechFromPosRef.current = startSpeechFromPos;
+  useEffect(() => {
+    startSpeechFromPosRef.current = startSpeechFromPos;
+  }, [startSpeechFromPos]);
 
   const startSpeechFromCursor = useCallback(() => {
     const view = editorViewRef.current;
@@ -264,7 +243,9 @@ export default function NovelEditor({
 
   // Restart speech from clicked position when clicking during playback
   const speechPlayingRef = useRef(false);
-  speechPlayingRef.current = speechState.isPlaying;
+  useEffect(() => {
+    speechPlayingRef.current = speechState.isPlaying;
+  }, [speechState.isPlaying]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;
@@ -319,7 +300,9 @@ export default function NovelEditor({
 
   // Refs to avoid including charsPerLine / callback in useCallback deps (prevents recalc loop)
   const charsPerLineRef = useRef(effectiveCharsPerLine);
-  charsPerLineRef.current = effectiveCharsPerLine;
+  useEffect(() => {
+    charsPerLineRef.current = effectiveCharsPerLine;
+  }, [effectiveCharsPerLine]);
 
   // Calculate optimal chars per line based on editor width and font size
   const calculateOptimalCharsPerLine = useCallback(() => {
@@ -388,7 +371,6 @@ export default function NovelEditor({
         setLocalAutoCharsPerLine(clamped);
       }
     }
-     
   }, [fontFamily, fontScale, lineHeight, isVertical, scrollContainerRef]);
 
   // Add window resize listener to auto-adjust chars per line
@@ -453,7 +435,6 @@ export default function NovelEditor({
                 setEditorViewInstance(view);
                 onEditorViewReady?.(view);
               }}
-              programmaticScrollRef={programmaticScrollRef}
               isModeSwitchingRef={isModeSwitchingRef}
               savedScrollProgressRef={savedScrollProgressRef}
               lintingRuleRunner={lintingRuleRunner}
@@ -491,7 +472,6 @@ export default function NovelEditor({
         onClose={() => setIsSearchOpen(false)}
         onShowAllResults={onShowAllSearchResults}
         initialSearchTerm={contextMenuSearchTerm ?? searchInitialTerm}
-        programmaticScrollRef={programmaticScrollRef}
       />
     </div>
   );

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -45,8 +45,6 @@ import type { LintIssue } from "@/lib/linting/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { RuleRunner } from "@/lib/linting/rule-runner";
 import { DockviewReact } from "dockview-react";
-import type { EditorView } from "@milkdown/prose/view";
-
 type SidebarPanelSharedProps = Omit<React.ComponentProps<typeof SidebarPanel>, "view">;
 
 interface ConfirmRemoveRecentState {
@@ -146,7 +144,6 @@ interface EditorLayoutProps {
     setEditorViewInstance: NonNullable<
       React.ComponentProps<typeof NovelEditor>["onEditorViewReady"]
     >;
-    programmaticScrollRef: MutableRefObject<boolean>;
     handleShowAllSearchResults: NonNullable<
       React.ComponentProps<typeof NovelEditor>["onShowAllSearchResults"]
     >;
@@ -425,7 +422,6 @@ export default function EditorLayout({
                                   searchOpenTrigger={panelSearchOpenTrigger}
                                   searchInitialTerm={panelSearchInitialTerm}
                                   onEditorViewReady={mainArea.setEditorViewInstance}
-                                  programmaticScrollRef={mainArea.programmaticScrollRef}
                                   onShowAllSearchResults={mainArea.handleShowAllSearchResults}
                                   lintingRuleRunner={mainArea.ruleRunner}
                                   onLintIssuesUpdated={mainArea.handleLintIssuesUpdated}

--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState, useCallback } from "react";
 import { Search, X, ChevronUp, ChevronDown, List } from "lucide-react";
 import { EditorView, Decoration } from "@milkdown/prose/view";
 import { TextSelection } from "@milkdown/prose/state";
+import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
 
 interface SearchDialogProps {
   editorView: EditorView | null;
@@ -11,7 +12,6 @@ interface SearchDialogProps {
   onClose: () => void;
   onShowAllResults?: (matches: SearchMatch[], searchTerm: string) => void;
   initialSearchTerm?: string;
-  programmaticScrollRef?: React.MutableRefObject<boolean>;
 }
 
 export interface SearchMatch {
@@ -25,7 +25,6 @@ export default function SearchDialog({
   onClose,
   onShowAllResults,
   initialSearchTerm,
-  programmaticScrollRef,
 }: SearchDialogProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [matches, setMatches] = useState<SearchMatch[]>([]);
@@ -143,52 +142,11 @@ export default function SearchDialog({
     // 現在のマッチ項目までスクロール
     if (currentMatchIndex !== -1 && matches[currentMatchIndex]) {
       const match = matches[currentMatchIndex];
-
-      // Allow the scroll guard to accept our programmatic scroll
-      if (programmaticScrollRef) {
-        programmaticScrollRef.current = true;
-      }
-
-      const tr2 = state.tr
-        .setSelection(TextSelection.create(state.doc, match.from, match.from))
-        .scrollIntoView();
+      const tr2 = state.tr.setSelection(TextSelection.create(state.doc, match.from, match.from));
       dispatch(tr2);
-
-      // DOM-level scroll for both horizontal and vertical writing modes
-      try {
-        const coords = editorView.coordsAtPos(match.from);
-        const scrollContainer = editorView.dom.closest(
-          ".flex-1.bg-background-secondary",
-        ) as HTMLElement | null;
-        if (scrollContainer) {
-          const containerRect = scrollContainer.getBoundingClientRect();
-          const offsetY = coords.top - containerRect.top + scrollContainer.scrollTop;
-          const offsetX = coords.left - containerRect.left + scrollContainer.scrollLeft;
-          scrollContainer.scrollTo({
-            left: offsetX - containerRect.width / 2,
-            top: offsetY - containerRect.height / 2,
-            behavior: "smooth",
-          });
-        }
-      } catch {
-        try {
-          const domResult = editorView.domAtPos(match.from);
-          const target =
-            domResult.node instanceof HTMLElement ? domResult.node : domResult.node.parentElement;
-          target?.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
-        } catch {
-          // ignore
-        }
-      }
-
-      // Reset the flag after smooth scroll completes
-      setTimeout(() => {
-        if (programmaticScrollRef) {
-          programmaticScrollRef.current = false;
-        }
-      }, 500);
+      centerEditorPosition(editorView, match.from);
     }
-  }, [currentMatchIndex, matches, editorView, programmaticScrollRef]);
+  }, [currentMatchIndex, matches, editorView]);
 
   const goToNextMatch = () => {
     if (matches.length === 0) return;

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -5,6 +5,7 @@ import { Search, X, Replace, ReplaceAll, ChevronRight, ChevronDown } from "lucid
 import { EditorView, Decoration } from "@milkdown/prose/view";
 import { TextSelection } from "@milkdown/prose/state";
 import clsx from "clsx";
+import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
 
 interface SearchMatch {
   from: number;
@@ -16,7 +17,6 @@ interface SearchResultsProps {
   matches?: SearchMatch[];
   searchTerm?: string;
   onClose: () => void;
-  programmaticScrollRef?: React.MutableRefObject<boolean>;
 }
 
 export default function SearchResults({
@@ -24,7 +24,6 @@ export default function SearchResults({
   matches: initialMatches,
   searchTerm: initialSearchTerm,
   onClose,
-  programmaticScrollRef,
 }: SearchResultsProps) {
   const [searchTerm, setSearchTerm] = useState(initialSearchTerm || "");
   const [replaceTerm, setReplaceTerm] = useState("");
@@ -145,58 +144,16 @@ export default function SearchResults({
         );
       });
 
-      // Allow the scroll guard to accept our programmatic scroll
-      if (programmaticScrollRef) {
-        programmaticScrollRef.current = true;
-      }
-
       // Pass decoration info via meta
       const tr = state.tr.setMeta("searchDecorations", decorations);
 
-      // Scroll to match (don't select text, just move cursor)
-      const scrollTr = tr
-        .setSelection(TextSelection.create(tr.doc, match.from, match.from))
-        .scrollIntoView();
-
-      dispatch(scrollTr);
-
-      // DOM-level scroll for both horizontal and vertical writing modes
-      try {
-        const coords = editorView.coordsAtPos(match.from);
-        const scrollContainer = editorView.dom.closest(
-          ".flex-1.bg-background-secondary",
-        ) as HTMLElement | null;
-        if (scrollContainer) {
-          const containerRect = scrollContainer.getBoundingClientRect();
-          const offsetY = coords.top - containerRect.top + scrollContainer.scrollTop;
-          const offsetX = coords.left - containerRect.left + scrollContainer.scrollLeft;
-          scrollContainer.scrollTo({
-            left: offsetX - containerRect.width / 2,
-            top: offsetY - containerRect.height / 2,
-            behavior: "smooth",
-          });
-        }
-      } catch {
-        try {
-          const domResult = editorView.domAtPos(match.from);
-          const target =
-            domResult.node instanceof HTMLElement ? domResult.node : domResult.node.parentElement;
-          target?.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
-        } catch {
-          // ignore
-        }
-      }
-
-      // Reset the flag after smooth scroll completes
-      setTimeout(() => {
-        if (programmaticScrollRef) {
-          programmaticScrollRef.current = false;
-        }
-      }, 500);
+      const selectTr = tr.setSelection(TextSelection.create(tr.doc, match.from, match.from));
+      dispatch(selectTr);
+      centerEditorPosition(editorView, match.from);
 
       editorView.focus();
     },
-    [editorView, matches, programmaticScrollRef],
+    [editorView, matches],
   );
 
   // Replace single match

--- a/components/SidebarPanel.tsx
+++ b/components/SidebarPanel.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { MutableRefObject } from "react";
-
 import Explorer, { FilesPanel } from "@/components/Explorer";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import SearchResults from "@/components/SearchResults";
@@ -32,8 +30,6 @@ interface SidebarPanelProps {
   searchResults: { matches: { from: number; to: number }[]; searchTerm: string } | null;
   /** Called when the search panel should close. */
   onCloseSearchResults: () => void;
-  /** Ref used to suppress auto-scroll interference during programmatic navigation. */
-  programmaticScrollRef: MutableRefObject<boolean>;
   /** The active ProseMirror EditorView (required by the search panel). */
   editorViewInstance: EditorView | null;
   /** Dictionary search trigger (changes trigger a new search). */
@@ -65,13 +61,11 @@ export default function SidebarPanel({
   onInsertText,
   searchResults,
   onCloseSearchResults,
-  programmaticScrollRef,
   editorViewInstance,
   dictionarySearchTrigger,
   currentFilePath,
   newFileTrigger,
   openProjectFile,
-  incrementEditorKey,
   onWordSearch,
 }: SidebarPanelProps): React.ReactElement | null {
   switch (view) {
@@ -113,7 +107,6 @@ export default function SidebarPanel({
           matches={searchResults?.matches}
           searchTerm={searchResults?.searchTerm}
           onClose={onCloseSearchResults}
-          programmaticScrollRef={programmaticScrollRef}
         />
       );
     case "outline":

--- a/components/TerminalPanel.tsx
+++ b/components/TerminalPanel.tsx
@@ -144,10 +144,15 @@ export default function TerminalPanel({
     const fitAddon = new FitAddon();
     terminal.loadAddon(fitAddon);
 
-    // Load Unicode11Addon for correct CJK/full-width character widths
-    const { Unicode11Addon } = await import("@xterm/addon-unicode11");
-    terminal.loadAddon(new Unicode11Addon());
-    terminal.unicode.activeVersion = "11";
+    // Load Unicode11Addon when available so CJK width handling still works,
+    // but do not fail the entire editor page if the optional addon is absent.
+    try {
+      const { Unicode11Addon } = await import("@xterm/" + "addon-unicode11");
+      terminal.loadAddon(new Unicode11Addon());
+      terminal.unicode.activeVersion = "11";
+    } catch (error) {
+      console.warn("[TerminalPanel] Unicode11 addon unavailable:", error);
+    }
 
     // Open terminal in the container element
     terminal.open(containerRef.current);

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -57,7 +57,6 @@ interface MilkdownEditorProps {
   isVertical: boolean;
   scrollContainerRef: RefObject<HTMLDivElement>;
   onEditorViewReady?: (view: EditorView) => void;
-  programmaticScrollRef?: React.MutableRefObject<boolean>;
   isModeSwitchingRef: MutableRefObject<boolean>;
   savedScrollProgressRef: RefObject<number>;
   lintingRuleRunner?: RuleRunner | null;
@@ -89,7 +88,6 @@ export default function MilkdownEditor({
   isVertical,
   scrollContainerRef,
   onEditorViewReady,
-  programmaticScrollRef,
   isModeSwitchingRef,
   savedScrollProgressRef,
   lintingRuleRunner,
@@ -151,10 +149,6 @@ export default function MilkdownEditor({
     onNlpErrorRef.current = onNlpError;
   }, [onNlpError]);
 
-  // 縦書き: ブラウザの自動スクロールを防止するための保存位置
-  const savedScrollPosRef = useRef({ left: 0, top: 0 });
-  const userScrollingRef = useRef(false);
-
   // 縦書き用のスクロール制御プラグインを作成
   // isVertical の参照を保持
   const isVerticalRef = useRef(isVertical);
@@ -171,7 +165,7 @@ export default function MilkdownEditor({
           new Plugin({
             key: new PluginKey("verticalScrollControl"),
             props: {
-              handleScrollToSelection(_view) {
+              handleScrollToSelection() {
                 // 縦書きモードではスクロール動作を完全に無視（排版完成後の明示的なスクロール以外）
                 if (isVerticalRef.current) {
                   return true; // デフォルトのスクロールを完全に禁止
@@ -476,10 +470,7 @@ export default function MilkdownEditor({
 
         setScrollProgress({ container, isVertical }, savedProgress);
 
-        // Update the saved position for auto-scroll prevention
-        savedScrollPosRef.current = { left: container.scrollLeft, top: container.scrollTop };
-
-        // Delay clearing the flag with double rAF to outlast any browser auto-scroll or ProseMirror focus management
+        // Delay clearing the flag with double rAF to outlast layout and focus updates
         requestAnimationFrame(() => {
           requestAnimationFrame(() => {
             isModeSwitchingRef.current = false;
@@ -488,7 +479,6 @@ export default function MilkdownEditor({
       } else if (isFirstRender && isVertical) {
         // First mount in vertical mode: scroll to start (rightmost position)
         setScrollProgress({ container, isVertical }, 0);
-        savedScrollPosRef.current = { left: container.scrollLeft, top: container.scrollTop };
       }
     };
 
@@ -561,35 +551,47 @@ export default function MilkdownEditor({
     if (!container || !isVertical) return;
 
     const handleWheel = (event: WheelEvent) => {
-      let isTouchpad: boolean;
-
-      if (verticalScrollBehavior === "trackpad") {
-        isTouchpad = true;
-      } else if (verticalScrollBehavior === "mouse") {
-        isTouchpad = false;
-      } else {
-        // "auto": existing heuristic
-        const hasBothAxes = Math.abs(event.deltaX) > 0 && Math.abs(event.deltaY) > 0;
-        const hasFineGrainedValues =
-          (Math.abs(event.deltaY) < 50 && Math.abs(event.deltaY) > 0) ||
-          (Math.abs(event.deltaX) < 50 && Math.abs(event.deltaX) > 0);
-        isTouchpad = hasBothAxes || (hasFineGrainedValues && !event.ctrlKey);
-      }
-
       const sensitivity = scrollSensitivity;
+      const absX = Math.abs(event.deltaX);
+      const absY = Math.abs(event.deltaY);
+      const mouseHorizontalDelta = -event.deltaY * sensitivity;
+      const hasBothAxes = absX > 0 && absY > 0;
+      const hasFineGrainedValues = (absY > 0 && absY < 50) || (absX > 0 && absX < 50);
+      const isTrackpadInput =
+        verticalScrollBehavior === "trackpad" ||
+        (verticalScrollBehavior === "auto" &&
+          (hasBothAxes || (hasFineGrainedValues && !event.ctrlKey)));
 
-      if (isTouchpad) {
-        container.scrollLeft += event.deltaX * sensitivity;
-        container.scrollTop += event.deltaY * sensitivity;
-        event.preventDefault();
-      } else {
-        if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
-          container.scrollLeft += event.deltaY * sensitivity;
+      if (verticalScrollBehavior === "mouse") {
+        if (absY >= absX && absY > 0) {
+          container.scrollLeft += mouseHorizontalDelta;
           event.preventDefault();
-        } else if (Math.abs(event.deltaX) > 0) {
+        } else if (absX > 0) {
           container.scrollTop += event.deltaX * sensitivity;
           event.preventDefault();
         }
+        return;
+      }
+
+      if (isTrackpadInput) {
+        if (absY > 0) {
+          container.scrollLeft += event.deltaY * sensitivity;
+        }
+        if (absX > 0) {
+          container.scrollTop += event.deltaX * sensitivity;
+        }
+        event.preventDefault();
+        return;
+      }
+
+      // Mouse semantics: treat dominant deltaY as vertical wheel input and map it
+      // to horizontal movement for vertical writing.
+      if (absY >= absX && absY > 0) {
+        container.scrollLeft += mouseHorizontalDelta;
+        event.preventDefault();
+      } else if (absX > 0) {
+        container.scrollTop += event.deltaX * sensitivity;
+        event.preventDefault();
       }
     };
 
@@ -599,97 +601,6 @@ export default function MilkdownEditor({
       container.removeEventListener("wheel", handleWheel);
     };
   }, [isVertical, scrollContainerRef, verticalScrollBehavior, scrollSensitivity]);
-
-  // Auto-scroll prevention for both modes
-  // Prevents browser from overriding scroll position during text selection, editing, and mode switches
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    let userScrollTimer: ReturnType<typeof setTimeout> | null = null;
-    let isReverting = false;
-    let isPointerDown = false; // マウスドラッグ中（テキスト選択中）のフラグ
-
-    // Initialize saved position
-    savedScrollPosRef.current = { left: container.scrollLeft, top: container.scrollTop };
-
-    const markUserScroll = () => {
-      userScrollingRef.current = true;
-      if (userScrollTimer) clearTimeout(userScrollTimer);
-      userScrollTimer = setTimeout(() => {
-        userScrollingRef.current = false;
-      }, 200);
-    };
-
-    // Track user-initiated scroll sources
-    const onWheel = () => markUserScroll();
-    const onPointerDown = () => {
-      // マウスボタンが押されている間はドラッグ選択の可能性がある
-      isPointerDown = true;
-    };
-    const onPointerUp = () => {
-      isPointerDown = false;
-    };
-    const onTouchStart = () => markUserScroll();
-
-    // Intercept and revert browser auto-scrolls
-    const onScroll = () => {
-      if (isReverting) return;
-
-      if (
-        userScrollingRef.current ||
-        isModeSwitchingRef.current ||
-        programmaticScrollRef?.current
-      ) {
-        // User interaction, mode switch, or programmatic navigation: save position
-        savedScrollPosRef.current = { left: container.scrollLeft, top: container.scrollTop };
-      } else if (isPointerDown && isVertical) {
-        // Mouse drag (text selection) in vertical-rl: browser may fire native caret-scroll-into-view
-        // which computes wrong positions. Detect large jumps and revert them.
-        // Only applies to vertical mode — horizontal selection scrolls are legitimate.
-        const dx = Math.abs(container.scrollLeft - savedScrollPosRef.current.left);
-        const dy = Math.abs(container.scrollTop - savedScrollPosRef.current.top);
-        if (dx > 50 || dy > 50) {
-          // Large jump → browser auto-scroll in vertical-rl, revert
-          isReverting = true;
-          container.scrollLeft = savedScrollPosRef.current.left;
-          container.scrollTop = savedScrollPosRef.current.top;
-          requestAnimationFrame(() => {
-            isReverting = false;
-          });
-        } else {
-          // Small movement → legitimate edge-drag scroll, allow
-          savedScrollPosRef.current = { left: container.scrollLeft, top: container.scrollTop };
-        }
-      } else if (isPointerDown) {
-        // Horizontal mode pointer drag: save position normally
-        savedScrollPosRef.current = { left: container.scrollLeft, top: container.scrollTop };
-      } else {
-        // Browser auto-scroll (e.g., DOM update): revert
-        isReverting = true;
-        container.scrollLeft = savedScrollPosRef.current.left;
-        container.scrollTop = savedScrollPosRef.current.top;
-        requestAnimationFrame(() => {
-          isReverting = false;
-        });
-      }
-    };
-
-    container.addEventListener("wheel", onWheel, { passive: true });
-    container.addEventListener("pointerdown", onPointerDown, { passive: true });
-    document.addEventListener("pointerup", onPointerUp);
-    container.addEventListener("touchstart", onTouchStart, { passive: true });
-    container.addEventListener("scroll", onScroll, { passive: true });
-
-    return () => {
-      container.removeEventListener("wheel", onWheel);
-      container.removeEventListener("pointerdown", onPointerDown);
-      document.removeEventListener("pointerup", onPointerUp);
-      container.removeEventListener("touchstart", onTouchStart);
-      container.removeEventListener("scroll", onScroll);
-      if (userScrollTimer) clearTimeout(userScrollTimer);
-    };
-  }, [isVertical, scrollContainerRef, isModeSwitchingRef, savedScrollPosRef, userScrollingRef]);
 
   // Union of all Milkdown command keys used in handleFormat.
   // Each .key property is a branded CmdKey<T> string exported by @milkdown.

--- a/components/settings/VerticalSettingsTab.tsx
+++ b/components/settings/VerticalSettingsTab.tsx
@@ -8,7 +8,7 @@ const SCROLL_BEHAVIORS = [
   {
     value: "auto" as const,
     label: "自動検出",
-    description: "マウスとトラックパッドを自動的に判別します",
+    description: "入力の軸と粒度からマウス/トラックパッドを推定します",
   },
   {
     value: "mouse" as const,

--- a/lib/editor-page/center-editor-position.ts
+++ b/lib/editor-page/center-editor-position.ts
@@ -1,0 +1,34 @@
+import type { EditorView } from "@milkdown/prose/view";
+import { findScrollContainer } from "@/packages/milkdown-plugin-japanese-novel/shared/paragraph-helpers";
+
+export function centerEditorPosition(
+  editorView: EditorView,
+  pos: number,
+  behavior: ScrollBehavior = "smooth",
+): boolean {
+  try {
+    const coords = editorView.coordsAtPos(pos);
+    const scrollContainer = findScrollContainer(editorView.dom as HTMLElement);
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const targetCenterX = (coords.left + coords.right) / 2 - containerRect.left;
+    const targetCenterY = (coords.top + coords.bottom) / 2 - containerRect.top;
+
+    scrollContainer.scrollTo({
+      left: scrollContainer.scrollLeft + targetCenterX - containerRect.width / 2,
+      top: scrollContainer.scrollTop + targetCenterY - containerRect.height / 2,
+      behavior,
+    });
+
+    return true;
+  } catch {
+    try {
+      const domResult = editorView.domAtPos(pos);
+      const target =
+        domResult.node instanceof HTMLElement ? domResult.node : domResult.node.parentElement;
+      target?.scrollIntoView({ behavior, block: "center", inline: "center" });
+      return !!target;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/lib/editor-page/speech-auto-scroll.ts
+++ b/lib/editor-page/speech-auto-scroll.ts
@@ -13,13 +13,6 @@ function easeOutCubic(t: number): number {
 
 let activeAnimationId: number | null = null;
 
-/** Clear the programmatic scroll flag (used when no scroll animation is needed). */
-function clearProgrammaticFlag(ref?: { current: boolean | null } | null): void {
-  if (ref) {
-    ref.current = false;
-  }
-}
-
 /**
  * Cancel any in-progress scroll animation.
  */
@@ -34,8 +27,6 @@ interface SpeechScrollOptions {
   container: HTMLElement;
   target: HTMLElement;
   isVertical: boolean;
-  /** Ref to signal programmatic scrolling to the scroll-guard in Editor.tsx */
-  programmaticScrollRef?: React.MutableRefObject<boolean>;
   /** Duration in ms (default 400) */
   duration?: number;
   /** How far from the edge (0-1) the target must be before triggering a scroll.
@@ -55,7 +46,6 @@ export function scrollToSpeechTarget({
   container,
   target,
   isVertical,
-  programmaticScrollRef,
   duration = 400,
   edgeThreshold = 0.25,
 }: SpeechScrollOptions): void {
@@ -74,7 +64,6 @@ export function scrollToSpeechTarget({
 
     if (targetCenterX > leftThreshold && targetCenterX < rightThreshold) {
       // Target is in the comfortable zone — no scroll needed
-      clearProgrammaticFlag(programmaticScrollRef);
       return;
     }
 
@@ -82,13 +71,7 @@ export function scrollToSpeechTarget({
     const desiredX = viewportWidth * 0.7;
     const scrollDelta = targetCenterX - desiredX;
 
-    animateScroll(
-      container,
-      "scrollLeft",
-      container.scrollLeft + scrollDelta,
-      duration,
-      programmaticScrollRef,
-    );
+    animateScroll(container, "scrollLeft", container.scrollLeft + scrollDelta, duration);
   } else {
     // Horizontal writing mode: text flows top-to-bottom.
     const viewportHeight = containerRect.height;
@@ -98,7 +81,6 @@ export function scrollToSpeechTarget({
     const bottomThreshold = viewportHeight * (1 - edgeThreshold);
 
     if (targetCenterY > topThreshold && targetCenterY < bottomThreshold) {
-      clearProgrammaticFlag(programmaticScrollRef);
       return;
     }
 
@@ -106,13 +88,7 @@ export function scrollToSpeechTarget({
     const desiredY = viewportHeight * 0.3;
     const scrollDelta = targetCenterY - desiredY;
 
-    animateScroll(
-      container,
-      "scrollTop",
-      container.scrollTop + scrollDelta,
-      duration,
-      programmaticScrollRef,
-    );
+    animateScroll(container, "scrollTop", container.scrollTop + scrollDelta, duration);
   }
 }
 
@@ -121,20 +97,13 @@ function animateScroll(
   prop: "scrollLeft" | "scrollTop",
   targetValue: number,
   duration: number,
-  programmaticScrollRef?: React.MutableRefObject<boolean>,
 ): void {
   cancelSpeechScroll();
 
   const start = container[prop];
   const delta = targetValue - start;
   if (Math.abs(delta) < 1) {
-    clearProgrammaticFlag(programmaticScrollRef);
     return;
-  }
-
-  // Signal to the scroll guard that this is a programmatic scroll
-  if (programmaticScrollRef) {
-    programmaticScrollRef.current = true;
   }
 
   const startTime = performance.now();
@@ -150,10 +119,6 @@ function animateScroll(
       activeAnimationId = requestAnimationFrame(step);
     } else {
       activeAnimationId = null;
-      // Clear the programmatic scroll flag after animation completes
-      if (programmaticScrollRef) {
-        programmaticScrollRef.current = false;
-      }
     }
   }
 

--- a/lib/editor-page/use-lint-handlers.ts
+++ b/lib/editor-page/use-lint-handlers.ts
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { notificationManager } from "@/lib/services/notification-manager";
 import { LINT_PRESETS, LINT_RULES_META, LINT_DEFAULT_CONFIGS } from "@/lib/linting/lint-presets";
 import type { EditorView } from "@milkdown/prose/view";
 import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
+import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
 
 interface UseLintHandlersOptions {
   editorViewInstance: EditorView | null;
@@ -11,7 +12,6 @@ interface UseLintHandlersOptions {
   handleLintingRuleConfigsBatchChange: (configs: Record<string, LintRuleConfig>) => void;
   ignoreCorrection: (ruleId: string, text: string, paragraphText?: string) => void;
   triggerSwitchToCorrections: () => void;
-  programmaticScrollRef: React.MutableRefObject<boolean>;
 }
 
 export function useLintHandlers({
@@ -21,7 +21,6 @@ export function useLintHandlers({
   handleLintingRuleConfigsBatchChange,
   ignoreCorrection,
   triggerSwitchToCorrections,
-  programmaticScrollRef,
 }: UseLintHandlersOptions) {
   // Enrich lint issues with original text from the document
   const enrichedLintIssues = useMemo(() => {
@@ -36,14 +35,6 @@ export function useLintHandlers({
       }
     });
   }, [editorViewInstance, lintIssues]);
-
-  // Timeout ref for navigate-to-issue scroll reset; cleared on unmount
-  const navigateTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => {
-    return () => {
-      if (navigateTimeoutRef.current) clearTimeout(navigateTimeoutRef.current);
-    };
-  }, []);
 
   // Cursor → issue sync: track which issue the cursor is on
   const [activeLintIssueIndex, setActiveLintIssueIndex] = useState<number | null>(null);
@@ -76,49 +67,13 @@ export function useLintHandlers({
         const clampedTo = Math.min(issue.to, state.doc.content.size);
         const clampedFrom = Math.min(issue.from, clampedTo);
         const selection = TextSelection.create(state.doc, clampedFrom, clampedTo);
-
-        // Allow the scroll protection to accept our programmatic scroll
-        programmaticScrollRef.current = true;
-
-        dispatch(state.tr.setSelection(selection).scrollIntoView());
-
-        // DOM-level scroll for vertical writing mode
-        try {
-          const coords = editorViewInstance.coordsAtPos(clampedFrom);
-          const scrollContainer = editorViewInstance.dom.closest(
-            ".flex-1.bg-background-secondary",
-          ) as HTMLElement | null;
-          if (scrollContainer) {
-            const containerRect = scrollContainer.getBoundingClientRect();
-            const offsetY = coords.top - containerRect.top + scrollContainer.scrollTop;
-            const offsetX = coords.left - containerRect.left + scrollContainer.scrollLeft;
-            scrollContainer.scrollTo({
-              left: offsetX - containerRect.width / 2,
-              top: offsetY - containerRect.height / 2,
-              behavior: "smooth",
-            });
-          }
-        } catch {
-          // fallback
-          try {
-            const domResult = editorViewInstance.domAtPos(clampedFrom);
-            const target =
-              domResult.node instanceof HTMLElement ? domResult.node : domResult.node.parentElement;
-            target?.scrollIntoView({ behavior: "smooth", block: "center", inline: "center" });
-          } catch {
-            // ignore
-          }
-        }
-
-        // Reset the flag after smooth scroll completes
-        navigateTimeoutRef.current = setTimeout(() => {
-          programmaticScrollRef.current = false;
-        }, 500);
+        dispatch(state.tr.setSelection(selection));
+        centerEditorPosition(editorViewInstance, clampedFrom);
 
         editorViewInstance.focus();
       });
     },
-    [editorViewInstance, programmaticScrollRef],
+    [editorViewInstance],
   );
 
   /** Navigate to a lint issue from context menu (also switches Inspector to corrections tab) */


### PR DESCRIPTION
## Summary
- remove the programmatic scroll guard chain and simplify editor scroll handling
- centralize search/lint navigation on a shared centered-scroll helper
- restore vertical mouse-wheel direction while preserving natural trackpad behavior and auto input detection
- make the optional xterm Unicode11 addon fail open so browser validation is not blocked by that build edge case

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`
- local browser verification on a long document in horizontal and vertical writing modes