### PR TITLE
feat(editor): render .txt files as plain text with line-based paragraphs

### DIFF
--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -25,7 +25,8 @@ import { linting } from "@/packages/milkdown-plugin-japanese-novel/linting-plugi
 import clsx from "clsx";
 import { EditorView } from "@milkdown/prose/view";
 import { AllSelection, Plugin, PluginKey } from "@milkdown/prose/state";
-import { $prose, replaceAll } from "@milkdown/utils";
+import { $prose, $remark, replaceAll } from "@milkdown/utils";
+import { remarkPlainTextPlugin } from "@/packages/milkdown-plugin-japanese-novel/syntax/remark-plain-text";
 import BubbleMenu, { type FormatType } from "../BubbleMenu";
 import { searchHighlightPlugin } from "@/lib/editor-page/search-highlight-plugin";
 import { speechHighlightPlugin } from "@/lib/editor-page/speech-highlight-plugin";
@@ -177,6 +178,12 @@ export default function MilkdownEditor({
     [],
   );
 
+  // Derive plain-text mode: fileType ".txt" has both GFM and MDI disabled.
+  // This value is captured at editor mount time, which is safe because each
+  // tab has its own editor instance (keyed by bufferId+editorKey) and a tab's
+  // file type never changes during its lifetime.
+  const isPlainText = !gfmEnabled && !mdiExtensionsEnabled;
+
   const { get } = useEditor(
     (root) => {
       const value = initialContentRef.current;
@@ -189,15 +196,34 @@ export default function MilkdownEditor({
         // listenerCtx 参照より先に listener を読み込む
         .use(listener)
         .config((ctx) => {
-          ctx.get(listenerCtx).markdownUpdated((_ctx, markdown) => {
-            onChangeRef.current?.(markdown);
-          });
+          // Plain-text (.txt) mode: extract raw text directly from ProseMirror
+          // nodes so that tab.content stays as plain text without any markdown
+          // escaping. Non-plain-text mode uses the standard markdown serializer.
+          if (isPlainText) {
+            ctx.get(listenerCtx).updated((_ctx, doc) => {
+              const lines: string[] = [];
+              doc.forEach((node) => {
+                lines.push(node.textContent);
+              });
+              onChangeRef.current?.(lines.join("\n"));
+            });
+          } else {
+            ctx.get(listenerCtx).markdownUpdated((_ctx, markdown) => {
+              onChangeRef.current?.(markdown);
+            });
+          }
         })
         .use(commonmark);
 
       // GFM: conditionally loaded
       if (gfmEnabled) {
         editor = editor.use(gfm);
+      }
+
+      // Plain-text mode: remark plugin converts raw lines to paragraphs,
+      // bypassing all CommonMark syntax interpretation.
+      if (isPlainText) {
+        editor = editor.use($remark("plainText", () => remarkPlainTextPlugin));
       }
 
       // MDI extensions: conditionally loaded

--- a/packages/milkdown-plugin-japanese-novel/syntax/remark-plain-text.ts
+++ b/packages/milkdown-plugin-japanese-novel/syntax/remark-plain-text.ts
@@ -1,4 +1,4 @@
-import type { Root } from "mdast";
+import type { Paragraph, Root, Text } from "mdast";
 import type { VFile } from "vfile";
 
 /**
@@ -25,11 +25,9 @@ export function remarkPlainTextPlugin() {
     // Replace the entire parsed mdast with one paragraph per line.
     // An empty line produces an empty paragraph (no children), which
     // ProseMirror renders as a blank line and textContent returns "".
-    (tree as unknown as { children: unknown[] }).children = lines.map(
-      (line) => ({
-        type: "paragraph",
-        children: line.length > 0 ? [{ type: "text", value: line }] : [],
-      }),
-    );
+    tree.children = lines.map((line): Paragraph => ({
+      type: "paragraph",
+      children: line.length > 0 ? [{ type: "text", value: line } as Text] : [],
+    }));
   };
 }

--- a/packages/milkdown-plugin-japanese-novel/syntax/remark-plain-text.ts
+++ b/packages/milkdown-plugin-japanese-novel/syntax/remark-plain-text.ts
@@ -16,18 +16,18 @@ import type { VFile } from "vfile";
 export function remarkPlainTextPlugin() {
   return function transformer(tree: Root, file: VFile): void {
     // Normalize line endings before splitting
-    const source = String(file.value)
-      .replace(/\r\n/g, "\n")
-      .replace(/\r/g, "\n");
+    const source = String(file.value).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 
     const lines = source.split("\n");
 
     // Replace the entire parsed mdast with one paragraph per line.
     // An empty line produces an empty paragraph (no children), which
     // ProseMirror renders as a blank line and textContent returns "".
-    tree.children = lines.map((line): Paragraph => ({
-      type: "paragraph",
-      children: line.length > 0 ? [{ type: "text", value: line } as Text] : [],
-    }));
+    tree.children = lines.map(
+      (line): Paragraph => ({
+        type: "paragraph",
+        children: line.length > 0 ? [{ type: "text", value: line } as Text] : [],
+      }),
+    );
   };
 }

--- a/packages/milkdown-plugin-japanese-novel/syntax/remark-plain-text.ts
+++ b/packages/milkdown-plugin-japanese-novel/syntax/remark-plain-text.ts
@@ -1,0 +1,35 @@
+import type { Root } from "mdast";
+import type { VFile } from "vfile";
+
+/**
+ * Remark plugin for plain-text (.txt) mode.
+ *
+ * Bypasses CommonMark parsing entirely by reading the raw source string
+ * from the VFile and splitting it into lines. Each line becomes a single
+ * paragraph node, so special characters such as `#`, `*`, `>`, `-` are
+ * never interpreted as markdown syntax.
+ *
+ * This plugin must be added AFTER remark-parse (which is the default when
+ * using Milkdown's $remark utility) so that it can replace the already-
+ * parsed tree with the line-based structure.
+ */
+export function remarkPlainTextPlugin() {
+  return function transformer(tree: Root, file: VFile): void {
+    // Normalize line endings before splitting
+    const source = String(file.value)
+      .replace(/\r\n/g, "\n")
+      .replace(/\r/g, "\n");
+
+    const lines = source.split("\n");
+
+    // Replace the entire parsed mdast with one paragraph per line.
+    // An empty line produces an empty paragraph (no children), which
+    // ProseMirror renders as a blank line and textContent returns "".
+    (tree as unknown as { children: unknown[] }).children = lines.map(
+      (line) => ({
+        type: "paragraph",
+        children: line.length > 0 ? [{ type: "text", value: line }] : [],
+      }),
+    );
+  };
+}


### PR DESCRIPTION
## Summary

- TXT ファイルを開くと `#` が見出し、`*` が斜体など CommonMark 構文として解釈されてしまう問題を修正
- remark plugin により生のソース文字列を直接行分割し、各行を段落ノードに変換。CommonMark の解釈をバイパス
- ProseMirror の `textContent` から直接テキスト抽出することで、`tab.content` が常に生の plain text を維持
- 段落番号が行番号と 1:1 で対応するようになる

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `packages/milkdown-plugin-japanese-novel/syntax/remark-plain-text.ts` | 新規: 行分割 remark plugin |
| `components/editor/MilkdownEditor.tsx` | `.txt` モード時に plugin 追加・serializer を `listenerCtx.updated` に切り替え |

**変更しないファイル**: 保存・読み込みパス全て（`use-file-io`, `use-auto-save`, `use-close-dialog`, `use-tab-persistence`, `use-file-watch-integration`）— `tab.content` は常に生 plain text なのでタブ管理層の変更は不要

## Test plan

- [ ] `# heading`、`*bold*`、`> quote`、`- list`、`C:\Users\test` を含む `.txt` ファイルを Electron で開き、全行が装飾なしプレーンテキストで表示されることを確認
- [ ] 段落番号（行番号）が各行に正しく付与されることを確認
- [ ] ファイルを編集して保存後、元ファイルと diff なし（バイト完全一致）を確認
- [ ] `.mdi`・`.md` ファイルで従来通りマークダウン描画されることを確認
- [ ] ファイルウォッチャー更新・セッション復元後も正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)