### PR TITLE
fix(history): auto-refresh panel and strip HTML from diffs

### DIFF
--- a/components/HistoryPanel.tsx
+++ b/components/HistoryPanel.tsx
@@ -127,6 +127,14 @@ export default function HistoryPanel({
     setDisplayCount(SNAPSHOTS_PER_PAGE);
   }, [loadSnapshots]);
 
+  // Refresh when new snapshots are created (auto-save or manual from other source)
+  useEffect(() => {
+    const historyService = getHistoryService();
+    return historyService.onSnapshotCreated(() => {
+      void loadSnapshots();
+    });
+  }, [loadSnapshots]);
+
   /** Map of snapshot ID → diff stats relative to previous version */
   const [diffStatsMap, setDiffStatsMap] = useState<Map<string, DiffStats>>(new Map());
 

--- a/components/HistoryPanel/DiffIndicator.tsx
+++ b/components/HistoryPanel/DiffIndicator.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { createPortal } from "react-dom";
+import { stripHtmlForDiff } from "@/lib/services/diff-service";
 
 // -----------------------------------------------------------------------
 // Types
@@ -26,12 +27,14 @@ export interface DiffStats {
  * 共通の接頭辞と接尾辞を照合して文字レベルの追加・削除数を近似計算する。
  */
 export function computeDiffStats(oldText: string, newText: string): DiffStats {
-  const oldLen = oldText.length;
-  const newLen = newText.length;
+  const oldNorm = stripHtmlForDiff(oldText);
+  const newNorm = stripHtmlForDiff(newText);
+  const oldLen = oldNorm.length;
+  const newLen = newNorm.length;
   const minLen = Math.min(oldLen, newLen);
 
   let prefixLen = 0;
-  while (prefixLen < minLen && oldText[prefixLen] === newText[prefixLen]) {
+  while (prefixLen < minLen && oldNorm[prefixLen] === newNorm[prefixLen]) {
     prefixLen++;
   }
 
@@ -39,7 +42,7 @@ export function computeDiffStats(oldText: string, newText: string): DiffStats {
   const maxSuffix = minLen - prefixLen;
   while (
     suffixLen < maxSuffix &&
-    oldText[oldLen - 1 - suffixLen] === newText[newLen - 1 - suffixLen]
+    oldNorm[oldLen - 1 - suffixLen] === newNorm[newLen - 1 - suffixLen]
   ) {
     suffixLen++;
   }
@@ -49,8 +52,8 @@ export function computeDiffStats(oldText: string, newText: string): DiffStats {
   const addedStart = prefixLen;
   const addedEnd = newLen - suffixLen;
 
-  const removedText = oldText.slice(removedStart, removedEnd);
-  const addedText = newText.slice(addedStart, addedEnd);
+  const removedText = oldNorm.slice(removedStart, removedEnd);
+  const addedText = newNorm.slice(addedStart, addedEnd);
 
   return {
     added: addedText.length,

--- a/lib/services/diff-service.ts
+++ b/lib/services/diff-service.ts
@@ -9,6 +9,18 @@ import { diffChars } from "diff";
 
 import type { Change } from "diff";
 
+/**
+ * Normalize text for diff comparison by stripping HTML tags.
+ * Converts `<br>` to newlines and removes other HTML tags so that
+ * formatting-only changes don't appear as content diffs.
+ *
+ * diff比較用にHTMLタグを除去する。`<br>`は改行に変換し、
+ * その他のHTMLタグは削除する。
+ */
+export function stripHtmlForDiff(text: string): string {
+  return text.replace(/<br\s*\/?>/gi, "\n").replace(/<[^>]+>/g, "");
+}
+
 /** A single diff chunk with type and value */
 export interface DiffChunk {
   type: "added" | "removed" | "unchanged";
@@ -27,7 +39,7 @@ export interface DiffChunk {
  * @returns Array of diff chunks
  */
 export function computeDiff(oldText: string, newText: string): DiffChunk[] {
-  const changes: Change[] = diffChars(oldText, newText);
+  const changes: Change[] = diffChars(stripHtmlForDiff(oldText), stripHtmlForDiff(newText));
 
   return changes.map((change) => ({
     type: change.added ? "added" : change.removed ? "removed" : "unchanged",

--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -229,6 +229,21 @@ export class HistoryService {
   private vfs: VirtualFileSystem;
   private readonly indexMutex = new AsyncMutex();
   private readonly bookmarkMutex = new AsyncMutex();
+  private readonly snapshotListeners = new Set<() => void>();
+
+  /** Register a listener that fires whenever a snapshot is created. */
+  onSnapshotCreated(listener: () => void): () => void {
+    this.snapshotListeners.add(listener);
+    return () => {
+      this.snapshotListeners.delete(listener);
+    };
+  }
+
+  private notifySnapshotCreated(): void {
+    for (const listener of this.snapshotListeners) {
+      listener();
+    }
+  }
 
   constructor() {
     this.vfs = getVFS();
@@ -295,6 +310,7 @@ export class HistoryService {
         await this.pruneSnapshotsPerFileUnsafe(sourcePath);
       });
 
+      this.notifySnapshotCreated();
       return entry;
     } catch (error) {
       console.error("Failed to create snapshot / スナップショットの作成に失敗しました:", error);

--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -241,7 +241,11 @@ export class HistoryService {
 
   private notifySnapshotCreated(): void {
     for (const listener of this.snapshotListeners) {
-      listener();
+      try {
+        listener();
+      } catch (err) {
+        console.error("Snapshot listener error / スナップショットリスナーエラー:", err);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- 履歴パネルが自動保存スナップショット作成後に自動更新されない問題を修正
- HTMLタグ（`<br />`等）の変更のみで差分が表示される問題を修正

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `lib/services/history-service.ts` | `HistoryService`にイベントリスナー機能を追加。`createSnapshot`成功後にリスナーへ通知 |
| `components/HistoryPanel.tsx` | `onSnapshotCreated`をサブスクライブし、新スナップショット作成時に自動リロード |
| `lib/services/diff-service.ts` | `stripHtmlForDiff()`を追加。`computeDiff`で比較前にHTMLタグを除去 |
| `components/HistoryPanel/DiffIndicator.tsx` | `computeDiffStats`でHTMLタグを除去してから差分計算 |

## Test plan

- [ ] プロジェクトモードでファイルを編集・保存し、履歴タブが自動的に新しいスナップショットを表示することを確認
- [ ] `<br />`タグの変更のみのスナップショット間で「変更なし」と表示されることを確認
- [ ] 差分表示画面（比較ボタン）でHTMLタグが差分として表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)