### PR TITLE
feat(pdf-export): add live preview panel to PDF export dialog

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -508,6 +508,7 @@ export default function EditorPage() {
         metadata: pdfExportMetadataRef.current,
         verticalWriting: settings.verticalWriting,
         pageSize: settings.pageSize,
+        landscape: settings.landscape,
         margins: settings.margins,
         charsPerLine: settings.charsPerLine,
         linesPerPage: settings.linesPerPage,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -478,12 +478,16 @@ export default function EditorPage() {
 
   // PDF export dialog state
   const [showPdfExportDialog, setShowPdfExportDialog] = useState(false);
+  const [pdfExportContent, setPdfExportContent] = useState("");
+  const [pdfExportMetadata, setPdfExportMetadata] = useState<ExportMetadata>({ title: "" });
   const pdfExportContentRef = useRef("");
   const pdfExportMetadataRef = useRef<ExportMetadata>({ title: "" });
 
   const handlePdfExportRequest = useCallback((pdfContent: string, metadata: ExportMetadata) => {
     pdfExportContentRef.current = pdfContent;
     pdfExportMetadataRef.current = metadata;
+    setPdfExportContent(pdfContent);
+    setPdfExportMetadata(metadata);
     setShowPdfExportDialog(true);
   }, []);
 
@@ -907,6 +911,8 @@ export default function EditorPage() {
         showPdfExportDialog,
         setShowPdfExportDialog,
         handlePdfExportConfirm,
+        pdfExportContent,
+        pdfExportMetadata,
       }}
       recovery={{
         wasAutoRecovered,

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -43,6 +43,7 @@ import { isEditorTab, type EditorTabState, type TabState } from "@/lib/tab-manag
 import type { ContextMenuState } from "@/lib/hooks/use-context-menu";
 import type { LintIssue } from "@/lib/linting/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
+import type { ExportMetadata } from "@/lib/export/types";
 import type { RuleRunner } from "@/lib/linting/rule-runner";
 import { DockviewReact } from "dockview-react";
 type SidebarPanelSharedProps = Omit<React.ComponentProps<typeof SidebarPanel>, "view">;
@@ -97,6 +98,8 @@ interface EditorLayoutProps {
     showPdfExportDialog: boolean;
     setShowPdfExportDialog: (show: boolean) => void;
     handlePdfExportConfirm: (settings: PdfExportSettings) => void;
+    pdfExportContent: string;
+    pdfExportMetadata: ExportMetadata;
   };
   recovery: {
     wasAutoRecovered?: boolean;
@@ -264,6 +267,8 @@ export default function EditorLayout({
               isOpen={dialogs.showPdfExportDialog}
               onClose={() => dialogs.setShowPdfExportDialog(false)}
               onExport={dialogs.handlePdfExportConfirm}
+              content={dialogs.pdfExportContent}
+              metadata={dialogs.pdfExportMetadata}
             />
 
             {!chrome.isElectron && recovery.wasAutoRecovered && !recovery.dismissedRecovery && (

--- a/components/PdfExportDialog.tsx
+++ b/components/PdfExportDialog.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import { useState, useCallback, type KeyboardEvent } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo, type KeyboardEvent } from "react";
 import clsx from "clsx";
 import GlassDialog from "./GlassDialog";
-import { loadPdfExportSettings, savePdfExportSettings } from "@/lib/export/pdf-export-settings";
+import { loadPdfExportSettings, savePdfExportSettings, calculateTypesetting, PAGE_DIMENSIONS } from "@/lib/export/pdf-export-settings";
+import { mdiToHtml } from "@/lib/export/mdi-to-html";
 
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
+import type { ExportMetadata } from "@/lib/export/types";
 
 interface PdfExportDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onExport: (settings: PdfExportSettings) => void;
+  content: string;
+  metadata: ExportMetadata;
 }
 
 type PageSize = PdfExportSettings["pageSize"];
@@ -37,17 +41,24 @@ const numberInputClass =
   "w-24 px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground text-sm text-center focus:outline-none focus:ring-2 focus:ring-accent";
 const labelClass = "block text-sm font-medium text-foreground mb-1";
 
+// 96dpi: 1mm = 96/25.4 px
+const MM_TO_PX = 96 / 25.4;
+// Fixed width of the preview thumbnail container in px
+const PREVIEW_CONTAINER_WIDTH = 300;
+
 /**
  * Wrapper that unmounts the inner form when closed,
  * so useState initializer reloads settings each time the dialog opens.
  */
-export default function PdfExportDialog({ isOpen, onClose, onExport }: PdfExportDialogProps) {
+export default function PdfExportDialog({ isOpen, onClose, onExport, content, metadata }: PdfExportDialogProps) {
   if (!isOpen) return null;
-  return <PdfExportDialogInner onClose={onClose} onExport={onExport} />;
+  return <PdfExportDialogInner onClose={onClose} onExport={onExport} content={content} metadata={metadata} />;
 }
 
-function PdfExportDialogInner({ onClose, onExport }: Omit<PdfExportDialogProps, "isOpen">) {
+function PdfExportDialogInner({ onClose, onExport, content, metadata }: Omit<PdfExportDialogProps, "isOpen">) {
   const [settings, setSettings] = useState<PdfExportSettings>(() => loadPdfExportSettings());
+  const [previewHtml, setPreviewHtml] = useState("");
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const updateField = useCallback(
     <K extends keyof PdfExportSettings>(key: K, value: PdfExportSettings[K]) => {
@@ -75,184 +86,276 @@ function PdfExportDialogInner({ onClose, onExport }: Omit<PdfExportDialogProps, 
     [onClose],
   );
 
+  // Regenerate preview HTML with debounce when settings or content change
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const { fontSizeMm, lineHeightRatio } = calculateTypesetting(
+        settings.pageSize,
+        settings.margins,
+        settings.charsPerLine,
+        settings.linesPerPage,
+        settings.verticalWriting,
+      );
+      const html = mdiToHtml(content, {
+        metadata,
+        verticalWriting: settings.verticalWriting,
+        typesetting: {
+          fontFamily: settings.fontFamily,
+          fontSizeMm,
+          lineHeightRatio,
+          textIndentEm: settings.textIndent,
+          margins: settings.margins,
+        },
+      });
+      setPreviewHtml(html);
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [settings, content, metadata]);
+
+  // Calculate iframe scale from page size
+  const { pageWidthPx, pageHeightPx, scale } = useMemo(() => {
+    const dims = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
+    const w = dims.width * MM_TO_PX;
+    const h = dims.height * MM_TO_PX;
+    return { pageWidthPx: w, pageHeightPx: h, scale: PREVIEW_CONTAINER_WIDTH / w };
+  }, [settings.pageSize]);
+
+  const scaledHeight = Math.round(pageHeightPx * scale);
+  const dims = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
+
   return (
     <GlassDialog
       isOpen
       onBackdropClick={onClose}
       ariaLabel="PDFエクスポート設定"
-      panelClassName="mx-4 w-full max-w-lg p-6"
+      panelClassName="mx-4 w-full max-w-5xl p-0 overflow-hidden"
     >
-      <div onKeyDown={handleKeyDown}>
-        <h2 className="text-lg font-semibold text-foreground mb-4">PDFエクスポート設定</h2>
-
-        <div className="space-y-4 max-h-[60vh] overflow-y-auto pr-1">
-          {/* Paper size */}
-          <div>
-            <label className={labelClass}>用紙サイズ</label>
-            <select
-              className={inputClass}
-              value={settings.pageSize}
-              onChange={(e) => updateField("pageSize", e.target.value as PageSize)}
-            >
-              {PAGE_SIZE_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
+      <div onKeyDown={handleKeyDown} className="flex max-h-[85vh]">
+        {/* Left: Settings panel */}
+        <div className="w-80 flex-shrink-0 flex flex-col border-r border-border">
+          <div className="px-6 pt-6 pb-4 border-b border-border">
+            <h2 className="text-lg font-semibold text-foreground">PDFエクスポート設定</h2>
           </div>
 
-          {/* Writing direction */}
-          <div>
-            <label className={labelClass}>組方向</label>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                className={clsx(
-                  "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
-                  settings.verticalWriting
-                    ? "bg-accent text-accent-foreground border-accent"
-                    : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
-                )}
-                onClick={() => updateField("verticalWriting", true)}
+          <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+            {/* Paper size */}
+            <div>
+              <label className={labelClass}>用紙サイズ</label>
+              <select
+                className={inputClass}
+                value={settings.pageSize}
+                onChange={(e) => updateField("pageSize", e.target.value as PageSize)}
               >
-                縦書き
-              </button>
-              <button
-                type="button"
-                className={clsx(
-                  "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
-                  !settings.verticalWriting
-                    ? "bg-accent text-accent-foreground border-accent"
-                    : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
-                )}
-                onClick={() => updateField("verticalWriting", false)}
-              >
-                横書き
-              </button>
+                {PAGE_SIZE_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
             </div>
-          </div>
 
-          {/* Chars per line + Lines per page — side by side */}
-          <div className="grid grid-cols-2 gap-4">
+            {/* Writing direction */}
             <div>
-              <label className={labelClass}>一行の文字数</label>
-              <input
-                type="number"
-                className={numberInputClass + " w-full"}
-                min={10}
-                max={60}
-                step={1}
-                value={settings.charsPerLine}
-                onChange={(e) => updateField("charsPerLine", clampInt(e.target.value, 10, 60))}
-              />
-            </div>
-            <div>
-              <label className={labelClass}>一頁の行数</label>
-              <input
-                type="number"
-                className={numberInputClass + " w-full"}
-                min={10}
-                max={50}
-                step={1}
-                value={settings.linesPerPage}
-                onChange={(e) => updateField("linesPerPage", clampInt(e.target.value, 10, 50))}
-              />
-            </div>
-          </div>
-
-          {/* Font */}
-          <div>
-            <label className={labelClass}>フォント</label>
-            <select
-              className={inputClass}
-              value={settings.fontFamily}
-              onChange={(e) => updateField("fontFamily", e.target.value)}
-            >
-              {FONT_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
-          </div>
-
-          {/* Indent + Page numbers — side by side */}
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className={labelClass}>字下げ（em）</label>
-              <input
-                type="number"
-                className={numberInputClass + " w-full"}
-                min={0}
-                max={4}
-                step={0.5}
-                value={settings.textIndent}
-                onChange={(e) => updateField("textIndent", clampFloat(e.target.value, 0, 4))}
-              />
-            </div>
-            <div>
-              <label className={labelClass}>ページ番号</label>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={settings.showPageNumbers}
-                onClick={() => updateField("showPageNumbers", !settings.showPageNumbers)}
-                className={clsx(
-                  "relative inline-flex h-9 w-16 shrink-0 items-center rounded-full transition-colors mt-0.5",
-                  settings.showPageNumbers ? "bg-accent" : "bg-border-secondary",
-                )}
-              >
-                <span
+              <label className={labelClass}>組方向</label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
                   className={clsx(
-                    "inline-block h-5 w-5 transform rounded-full bg-background transition-transform",
-                    settings.showPageNumbers ? "translate-x-9" : "translate-x-2",
+                    "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                    settings.verticalWriting
+                      ? "bg-accent text-accent-foreground border-accent"
+                      : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
                   )}
+                  onClick={() => updateField("verticalWriting", true)}
+                >
+                  縦書き
+                </button>
+                <button
+                  type="button"
+                  className={clsx(
+                    "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                    !settings.verticalWriting
+                      ? "bg-accent text-accent-foreground border-accent"
+                      : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                  )}
+                  onClick={() => updateField("verticalWriting", false)}
+                >
+                  横書き
+                </button>
+              </div>
+            </div>
+
+            {/* Chars per line + Lines per page */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className={labelClass}>一行の文字数</label>
+                <input
+                  type="number"
+                  className={numberInputClass + " w-full"}
+                  min={10}
+                  max={60}
+                  step={1}
+                  value={settings.charsPerLine}
+                  onChange={(e) => updateField("charsPerLine", clampInt(e.target.value, 10, 60))}
                 />
-              </button>
+              </div>
+              <div>
+                <label className={labelClass}>一頁の行数</label>
+                <input
+                  type="number"
+                  className={numberInputClass + " w-full"}
+                  min={10}
+                  max={50}
+                  step={1}
+                  value={settings.linesPerPage}
+                  onChange={(e) => updateField("linesPerPage", clampInt(e.target.value, 10, 50))}
+                />
+              </div>
+            </div>
+
+            {/* Font */}
+            <div>
+              <label className={labelClass}>フォント</label>
+              <select
+                className={inputClass}
+                value={settings.fontFamily}
+                onChange={(e) => updateField("fontFamily", e.target.value)}
+              >
+                {FONT_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Indent + Page numbers */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className={labelClass}>字下げ（em）</label>
+                <input
+                  type="number"
+                  className={numberInputClass + " w-full"}
+                  min={0}
+                  max={4}
+                  step={0.5}
+                  value={settings.textIndent}
+                  onChange={(e) => updateField("textIndent", clampFloat(e.target.value, 0, 4))}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>ページ番号</label>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={settings.showPageNumbers}
+                  onClick={() => updateField("showPageNumbers", !settings.showPageNumbers)}
+                  className={clsx(
+                    "relative inline-flex h-9 w-16 shrink-0 items-center rounded-full transition-colors mt-0.5",
+                    settings.showPageNumbers ? "bg-accent" : "bg-border-secondary",
+                  )}
+                >
+                  <span
+                    className={clsx(
+                      "inline-block h-5 w-5 transform rounded-full bg-background transition-transform",
+                      settings.showPageNumbers ? "translate-x-9" : "translate-x-2",
+                    )}
+                  />
+                </button>
+              </div>
+            </div>
+
+            {/* Margins */}
+            <div>
+              <label className={labelClass}>余白（mm）</label>
+              <div className="grid grid-cols-4 gap-2">
+                {(["top", "bottom", "left", "right"] as const).map((side) => (
+                  <div key={side}>
+                    <label className="block text-xs text-foreground-tertiary mb-1 text-center">
+                      {{ top: "上", bottom: "下", left: "左", right: "右" }[side]}
+                    </label>
+                    <input
+                      type="number"
+                      className={numberInputClass + " w-full"}
+                      min={0}
+                      max={50}
+                      step={1}
+                      value={settings.margins[side]}
+                      onChange={(e) => updateMargin(side, clampInt(e.target.value, 0, 50))}
+                    />
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
 
-          {/* Margins */}
-          <div>
-            <label className={labelClass}>余白（mm）</label>
-            <div className="grid grid-cols-4 gap-2">
-              {(["top", "bottom", "left", "right"] as const).map((side) => (
-                <div key={side}>
-                  <label className="block text-xs text-foreground-tertiary mb-1 text-center">
-                    {{ top: "上", bottom: "下", left: "左", right: "右" }[side]}
-                  </label>
-                  <input
-                    type="number"
-                    className={numberInputClass + " w-full"}
-                    min={0}
-                    max={50}
-                    step={1}
-                    value={settings.margins[side]}
-                    onChange={(e) => updateMargin(side, clampInt(e.target.value, 0, 50))}
-                  />
-                </div>
-              ))}
-            </div>
+          {/* Actions */}
+          <div className="flex justify-end gap-3 px-6 py-4 border-t border-border flex-shrink-0">
+            <button
+              type="button"
+              className="px-4 py-2 rounded-lg text-sm text-foreground-secondary hover:bg-hover transition-colors"
+              onClick={onClose}
+            >
+              キャンセル
+            </button>
+            <button
+              type="button"
+              className="px-4 py-2 rounded-lg text-sm bg-accent text-accent-foreground hover:bg-accent-hover transition-colors"
+              onClick={handleExport}
+            >
+              エクスポート
+            </button>
           </div>
         </div>
 
-        {/* Actions */}
-        <div className="flex justify-end gap-3 mt-6">
-          <button
-            type="button"
-            className="px-4 py-2 rounded-lg text-sm text-foreground-secondary hover:bg-hover transition-colors"
-            onClick={onClose}
-          >
-            キャンセル
-          </button>
-          <button
-            type="button"
-            className="px-4 py-2 rounded-lg text-sm bg-accent text-accent-foreground hover:bg-accent-hover transition-colors"
-            onClick={handleExport}
-          >
-            エクスポート
-          </button>
+        {/* Right: Preview panel */}
+        <div className="flex-1 flex flex-col bg-background-secondary min-w-0">
+          <div className="px-4 py-3 border-b border-border flex items-center justify-between flex-shrink-0">
+            <span className="text-sm font-medium text-foreground">プレビュー</span>
+            <span className="text-xs text-foreground-tertiary">
+              {settings.pageSize} · {settings.verticalWriting ? "縦書き" : "横書き"}
+            </span>
+          </div>
+
+          <div className="flex-1 overflow-auto flex items-start justify-center p-6">
+            {previewHtml ? (
+              <div className="flex flex-col items-center gap-2">
+                <div
+                  className="shadow-xl bg-white"
+                  style={{
+                    width: PREVIEW_CONTAINER_WIDTH,
+                    height: scaledHeight,
+                    overflow: "hidden",
+                    flexShrink: 0,
+                  }}
+                >
+                  <iframe
+                    srcDoc={previewHtml}
+                    sandbox="allow-same-origin"
+                    title="プレビュー"
+                    style={{
+                      width: pageWidthPx,
+                      height: pageHeightPx,
+                      transform: `scale(${scale})`,
+                      transformOrigin: "top left",
+                      border: "none",
+                      display: "block",
+                    }}
+                  />
+                </div>
+                <p className="text-xs text-foreground-tertiary">
+                  {dims.width}×{dims.height}mm
+                </p>
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-full text-foreground-tertiary text-sm">
+                生成中...
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </GlassDialog>

--- a/components/PdfExportDialog.tsx
+++ b/components/PdfExportDialog.tsx
@@ -93,7 +93,12 @@ export default function PdfExportDialog({
 }: PdfExportDialogProps) {
   if (!isOpen) return null;
   return (
-    <PdfExportDialogInner onClose={onClose} onExport={onExport} content={content} metadata={metadata} />
+    <PdfExportDialogInner
+      onClose={onClose}
+      onExport={onExport}
+      content={content}
+      metadata={metadata}
+    />
   );
 }
 
@@ -106,6 +111,8 @@ function PdfExportDialogInner({
   const [settings, setSettings] = useState<PdfExportSettings>(() => loadPdfExportSettings());
   // Page content chunks (split by estimated chars per page)
   const [pageChunks, setPageChunks] = useState<string[]>([]);
+  // Whether the initial debounce has completed (to distinguish "loading" from "no content")
+  const [ready, setReady] = useState(false);
   // How many pages are currently rendered in the preview
   const [visibleCount, setVisibleCount] = useState(INITIAL_PAGES);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -145,13 +152,18 @@ function PdfExportDialogInner({
       const chunks = splitContentIntoPages(content, charsPerPage);
       setPageChunks(chunks);
       setVisibleCount(INITIAL_PAGES);
+      setReady(true);
     }, 300);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
   }, [settings, content]);
 
-  // IntersectionObserver: load more pages when sentinel scrolls into view
+  const hasMore = visibleCount < pageChunks.length;
+
+  // IntersectionObserver: load more pages when sentinel scrolls into view.
+  // Depends on hasMore so it re-registers whenever the sentinel element
+  // appears (false→true) or disappears (true→false) in the DOM.
   useEffect(() => {
     const sentinel = sentinelRef.current;
     if (!sentinel) return;
@@ -166,7 +178,7 @@ function PdfExportDialogInner({
     );
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, []);
+  }, [hasMore]);
 
   // Memoize typesetting options from current settings
   const typesettingOptions = useMemo(() => {
@@ -176,6 +188,7 @@ function PdfExportDialogInner({
       settings.charsPerLine,
       settings.linesPerPage,
       settings.verticalWriting,
+      settings.landscape,
     );
     return {
       metadata,
@@ -196,16 +209,18 @@ function PdfExportDialogInner({
     return pageChunks.slice(0, limit).map((chunk) => mdiToHtml(chunk, typesettingOptions));
   }, [pageChunks, visibleCount, typesettingOptions]);
 
-  // Page thumbnail dimensions
+  // Page thumbnail dimensions (swap width/height when landscape)
   const { pageWidthPx, pageHeightPx, scale, dims } = useMemo(() => {
-    const d = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
+    const base = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
+    const d = settings.landscape
+      ? { width: base.height, height: base.width }
+      : base;
     const w = d.width * MM_TO_PX;
     const h = d.height * MM_TO_PX;
     return { pageWidthPx: w, pageHeightPx: h, scale: PREVIEW_PAGE_WIDTH / w, dims: d };
-  }, [settings.pageSize]);
+  }, [settings.pageSize, settings.landscape]);
 
   const scaledHeight = Math.round(pageHeightPx * scale);
-  const hasMore = visibleCount < pageChunks.length;
   const isEmpty = pageChunks.length === 0;
 
   return (
@@ -237,6 +252,37 @@ function PdfExportDialogInner({
                   </option>
                 ))}
               </select>
+            </div>
+
+            {/* Page orientation */}
+            <div>
+              <label className={labelClass}>用紙の向き</label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className={clsx(
+                    "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                    !settings.landscape
+                      ? "bg-accent text-accent-foreground border-accent"
+                      : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                  )}
+                  onClick={() => updateField("landscape", false)}
+                >
+                  縦置き
+                </button>
+                <button
+                  type="button"
+                  className={clsx(
+                    "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                    settings.landscape
+                      ? "bg-accent text-accent-foreground border-accent"
+                      : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                  )}
+                  onClick={() => updateField("landscape", true)}
+                >
+                  横置き
+                </button>
+              </div>
             </div>
 
             {/* Writing direction */}
@@ -398,15 +444,20 @@ function PdfExportDialogInner({
           <div className="px-4 py-3 border-b border-border flex items-center justify-between flex-shrink-0">
             <span className="text-sm font-medium text-foreground">プレビュー</span>
             <span className="text-xs text-foreground-tertiary">
-              {settings.pageSize} · {settings.verticalWriting ? "縦書き" : "横書き"}
+              {settings.pageSize} · {settings.landscape ? "横置き" : "縦置き"} ·{" "}
+              {settings.verticalWriting ? "縦書き" : "横書き"}
               {pageChunks.length > 0 && ` · 全${pageChunks.length}ページ`}
             </span>
           </div>
 
           <div className="flex-1 overflow-y-auto">
-            {isEmpty ? (
+            {!ready ? (
               <div className="flex items-center justify-center h-full text-foreground-tertiary text-sm">
                 生成中...
+              </div>
+            ) : isEmpty ? (
+              <div className="flex items-center justify-center h-full text-foreground-tertiary text-sm">
+                コンテンツがありません
               </div>
             ) : (
               <div className="flex flex-col items-center gap-4 p-6">

--- a/components/PdfExportDialog.tsx
+++ b/components/PdfExportDialog.tsx
@@ -3,7 +3,12 @@
 import { useState, useCallback, useEffect, useRef, useMemo, type KeyboardEvent } from "react";
 import clsx from "clsx";
 import GlassDialog from "./GlassDialog";
-import { loadPdfExportSettings, savePdfExportSettings, calculateTypesetting, PAGE_DIMENSIONS } from "@/lib/export/pdf-export-settings";
+import {
+  loadPdfExportSettings,
+  savePdfExportSettings,
+  calculateTypesetting,
+  PAGE_DIMENSIONS,
+} from "@/lib/export/pdf-export-settings";
 import { mdiToHtml } from "@/lib/export/mdi-to-html";
 
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
@@ -43,22 +48,68 @@ const labelClass = "block text-sm font-medium text-foreground mb-1";
 
 // 96dpi: 1mm = 96/25.4 px
 const MM_TO_PX = 96 / 25.4;
-// Fixed width of the preview thumbnail container in px
-const PREVIEW_CONTAINER_WIDTH = 300;
+// Fixed width of each page thumbnail in px
+const PREVIEW_PAGE_WIDTH = 300;
+// Pages shown initially before lazy loading
+const INITIAL_PAGES = 5;
+// Additional pages loaded per scroll batch
+const PAGES_PER_BATCH = 3;
+
+/**
+ * Split MDI content into page-sized chunks based on estimated chars per page.
+ * Splits on paragraph boundaries (double newlines) to avoid breaking mid-paragraph.
+ */
+function splitContentIntoPages(content: string, charsPerPage: number): string[] {
+  const trimmed = content.trim();
+  if (!trimmed) return [];
+
+  const paragraphs = trimmed.split(/\n{2,}/);
+  const pages: string[] = [];
+  let current = "";
+
+  for (const para of paragraphs) {
+    if (current.length > 0 && current.length + para.length > charsPerPage) {
+      pages.push(current);
+      current = para;
+    } else {
+      current = current ? current + "\n\n" + para : para;
+    }
+  }
+  if (current.trim()) pages.push(current);
+
+  return pages.length > 0 ? pages : [trimmed];
+}
 
 /**
  * Wrapper that unmounts the inner form when closed,
  * so useState initializer reloads settings each time the dialog opens.
  */
-export default function PdfExportDialog({ isOpen, onClose, onExport, content, metadata }: PdfExportDialogProps) {
+export default function PdfExportDialog({
+  isOpen,
+  onClose,
+  onExport,
+  content,
+  metadata,
+}: PdfExportDialogProps) {
   if (!isOpen) return null;
-  return <PdfExportDialogInner onClose={onClose} onExport={onExport} content={content} metadata={metadata} />;
+  return (
+    <PdfExportDialogInner onClose={onClose} onExport={onExport} content={content} metadata={metadata} />
+  );
 }
 
-function PdfExportDialogInner({ onClose, onExport, content, metadata }: Omit<PdfExportDialogProps, "isOpen">) {
+function PdfExportDialogInner({
+  onClose,
+  onExport,
+  content,
+  metadata,
+}: Omit<PdfExportDialogProps, "isOpen">) {
   const [settings, setSettings] = useState<PdfExportSettings>(() => loadPdfExportSettings());
-  const [previewHtml, setPreviewHtml] = useState("");
+  // Page content chunks (split by estimated chars per page)
+  const [pageChunks, setPageChunks] = useState<string[]>([]);
+  // How many pages are currently rendered in the preview
+  const [visibleCount, setVisibleCount] = useState(INITIAL_PAGES);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
 
   const updateField = useCallback(
     <K extends keyof PdfExportSettings>(key: K, value: PdfExportSettings[K]) => {
@@ -86,45 +137,76 @@ function PdfExportDialogInner({ onClose, onExport, content, metadata }: Omit<Pdf
     [onClose],
   );
 
-  // Regenerate preview HTML with debounce when settings or content change
+  // Debounced re-split when settings or content change
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      const { fontSizeMm, lineHeightRatio } = calculateTypesetting(
-        settings.pageSize,
-        settings.margins,
-        settings.charsPerLine,
-        settings.linesPerPage,
-        settings.verticalWriting,
-      );
-      const html = mdiToHtml(content, {
-        metadata,
-        verticalWriting: settings.verticalWriting,
-        typesetting: {
-          fontFamily: settings.fontFamily,
-          fontSizeMm,
-          lineHeightRatio,
-          textIndentEm: settings.textIndent,
-          margins: settings.margins,
-        },
-      });
-      setPreviewHtml(html);
+      const charsPerPage = settings.charsPerLine * settings.linesPerPage;
+      const chunks = splitContentIntoPages(content, charsPerPage);
+      setPageChunks(chunks);
+      setVisibleCount(INITIAL_PAGES);
     }, 300);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [settings, content, metadata]);
+  }, [settings, content]);
 
-  // Calculate iframe scale from page size
-  const { pageWidthPx, pageHeightPx, scale } = useMemo(() => {
-    const dims = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
-    const w = dims.width * MM_TO_PX;
-    const h = dims.height * MM_TO_PX;
-    return { pageWidthPx: w, pageHeightPx: h, scale: PREVIEW_CONTAINER_WIDTH / w };
+  // IntersectionObserver: load more pages when sentinel scrolls into view
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setVisibleCount((prev) => prev + PAGES_PER_BATCH);
+        }
+      },
+      { threshold: 0 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []);
+
+  // Memoize typesetting options from current settings
+  const typesettingOptions = useMemo(() => {
+    const { fontSizeMm, lineHeightRatio } = calculateTypesetting(
+      settings.pageSize,
+      settings.margins,
+      settings.charsPerLine,
+      settings.linesPerPage,
+      settings.verticalWriting,
+    );
+    return {
+      metadata,
+      verticalWriting: settings.verticalWriting,
+      typesetting: {
+        fontFamily: settings.fontFamily,
+        fontSizeMm,
+        lineHeightRatio,
+        textIndentEm: settings.textIndent,
+        margins: settings.margins,
+      },
+    };
+  }, [settings, metadata]);
+
+  // Generate HTML only for currently visible pages
+  const visiblePageHtml = useMemo(() => {
+    const limit = Math.min(visibleCount, pageChunks.length);
+    return pageChunks.slice(0, limit).map((chunk) => mdiToHtml(chunk, typesettingOptions));
+  }, [pageChunks, visibleCount, typesettingOptions]);
+
+  // Page thumbnail dimensions
+  const { pageWidthPx, pageHeightPx, scale, dims } = useMemo(() => {
+    const d = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
+    const w = d.width * MM_TO_PX;
+    const h = d.height * MM_TO_PX;
+    return { pageWidthPx: w, pageHeightPx: h, scale: PREVIEW_PAGE_WIDTH / w, dims: d };
   }, [settings.pageSize]);
 
   const scaledHeight = Math.round(pageHeightPx * scale);
-  const dims = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
+  const hasMore = visibleCount < pageChunks.length;
+  const isEmpty = pageChunks.length === 0;
 
   return (
     <GlassDialog
@@ -317,48 +399,94 @@ function PdfExportDialogInner({ onClose, onExport, content, metadata }: Omit<Pdf
             <span className="text-sm font-medium text-foreground">プレビュー</span>
             <span className="text-xs text-foreground-tertiary">
               {settings.pageSize} · {settings.verticalWriting ? "縦書き" : "横書き"}
+              {pageChunks.length > 0 && ` · 全${pageChunks.length}ページ`}
             </span>
           </div>
 
-          <div className="flex-1 overflow-auto flex items-start justify-center p-6">
-            {previewHtml ? (
-              <div className="flex flex-col items-center gap-2">
-                <div
-                  className="shadow-xl bg-white"
-                  style={{
-                    width: PREVIEW_CONTAINER_WIDTH,
-                    height: scaledHeight,
-                    overflow: "hidden",
-                    flexShrink: 0,
-                  }}
-                >
-                  <iframe
-                    srcDoc={previewHtml}
-                    sandbox="allow-same-origin"
-                    title="プレビュー"
-                    style={{
-                      width: pageWidthPx,
-                      height: pageHeightPx,
-                      transform: `scale(${scale})`,
-                      transformOrigin: "top left",
-                      border: "none",
-                      display: "block",
-                    }}
-                  />
-                </div>
-                <p className="text-xs text-foreground-tertiary">
-                  {dims.width}×{dims.height}mm
-                </p>
-              </div>
-            ) : (
+          <div className="flex-1 overflow-y-auto">
+            {isEmpty ? (
               <div className="flex items-center justify-center h-full text-foreground-tertiary text-sm">
                 生成中...
+              </div>
+            ) : (
+              <div className="flex flex-col items-center gap-4 p-6">
+                {visiblePageHtml.map((html, i) => (
+                  <PageThumbnail
+                    key={i}
+                    html={html}
+                    pageNumber={i + 1}
+                    pageWidthPx={pageWidthPx}
+                    pageHeightPx={pageHeightPx}
+                    scale={scale}
+                    scaledHeight={scaledHeight}
+                    dims={dims}
+                  />
+                ))}
+
+                {/* Sentinel: triggers loading more pages when scrolled into view */}
+                {hasMore && (
+                  <div ref={sentinelRef} className="w-full flex justify-center py-2">
+                    <span className="text-xs text-foreground-tertiary">読み込み中...</span>
+                  </div>
+                )}
+
+                {!hasMore && pageChunks.length > 0 && (
+                  <p className="text-xs text-foreground-tertiary py-2">
+                    全{pageChunks.length}ページ表示済み
+                  </p>
+                )}
               </div>
             )}
           </div>
         </div>
       </div>
     </GlassDialog>
+  );
+}
+
+interface PageThumbnailProps {
+  html: string;
+  pageNumber: number;
+  pageWidthPx: number;
+  pageHeightPx: number;
+  scale: number;
+  scaledHeight: number;
+  dims: { width: number; height: number };
+}
+
+function PageThumbnail({
+  html,
+  pageNumber,
+  pageWidthPx,
+  pageHeightPx,
+  scale,
+  scaledHeight,
+  dims,
+}: PageThumbnailProps) {
+  return (
+    <div className="flex flex-col items-center gap-1 flex-shrink-0">
+      <div
+        className="shadow-lg bg-white"
+        style={{ width: PREVIEW_PAGE_WIDTH, height: scaledHeight, overflow: "hidden" }}
+      >
+        <iframe
+          srcDoc={html}
+          sandbox="allow-same-origin"
+          title={`ページ ${pageNumber}`}
+          style={{
+            width: pageWidthPx,
+            height: pageHeightPx,
+            transform: `scale(${scale})`,
+            transformOrigin: "top left",
+            border: "none",
+            display: "block",
+          }}
+        />
+      </div>
+      <span className="text-xs text-foreground-tertiary">
+        {pageNumber} / {dims.width}×{dims.height}mm
+      </span>
+    </div>
   );
 }
 

--- a/components/PdfExportDialog.tsx
+++ b/components/PdfExportDialog.tsx
@@ -212,9 +212,7 @@ function PdfExportDialogInner({
   // Page thumbnail dimensions (swap width/height when landscape)
   const { pageWidthPx, pageHeightPx, scale, dims } = useMemo(() => {
     const base = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
-    const d = settings.landscape
-      ? { width: base.height, height: base.width }
-      : base;
+    const d = settings.landscape ? { width: base.height, height: base.width } : base;
     const w = d.width * MM_TO_PX;
     const h = d.height * MM_TO_PX;
     return { pageWidthPx: w, pageHeightPx: h, scale: PREVIEW_PAGE_WIDTH / w, dims: d };

--- a/components/PdfExportDialog.tsx
+++ b/components/PdfExportDialog.tsx
@@ -109,6 +109,8 @@ function PdfExportDialogInner({
   metadata,
 }: Omit<PdfExportDialogProps, "isOpen">) {
   const [settings, setSettings] = useState<PdfExportSettings>(() => loadPdfExportSettings());
+  // Debounced copy of settings used for preview rendering (updated every 300ms)
+  const [previewSettings, setPreviewSettings] = useState<PdfExportSettings>(settings);
   // Page content chunks (split by estimated chars per page)
   const [pageChunks, setPageChunks] = useState<string[]>([]);
   // Whether the initial debounce has completed (to distinguish "loading" from "no content")
@@ -148,6 +150,7 @@ function PdfExportDialogInner({
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
+      setPreviewSettings(settings);
       const charsPerPage = settings.charsPerLine * settings.linesPerPage;
       const chunks = splitContentIntoPages(content, charsPerPage);
       setPageChunks(chunks);
@@ -180,28 +183,28 @@ function PdfExportDialogInner({
     return () => observer.disconnect();
   }, [hasMore]);
 
-  // Memoize typesetting options from current settings
+  // Memoize typesetting options from debounced settings so preview updates at most every 300ms
   const typesettingOptions = useMemo(() => {
     const { fontSizeMm, lineHeightRatio } = calculateTypesetting(
-      settings.pageSize,
-      settings.margins,
-      settings.charsPerLine,
-      settings.linesPerPage,
-      settings.verticalWriting,
-      settings.landscape,
+      previewSettings.pageSize,
+      previewSettings.margins,
+      previewSettings.charsPerLine,
+      previewSettings.linesPerPage,
+      previewSettings.verticalWriting,
+      previewSettings.landscape,
     );
     return {
       metadata,
-      verticalWriting: settings.verticalWriting,
+      verticalWriting: previewSettings.verticalWriting,
       typesetting: {
-        fontFamily: settings.fontFamily,
+        fontFamily: previewSettings.fontFamily,
         fontSizeMm,
         lineHeightRatio,
-        textIndentEm: settings.textIndent,
-        margins: settings.margins,
+        textIndentEm: previewSettings.textIndent,
+        margins: previewSettings.margins,
       },
     };
-  }, [settings, metadata]);
+  }, [previewSettings, metadata]);
 
   // Generate HTML only for currently visible pages
   const visiblePageHtml = useMemo(() => {
@@ -209,14 +212,14 @@ function PdfExportDialogInner({
     return pageChunks.slice(0, limit).map((chunk) => mdiToHtml(chunk, typesettingOptions));
   }, [pageChunks, visibleCount, typesettingOptions]);
 
-  // Page thumbnail dimensions (swap width/height when landscape)
+  // Page thumbnail dimensions (swap width/height when landscape) — uses debounced settings
   const { pageWidthPx, pageHeightPx, scale, dims } = useMemo(() => {
-    const base = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
-    const d = settings.landscape ? { width: base.height, height: base.width } : base;
+    const base = PAGE_DIMENSIONS[previewSettings.pageSize] ?? PAGE_DIMENSIONS["A5"];
+    const d = previewSettings.landscape ? { width: base.height, height: base.width } : base;
     const w = d.width * MM_TO_PX;
     const h = d.height * MM_TO_PX;
     return { pageWidthPx: w, pageHeightPx: h, scale: PREVIEW_PAGE_WIDTH / w, dims: d };
-  }, [settings.pageSize, settings.landscape]);
+  }, [previewSettings.pageSize, previewSettings.landscape]);
 
   const scaledHeight = Math.round(pageHeightPx * scale);
   const isEmpty = pageChunks.length === 0;
@@ -361,7 +364,7 @@ function PdfExportDialogInner({
             {/* Indent + Page numbers */}
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className={labelClass}>字下げ（文字）</label>
+                <label className={labelClass}>字下げ（em）</label>
                 <input
                   type="number"
                   className={numberInputClass + " w-full"}
@@ -442,8 +445,8 @@ function PdfExportDialogInner({
           <div className="px-4 py-3 border-b border-border flex items-center justify-between flex-shrink-0">
             <span className="text-sm font-medium text-foreground">プレビュー</span>
             <span className="text-xs text-foreground-tertiary">
-              {settings.pageSize} · {settings.landscape ? "横置き" : "縦置き"} ·{" "}
-              {settings.verticalWriting ? "縦書き" : "横書き"}
+              {previewSettings.pageSize} · {previewSettings.landscape ? "横置き" : "縦置き"} ·{" "}
+              {previewSettings.verticalWriting ? "縦書き" : "横書き"}
               {pageChunks.length > 0 && ` · 全${pageChunks.length}ページ`}
             </span>
           </div>

--- a/components/PdfExportDialog.tsx
+++ b/components/PdfExportDialog.tsx
@@ -363,7 +363,7 @@ function PdfExportDialogInner({
             {/* Indent + Page numbers */}
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label className={labelClass}>字下げ（em）</label>
+                <label className={labelClass}>字下げ（文字）</label>
                 <input
                   type="number"
                   className={numberInputClass + " w-full"}

--- a/lib/export/pdf-export-settings.ts
+++ b/lib/export/pdf-export-settings.ts
@@ -7,6 +7,7 @@
 
 export interface PdfExportSettings {
   pageSize: "A4" | "A5" | "B5" | "B6";
+  landscape: boolean;
   verticalWriting: boolean;
   charsPerLine: number;
   linesPerPage: number;
@@ -18,6 +19,7 @@ export interface PdfExportSettings {
 
 export const DEFAULT_PDF_SETTINGS: PdfExportSettings = {
   pageSize: "A5",
+  landscape: false,
   verticalWriting: true,
   charsPerLine: 30,
   linesPerPage: 17,
@@ -65,6 +67,7 @@ export function savePdfExportSettings(settings: PdfExportSettings): void {
  *
  * For horizontal writing, chars flow left-to-right → font size derived from page width.
  * For vertical writing, chars flow top-to-bottom → font size derived from page height.
+ * For landscape orientation, the page width and height are swapped before calculation.
  */
 export function calculateTypesetting(
   pageSize: string,
@@ -72,8 +75,11 @@ export function calculateTypesetting(
   charsPerLine: number,
   linesPerPage: number,
   verticalWriting: boolean,
+  landscape: boolean = false,
 ): { fontSizeMm: number; lineHeightRatio: number } {
-  const dims = PAGE_DIMENSIONS[pageSize] ?? PAGE_DIMENSIONS["A5"];
+  const base = PAGE_DIMENSIONS[pageSize] ?? PAGE_DIMENSIONS["A5"];
+  // Swap width/height when landscape
+  const dims = landscape ? { width: base.height, height: base.width } : base;
 
   let primarySpan: number;
   let crossSpan: number;

--- a/lib/export/pdf-export-settings.ts
+++ b/lib/export/pdf-export-settings.ts
@@ -18,12 +18,12 @@ export interface PdfExportSettings {
 }
 
 export const DEFAULT_PDF_SETTINGS: PdfExportSettings = {
-  pageSize: "A5",
-  landscape: false,
+  pageSize: "A4",
+  landscape: true,
   verticalWriting: true,
-  charsPerLine: 30,
-  linesPerPage: 17,
-  margins: { top: 20, bottom: 20, left: 15, right: 15 },
+  charsPerLine: 40,
+  linesPerPage: 30,
+  margins: { top: 35, bottom: 30, left: 30, right: 40 },
   fontFamily: "serif",
   showPageNumbers: true,
   textIndent: 1,

--- a/lib/export/pdf-export-settings.ts
+++ b/lib/export/pdf-export-settings.ts
@@ -59,3 +59,35 @@ export function savePdfExportSettings(settings: PdfExportSettings): void {
     // localStorage quota exceeded — silently ignore
   }
 }
+
+/**
+ * Calculate font size and line height from page layout parameters.
+ *
+ * For horizontal writing, chars flow left-to-right → font size derived from page width.
+ * For vertical writing, chars flow top-to-bottom → font size derived from page height.
+ */
+export function calculateTypesetting(
+  pageSize: string,
+  margins: { top: number; bottom: number; left: number; right: number },
+  charsPerLine: number,
+  linesPerPage: number,
+  verticalWriting: boolean,
+): { fontSizeMm: number; lineHeightRatio: number } {
+  const dims = PAGE_DIMENSIONS[pageSize] ?? PAGE_DIMENSIONS["A5"];
+
+  let primarySpan: number;
+  let crossSpan: number;
+
+  if (verticalWriting) {
+    primarySpan = dims.height - margins.top - margins.bottom;
+    crossSpan = dims.width - margins.left - margins.right;
+  } else {
+    primarySpan = dims.width - margins.left - margins.right;
+    crossSpan = dims.height - margins.top - margins.bottom;
+  }
+
+  const fontSizeMm = primarySpan / charsPerLine;
+  const lineHeightRatio = crossSpan / linesPerPage / fontSizeMm;
+
+  return { fontSizeMm, lineHeightRatio };
+}

--- a/lib/export/pdf-exporter.ts
+++ b/lib/export/pdf-exporter.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ExportMetadata } from "./types";
-import { PAGE_DIMENSIONS } from "./pdf-export-settings";
+import { calculateTypesetting, PAGE_DIMENSIONS } from "./pdf-export-settings";
 
 export interface PdfExportOptions {
   metadata: ExportMetadata;
@@ -23,42 +23,6 @@ export interface PdfExportOptions {
   showPageNumbers?: boolean;
   /** First-line indent in em units */
   textIndent?: number;
-}
-
-/**
- * Calculate font size and line height from page layout parameters.
- *
- * For horizontal writing, chars flow left-to-right → font size derived from page width.
- * For vertical writing, chars flow top-to-bottom → font size derived from page height.
- */
-function calculateTypesetting(
-  pageSize: string,
-  margins: { top: number; bottom: number; left: number; right: number },
-  charsPerLine: number,
-  linesPerPage: number,
-  verticalWriting: boolean,
-): { fontSizeMm: number; lineHeightRatio: number } {
-  const dims = PAGE_DIMENSIONS[pageSize] ?? PAGE_DIMENSIONS["A5"];
-
-  // Primary axis: direction characters flow along
-  // Cross axis: direction lines stack along
-  let primarySpan: number;
-  let crossSpan: number;
-
-  if (verticalWriting) {
-    // Vertical: chars flow top→bottom, lines stack right→left
-    primarySpan = dims.height - margins.top - margins.bottom;
-    crossSpan = dims.width - margins.left - margins.right;
-  } else {
-    // Horizontal: chars flow left→right, lines stack top→bottom
-    primarySpan = dims.width - margins.left - margins.right;
-    crossSpan = dims.height - margins.top - margins.bottom;
-  }
-
-  const fontSizeMm = primarySpan / charsPerLine;
-  const lineHeightRatio = crossSpan / linesPerPage / fontSizeMm;
-
-  return { fontSizeMm, lineHeightRatio };
 }
 
 /**

--- a/lib/export/pdf-exporter.ts
+++ b/lib/export/pdf-exporter.ts
@@ -52,6 +52,7 @@ export async function generatePdf(content: string, options: PdfExportOptions): P
           options.charsPerLine!,
           options.linesPerPage!,
           options.verticalWriting ?? false,
+          options.landscape ?? false,
         );
         return {
           fontFamily: options.fontFamily,


### PR DESCRIPTION
## Summary

- PDFエクスポートダイアログに右パネルのプレビュー表示を追加
- 設定変更から300msのデバウンスでリアルタイム更新
- `calculateTypesetting()` を `pdf-export-settings.ts` に移動してブラウザ環境でも利用可能に

## Changes

- `lib/export/pdf-export-settings.ts` — `calculateTypesetting()` を追加エクスポート
- `lib/export/pdf-exporter.ts` — 重複実装を削除し、settings からインポートに変更
- `app/page.tsx` — content/metadata を state として保持し dialogs に追加
- `components/EditorLayout.tsx` — PdfExportDialog に content/metadata props を追加
- `components/PdfExportDialog.tsx` — 2カラムレイアウト（設定 + プレビュー iframe）に刷新

## Preview behavior

- ダイアログ開時: 300ms後に初回プレビュー生成
- 設定変更: 300msデバウンスで再生成
- `iframe sandbox="allow-same-origin"` (スクリプト無効) で安全に表示
- 用紙寸法表示: 148×210mm など

## Test plan

- [ ] Electron起動 → メニュー「PDF としてエクスポート」でダイアログ表示
- [ ] 右パネルにページプレビューが表示される
- [ ] 用紙サイズ・縦横切替でプレビューが更新される
- [ ] エクスポートボタンで従来通りPDFが保存される
- [ ] `npx tsc --noEmit` でエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)