### PR TITLE
fix(linting): reduce false positives in L1 lint rules

### DIFF
--- a/lib/linting/__tests__/l1-rules-false-positives.test.ts
+++ b/lib/linting/__tests__/l1-rules-false-positives.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for L1 rule false-positive fixes.
+ *
+ * Each section tests that:
+ *  - True positives are still detected
+ *  - Known false positives are suppressed
+ */
+import { describe, it, expect } from "vitest";
+
+import type { LintRuleConfig } from "../types";
+import { createManuscriptL1Rules } from "../rules/json-l1/manuscript-l1-rules";
+import { createNihongoHyoukiL1Rules } from "../rules/json-l1/nihongo-hyouki-l1-rules";
+import { createJtfL1Rules } from "../rules/json-l1/jtf-l1-rules";
+
+const CFG: LintRuleConfig = { enabled: true, severity: "warning" };
+
+function findRule<T extends { id: string }>(rules: T[], id: string): T {
+  const rule = rules.find((r) => r.id === id);
+  if (!rule) throw new Error(`Rule ${id} not found`);
+  return rule;
+}
+
+// ---------------------------------------------------------------------------
+// me2-13-unit-symbols
+// ---------------------------------------------------------------------------
+describe("me2-13-unit-symbols", () => {
+  const rule = findRule(createManuscriptL1Rules(), "me2-13-unit-symbols");
+
+  it("should flag missing spacing: 5km -> 5 km", () => {
+    const issues = rule.lint("5km", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe(" km");
+  });
+
+  it("should flag missing spacing: 100mg", () => {
+    const issues = rule.lint("100mg", CFG);
+    expect(issues).toHaveLength(1);
+  });
+
+  it("should NOT flag already-spaced units: 5 km", () => {
+    const issues = rule.lint("5 km", CFG);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("should no longer suggest katakana conversion", () => {
+    // Previously this rule would suggest km -> キロメートル
+    const issues = rule.lint("5 km", CFG);
+    const katakanaIssue = issues.find((i) => i.fix?.replacement === "キロメートル");
+    expect(katakanaIssue).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nh-10-units
+// ---------------------------------------------------------------------------
+describe("nh-10-units", () => {
+  const rule = findRule(createNihongoHyoukiL1Rules(), "nh-10-units");
+
+  it("should flag incorrect SI casing: 5KG -> kg", () => {
+    const issues = rule.lint("5KG", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("kg");
+  });
+
+  it("should flag incorrect SI casing: 100HZ -> Hz", () => {
+    const issues = rule.lint("100HZ", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("Hz");
+  });
+
+  it("should flag spacing: 5 kg -> remove space", () => {
+    const issues = rule.lint("5 kg", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("");
+  });
+
+  it("should NOT flag full-width ＡＩ as a unit issue", () => {
+    const issues = rule.lint("ＡＩの技術", CFG);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("should NOT flag full-width ＨＴＭＬ as a unit issue", () => {
+    const issues = rule.lint("ＨＴＭＬファイル", CFG);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("should NOT flag full-width Ｃ as a unit issue", () => {
+    const issues = rule.lint("Ｃ言語", CFG);
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nh-11-symbols (dash detection)
+// ---------------------------------------------------------------------------
+describe("nh-11-symbols dash detection", () => {
+  const rule = findRule(createNihongoHyoukiL1Rules(), "nh-11-symbols");
+
+  it("should flag dash in Japanese context: 彼女は-と言った", () => {
+    const issues = rule.lint("彼女は-と言った", CFG);
+    const dashIssues = issues.filter((i) => i.fix?.replacement === "——");
+    expect(dashIssues.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should flag double dash in Japanese context: 彼女は--と言った", () => {
+    const issues = rule.lint("彼女は--と言った", CFG);
+    const dashIssues = issues.filter((i) => i.fix?.replacement === "——");
+    expect(dashIssues.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should NOT flag hyphenated English words: foo-bar", () => {
+    const issues = rule.lint("foo-bar", CFG);
+    const dashIssues = issues.filter((i) => i.fix?.replacement === "——");
+    expect(dashIssues).toHaveLength(0);
+  });
+
+  it("should NOT flag dates: 2024-01-01", () => {
+    const issues = rule.lint("2024-01-01", CFG);
+    const dashIssues = issues.filter((i) => i.fix?.replacement === "——");
+    expect(dashIssues).toHaveLength(0);
+  });
+
+  it("should NOT flag command-line flags: --verbose", () => {
+    const issues = rule.lint("--verbose", CFG);
+    const dashIssues = issues.filter((i) => i.fix?.replacement === "——");
+    expect(dashIssues).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jtf-2-2-1-kanji
+// ---------------------------------------------------------------------------
+describe("jtf-2-2-1-kanji word boundary", () => {
+  const rule = findRule(createJtfL1Rules(), "jtf-2-2-1-kanji");
+
+  it("should flag standalone もっとも -> 最も", () => {
+    const issues = rule.lint("もっとも重要な", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("最も");
+  });
+
+  it("should NOT flag もっとも inside もっともらしい", () => {
+    const issues = rule.lint("もっともらしい説明", CFG);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("should flag standalone まったく -> 全く", () => {
+    const issues = rule.lint("まったく問題ない", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("全く");
+  });
+
+  it("should flag standalone すべて -> 全て", () => {
+    const issues = rule.lint("すべての人", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("全て");
+  });
+
+  it("should flag すでに even when followed by hiragana particle", () => {
+    const issues = rule.lint("すでにある", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("既に");
+  });
+
+  it("should flag かならず followed by kanji", () => {
+    const issues = rule.lint("かならず来る", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("必ず");
+  });
+
+  it("should flag すべて at end of text", () => {
+    const issues = rule.lint("問題はすべて", CFG);
+    expect(issues).toHaveLength(1);
+  });
+
+  it("should flag いっさい preceded by kanji", () => {
+    const issues = rule.lint("関係いっさい無し", CFG);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("一切");
+  });
+});

--- a/lib/linting/__tests__/l1-rules-false-positives.test.ts
+++ b/lib/linting/__tests__/l1-rules-false-positives.test.ts
@@ -125,6 +125,12 @@ describe("nh-11-symbols dash detection", () => {
     const dashIssues = issues.filter((i) => i.fix?.replacement === "——");
     expect(dashIssues).toHaveLength(0);
   });
+
+  it("should NOT flag Markdown horizontal rules: ---", () => {
+    const issues = rule.lint("---", CFG);
+    const dashIssues = issues.filter((i) => i.fix?.replacement === "——");
+    expect(dashIssues).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -177,5 +183,21 @@ describe("jtf-2-2-1-kanji word boundary", () => {
     const issues = rule.lint("関係いっさい無し", CFG);
     expect(issues).toHaveLength(1);
     expect(issues[0].fix?.replacement).toBe("一切");
+  });
+
+  it("should NOT flag すべて inside すべからく", () => {
+    const issues = rule.lint("すべからく努力すべし", CFG);
+    const subet = issues.filter((i) => i.fix?.replacement === "全て");
+    expect(subet).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Preset configuration
+// ---------------------------------------------------------------------------
+describe("lint preset configuration", () => {
+  it("should disable me2-11 in strict preset to avoid contradiction with me2-12", async () => {
+    const { LINT_PRESETS } = await import("../lint-presets");
+    expect(LINT_PRESETS.strict.configs["me2-11-vertical-numbers"].enabled).toBe(false);
   });
 });

--- a/lib/linting/lint-presets.ts
+++ b/lib/linting/lint-presets.ts
@@ -182,7 +182,7 @@ export const LINT_RULES_META: LintRuleMeta[] = [
   {
     id: "me2-13-unit-symbols",
     nameJa: "単位記号の表記",
-    descriptionJa: "横組では数値と欧字単位記号の間にスペースを入れます",
+    descriptionJa: "数値と欧字単位記号の間にスペースがない箇所を検出します",
     guidelineId: "editors-rulebook",
   },
   {
@@ -429,7 +429,7 @@ export const LINT_PRESETS: Record<string, LintPreset> = {
       "me2-4-kanji-font": { enabled: true, severity: "error" },
       "me2-8-katakana": { enabled: true, severity: "warning" },
       "me2-9-foreign-words": { enabled: true, severity: "error" },
-      "me2-11-vertical-numbers": { enabled: true, severity: "warning" },
+      "me2-11-vertical-numbers": { enabled: false, severity: "warning" },
       "me2-12-horizontal-numbers": { enabled: true, severity: "warning" },
       "me2-13-unit-symbols": { enabled: true, severity: "warning" },
       "me2-14-pre-post-symbols": { enabled: true, severity: "error" },

--- a/lib/linting/rules/json-l1/jtf-l1-rules.ts
+++ b/lib/linting/rules/json-l1/jtf-l1-rules.ts
@@ -161,6 +161,14 @@ const HIRAGANA_TO_KANJI: ReadonlyArray<[string, string]> = [
   ["わずか", "僅か"],
 ];
 
+/**
+ * Known compound words that start with a HIRAGANA_TO_KANJI entry but form a
+ * different word. Used to suppress false positives in substring matching.
+ */
+const KANJI_EXCLUSION_PATTERNS: ReadonlyMap<string, RegExp> = new Map([
+  ["もっとも", /もっともらし/],
+]);
+
 // ============================================================================
 // Implemented rule classes (21 rules)
 // ============================================================================
@@ -516,8 +524,14 @@ class JtfKanjiRule extends AbstractL1Rule {
 
     for (const [hiragana, kanji] of HIRAGANA_TO_KANJI) {
       const pattern = new RegExp(hiragana, "g");
+      const exclusion = KANJI_EXCLUSION_PATTERNS.get(hiragana);
       let m: RegExpExecArray | null;
       while ((m = pattern.exec(text)) !== null) {
+        // Skip if this match is part of a known compound word
+        if (exclusion) {
+          const slice = text.slice(m.index);
+          if (exclusion.test(slice)) continue;
+        }
         issues.push({
           ruleId: this.id,
           severity: config.severity,

--- a/lib/linting/rules/json-l1/jtf-l1-rules.ts
+++ b/lib/linting/rules/json-l1/jtf-l1-rules.ts
@@ -164,9 +164,13 @@ const HIRAGANA_TO_KANJI: ReadonlyArray<[string, string]> = [
 /**
  * Known compound words that start with a HIRAGANA_TO_KANJI entry but form a
  * different word. Used to suppress false positives in substring matching.
+ *
+ * Add new entries here when a HIRAGANA_TO_KANJI word is a prefix of a
+ * compound that should not be converted (e.g. もっとも vs もっともらしい).
  */
 const KANJI_EXCLUSION_PATTERNS: ReadonlyMap<string, RegExp> = new Map([
   ["もっとも", /もっともらし/],
+  ["すべて", /すべからく/],
 ]);
 
 // ============================================================================

--- a/lib/linting/rules/json-l1/manuscript-l1-rules.ts
+++ b/lib/linting/rules/json-l1/manuscript-l1-rules.ts
@@ -345,23 +345,13 @@ class HorizontalNumbersRule extends AbstractL1Rule {
 }
 
 class UnitSymbolsRule extends AbstractL1Rule {
-  private readonly katakanaUnits = new Map([
-    ["km", "キロメートル"],
-    ["m", "メートル"],
-    ["cm", "センチメートル"],
-    ["mm", "ミリメートル"],
-    ["kg", "キログラム"],
-    ["g", "グラム"],
-    ["L", "リットル"],
-  ]);
-
   constructor() {
     super(findRuleMeta("rule_ME2_13_unit_symbols"), {
       id: "me2-13-unit-symbols",
       name: "Unit symbols",
       nameJa: "単位記号",
-      description: "Detects unit notation issues for manuscript layout",
-      descriptionJa: "単位表記と数字の組み方の崩れを検出します。",
+      description: "Detects missing spacing between numbers and unit symbols",
+      descriptionJa: "数値と欧字単位記号の間にスペースがない箇所を検出します。",
       defaultConfig: { enabled: true, severity: "warning" },
     });
   }
@@ -396,29 +386,6 @@ class UnitSymbolsRule extends AbstractL1Rule {
           "原稿編集 第2版に基づき、欧字の単位記号を使う場合は数値との間を密着させずに組みます。",
         ),
       );
-    }
-
-    for (const [unit, katakana] of this.katakanaUnits) {
-      const pattern = new RegExp(`\\d+(?:\\.\\d+)? ${escapeRegex(unit)}\\b`, "g");
-      for (const match of text.matchAll(pattern)) {
-        if (match.index === undefined) {
-          continue;
-        }
-
-        const from = match.index + match[0].length - unit.length;
-        issues.push(
-          createIssue(
-            this,
-            config,
-            from,
-            match.index + match[0].length,
-            unit,
-            katakana,
-            "Use katakana unit names for vertical layout",
-            "原稿編集 第2版に基づき、縦組では単位を片仮名で表すのが原則です。",
-          ),
-        );
-      }
     }
 
     return issues;

--- a/lib/linting/rules/json-l1/nihongo-hyouki-l1-rules.ts
+++ b/lib/linting/rules/json-l1/nihongo-hyouki-l1-rules.ts
@@ -115,8 +115,6 @@ function issue(
 
 class UnitsRule extends AbstractL1Rule {
   private readonly unitCaseFixes: ReadonlyArray<[RegExp, string]> = [
-    [/[Ａ-Ｚａ-ｚ]+/g, ""],
-    [/\d\s+(kg|g|mg|m|cm|mm|km|s|ms|Hz|kHz|MHz|GHz|MB|GB|TB|°C)\b/g, ""],
     [/\d+(?:\.\d+)?Kg\b/g, "kg"],
     [/\d+(?:\.\d+)?KG\b/g, "kg"],
     [/\d+(?:\.\d+)?Mm\b/g, "mm"],
@@ -131,8 +129,8 @@ class UnitsRule extends AbstractL1Rule {
       id: "nh-10-units",
       name: "Units",
       nameJa: "単位",
-      description: "Detects unit notation issues",
-      descriptionJa: "単位の英字表記や数字との間隔の問題を検出します。",
+      description: "Detects unit casing and spacing issues",
+      descriptionJa: "単位記号の大文字・小文字と数字との間隔の問題を検出します。",
       defaultConfig: { enabled: true, severity: "warning" },
     });
   }
@@ -143,28 +141,6 @@ class UnitsRule extends AbstractL1Rule {
     }
 
     const issues: LintIssue[] = [];
-
-    for (const match of text.matchAll(/[Ａ-Ｚａ-ｚ]+/g)) {
-      if (match.index === undefined) {
-        continue;
-      }
-
-      const replacement = match[0].replace(/[Ａ-Ｚａ-ｚ]/g, (char) =>
-        String.fromCharCode(char.charCodeAt(0) - 0xfee0),
-      );
-      issues.push(
-        issue(
-          this,
-          config,
-          match.index,
-          match.index + match[0].length,
-          match[0],
-          replacement,
-          "Use half-width Latin letters for unit symbols",
-          "日本語表記ルールブック 第2版に基づき、単位記号は半角英字で表記します。",
-        ),
-      );
-    }
 
     for (const match of text.matchAll(
       /\d\s+(kg|g|mg|m|cm|mm|km|s|ms|Hz|kHz|MHz|GHz|MB|GB|TB|°C)\b/g,
@@ -188,7 +164,7 @@ class UnitsRule extends AbstractL1Rule {
       );
     }
 
-    for (const [pattern, replacement] of this.unitCaseFixes.slice(2)) {
+    for (const [pattern, replacement] of this.unitCaseFixes) {
       for (const match of text.matchAll(pattern)) {
         if (match.index === undefined) {
           continue;
@@ -295,8 +271,16 @@ class SymbolsRule extends AbstractL1Rule {
       );
     }
 
-    for (const match of text.matchAll(/--|(?<!-)-(?!-)/g)) {
+    // Only match dashes in Japanese context (preceded or followed by CJK/kana)
+    const jaContext = /[\u3041-\u3096\u30A1-\u30F6\u4E00-\u9FFF\u3400-\u4DBF]/;
+    for (const match of text.matchAll(/--?/g)) {
       if (match.index === undefined) {
+        continue;
+      }
+
+      const before = match.index > 0 ? text[match.index - 1] : "";
+      const after = text[match.index + match[0].length] ?? "";
+      if (!jaContext.test(before) && !jaContext.test(after)) {
         continue;
       }
 


### PR DESCRIPTION
## Summary

Targeted fixes for 5 categories of false positives and contradictions in L1 lint rules, without changing rule IDs or breaking existing configurations.

### Changes

| Rule | Problem | Fix |
|------|---------|-----|
| `me2-13-unit-symbols` | Mixed vertical/horizontal logic (katakana conversion + spacing in one rule) | Removed vertical-only katakana conversion; kept spacing check |
| `nh-10-units` | `/[Ａ-Ｚａ-ｚ]+/` flagged ＡＩ, ＨＴＭＬ as "unit issues" | Removed broad full-width alphabet check; kept SI casing + spacing |
| `nh-11-symbols` | `/--|(?<!-)-(?!-)/` flagged `foo-bar`, `2024-01-01` | Restricted dash detection to Japanese context only |
| `jtf-2-2-1-kanji` | Bare substring match: `もっとも` inside `もっともらしい` | Added exclusion patterns for known compound words |
| `strict` preset | `me2-11` + `me2-12` both enabled = contradictory | Disabled `me2-11` (vertical-only, needs writing-mode info) |

### No rules disabled at L1

All rules remain functional. The fixes narrow detection scope to reduce false positives rather than disabling rules entirely. The `me2-13` katakana conversion was the only logic removed — it was vertical-layout-specific and cannot be correctly evaluated without writing-mode information.

## Test plan

- [x] 23 new tests in `l1-rules-false-positives.test.ts` covering true positive retention and false positive suppression
- [x] All 53 linting tests pass
- [x] TypeScript strict mode passes (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)