### PR TITLE
fix(dockview): position terminal panel via addPanel instead of post-hoc moveTo (#1203)

### DIFF
--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -61,40 +61,38 @@ export interface UseDockviewAdapterReturn {
 // ---------------------------------------------------------------------------
 
 /**
- * Position a newly added terminal panel in the bottom split.
- * - If another terminal already exists, move into its group ("center").
- * - Otherwise, split below an existing editor panel ("bottom").
+ * Build the `position` option for `addPanel` so a new terminal panel is placed
+ * in the correct location immediately, without a post-hoc `moveTo()` call.
+ *
+ * - If another terminal panel already exists → use `direction: 'within'` to
+ *   open the new terminal as a tab in the same group (VS Code behaviour).
+ * - Otherwise → use `direction: 'below'` relative to the active (or first)
+ *   editor panel to create a bottom split.
+ * - If there are no other panels yet → return undefined (panel becomes the
+ *   only panel in the layout).
  */
-function positionTerminalPanel(api: DockviewApi, newPanel: IDockviewPanel, tabs: TabState[]): void {
+function buildTerminalPanelPosition(
+  api: DockviewApi,
+  newPanelId: string,
+  tabs: TabState[],
+): { referencePanel: string; direction: "within" | "below" } | undefined {
   // Look for an existing terminal panel to group with
   for (const panel of api.panels) {
-    if (panel.id === newPanel.id) continue;
+    if (panel.id === newPanelId) continue;
     const tab = tabs.find((t) => t.id === panel.id);
     if (tab && isTerminalTab(tab)) {
-      try {
-        newPanel.api.moveTo({
-          group: panel.group,
-          position: "center",
-        });
-      } catch {
-        // Move failed; panel stays in default group
-      }
-      return;
+      return { referencePanel: panel.id, direction: "within" };
     }
   }
 
   // No terminal group yet — split below the active (or first) editor panel
   const refPanel = api.activePanel ?? api.panels[0];
-  if (refPanel && refPanel.id !== newPanel.id) {
-    try {
-      newPanel.api.moveTo({
-        group: refPanel.group,
-        position: "bottom",
-      });
-    } catch {
-      // Move failed; panel stays in default group
-    }
+  if (refPanel && refPanel.id !== newPanelId) {
+    return { referencePanel: refPanel.id, direction: "below" };
   }
+
+  // No other panels — let dockview place the panel freely
+  return undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -292,11 +290,13 @@ export function useDockviewAdapter({
             },
           });
         } else if (isTerminalTab(tab)) {
+          const termPosition = buildTerminalPanelPosition(api, tab.id, tabs);
           api.addPanel<TerminalPanelParams>({
             id: tab.id,
             component: "terminal",
             title: tab.label,
             params: { sessionId: tab.sessionId },
+            ...(termPosition ? { position: termPosition } : {}),
           });
         } else if (isDiffTab(tab)) {
           api.addPanel<DiffPanelParams>({
@@ -404,14 +404,16 @@ export function useDockviewAdapter({
             },
           });
         } else if (isTerminalTab(tab)) {
-          // Add terminal panel then move it to the bottom split (like VS Code)
-          const termPanel = api.addPanel<TerminalPanelParams>({
+          // Add terminal panel with the correct position directly in addPanel,
+          // avoiding a post-hoc moveTo() that silently fails.
+          const termPosition = buildTerminalPanelPosition(api, tab.id, tabs);
+          api.addPanel<TerminalPanelParams>({
             id: tab.id,
             component: "terminal",
             title: tab.label,
             params: { sessionId: tab.sessionId },
+            ...(termPosition ? { position: termPosition } : {}),
           });
-          positionTerminalPanel(api, termPanel, tabs);
         } else if (isDiffTab(tab)) {
           api.addPanel<DiffPanelParams>({
             id: tab.id,


### PR DESCRIPTION
## Summary

- **Root cause**: `positionTerminalPanel()` called `panel.api.moveTo()` after `addPanel()` had already placed the panel in the active editor group. The `moveTo()` silently failed in a catch block, leaving the terminal tab invisible as a separate panel.
- **Fix**: Replaced `positionTerminalPanel()` with `buildTerminalPanelPosition()` which returns a `{ referencePanel, direction }` object passed directly as the `position` option to `addPanel()`. This leverages the dockview API's built-in positioning to create the panel in the correct location atomically.
- **Behavior**: Terminal now opens as a bottom split (first terminal) or as a tab in the existing terminal group (subsequent terminals), matching VS Code behaviour.

## Changes

- `lib/dockview/use-dockview-adapter.ts`: Replaced `positionTerminalPanel(api, termPanel, tabs)` pattern with `buildTerminalPanelPosition(api, tab.id, tabs)` returning a position option for `addPanel()`. Applied to both `handleDockviewReady` (initialization path) and the sync effect (runtime path).

## Test plan

- [ ] Click Terminal button in left sidebar — terminal panel should open as a bottom split below editor panels
- [ ] Click Terminal button again — second terminal should open as a tab within the existing terminal group
- [ ] Close all terminals and reopen — should create bottom split again
- [ ] Restart app with a terminal tab persisted in state — should restore to bottom position

Closes #1203

🤖 Generated with [Claude Code](https://claude.com/claude-code)