### PR TITLE
fix: address Copilot review findings from v1.1.5

### DIFF
--- a/electron/ipc/auth-ipc.js
+++ b/electron/ipc/auth-ipc.js
@@ -116,11 +116,13 @@ function registerAuthHandlers() {
   });
 
   // Clean up pending auth entries when a window is closed
-  app.on("browser-window-close", (_, win) => {
-    const winId = win.id;
-    for (const [state, entry] of pendingAuthByState) {
-      if (entry.windowId === winId) pendingAuthByState.delete(state);
-    }
+  app.on("browser-window-created", (_, win) => {
+    win.on("closed", () => {
+      const winId = win.id;
+      for (const [state, entry] of pendingAuthByState) {
+        if (entry.windowId === winId) pendingAuthByState.delete(state);
+      }
+    });
   });
 }
 

--- a/electron/ipc/auth-ipc.js
+++ b/electron/ipc/auth-ipc.js
@@ -116,13 +116,21 @@ function registerAuthHandlers() {
   });
 
   // Clean up pending auth entries when a window is closed
-  app.on("browser-window-created", (_, win) => {
+  function attachAuthCleanup(win) {
     win.on("closed", () => {
       const winId = win.id;
       for (const [state, entry] of pendingAuthByState) {
         if (entry.windowId === winId) pendingAuthByState.delete(state);
       }
     });
+  }
+  // Register for windows that already exist (e.g. main window created before this call)
+  for (const win of BrowserWindow.getAllWindows()) {
+    attachAuthCleanup(win);
+  }
+  // Register for future windows
+  app.on("browser-window-created", (_, win) => {
+    attachAuthCleanup(win);
   });
 }
 

--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -338,21 +338,31 @@ function registerVFSHandlers() {
   // single-threaded. Each entry maps a lock key to the webContents id that
   // holds it. A queue of { resolve } entries handles waiters.
   const indexLockOwner = new Map(); // key -> webContentsId
-  const indexLockQueue = new Map(); // key -> Array<{ resolve: () => void }>
+  const indexLockQueue = new Map(); // key -> Array<{ resolve: () => void, senderId: number }>
 
   /**
    * Dequeue the next waiter for a lock key, if any.
+   * Skips waiters whose webContents have been destroyed to prevent stuck locks.
    * The dequeued entry's resolve() will set the owner itself.
    * @param {string} key
    */
   function processIndexLockQueue(key) {
     const queue = indexLockQueue.get(key) || [];
-    if (queue.length > 0 && !indexLockOwner.has(key)) {
+    while (queue.length > 0 && !indexLockOwner.has(key)) {
       const next = queue.shift();
       if (queue.length === 0) {
         indexLockQueue.delete(key);
       }
+      // Skip waiters whose webContents have been destroyed
+      const wc = require("electron").webContents.fromId(next.senderId);
+      if (!wc || wc.isDestroyed()) {
+        continue;
+      }
       next.resolve();
+      return;
+    }
+    if (queue.length === 0) {
+      indexLockQueue.delete(key);
     }
   }
 
@@ -368,7 +378,7 @@ function registerVFSHandlers() {
     // Lock is held — enqueue this waiter and suspend until released
     await new Promise((resolve) => {
       const queue = indexLockQueue.get(key) || [];
-      queue.push({ resolve });
+      queue.push({ resolve, senderId });
       indexLockQueue.set(key, queue);
     });
 

--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -4,7 +4,7 @@
  * Provides file system operations for the renderer process
  */
 
-const { ipcMain, dialog, app, BrowserWindow } = require("electron");
+const { ipcMain, dialog, app, BrowserWindow, webContents } = require("electron");
 const fs = require("fs/promises");
 const path = require("path");
 const os = require("os");
@@ -354,7 +354,7 @@ function registerVFSHandlers() {
         indexLockQueue.delete(key);
       }
       // Skip waiters whose webContents have been destroyed
-      const wc = require("electron").webContents.fromId(next.senderId);
+      const wc = webContents.fromId(next.senderId);
       if (!wc || wc.isDestroyed()) {
         continue;
       }

--- a/lib/auth/web-auth.ts
+++ b/lib/auth/web-auth.ts
@@ -84,5 +84,5 @@ export function getPendingAuth(): { state: string; codeVerifier: string } | null
 
 /** Remove the pending auth data after a successful token exchange. */
 export function clearPendingAuth(): void {
-  sessionStorage.removeItem(PENDING_AUTH_KEY);
+  safeSessionStorageRemove(PENDING_AUTH_KEY);
 }

--- a/lib/editor-page/use-auto-restore.ts
+++ b/lib/editor-page/use-auto-restore.ts
@@ -35,8 +35,7 @@ export function useAutoRestore({
     void (async () => {
       let success = false;
       try {
-        await handleOpenRecentProject(autoRestoreProjectId);
-        success = true;
+        success = await handleOpenRecentProject(autoRestoreProjectId);
       } catch {
         // handleOpenRecentProject catches its own errors internally
       }

--- a/lib/storage/__tests__/web-storage.test.ts
+++ b/lib/storage/__tests__/web-storage.test.ts
@@ -85,6 +85,9 @@ const mockDb = {
 // The WebStorageDatabase extends Dexie, so we need to replace the
 // Dexie constructor and the version().stores() chain.
 // -----------------------------------------------------------------------
+/** Captured upgrade callbacks keyed by version number */
+const capturedUpgrades: Map<number, (tx: any) => any> = new Map();
+
 vi.mock("dexie", () => {
   class FakeDexie {
     constructor() {
@@ -100,10 +103,13 @@ vi.mock("dexie", () => {
         kvStore: mockDb.kvStore,
       });
     }
-    version() {
+    version(num: number) {
       const versionObj: Record<string, unknown> = {};
       versionObj.stores = () => versionObj;
-      versionObj.upgrade = () => versionObj;
+      versionObj.upgrade = (cb: (tx: any) => any) => {
+        capturedUpgrades.set(num, cb);
+        return versionObj;
+      };
       return versionObj;
     }
   }
@@ -389,6 +395,61 @@ describe("WebStorageProvider", () => {
       expect(await provider.loadAppState()).toBeNull();
       expect(await provider.getRecentFiles()).toEqual([]);
       expect(await provider.loadEditorBuffer()).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Dexie v4 migration: backfill handleKey
+  // -----------------------------------------------------------------------
+  describe("v4 migration (handleKey backfill)", () => {
+    /** Helper to run the captured v4 upgrade callback against simulated records */
+    function runV4Migration(records: Record<string, unknown>[]) {
+      const upgradeFn = capturedUpgrades.get(4);
+      expect(upgradeFn).toBeDefined();
+
+      // Simulate Dexie tx.table().toCollection().modify()
+      const fakeTx = {
+        table: () => ({
+          toCollection: () => ({
+            modify: (cb: (record: Record<string, unknown>) => void) => {
+              for (const rec of records) cb(rec);
+            },
+          }),
+        }),
+      };
+      upgradeFn!(fakeTx);
+    }
+
+    it("generates handleKey from projectId and rootDirName", () => {
+      const record = { projectId: "proj-1", rootDirName: "my-novel" };
+      runV4Migration([record]);
+      expect(record).toHaveProperty("handleKey", "proj-1:my-novel");
+    });
+
+    it("derives rootDirName from rootHandle.name when missing", () => {
+      const record: Record<string, unknown> = {
+        projectId: "proj-2",
+        rootHandle: { name: "derived-dir" },
+      };
+      runV4Migration([record]);
+      expect(record.handleKey).toBe("proj-2:derived-dir");
+      expect(record.rootDirName).toBe("derived-dir");
+    });
+
+    it("falls back to projectId when rootDirName and rootHandle.name are both missing", () => {
+      const record: Record<string, unknown> = { projectId: "proj-3" };
+      runV4Migration([record]);
+      expect(record.handleKey).toBe("proj-3:proj-3");
+    });
+
+    it("skips records that already have handleKey", () => {
+      const record = {
+        handleKey: "existing:key",
+        projectId: "proj-4",
+        rootDirName: "dir",
+      };
+      runV4Migration([record]);
+      expect(record.handleKey).toBe("existing:key");
     });
   });
 });

--- a/lib/storage/__tests__/web-storage.test.ts
+++ b/lib/storage/__tests__/web-storage.test.ts
@@ -101,11 +101,10 @@ vi.mock("dexie", () => {
       });
     }
     version() {
-      return {
-        stores: () => ({
-          version: () => ({ stores: () => ({}) }),
-        }),
-      };
+      const versionObj: Record<string, unknown> = {};
+      versionObj.stores = () => versionObj;
+      versionObj.upgrade = () => versionObj;
+      return versionObj;
     }
   }
   return { default: FakeDexie };

--- a/lib/storage/app-state-manager.ts
+++ b/lib/storage/app-state-manager.ts
@@ -105,7 +105,11 @@ export async function fetchWindowState(windowKey: string): Promise<WindowState |
   const key = `window_state:${windowKey}`;
   const data = await storage.getItem(key);
   if (data) {
-    return JSON.parse(data) as WindowState;
+    try {
+      return JSON.parse(data) as WindowState;
+    } catch {
+      // Corrupted data — fall through to migration fallback
+    }
   }
   // Migration fallback: existing sessions stored tabs/layout in global AppState.
   const appState = await storage.loadAppState();

--- a/lib/storage/app-state-manager.ts
+++ b/lib/storage/app-state-manager.ts
@@ -74,7 +74,10 @@ export async function persistWindowState(
     let parsed: WindowState = {};
     if (existing) {
       try {
-        parsed = JSON.parse(existing) as WindowState;
+        const raw: unknown = JSON.parse(existing);
+        if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+          parsed = raw as WindowState;
+        }
       } catch {
         // Corrupted data — overwrite with fresh state
       }
@@ -106,9 +109,12 @@ export async function fetchWindowState(windowKey: string): Promise<WindowState |
   const data = await storage.getItem(key);
   if (data) {
     try {
-      return JSON.parse(data) as WindowState;
+      const raw: unknown = JSON.parse(data);
+      if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+        return raw as WindowState;
+      }
     } catch {
-      // Corrupted data — fall through to migration fallback
+      // Corrupted or non-object data — fall through to migration fallback
     }
   }
   // Migration fallback: existing sessions stored tabs/layout in global AppState.

--- a/lib/storage/app-state-manager.ts
+++ b/lib/storage/app-state-manager.ts
@@ -71,7 +71,14 @@ export async function persistWindowState(
     await storage.initialize();
     const key = `window_state:${windowKey}`;
     const existing = await storage.getItem(key);
-    const parsed: WindowState = existing ? (JSON.parse(existing) as WindowState) : {};
+    let parsed: WindowState = {};
+    if (existing) {
+      try {
+        parsed = JSON.parse(existing) as WindowState;
+      } catch {
+        // Corrupted data — overwrite with fresh state
+      }
+    }
     const merged: WindowState = { ...parsed, ...updates };
     await storage.setItem(key, JSON.stringify(merged));
   } finally {

--- a/lib/storage/web-storage.ts
+++ b/lib/storage/web-storage.ts
@@ -96,13 +96,28 @@ class WebStorageDatabase extends Dexie {
     // v4: Change projectHandles primary key to composite handleKey (projectId:rootDirName)
     // to prevent PRIMARY KEY collision when duplicate project directories share the same projectId.
     // 複製されたプロジェクトディレクトリが同一 projectId を持つ場合の衝突修正 (#1070)。
-    this.version(4).stores({
-      appState: "id",
-      recentFiles: "id, path",
-      editorBuffer: "id",
-      projectHandles: "handleKey, projectId, lastAccessedAt",
-      kvStore: "key",
-    });
+    this.version(4)
+      .stores({
+        appState: "id",
+        recentFiles: "id, path",
+        editorBuffer: "id",
+        projectHandles: "handleKey, projectId, lastAccessedAt",
+        kvStore: "key",
+      })
+      .upgrade((tx) => {
+        // Backfill handleKey for existing records that only have projectId as PK.
+        // 既存レコードに handleKey がない場合は projectId をフォールバックとして使用。
+        return tx
+          .table("projectHandles")
+          .toCollection()
+          .modify((record: Record<string, unknown>) => {
+            if (!record.handleKey) {
+              const pid = (record.projectId as string) || "unknown";
+              const dirName = (record.rootDirName as string) || pid;
+              record.handleKey = `${pid}:${dirName}`;
+            }
+          });
+      });
   }
 }
 

--- a/lib/storage/web-storage.ts
+++ b/lib/storage/web-storage.ts
@@ -106,14 +106,28 @@ class WebStorageDatabase extends Dexie {
       })
       .upgrade((tx) => {
         // Backfill handleKey for existing records that only have projectId as PK.
-        // 既存レコードに handleKey がない場合は projectId をフォールバックとして使用。
+        // rootDirName が欠けている場合は、永続化済み rootHandle.name から復元して
+        // 通常保存時と同じ handleKey 形式を維持する。
         return tx
           .table("projectHandles")
           .toCollection()
           .modify((record: Record<string, unknown>) => {
             if (!record.handleKey) {
               const pid = (record.projectId as string) || "unknown";
-              const dirName = (record.rootDirName as string) || pid;
+              // Prefer stored rootDirName, then derive from rootHandle.name
+              const storedDirName =
+                typeof record.rootDirName === "string" && record.rootDirName.length > 0
+                  ? (record.rootDirName as string)
+                  : undefined;
+              let derivedDirName: string | undefined;
+              if (!storedDirName) {
+                const rh = record.rootHandle as { name?: string } | null | undefined;
+                if (rh && typeof rh.name === "string" && rh.name.length > 0) {
+                  derivedDirName = rh.name;
+                  record.rootDirName = derivedDirName;
+                }
+              }
+              const dirName = storedDirName ?? derivedDirName ?? pid;
               record.handleKey = `${pid}:${dirName}`;
             }
           });


### PR DESCRIPTION
## Summary

Hotfix addressing 6 issues flagged by Copilot review on #1237 (v1.1.5 release).

### Bug fixes
- **`auth-ipc.js`**: `app.on("browser-window-close")` is not a valid Electron event — replaced with `app.on("browser-window-created")` + `win.on("closed")` so OAuth pending state is correctly cleaned up when windows close
- **`use-auto-restore.ts`**: `handleOpenRecentProject()` returns `boolean` but the result was ignored — now captures the return value so restore failures correctly show the error banner
- **`vfs-ipc.js`**: Index lock queue entries now track `senderId`; `processIndexLockQueue` skips destroyed webContents to prevent permanently stuck locks

### Robustness improvements
- **`web-auth.ts`**: `clearPendingAuth()` now uses `safeSessionStorageRemove()` consistent with all other session storage access in the module
- **`app-state-manager.ts`**: `JSON.parse` in `persistWindowState` wrapped in try/catch to gracefully handle corrupted stored data
- **`web-storage.ts`**: Added Dexie v4 `.upgrade()` step to backfill `handleKey` for existing `projectHandles` records, preventing data loss on schema migration

## Test plan
- [ ] Verify OAuth cleanup: open login flow, close window mid-auth, confirm no leaked pending state
- [ ] Verify auto-restore failure: point to non-existent project path, confirm error banner appears
- [ ] Verify index lock: close a window while it holds a VFS index lock, confirm other windows can still acquire it
- [ ] Verify Dexie migration: clear IndexedDB, create a project with v3 schema, upgrade to v4, confirm project handle is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)