### PR TITLE
chore(gitignore): add Obsidian vault config and review-loop artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,14 @@ public/swe-worker*
 # WebStorm
 .idea
 
+# Obsidian (local vault config)
+docs/.obsidian/
+
+# Review loop artifacts
+reviews/
+.claude/review-loop.log
+.claude/*.local.md
+
 # auto-generated files
 /generated/
 


### PR DESCRIPTION
## Summary

- Ignore `docs/.obsidian/` entirely instead of selective workspace-only entries
- Add `reviews/` directory and `.claude/review-loop.*` local artifacts to gitignore

## Changes

| File | Change |
|------|--------|
| `.gitignore` | Add Obsidian vault config, review-loop output, Claude local files |

## Test plan

- [ ] `git status` no longer shows `docs/.obsidian/`, `reviews/`, `.claude/review-loop.*` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)