### PR TITLE
feat(speech): 音声機能UI改善（読み上げ改名・設定タブ刷新）

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -37,6 +37,8 @@ interface EditorProps {
   lintingRuleRunner?: RuleRunner | null;
   onLintIssuesUpdated?: (issues: LintIssue[], options?: { llmPending?: boolean }) => void;
   onNlpError?: (error: Error) => void;
+  // 音声設定を開くコールバック
+  onOpenSpeechSettings?: () => void;
   // 書式コールバック
   onOpenRubyDialog?: () => void;
   onToggleTcy?: () => void;
@@ -68,6 +70,7 @@ export default function NovelEditor({
   lintingRuleRunner,
   onLintIssuesUpdated,
   onNlpError,
+  onOpenSpeechSettings,
   onOpenRubyDialog,
   onToggleTcy,
   onOpenDictionary,
@@ -428,6 +431,7 @@ export default function NovelEditor({
         onSearchClick={handleSearchToggle}
         speechState={speechState}
         onSpeakToggle={handleSpeakToggle}
+        onOpenSpeechSettings={onOpenSpeechSettings}
       />
 
       {/* エディタ領域 */}

--- a/components/EditorContextMenu.tsx
+++ b/components/EditorContextMenu.tsx
@@ -208,7 +208,7 @@ export default function EditorContextMenu({
             />
           )}
 
-          {/* 朗読: hide when speech feature is not available */}
+          {/* 読み上げ: hide when speech feature is not available */}
           {onStartSpeech != null && (
             <>
               <Separator />

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -431,6 +431,10 @@ export default function EditorLayout({
                                   lintingRuleRunner={mainArea.ruleRunner}
                                   onLintIssuesUpdated={mainArea.handleLintIssuesUpdated}
                                   onNlpError={mainArea.handleNlpError}
+                                  onOpenSpeechSettings={() => {
+                                    dialogs.setSettingsInitialCategory("speech");
+                                    dialogs.setShowSettingsModal(true);
+                                  }}
                                   onOpenRubyDialog={mainArea.handleOpenRubyDialog}
                                   onToggleTcy={mainArea.handleToggleTcy}
                                   onOpenDictionary={mainArea.handleOpenDictionary}

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -188,7 +188,7 @@ export default function SettingsModal({ isOpen, onClose, initialCategory }: Sett
                 )}
               >
                 <AudioLines className="w-4 h-4" />
-                聴写/朗読
+                音声入力/読み上げ
               </button>
               <button
                 onClick={() => setActiveCategory("keymap")}

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -78,7 +78,7 @@ export default function EditorToolbar({
           <button
             onClick={onSpeakToggle}
             className="flex items-center gap-2 px-3 py-1.5 rounded text-sm font-medium bg-background-tertiary text-foreground-secondary hover:bg-hover transition-colors"
-            title={speechState.isPlaying ? "朗読を一時停止" : "朗読"}
+            title={speechState.isPlaying ? "読み上げを一時停止" : "読み上げ"}
           >
             {speechState.isPlaying ? (
               <Pause className="w-4 h-4" />

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -11,12 +11,14 @@ export default function EditorToolbar({
   onSearchClick,
   speechState,
   onSpeakToggle,
+  onOpenSpeechSettings,
 }: {
   isVertical: boolean;
   onToggleVertical: () => void;
   onSearchClick: () => void;
   speechState: SpeechState;
   onSpeakToggle: () => void;
+  onOpenSpeechSettings?: () => void;
 }) {
   const {
     fontScale,
@@ -77,6 +79,10 @@ export default function EditorToolbar({
         {speechState.isSupported && (
           <button
             onClick={onSpeakToggle}
+            onContextMenu={(e) => {
+              e.preventDefault();
+              onOpenSpeechSettings?.();
+            }}
             className="flex items-center gap-2 px-3 py-1.5 rounded text-sm font-medium bg-background-tertiary text-foreground-secondary hover:bg-hover transition-colors"
             title={speechState.isPlaying ? "読み上げを一時停止" : "読み上げ"}
           >

--- a/components/settings/SpeechSettingsTab.tsx
+++ b/components/settings/SpeechSettingsTab.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import type React from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useSpeechSettings } from "@/contexts/EditorSettingsContext";
 
 /**
- * Settings tab for text-to-speech (朗読) and speech recognition (聴写).
+ * Settings tab for text-to-speech (読み上げ) and speech recognition (音声入力).
  * Covers: voice selection, playback rate, pitch, and volume.
  * Available Japanese voices are loaded asynchronously from the Web Speech API.
  */
@@ -21,6 +21,7 @@ export default function SpeechSettingsTab(): React.ReactElement {
     onSpeechVolumeChange,
   } = useSpeechSettings();
   const [availableVoices, setAvailableVoices] = useState<SpeechSynthesisVoice[]>([]);
+  const [isSpeaking, setIsSpeaking] = useState(false);
 
   // Load available Japanese voices (may arrive asynchronously)
   useEffect(() => {
@@ -36,44 +37,135 @@ export default function SpeechSettingsTab(): React.ReactElement {
     };
   }, []);
 
+  const handlePreview = useCallback((): void => {
+    if (typeof window === "undefined" || !("speechSynthesis" in window)) return;
+    if (isSpeaking) {
+      window.speechSynthesis.cancel();
+      setIsSpeaking(false);
+      return;
+    }
+    // Re-fetch voices at speak time — stale voice references cause silence in Chromium/Electron
+    const freshVoices = window.speechSynthesis.getVoices();
+    const selectedVoice = freshVoices.find((v) => v.voiceURI === speechVoiceURI) ?? null;
+    const voiceName = selectedVoice
+      ? selectedVoice.name.replace(/\s*\([^)]*\([^)]*\)\)$/, "").trim()
+      : "illusions";
+    const utterance = new SpeechSynthesisUtterance(`こんにちは、私は${voiceName}です。`);
+    if (selectedVoice) utterance.voice = selectedVoice;
+    utterance.rate = speechRate;
+    utterance.pitch = speechPitch;
+    utterance.volume = speechVolume;
+    utterance.lang = "ja-JP";
+    utterance.onend = () => setIsSpeaking(false);
+    utterance.onerror = () => setIsSpeaking(false);
+    setIsSpeaking(true);
+    // resume() is a workaround for the Chromium bug where speechSynthesis enters a paused state
+    window.speechSynthesis.resume();
+    window.speechSynthesis.speak(utterance);
+  }, [isSpeaking, speechVoiceURI, speechRate, speechPitch, speechVolume]);
+
   return (
     <div className="space-y-8 p-6">
-      {/* 聴写 section */}
-      <div>
-        <h3 className="text-lg font-semibold text-foreground mb-1">聴写</h3>
-        <p className="text-sm text-foreground-tertiary">
-          音声認識による入力機能は今後のアップデートで追加予定です。
-        </p>
+      {/* 音声入力 section */}
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-lg font-semibold text-foreground mb-1">音声入力</h3>
+          <p className="text-sm text-foreground-tertiary">
+            Illusionsには独自の音声入力機能はありませんが外部ツールの Superwhisper
+            とは非常に相性が良いです。ぜひ併用を検討してみてください。
+          </p>
+        </div>
+
+        {/* Superwhisper card */}
+        <div className="flex items-center gap-4 px-4 py-3 border border-border rounded-xl bg-background-secondary">
+          <img
+            src="/image/superwhisper_logo.png"
+            alt="Superwhisper"
+            className="w-12 h-12 rounded-xl object-contain flex-shrink-0"
+          />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-foreground">Superwhisper</p>
+            <p className="text-xs text-foreground-tertiary">macOS/Windows向け音声入力ツール</p>
+          </div>
+          <a
+            href="https://superwhisper.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs font-semibold px-4 py-1.5 rounded-full bg-foreground text-background hover:opacity-75 transition-opacity flex-shrink-0"
+          >
+            ダウンロード
+          </a>
+        </div>
       </div>
 
       <div className="border-t border-border" />
 
-      {/* 朗読 section */}
+      {/* 読み上げ section */}
       <div className="space-y-6">
         <div>
-          <h3 className="text-lg font-semibold text-foreground mb-1">朗読</h3>
+          <h3 className="text-lg font-semibold text-foreground mb-1">読み上げ</h3>
           <p className="text-sm text-foreground-secondary mb-4">
             テキストの読み上げ（Text-to-Speech）の設定を調整します。
           </p>
         </div>
 
-        {/* Voice selection */}
-        <div>
-          <label className="block text-sm font-medium text-foreground mb-2">音声</label>
-          <select
-            value={speechVoiceURI}
-            onChange={(e) => onSpeechVoiceURIChange(e.target.value)}
-            className="w-full px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
-          >
-            <option value="">自動（デフォルト）</option>
-            {availableVoices.map((voice) => (
-              <option key={voice.voiceURI} value={voice.voiceURI}>
-                {voice.name}
-              </option>
-            ))}
-          </select>
+        {/* Voice selection + preview */}
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-foreground">音声</label>
+          <div className="flex items-center gap-2">
+            <select
+              value={speechVoiceURI}
+              onChange={(e) => onSpeechVoiceURIChange(e.target.value)}
+              className="flex-1 px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+            >
+              <option value="">自動（デフォルト）</option>
+              {availableVoices.map((voice) => (
+                <option key={voice.voiceURI} value={voice.voiceURI}>
+                  {voice.name.replace(/\s*\([^)]*\([^)]*\)\)$/, "").trim()}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={handlePreview}
+              title={isSpeaking ? "停止" : "試聴"}
+              className="flex items-center gap-1.5 px-3 py-2 rounded-lg border border-border text-sm font-medium text-foreground hover:bg-background-hover transition-colors flex-shrink-0"
+            >
+              {isSpeaking ? (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="w-4 h-4"
+                >
+                  <rect x="6" y="4" width="4" height="16" rx="1" />
+                  <rect x="14" y="4" width="4" height="16" rx="1" />
+                </svg>
+              ) : (
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="w-4 h-4"
+                >
+                  <path d="M8 5.14v14l11-7-11-7z" />
+                </svg>
+              )}
+              {isSpeaking ? "停止" : "試聴"}
+            </button>
+          </div>
+          <p className="text-xs text-foreground-tertiary">
+            「こんにちは、私は
+            {availableVoices.find((v) => v.voiceURI === speechVoiceURI)
+              ? availableVoices
+                  .find((v) => v.voiceURI === speechVoiceURI)!
+                  .name.replace(/\s*\([^)]*\([^)]*\)\)$/, "")
+                  .trim()
+              : "illusions"}
+            です。」
+          </p>
           {availableVoices.length === 0 && (
-            <p className="text-xs text-foreground-tertiary mt-1">
+            <p className="text-xs text-foreground-tertiary">
               日本語の音声が見つかりません。OSの音声設定をご確認ください。
             </p>
           )}

--- a/lib/hooks/use-speech.ts
+++ b/lib/hooks/use-speech.ts
@@ -103,11 +103,15 @@ export function useSpeech(config?: SpeechConfig): {
 
     // Cancel whatever is currently playing before starting new speech.
     window.speechSynthesis.cancel();
+    // Chromium/Electron bug: speechSynthesis can remain in a paused state after
+    // cancel(). Calling resume() before speak() ensures the queue is unblocked.
+    window.speechSynthesis.resume();
 
     const cfg = configRef.current;
     const utterance = new SpeechSynthesisUtterance(text);
     utterance.lang = "ja-JP";
 
+    // Re-fetch voices at speak time — stale voice references cause silence in Chromium/Electron.
     const voice = findJapaneseVoice(cfg?.voiceURI);
     if (voice !== undefined) {
       utterance.voice = voice;
@@ -158,8 +162,11 @@ export function useSpeech(config?: SpeechConfig): {
     onEndRef.current = callbacks?.onEnd;
 
     window.speechSynthesis.cancel();
+    // Chromium/Electron bug: resume() needed after cancel() to unblock the queue.
+    window.speechSynthesis.resume();
 
     const cfg = configRef.current;
+    // Re-fetch voices at speak time to avoid stale references.
     const voice = findJapaneseVoice(cfg?.voiceURI);
     const utterances = segments.map((text, i) => {
       const u = new SpeechSynthesisUtterance(text);

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -132,7 +132,7 @@ export interface AppState {
     llmEnabled?: boolean;
   } | null;
 
-  // 朗読（TTS）設定
+  // 読み上げ（TTS）設定
   speechVoiceURI?: string;
   speechRate?: number;
   speechPitch?: number;


### PR DESCRIPTION
## Summary

- 「朗読」「聴写」という表記を「読み上げ」「音声入力」に統一
- 音声設定タブを刷新：音声プレビューボタン追加、Superwhisper 紹介カード追加

## Changes

| ファイル | 変更内容 |
|---|---|
| `components/settings/SpeechSettingsTab.tsx` | プレビューボタン追加、Superwhisperカード追加、表記変更 |
| `lib/hooks/use-speech.ts` | フック更新 |
| `components/EditorContextMenu.tsx` | 「朗読」→「読み上げ」 |
| `components/SettingsModal.tsx` | 「聴写/朗読」→「音声入力/読み上げ」 |
| `components/editor/EditorToolbar.tsx` | ツールチップ表記変更 |
| `lib/storage/storage-types.ts` | コメント表記変更 |

## Test plan

- [ ] 設定モーダル > 音声タブ を開き、音声プレビューボタンが動作することを確認
- [ ] Superwhisper カードが表示されることを確認
- [ ] ツールバー・コンテキストメニューの表記が「読み上げ」になっていることを確認
- [ ] Electron / Web 両環境で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)