### PR TITLE
fix(editor): reload editor when external file changes are detected

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -216,6 +216,7 @@ export default function EditorPage() {
     vfsReadyPromise: vfsGate.promise,
     flushLayoutState: stableFlushLayoutState,
     windowKey,
+    onEditorRemountNeeded: incrementEditorKey,
   });
   const {
     content,
@@ -629,13 +630,18 @@ export default function EditorPage() {
 
   // --- Text statistics hook ---
   const {
-    charCount,
+    visibleTextCharCount,
+    manuscriptCellCount,
+    manuscriptPages,
     paragraphCount,
     sentenceCount,
     charTypeAnalysis,
     charUsageRates,
     readabilityAnalysis,
   } = useTextStatistics(content);
+
+  // charCount は旧インターフェース互換用エイリアス（可視本文文字数）
+  const charCount = visibleTextCharCount;
 
   // --- Previous day comparison ---
   const previousDayStats = usePreviousDayStats(currentFile?.name, isProjectMode(editorMode));
@@ -827,6 +833,8 @@ export default function EditorPage() {
     charCount,
     selectedCharCount,
     paragraphCount,
+    manuscriptCellCount,
+    manuscriptPages,
     fileName,
     isDirty,
     isSaving,

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -419,7 +419,7 @@ export default function EditorLayout({
                                 className="h-full"
                               >
                                 <NovelEditor
-                                  key={`tab-${panelBufferId}-${panelFilePath}-${panelEditorKey}-${panelParams?.pendingExternalContent ?? ""}`}
+                                  key={`tab-${panelBufferId}-${panelFilePath}-${panelEditorKey}`}
                                   initialContent={panelContent}
                                   onChange={mainArea.handleChange}
                                   onInsertText={mainArea.handleInsertText}

--- a/lib/services/__tests__/file-watch-integration.test.ts
+++ b/lib/services/__tests__/file-watch-integration.test.ts
@@ -47,6 +47,7 @@ function buildOnChangedForTest(
   setTabs: SetTabsFn,
   tabsRef: MutableRefObject<TabState[]>,
   notifications: SimulatedNotification[],
+  onEditorRemountNeeded?: () => void,
 ): (diskContent: string, lastModified: number) => void {
   return (diskContent: string, _lastModified: number) => {
     const currentTabs = tabsRef.current;
@@ -70,6 +71,7 @@ function buildOnChangedForTest(
           } as EditorTabState;
         }),
       );
+      onEditorRemountNeeded?.();
       notifications.push({
         message: `「${fileName}」が更新されました`,
         type: "info",
@@ -115,6 +117,7 @@ function buildOnChangedForTest(
             } as EditorTabState;
           }),
         );
+        onEditorRemountNeeded?.();
       };
 
       notifications.push({
@@ -159,11 +162,18 @@ function buildContext(initialTab: EditorTabState) {
   };
 
   const notifications: SimulatedNotification[] = [];
-  const onChanged = buildOnChangedForTest(initialTab.id, setTabs, tabsRef, notifications);
+  const onEditorRemountNeeded = vi.fn();
+  const onChanged = buildOnChangedForTest(
+    initialTab.id,
+    setTabs,
+    tabsRef,
+    notifications,
+    onEditorRemountNeeded,
+  );
 
   const getTab = () => tabs.find((t) => t.id === initialTab.id) as EditorTabState;
 
-  return { onChanged, getTab, notifications };
+  return { onChanged, getTab, notifications, onEditorRemountNeeded };
 }
 
 // ---------------------------------------------------------------------------
@@ -205,6 +215,15 @@ describe("file-watch: clean tab receives external change", () => {
     onChanged("new disk content", Date.now());
 
     expect(getTab().pendingExternalContent).toBe("new disk content");
+  });
+
+  it("calls onEditorRemountNeeded after auto-reload", () => {
+    const tab = makeEditorTab({ fileSyncStatus: "clean", content: "old", lastSavedContent: "old" });
+    const { onChanged, onEditorRemountNeeded } = buildContext(tab);
+
+    onChanged("new disk content", Date.now());
+
+    expect(onEditorRemountNeeded).toHaveBeenCalledTimes(1);
   });
 
   it("emits an info notification", () => {
@@ -361,6 +380,20 @@ describe("file-watch: 'ディスクの内容を採用' action", () => {
     adoptAction?.onClick();
 
     expect(getTab().conflictDiskContent).toBeNull();
+  });
+
+  it("calls onEditorRemountNeeded after adopting disk content", () => {
+    const tab = makeEditorTab({ fileSyncStatus: "dirty", content: "my edits", isDirty: true });
+    const { onChanged, notifications, onEditorRemountNeeded } = buildContext(tab);
+
+    onChanged("disk changes", Date.now());
+    // onEditorRemountNeeded should NOT be called for dirty→conflicted transition
+    expect(onEditorRemountNeeded).not.toHaveBeenCalled();
+
+    const adoptAction = notifications[0].actions.find((a) => a.label === "ディスクの内容を採用");
+    adoptAction?.onClick();
+
+    expect(onEditorRemountNeeded).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -32,6 +32,8 @@ export function useTabManager(options?: {
    * state so multiple windows with different projects do not overwrite each other.
    */
   windowKey?: string | null;
+  /** Callback to trigger editor remount when external file changes are detected. */
+  onEditorRemountNeeded?: () => void;
 }): UseTabManagerReturn {
   const skipAutoRestore = options?.skipAutoRestore ?? false;
   const autoSaveEnabled = options?.autoSave ?? true;
@@ -130,6 +132,7 @@ export function useTabManager(options?: {
     isProjectRef: tabState.isProjectRef,
     isElectron: tabState.isElectron,
     openDiffTab: tabState.openDiffTab,
+    onEditorRemountNeeded: options?.onEditorRemountNeeded,
   });
 
   // --- Tab persistence (save/restore to AppState) -------------------------

--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -29,6 +29,15 @@ export interface UseFileWatchIntegrationParams extends TabManagerCore {
     remoteContent: string,
     remoteTimestamp: number,
   ) => void;
+  /**
+   * Callback to trigger an editor remount (increment editorKey).
+   * Called after applying external content so the Milkdown instance
+   * re-initializes with the updated content.
+   *
+   * エディタの再マウントをトリガーするコールバック（editorKey をインクリメント）。
+   * 外部コンテンツ適用後に呼び出し、Milkdown インスタンスを再初期化する。
+   */
+  onEditorRemountNeeded?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -47,6 +56,7 @@ function buildOnChanged(
   setTabs: TabManagerCore["setTabs"],
   tabsRef: TabManagerCore["tabsRef"],
   openDiffTab: UseFileWatchIntegrationParams["openDiffTab"],
+  onEditorRemountNeeded?: () => void,
 ): (diskContent: string, lastModified: number) => void {
   return (diskContent: string, lastModified: number) => {
     const currentTabs = tabsRef.current;
@@ -70,6 +80,7 @@ function buildOnChanged(
           } satisfies EditorTabState;
         }),
       );
+      onEditorRemountNeeded?.();
       notificationManager.info(`「${fileName}」が更新されました`, 3000);
     } else if (tab.fileSyncStatus === "dirty") {
       // Dirty tab: do NOT touch buffer; enter conflicted state
@@ -111,13 +122,10 @@ function buildOnChanged(
                     isDirty: false,
                     fileSyncStatus: "clean",
                     conflictDiskContent: null,
-                    // Trigger live editor update via externalContent prop.
-                    // Without this, the tab state is updated but the active
-                    // editor instance continues to show the stale content.
-                    pendingExternalContent: diskContent,
                   } satisfies EditorTabState;
                 }),
               );
+              onEditorRemountNeeded?.();
             },
           },
           {
@@ -164,7 +172,8 @@ function buildOnChanged(
  * CPU 節約のため一時停止する。タブを閉じるとウォッチャーも停止する。
  */
 export function useFileWatchIntegration(params: UseFileWatchIntegrationParams): void {
-  const { tabs, setTabs, activeTabId, tabsRef, isElectron, openDiffTab } = params;
+  const { tabs, setTabs, activeTabId, tabsRef, isElectron, openDiffTab, onEditorRemountNeeded } =
+    params;
 
   /**
    * Map from tabId to its FileWatcher instance.
@@ -226,7 +235,13 @@ export function useFileWatchIntegration(params: UseFileWatchIntegrationParams): 
 
       if (!watchers.has(tab.id)) {
         // Create a new watcher for this tab
-        const onChanged = buildOnChanged(tab.id, setTabs, tabsRef, openDiffTab);
+        const onChanged = buildOnChanged(
+          tab.id,
+          setTabs,
+          tabsRef,
+          openDiffTab,
+          onEditorRemountNeeded,
+        );
         const watcher = createFileWatcher({ path: filePath, onChanged });
 
         if (isActiveTab) {
@@ -237,7 +252,7 @@ export function useFileWatchIntegration(params: UseFileWatchIntegrationParams): 
         watcherPaths.set(tab.id, filePath);
       }
     }
-  }, [tabs, activeTabId, isElectron, setTabs, tabsRef, openDiffTab]);
+  }, [tabs, activeTabId, isElectron, setTabs, tabsRef, openDiffTab, onEditorRemountNeeded]);
 
   // ---------------------------------------------------------------------------
   // Pause/resume watchers based on active tab


### PR DESCRIPTION
## Summary

- 外部ツール（Claude Code など）がファイルを編集しても、エディタに変更が反映されないバグを修正
- clean タブへの外部変更検出時、タブ状態は正しく更新されていたが Milkdown インスタンスが再初期化されず古い内容を表示し続けていた
- その状態でユーザーが編集すると古い内容に上書きされ、外部変更が消えていた
- 「ディスクの内容を採用」も同様に、エディタ表示が更新されないケースがあった

## Changes

| ファイル | 変更内容 |
|---|---|
| `lib/tab-manager/use-file-watch-integration.ts` | `onEditorRemountNeeded` コールバックを追加。clean タブ自動リロードと「ディスクの内容を採用」後に呼び出す |
| `lib/tab-manager/index.ts` | `useTabManager` オプションに `onEditorRemountNeeded` を追加し `useFileWatchIntegration` に渡す |
| `app/page.tsx` | `incrementEditorKey` を `onEditorRemountNeeded` として渡す |
| `components/EditorLayout.tsx` | `NovelEditor` の key から `pendingExternalContent` を削除（`editorKey` のインクリメントで再マウント管理するため不要） |
| `lib/services/__tests__/file-watch-integration.test.ts` | `onEditorRemountNeeded` spy を追加、新規 2 テストケース追加 |

## Test plan

- [ ] `npx vitest run lib/services/__tests__/file-watch-integration.test.ts` — 21 テスト全通過を確認
- [ ] `npx tsc --noEmit` — 型エラーなしを確認
- [ ] Electron で任意のファイルを開き、外部から `echo "changed" >> file.mdi` → エディタが数秒以内に更新されトースト通知が表示されること
- [ ] dirty タブ（未保存編集あり）に外部変更 → コンフリクト通知が表示されること
- [ ] 「ディスクの内容を採用」クリック → エディタがディスクの内容に更新されること
- [ ] 「エディタの内容を保持」クリック → バッファ内容が保たれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)