### PR TITLE
fix(editor): correct vertical chars-per-line off-by-two

### DIFF
--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -473,7 +473,7 @@ export default function MilkdownEditor({
 
       if (charsPerLine > 0 && charWidth > 0) {
         if (isVertical) {
-          const targetHeight = charWidth * Math.max(charsPerLine - 1, 1);
+          const targetHeight = charWidth * charsPerLine;
           measureBox.style.height = `${targetHeight}px`;
           measureBox.style.maxHeight = `${targetHeight}px`;
           measureBox.style.minHeight = `${targetHeight}px`;
@@ -841,6 +841,7 @@ export default function MilkdownEditor({
         div :global(.milkdown .ProseMirror.milkdown-japanese-vertical p) {
           text-indent: ${textIndent}em;
           margin-left: ${paragraphSpacing}em;
+          margin-bottom: 0;
           ${showParagraphNumbers ? "counter-increment: paragraph;" : ""}
           ${showParagraphNumbers ? "position: relative;" : ""}
         }


### PR DESCRIPTION
## Summary

- 縦書きモードで「1行あたりの文字数制限」の設定値より2文字少なく表示されるバグを修正
- 例: 40字に設定 → 実際は38字しか表示されなかった → 修正後は40字表示

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `components/editor/MilkdownEditor.tsx` | 高さ計算を `charWidth * (charsPerLine - 1)` → `charWidth * charsPerLine` に修正 |
| `components/editor/MilkdownEditor.tsx` | 縦書き段落の `margin-bottom: 0.5em`（globals.css から継承）をリセット。縦書きでは段落間隔は `margin-left` で制御されており、`margin-bottom` は inline-end のスペースを不要に消費していた |

## Test plan

- [x] 縦書きモードで文字数制限を40に設定 → 1列に40文字表示されることを確認
- [x] 横書きモードの文字数制限が影響を受けていないことを確認
- [x] 段落間の間隔が縦書き・横書きともに正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)