### PR TITLE
feat(dict): illusionsDict マスター辞典統合

### DIFF
--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -11,12 +11,16 @@ import {
   Search,
   Globe,
   ExternalLink,
+  Download,
+  Loader2,
 } from "lucide-react";
 import type { UserDictionaryEntry } from "@/lib/project/project-types";
 import type { EditorMode } from "@/lib/project/project-types";
 import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
 import { getUserDictionaryService } from "@/lib/services/user-dictionary-service";
 import DictionaryEntryDialog from "./Dictionary/DictionaryEntryDialog";
+import { getDictService } from "@/lib/dict/dict-service";
+import type { DictEntry, DictDownloadStatus } from "@/lib/dict/dict-types";
 
 // Web dictionary sources
 interface WebDictionarySource {
@@ -76,6 +80,12 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   const [globalSearchQuery, setGlobalSearchQuery] = useState("");
   const [activeSearchQuery, setActiveSearchQuery] = useState("");
 
+  // Master dict state
+  const [masterResults, setMasterResults] = useState<DictEntry[]>([]);
+  const [masterLoading, setMasterLoading] = useState(false);
+  const [masterStatus, setMasterStatus] = useState<DictDownloadStatus>("not-installed");
+  const [expandedMasterId, setExpandedMasterId] = useState<string | null>(null);
+
   // Persistence
   const dictService = getUserDictionaryService();
 
@@ -113,6 +123,14 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
     void loadEntries();
   }, [loadEntries]);
 
+  // Check master dict status on mount
+  useEffect(() => {
+    getDictService()
+      .getDownloadState("illusions-dict")
+      .then((state) => setMasterStatus(state.status))
+      .catch(() => {});
+  }, []);
+
   // Update search when initialSearchTerm changes
   useEffect(() => {
     if (initialSearchTerm && searchTriggerId) {
@@ -120,6 +138,26 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
       setActiveSearchQuery(initialSearchTerm);
     }
   }, [initialSearchTerm, searchTriggerId]);
+
+  // Query master dict when search changes
+  useEffect(() => {
+    if (!activeSearchQuery.trim()) {
+      setMasterResults([]);
+      return;
+    }
+
+    setMasterLoading(true);
+    getDictService()
+      .query(activeSearchQuery.trim())
+      .then((result) => {
+        setMasterResults(result.entries);
+        if (result.providerUnavailable && !result.webApiPending) {
+          setMasterStatus("not-installed");
+        }
+      })
+      .catch(() => setMasterResults([]))
+      .finally(() => setMasterLoading(false));
+  }, [activeSearchQuery]);
 
   // --- Modal handlers ---
 
@@ -152,7 +190,6 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
     if (!formData.word?.trim()) return;
 
     if (editingEntry) {
-      // Update existing
       const updated = userEntries.map((e) =>
         e.id === editingEntry.id
           ? {
@@ -169,7 +206,6 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
       setUserEntries(updated);
       await persistEntries(updated);
     } else {
-      // Add new
       const entry: UserDictionaryEntry = {
         id: Date.now().toString(),
         word: formData.word.trim(),
@@ -201,7 +237,10 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
     setExpandedId((prev) => (prev === id ? null : id));
   }, []);
 
-  // Filtered entries — memoized to avoid re-filtering on unrelated renders
+  const toggleExpandMaster = useCallback((id: string) => {
+    setExpandedMasterId((prev) => (prev === id ? null : id));
+  }, []);
+
   const filteredEntries = useMemo(
     () =>
       userEntries.filter(
@@ -212,6 +251,20 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
       ),
     [userEntries, activeSearchQuery],
   );
+
+  const handleDownloadDict = useCallback(() => {
+    const api = (
+      window as Window & {
+        electronAPI?: { dict?: { download: () => Promise<{ success?: boolean; error?: string }> } };
+      }
+    ).electronAPI?.dict;
+    if (!api) return;
+
+    setMasterStatus("downloading");
+    void api.download().then((result) => {
+      setMasterStatus(result.success ? "installed" : "error");
+    });
+  }, []);
 
   return (
     <div className="h-full bg-background-secondary border-r border-border flex flex-col">
@@ -382,7 +435,6 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                             </p>
                           </div>
                         )}
-
                         {entry.examples && (
                           <div>
                             <h4 className="text-xs font-semibold text-foreground-secondary mb-1">
@@ -393,7 +445,6 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                             </p>
                           </div>
                         )}
-
                         {entry.notes && (
                           <div>
                             <h4 className="text-xs font-semibold text-foreground-secondary mb-1">
@@ -404,7 +455,6 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                             </p>
                           </div>
                         )}
-
                         {!entry.definition && !entry.examples && !entry.notes && (
                           <p className="text-sm text-foreground-tertiary">詳細情報はありません</p>
                         )}
@@ -428,52 +478,123 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
             )}
           </div>
         ) : (
-          /* Web dictionary tab */
+          /* Web dictionary tab — master dict results at top, web links below */
           <div className="flex flex-col h-full">
-            <div className="flex-1 overflow-y-auto p-4 space-y-3">
-              {!activeSearchQuery ? (
-                <div className="text-center py-8 text-foreground-secondary text-sm">
+            <div className="flex-1 overflow-y-auto">
+              {activeSearchQuery ? (
+                <div className="p-4 space-y-3">
+                  {/* Loading indicator */}
+                  {masterLoading && (
+                    <div className="flex items-center gap-2 text-sm text-foreground-secondary">
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      辞典を検索中...
+                    </div>
+                  )}
+
+                  {/* Not installed banner (Electron only) */}
+                  {!masterLoading &&
+                    masterStatus === "not-installed" &&
+                    isElectron() && (
+                      <div className="bg-background-elevated border border-border rounded-lg p-3 flex items-center justify-between gap-3">
+                        <span className="text-sm text-foreground-secondary">
+                          辞典データ未インストール
+                        </span>
+                        <button
+                          onClick={handleDownloadDict}
+                          className="flex items-center gap-1.5 px-2.5 py-1 text-xs bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors flex-shrink-0"
+                        >
+                          <Download className="w-3 h-3" />
+                          ダウンロード
+                        </button>
+                      </div>
+                    )}
+
+                  {/* Downloading indicator */}
+                  {masterStatus === "downloading" && (
+                    <div className="flex items-center gap-2 text-sm text-foreground-secondary">
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      ダウンロード中...
+                    </div>
+                  )}
+
+                  {/* Master dict results */}
+                  {!masterLoading && masterResults.length > 0 && (
+                    <div className="space-y-2">
+                      <div className="text-xs font-semibold text-foreground-tertiary">
+                        illusions辞典 ({masterResults.length} 件)
+                      </div>
+                      {masterResults.map((entry) => (
+                        <MasterDictCard
+                          key={`${entry.source}:${entry.id}`}
+                          entry={entry}
+                          isExpanded={expandedMasterId === entry.id}
+                          onToggle={() => toggleExpandMaster(entry.id)}
+                        />
+                      ))}
+                    </div>
+                  )}
+
+                  {/* No results */}
+                  {!masterLoading &&
+                    masterResults.length === 0 &&
+                    masterStatus === "installed" && (
+                      <p className="text-sm text-foreground-secondary">
+                        「{activeSearchQuery}」の辞典結果なし
+                      </p>
+                    )}
+
+                  {/* Divider */}
+                  <div className="border-t border-border pt-1">
+                    <div className="text-xs font-semibold text-foreground-tertiary mb-2">
+                      Web辞書
+                    </div>
+                  </div>
+
+                  {/* Web links */}
+                  <div className="space-y-2">
+                    {WEB_DICTIONARIES.map((dict) => {
+                      const searchUrl = dict.urlTemplate.replace(
+                        "{query}",
+                        encodeURIComponent(activeSearchQuery),
+                      );
+                      const handleOpenDictionary = () => {
+                        if (isElectron() && window.electronAPI?.openDictionaryPopup) {
+                          window.electronAPI.openDictionaryPopup(
+                            searchUrl,
+                            `${dict.name} - ${activeSearchQuery}`,
+                          );
+                        } else {
+                          window.open(searchUrl, "_blank", "noopener,noreferrer");
+                        }
+                      };
+                      return (
+                        <button
+                          key={dict.id}
+                          onClick={handleOpenDictionary}
+                          className="w-full bg-background-elevated border border-border rounded-lg p-3 hover:bg-hover transition-colors text-left flex items-center gap-3"
+                        >
+                          <Globe className="w-4 h-4 text-foreground-secondary flex-shrink-0" />
+                          <div className="flex-1 min-w-0">
+                            <div className="text-sm font-medium text-foreground">{dict.name}</div>
+                            <div className="text-xs text-foreground-tertiary truncate mt-0.5">
+                              {searchUrl}
+                            </div>
+                          </div>
+                          <ExternalLink className="w-3.5 h-3.5 text-foreground-tertiary flex-shrink-0" />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              ) : (
+                /* Empty state */
+                <div className="p-4 text-center py-8 text-foreground-secondary text-sm">
                   <Globe className="w-8 h-8 mx-auto mb-2 opacity-50" />
                   <p>検索語を入力してWeb辞書を検索</p>
                   <p className="mt-1 text-xs">
                     {WEB_DICTIONARIES.map((d) => d.name).join("、")}で検索します
                   </p>
                 </div>
-              ) : (
-                WEB_DICTIONARIES.map((dict) => {
-                  const searchUrl = dict.urlTemplate.replace(
-                    "{query}",
-                    encodeURIComponent(activeSearchQuery),
-                  );
-
-                  const handleOpenDictionary = () => {
-                    if (isElectron() && window.electronAPI?.openDictionaryPopup) {
-                      window.electronAPI.openDictionaryPopup(
-                        searchUrl,
-                        `${dict.name} - ${activeSearchQuery}`,
-                      );
-                    } else {
-                      window.open(searchUrl, "_blank", "noopener,noreferrer");
-                    }
-                  };
-
-                  return (
-                    <button
-                      key={dict.id}
-                      onClick={handleOpenDictionary}
-                      className="w-full bg-background-elevated border border-border rounded-lg p-4 hover:bg-hover transition-colors text-left flex items-center gap-3"
-                    >
-                      <Globe className="w-5 h-5 text-foreground-secondary flex-shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <div className="font-medium text-foreground">{dict.name}</div>
-                        <div className="text-xs text-foreground-tertiary truncate mt-0.5">
-                          {searchUrl}
-                        </div>
-                      </div>
-                      <ExternalLink className="w-4 h-4 text-foreground-tertiary flex-shrink-0" />
-                    </button>
-                  );
-                })
               )}
             </div>
           </div>
@@ -492,5 +613,126 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Master dict entry card
+// ---------------------------------------------------------------------------
+
+interface MasterDictCardProps {
+  entry: DictEntry;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+const MasterDictCard = memo(function MasterDictCard({
+  entry,
+  isExpanded,
+  onToggle,
+}: MasterDictCardProps) {
+  const firstDef = entry.definitions[0];
+  const hasSynonyms = entry.relationships.synonyms.length > 0;
+  const hasHomophones = entry.relationships.homophones.length > 0;
+  const hasAntonyms = entry.relationships.antonyms.length > 0;
+
+  return (
+    <div className="bg-background-elevated border border-border rounded-lg overflow-hidden">
+      <div
+        className="p-3 cursor-pointer hover:bg-hover transition-colors"
+        onClick={onToggle}
+      >
+        <div className="flex items-start gap-2">
+          {isExpanded ? (
+            <ChevronDown className="w-4 h-4 text-foreground-secondary flex-shrink-0 mt-0.5" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-foreground-secondary flex-shrink-0 mt-0.5" />
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <span className="font-semibold text-foreground">{entry.entry}</span>
+              {entry.reading.primary && (
+                <span className="text-sm text-foreground-tertiary">{entry.reading.primary}</span>
+              )}
+              {entry.partOfSpeech && (
+                <span className="text-xs px-1.5 py-0.5 bg-background rounded text-foreground-tertiary">
+                  {entry.partOfSpeech}
+                </span>
+              )}
+            </div>
+            {firstDef && (
+              <p className="text-sm text-foreground-secondary mt-1 line-clamp-1">
+                {firstDef.gloss}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {isExpanded && (
+        <div className="border-t border-border p-3 bg-background space-y-2">
+          {entry.definitions.length > 0 && (
+            <div>
+              <h4 className="text-xs font-semibold text-foreground-secondary mb-1">意味</h4>
+              <ol className="space-y-1">
+                {entry.definitions.map((def, i) => (
+                  <li key={i} className="text-sm text-foreground">
+                    {entry.definitions.length > 1 && (
+                      <span className="text-foreground-tertiary mr-1">{i + 1}.</span>
+                    )}
+                    {def.gloss}
+                    {def.register && (
+                      <span className="ml-1 text-xs text-foreground-tertiary">
+                        ({def.register})
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          {(hasSynonyms || hasHomophones || hasAntonyms) && (
+            <div className="space-y-1">
+              {hasSynonyms && (
+                <div>
+                  <span className="text-xs font-semibold text-foreground-secondary">類義語: </span>
+                  <span className="text-xs text-foreground">
+                    {entry.relationships.synonyms.slice(0, 8).join("・")}
+                  </span>
+                </div>
+              )}
+              {hasHomophones && (
+                <div>
+                  <span className="text-xs font-semibold text-foreground-secondary">
+                    同音異義語:{" "}
+                  </span>
+                  <span className="text-xs text-foreground">
+                    {entry.relationships.homophones.slice(0, 8).join("・")}
+                  </span>
+                </div>
+              )}
+              {hasAntonyms && (
+                <div>
+                  <span className="text-xs font-semibold text-foreground-secondary">対義語: </span>
+                  <span className="text-xs text-foreground">
+                    {entry.relationships.antonyms.slice(0, 8).join("・")}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
+
+          {entry.reading.alternatives.length > 0 && (
+            <div>
+              <span className="text-xs font-semibold text-foreground-secondary">別読み: </span>
+              <span className="text-xs text-foreground">
+                {entry.reading.alternatives.join("、")}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
 
 export default memo(Dictionary);

--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -637,7 +637,18 @@ const MasterDictCard = memo(function MasterDictCard({
 
   return (
     <div className="bg-background-elevated border border-border rounded-lg overflow-hidden">
-      <div className="p-3 cursor-pointer hover:bg-hover transition-colors" onClick={onToggle}>
+      <div
+        className="p-3 cursor-pointer hover:bg-hover transition-colors"
+        role="button"
+        tabIndex={0}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onToggle();
+          }
+        }}
+      >
         <div className="flex items-start gap-2">
           {isExpanded ? (
             <ChevronDown className="w-4 h-4 text-foreground-secondary flex-shrink-0 mt-0.5" />

--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -261,9 +261,14 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
     if (!api) return;
 
     setMasterStatus("downloading");
-    void api.download().then((result) => {
-      setMasterStatus(result.success ? "installed" : "error");
-    });
+    void api
+      .download()
+      .then((result) => {
+        setMasterStatus(result.success ? "installed" : "error");
+      })
+      .catch(() => {
+        setMasterStatus("error");
+      });
   }, []);
 
   return (

--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -497,22 +497,20 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                   )}
 
                   {/* Not installed banner (Electron only) */}
-                  {!masterLoading &&
-                    masterStatus === "not-installed" &&
-                    isElectron() && (
-                      <div className="bg-background-elevated border border-border rounded-lg p-3 flex items-center justify-between gap-3">
-                        <span className="text-sm text-foreground-secondary">
-                          辞典データ未インストール
-                        </span>
-                        <button
-                          onClick={handleDownloadDict}
-                          className="flex items-center gap-1.5 px-2.5 py-1 text-xs bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors flex-shrink-0"
-                        >
-                          <Download className="w-3 h-3" />
-                          ダウンロード
-                        </button>
-                      </div>
-                    )}
+                  {!masterLoading && masterStatus === "not-installed" && isElectron() && (
+                    <div className="bg-background-elevated border border-border rounded-lg p-3 flex items-center justify-between gap-3">
+                      <span className="text-sm text-foreground-secondary">
+                        辞典データ未インストール
+                      </span>
+                      <button
+                        onClick={handleDownloadDict}
+                        className="flex items-center gap-1.5 px-2.5 py-1 text-xs bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors flex-shrink-0"
+                      >
+                        <Download className="w-3 h-3" />
+                        ダウンロード
+                      </button>
+                    </div>
+                  )}
 
                   {/* Downloading indicator */}
                   {masterStatus === "downloading" && (
@@ -540,13 +538,11 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                   )}
 
                   {/* No results */}
-                  {!masterLoading &&
-                    masterResults.length === 0 &&
-                    masterStatus === "installed" && (
-                      <p className="text-sm text-foreground-secondary">
-                        「{activeSearchQuery}」の辞典結果なし
-                      </p>
-                    )}
+                  {!masterLoading && masterResults.length === 0 && masterStatus === "installed" && (
+                    <p className="text-sm text-foreground-secondary">
+                      「{activeSearchQuery}」の辞典結果なし
+                    </p>
+                  )}
 
                   {/* Divider */}
                   <div className="border-t border-border pt-1">
@@ -641,10 +637,7 @@ const MasterDictCard = memo(function MasterDictCard({
 
   return (
     <div className="bg-background-elevated border border-border rounded-lg overflow-hidden">
-      <div
-        className="p-3 cursor-pointer hover:bg-hover transition-colors"
-        onClick={onToggle}
-      >
+      <div className="p-3 cursor-pointer hover:bg-hover transition-colors" onClick={onToggle}>
         <div className="flex items-start gap-2">
           {isExpanded ? (
             <ChevronDown className="w-4 h-4 text-foreground-secondary flex-shrink-0 mt-0.5" />

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -12,6 +12,7 @@ import {
   Keyboard,
   Terminal,
   UserCircle,
+  BookOpen,
 } from "lucide-react";
 import clsx from "clsx";
 
@@ -26,6 +27,7 @@ import KeymapSettingsTab from "./settings/KeymapSettingsTab";
 import PowerSettingsTab from "./settings/PowerSettingsTab";
 import TerminalSettingsTab from "./settings/TerminalSettingsTab";
 import AccountSettingsTab from "./settings/AccountSettingsTab";
+import DictSettingsTab from "./settings/DictSettingsTab";
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -44,6 +46,7 @@ export type SettingsCategory =
   | "keymap"
   | "terminal"
   | "power"
+  | "dictionary"
   | "about";
 
 export default function SettingsModal({ isOpen, onClose, initialCategory }: SettingsModalProps) {
@@ -230,6 +233,18 @@ export default function SettingsModal({ isOpen, onClose, initialCategory }: Sett
                   省電力
                 </button>
               )}
+              <button
+                onClick={() => setActiveCategory("dictionary")}
+                className={clsx(
+                  "w-full text-left px-3 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-1.5",
+                  activeCategory === "dictionary"
+                    ? "bg-accent text-accent-foreground"
+                    : "text-foreground-secondary hover:bg-hover hover:text-foreground",
+                )}
+              >
+                <BookOpen className="w-4 h-4" />
+                辞典
+              </button>
               <div className="my-2 border-t border-border" />
               <button
                 onClick={() => setActiveCategory("about")}
@@ -261,6 +276,7 @@ export default function SettingsModal({ isOpen, onClose, initialCategory }: Sett
             {activeCategory === "keymap" && <KeymapSettingsTab />}
             {activeCategory === "terminal" && <TerminalSettingsTab />}
             {activeCategory === "power" && <PowerSettingsTab />}
+            {activeCategory === "dictionary" && <DictSettingsTab />}
             {activeCategory === "about" && <AboutSection />}
           </div>
         </div>

--- a/components/settings/DictSettingsTab.tsx
+++ b/components/settings/DictSettingsTab.tsx
@@ -19,6 +19,19 @@ function isElectron(): boolean {
   );
 }
 
+interface DictAPI {
+  getStatus: () => Promise<{ status: DictDownloadStatus; installedVersion?: string }>;
+  checkUpdate: () => Promise<UpdateInfo>;
+  download: () => Promise<{ success: boolean; version?: string; error?: string }>;
+  onDownloadProgress: (cb: (data: { progress: number }) => void) => () => void;
+}
+
+function getDict(): DictAPI | null {
+  return (
+    (window as Window & { electronAPI?: { dict?: DictAPI } }).electronAPI?.dict ?? null
+  );
+}
+
 export default function DictSettingsTab() {
   const {
     dictAutoCheckUpdates,
@@ -38,27 +51,9 @@ export default function DictSettingsTab() {
   const [isDownloading, setIsDownloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const electronDict = isElectron()
-    ? (window as Window & { electronAPI?: { dict?: unknown } }).electronAPI?.dict
-    : null;
-
-  const getDict = () =>
-    (
-      window as Window & {
-        electronAPI?: {
-          dict?: {
-            getStatus: () => Promise<{ status: DictDownloadStatus; installedVersion?: string }>;
-            checkUpdate: () => Promise<UpdateInfo>;
-            download: () => Promise<{ success: boolean; version?: string; error?: string }>;
-            onDownloadProgress: (cb: (data: { progress: number }) => void) => () => void;
-          };
-        };
-      }
-    ).electronAPI?.dict ?? null;
-
   // Load status on mount
   useEffect(() => {
-    if (!electronDict) return;
+    if (!isElectron()) return;
 
     const dict = getDict();
     if (!dict) return;

--- a/components/settings/DictSettingsTab.tsx
+++ b/components/settings/DictSettingsTab.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Download, RefreshCw, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
+import { useDictSettingsContext } from "@/contexts/EditorSettingsContext";
+import type { DictDownloadStatus } from "@/lib/dict/dict-types";
+
+interface UpdateInfo {
+  latestVersion?: string;
+  installedVersion?: string;
+  updateAvailable?: boolean;
+  error?: string;
+}
+
+function isElectron(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    !!(window as Window & { electronAPI?: unknown }).electronAPI
+  );
+}
+
+export default function DictSettingsTab() {
+  const {
+    dictAutoCheckUpdates,
+    dictAutoDownload,
+    dictInstalledVersion,
+    dictLastCheckedAt,
+    onDictAutoCheckUpdatesChange,
+    onDictAutoDownloadChange,
+    onDictInstalledVersionChange,
+    onDictLastCheckedAtChange,
+  } = useDictSettingsContext();
+
+  const [dbStatus, setDbStatus] = useState<DictDownloadStatus>("not-installed");
+  const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
+  const [checkResult, setCheckResult] = useState<UpdateInfo | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const electronDict = isElectron()
+    ? (window as Window & { electronAPI?: { dict?: unknown } }).electronAPI?.dict
+    : null;
+
+  const getDict = () =>
+    (
+      window as Window & {
+        electronAPI?: {
+          dict?: {
+            getStatus: () => Promise<{ status: DictDownloadStatus; installedVersion?: string }>;
+            checkUpdate: () => Promise<UpdateInfo>;
+            download: () => Promise<{ success: boolean; version?: string; error?: string }>;
+            onDownloadProgress: (cb: (data: { progress: number }) => void) => () => void;
+          };
+        };
+      }
+    ).electronAPI?.dict ?? null;
+
+  // Load status on mount
+  useEffect(() => {
+    if (!electronDict) return;
+
+    const dict = getDict();
+    if (!dict) return;
+
+    dict
+      .getStatus()
+      .then((s) => {
+        setDbStatus(s.status);
+        if (s.installedVersion && !dictInstalledVersion) {
+          onDictInstalledVersionChange(s.installedVersion);
+        }
+      })
+      .catch(() => {});
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleCheckUpdate = useCallback(async () => {
+    const dict = getDict();
+    if (!dict) return;
+
+    setIsChecking(true);
+    setError(null);
+    try {
+      const info = await dict.checkUpdate();
+      setCheckResult(info);
+      onDictLastCheckedAtChange(new Date().toISOString());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "更新確認に失敗しました");
+    } finally {
+      setIsChecking(false);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleDownload = useCallback(async () => {
+    const dict = getDict();
+    if (!dict) return;
+
+    setIsDownloading(true);
+    setDownloadProgress(0);
+    setError(null);
+
+    const cleanup = dict.onDownloadProgress(({ progress }) => {
+      setDownloadProgress(progress);
+    });
+
+    try {
+      const result = await dict.download();
+      if (result.success) {
+        setDbStatus("installed");
+        if (result.version) {
+          onDictInstalledVersionChange(result.version);
+        }
+        setCheckResult(null);
+      } else {
+        setError(result.error ?? "ダウンロードに失敗しました");
+        setDbStatus("error");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "ダウンロードに失敗しました");
+      setDbStatus("error");
+    } finally {
+      cleanup();
+      setIsDownloading(false);
+      setDownloadProgress(null);
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const formatDate = (iso: string | undefined) => {
+    if (!iso) return null;
+    try {
+      return new Date(iso).toLocaleDateString("ja-JP", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      });
+    } catch {
+      return iso;
+    }
+  };
+
+  const isInstalled = dbStatus === "installed";
+  const updateAvailable = checkResult?.updateAvailable ?? false;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-base font-semibold text-foreground mb-1">辞典データ</h3>
+        <p className="text-sm text-foreground-secondary">
+          illusions辞典データベース（日本語語彙・読み・品詞・類義語）
+        </p>
+      </div>
+
+      {/* Status card */}
+      <div className="bg-background-elevated border border-border rounded-lg p-4 space-y-3">
+        {/* Install state */}
+        <div className="flex items-center gap-2">
+          {isInstalled ? (
+            <CheckCircle2 className="w-4 h-4 text-success flex-shrink-0" />
+          ) : (
+            <AlertCircle className="w-4 h-4 text-foreground-tertiary flex-shrink-0" />
+          )}
+          <span className="text-sm text-foreground">
+            {isInstalled ? "インストール済み" : "未インストール"}
+          </span>
+        </div>
+
+        {/* Version */}
+        {dictInstalledVersion && (
+          <div className="text-xs text-foreground-secondary">
+            バージョン: {dictInstalledVersion}
+          </div>
+        )}
+
+        {/* Latest version info */}
+        {checkResult?.latestVersion && (
+          <div className="text-xs text-foreground-secondary">
+            最新バージョン: {checkResult.latestVersion}
+            {updateAvailable && (
+              <span className="ml-2 text-warning font-medium">更新あり</span>
+            )}
+            {!updateAvailable && isInstalled && (
+              <span className="ml-2 text-success">最新版です</span>
+            )}
+          </div>
+        )}
+
+        {/* Last checked */}
+        {dictLastCheckedAt && (
+          <div className="text-xs text-foreground-tertiary">
+            最終確認: {formatDate(dictLastCheckedAt)}
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div className="text-xs text-danger">{error}</div>
+        )}
+
+        {/* Download progress */}
+        {isDownloading && downloadProgress !== null && (
+          <div className="space-y-1">
+            <div className="flex items-center justify-between text-xs text-foreground-secondary">
+              <span>{downloadProgress < 95 ? "ダウンロード中..." : "展開中..."}</span>
+              <span>{downloadProgress}%</span>
+            </div>
+            <div className="w-full bg-background rounded-full h-1.5">
+              <div
+                className="bg-accent h-1.5 rounded-full transition-all duration-300"
+                style={{ width: `${downloadProgress}%` }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Action buttons */}
+        {isElectron() && (
+          <div className="flex gap-2 pt-1">
+            <button
+              onClick={() => void handleCheckUpdate()}
+              disabled={isChecking || isDownloading}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-background border border-border rounded hover:bg-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isChecking ? (
+                <Loader2 className="w-3 h-3 animate-spin" />
+              ) : (
+                <RefreshCw className="w-3 h-3" />
+              )}
+              今すぐ確認
+            </button>
+
+            {(!isInstalled || updateAvailable) && (
+              <button
+                onClick={() => void handleDownload()}
+                disabled={isDownloading || isChecking}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-xs bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isDownloading ? (
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                ) : (
+                  <Download className="w-3 h-3" />
+                )}
+                {isInstalled ? "更新" : "ダウンロード"}
+              </button>
+            )}
+          </div>
+        )}
+
+        {!isElectron() && (
+          <p className="text-xs text-foreground-tertiary">
+            辞典データはデスクトップ版でのみ利用できます。
+          </p>
+        )}
+      </div>
+
+      {/* Update settings */}
+      <div>
+        <h3 className="text-sm font-semibold text-foreground mb-3">アップデート設定</h3>
+        <div className="space-y-3">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={dictAutoCheckUpdates}
+              onChange={(e) => onDictAutoCheckUpdatesChange(e.target.checked)}
+              className="w-4 h-4 rounded accent-accent"
+            />
+            <div>
+              <div className="text-sm text-foreground">起動時に更新を確認する</div>
+              <div className="text-xs text-foreground-secondary">
+                アプリ起動時に自動で新バージョンを確認します
+              </div>
+            </div>
+          </label>
+
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={dictAutoDownload}
+              onChange={(e) => onDictAutoDownloadChange(e.target.checked)}
+              className="w-4 h-4 rounded accent-accent"
+            />
+            <div>
+              <div className="text-sm text-foreground">自動ダウンロード</div>
+              <div className="text-xs text-foreground-secondary">
+                新バージョンが見つかった場合に自動でダウンロードします（約 526 MB）
+              </div>
+            </div>
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/settings/DictSettingsTab.tsx
+++ b/components/settings/DictSettingsTab.tsx
@@ -14,8 +14,7 @@ interface UpdateInfo {
 
 function isElectron(): boolean {
   return (
-    typeof window !== "undefined" &&
-    !!(window as Window & { electronAPI?: unknown }).electronAPI
+    typeof window !== "undefined" && !!(window as Window & { electronAPI?: unknown }).electronAPI
   );
 }
 
@@ -27,9 +26,7 @@ interface DictAPI {
 }
 
 function getDict(): DictAPI | null {
-  return (
-    (window as Window & { electronAPI?: { dict?: DictAPI } }).electronAPI?.dict ?? null
-  );
+  return (window as Window & { electronAPI?: { dict?: DictAPI } }).electronAPI?.dict ?? null;
 }
 
 export default function DictSettingsTab() {
@@ -172,9 +169,7 @@ export default function DictSettingsTab() {
         {checkResult?.latestVersion && (
           <div className="text-xs text-foreground-secondary">
             最新バージョン: {checkResult.latestVersion}
-            {updateAvailable && (
-              <span className="ml-2 text-warning font-medium">更新あり</span>
-            )}
+            {updateAvailable && <span className="ml-2 text-warning font-medium">更新あり</span>}
             {!updateAvailable && isInstalled && (
               <span className="ml-2 text-success">最新版です</span>
             )}
@@ -189,9 +184,7 @@ export default function DictSettingsTab() {
         )}
 
         {/* Error */}
-        {error && (
-          <div className="text-xs text-danger">{error}</div>
-        )}
+        {error && <div className="text-xs text-danger">{error}</div>}
 
         {/* Download progress */}
         {isDownloading && downloadProgress !== null && (

--- a/components/settings/DictSettingsTab.tsx
+++ b/components/settings/DictSettingsTab.tsx
@@ -120,7 +120,7 @@ export default function DictSettingsTab() {
   const formatDate = (iso: string | undefined) => {
     if (!iso) return null;
     try {
-      return new Date(iso).toLocaleDateString("ja-JP", {
+      return new Date(iso).toLocaleString("ja-JP", {
         year: "numeric",
         month: "long",
         day: "numeric",

--- a/contexts/EditorSettingsContext.tsx
+++ b/contexts/EditorSettingsContext.tsx
@@ -222,3 +222,21 @@ export function useTerminalSettings() {
     [settings, handlers],
   );
 }
+
+/** Dictionary settings */
+export function useDictSettingsContext() {
+  const { settings, handlers } = useEditorSettingsContext();
+  return useMemo(
+    () => ({
+      dictAutoCheckUpdates: settings.dictAutoCheckUpdates,
+      dictAutoDownload: settings.dictAutoDownload,
+      dictInstalledVersion: settings.dictInstalledVersion,
+      dictLastCheckedAt: settings.dictLastCheckedAt,
+      onDictAutoCheckUpdatesChange: handlers.handleDictAutoCheckUpdatesChange,
+      onDictAutoDownloadChange: handlers.handleDictAutoDownloadChange,
+      onDictInstalledVersionChange: handlers.handleDictInstalledVersionChange,
+      onDictLastCheckedAtChange: handlers.handleDictLastCheckedAtChange,
+    }),
+    [settings, handlers],
+  );
+}

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -65,6 +65,13 @@ class DictManager {
     this._dbPath = null;
     this._versionPath = null;
     this._downloadMutex = new Mutex();
+    this._latestAssetUrl = null;
+    this._latestVersion = null;
+  }
+
+  /** Escape LIKE wildcards so user input cannot inject patterns. */
+  _escapeLike(str) {
+    return str.replace(/[%_\\]/g, "\\$&");
   }
 
   _getDictDir() {
@@ -102,19 +109,12 @@ class DictManager {
     const dbPath = this._getDbPath();
     if (!fs.existsSync(dbPath)) return null;
 
+    // Ensure indexes exist before opening readonly — uses a separate writable connection
+    this._ensureIndexes(dbPath);
+
     try {
-      // Use better-sqlite3 (already a dependency for storage)
       const Database = require("better-sqlite3");
       const db = new Database(dbPath, { readonly: true });
-
-      // Enable WAL mode for better concurrent read performance
-      db.pragma("journal_mode = WAL");
-      db.pragma("query_only = ON");
-
-      // Ensure indexes exist for fast prefix search
-      // (The build script should already create these, but we add them defensively)
-      this._ensureIndexes(db);
-
       this._db = db;
       console.log("[DictManager] Database opened:", dbPath);
       return db;
@@ -124,10 +124,19 @@ class DictManager {
     }
   }
 
-  _ensureIndexes(db) {
+  /**
+   * Check and create indexes if missing. Uses a short-lived writable connection
+   * so the main readonly handle is never leaked.
+   * @param {string} dbPath
+   */
+  _ensureIndexes(dbPath) {
+    let rwDb = null;
     try {
+      const Database = require("better-sqlite3");
+      rwDb = new Database(dbPath);
+
       // Check if the entries table exists at all
-      const tableCheck = db
+      const tableCheck = rwDb
         .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='entries'")
         .get();
       if (!tableCheck) {
@@ -135,30 +144,32 @@ class DictManager {
         return;
       }
 
-      // Add index on entry column if not present
-      const indexCheck = db
+      // Enable WAL mode (only effective on a writable connection)
+      rwDb.pragma("journal_mode = WAL");
+
+      // Add indexes if not present
+      const indexCheck = rwDb
         .prepare(
           "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_dict_entry_text'",
         )
         .get();
       if (!indexCheck) {
-        console.log("[DictManager] Creating index on entries.entry...");
-        // Use a writable connection just for index creation
-        const Database = require("better-sqlite3");
-        const dbPath = this._getDbPath();
-        const rwDb = new Database(dbPath);
+        console.log("[DictManager] Creating indexes...");
         rwDb.exec(
           "CREATE INDEX IF NOT EXISTS idx_dict_entry_text ON entries(entry);" +
             "CREATE INDEX IF NOT EXISTS idx_dict_definitions_entry_id ON definitions(entry_id);",
         );
-        rwDb.close();
         console.log("[DictManager] Indexes created");
-        // Re-open as readonly
-        this._db = null;
       }
     } catch (err) {
       // Index creation is best-effort; don't fail the whole open
       console.warn("[DictManager] Index check/create failed:", err);
+    } finally {
+      if (rwDb) {
+        try {
+          rwDb.close();
+        } catch {}
+      }
     }
   }
 
@@ -177,15 +188,17 @@ class DictManager {
     if (!db) return [];
 
     try {
-      // Exact match first, then prefix matches
+      // Exact match first, then prefix matches; escape LIKE wildcards
+      const escaped = this._escapeLike(term);
       const rows = db
         .prepare(
           `SELECT e.id, e.entry, e.reading, e.part_of_speech, e.inflections, e.relations
            FROM entries e
-           WHERE e.entry = ? OR e.entry LIKE ?
+           WHERE e.entry = ? OR e.entry LIKE ? ESCAPE '\\'
+           ORDER BY (e.entry = ?) DESC, e.entry
            LIMIT ?`,
         )
-        .all(term, `${term}%`, limit);
+        .all(term, `${escaped}%`, term, limit);
 
       return rows.map((row) => this._rowToEntry(row, db));
     } catch (err) {
@@ -205,15 +218,17 @@ class DictManager {
     if (!db) return [];
 
     try {
+      const escaped = this._escapeLike(reading);
       const rows = db
         .prepare(
           `SELECT e.id, e.entry, e.reading, e.part_of_speech, e.inflections, e.relations
            FROM entries e
            WHERE json_extract(e.reading, '$.primary') = ?
-              OR json_extract(e.reading, '$.primary') LIKE ?
+              OR json_extract(e.reading, '$.primary') LIKE ? ESCAPE '\\'
+           ORDER BY (json_extract(e.reading, '$.primary') = ?) DESC, e.entry
            LIMIT ?`,
         )
-        .all(reading, `${reading}%`, limit);
+        .all(reading, `${escaped}%`, reading, limit);
 
       return rows.map((row) => this._rowToEntry(row, db));
     } catch (err) {
@@ -330,6 +345,11 @@ class DictManager {
           },
         },
         (res) => {
+          if (res.statusCode !== 200) {
+            res.resume();
+            reject(new Error(`GitHub API returned HTTP ${res.statusCode}`));
+            return;
+          }
           let data = "";
           res.on("data", (chunk) => (data += chunk));
           res.on("end", () => {
@@ -436,8 +456,14 @@ class DictManager {
       }
 
       onProgress?.(100);
-      console.log("[DictManager] Download complete:", this._latestVersion);
-      return { success: true, version: this._latestVersion };
+      const version = this._latestVersion;
+      console.log("[DictManager] Download complete:", version);
+
+      // Clear cached release info so next download fetches fresh data
+      this._latestAssetUrl = null;
+      this._latestVersion = null;
+
+      return { success: true, version };
     } catch (err) {
       console.error("[DictManager] Download failed:", err);
       // Clean up partial files

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -1,0 +1,546 @@
+/* eslint-disable no-console */
+/**
+ * DictManager — Electron main process dictionary manager.
+ *
+ * Responsibilities:
+ *  - Open and cache the illusionsDict SQLite database
+ *  - Ensure indexes exist for fast prefix search
+ *  - Query entries and definitions
+ *  - Check for updates via GitHub Releases API
+ *  - Download and install new database versions
+ *  - Enforce a single-download mutex across multiple windows
+ */
+
+const path = require("path");
+const fs = require("fs");
+const https = require("https");
+const zlib = require("zlib");
+const { app } = require("electron");
+
+const PROVIDER_ID = "illusions-dict";
+const GITHUB_OWNER = "Iktahana";
+const GITHUB_REPO = "illusionsDict-Word-Database";
+const DB_FILENAME = "illusions_dict.db";
+const DB_TEMP_FILENAME = "illusions_dict.db.tmp";
+const VERSION_FILENAME = "illusions_dict_version.txt";
+
+// ---------------------------------------------------------------------------
+// Simple promise-chain mutex (main-process, no module import needed)
+// ---------------------------------------------------------------------------
+class Mutex {
+  constructor() {
+    this._queue = Promise.resolve();
+    this._locked = false;
+  }
+
+  /** Returns true if a download is currently in progress */
+  get locked() {
+    return this._locked;
+  }
+
+  /**
+   * Acquire the mutex. The returned release function MUST be called in finally.
+   * @returns {Promise<() => void>}
+   */
+  acquire() {
+    let release;
+    const next = new Promise((resolve) => {
+      release = resolve;
+    });
+    const result = this._queue.then(() => {
+      this._locked = true;
+      return () => {
+        this._locked = false;
+        release();
+      };
+    });
+    this._queue = this._queue.then(() => next);
+    return result;
+  }
+}
+
+class DictManager {
+  constructor() {
+    this._db = null;
+    this._dbPath = null;
+    this._versionPath = null;
+    this._downloadMutex = new Mutex();
+  }
+
+  _getDictDir() {
+    return path.join(app.getPath("userData"), "dict");
+  }
+
+  _getDbPath() {
+    if (!this._dbPath) {
+      this._dbPath = path.join(this._getDictDir(), DB_FILENAME);
+    }
+    return this._dbPath;
+  }
+
+  _getVersionPath() {
+    if (!this._versionPath) {
+      this._versionPath = path.join(this._getDictDir(), VERSION_FILENAME);
+    }
+    return this._versionPath;
+  }
+
+  _ensureDictDir() {
+    const dir = this._getDictDir();
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Database access
+  // ---------------------------------------------------------------------------
+
+  _openDb() {
+    if (this._db) return this._db;
+
+    const dbPath = this._getDbPath();
+    if (!fs.existsSync(dbPath)) return null;
+
+    try {
+      // Use better-sqlite3 (already a dependency for storage)
+      const Database = require("better-sqlite3");
+      const db = new Database(dbPath, { readonly: true });
+
+      // Enable WAL mode for better concurrent read performance
+      db.pragma("journal_mode = WAL");
+      db.pragma("query_only = ON");
+
+      // Ensure indexes exist for fast prefix search
+      // (The build script should already create these, but we add them defensively)
+      this._ensureIndexes(db);
+
+      this._db = db;
+      console.log("[DictManager] Database opened:", dbPath);
+      return db;
+    } catch (err) {
+      console.error("[DictManager] Failed to open database:", err);
+      return null;
+    }
+  }
+
+  _ensureIndexes(db) {
+    try {
+      // Check if the entries table exists at all
+      const tableCheck = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='entries'")
+        .get();
+      if (!tableCheck) {
+        console.warn("[DictManager] 'entries' table not found in database");
+        return;
+      }
+
+      // Add index on entry column if not present
+      const indexCheck = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_dict_entry_text'",
+        )
+        .get();
+      if (!indexCheck) {
+        console.log("[DictManager] Creating index on entries.entry...");
+        // Use a writable connection just for index creation
+        const Database = require("better-sqlite3");
+        const dbPath = this._getDbPath();
+        const rwDb = new Database(dbPath);
+        rwDb.exec(
+          "CREATE INDEX IF NOT EXISTS idx_dict_entry_text ON entries(entry);" +
+            "CREATE INDEX IF NOT EXISTS idx_dict_definitions_entry_id ON definitions(entry_id);",
+        );
+        rwDb.close();
+        console.log("[DictManager] Indexes created");
+        // Re-open as readonly
+        this._db = null;
+      }
+    } catch (err) {
+      // Index creation is best-effort; don't fail the whole open
+      console.warn("[DictManager] Index check/create failed:", err);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public: query
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Query entries by headword (exact or prefix).
+   * @param {string} term
+   * @param {number} limit
+   * @returns {import("../lib/dict/dict-types").DictEntry[]}
+   */
+  query(term, limit = 20) {
+    const db = this._openDb();
+    if (!db) return [];
+
+    try {
+      // Exact match first, then prefix matches
+      const rows = db
+        .prepare(
+          `SELECT e.id, e.entry, e.reading, e.part_of_speech, e.inflections, e.relations
+           FROM entries e
+           WHERE e.entry = ? OR e.entry LIKE ?
+           LIMIT ?`,
+        )
+        .all(term, `${term}%`, limit);
+
+      return rows.map((row) => this._rowToEntry(row, db));
+    } catch (err) {
+      console.error("[DictManager] query error:", err);
+      return [];
+    }
+  }
+
+  /**
+   * Query entries by kana reading (homophone lookup).
+   * @param {string} reading
+   * @param {number} limit
+   * @returns {import("../lib/dict/dict-types").DictEntry[]}
+   */
+  queryByReading(reading, limit = 20) {
+    const db = this._openDb();
+    if (!db) return [];
+
+    try {
+      const rows = db
+        .prepare(
+          `SELECT e.id, e.entry, e.reading, e.part_of_speech, e.inflections, e.relations
+           FROM entries e
+           WHERE json_extract(e.reading, '$.primary') = ?
+              OR json_extract(e.reading, '$.primary') LIKE ?
+           LIMIT ?`,
+        )
+        .all(reading, `${reading}%`, limit);
+
+      return rows.map((row) => this._rowToEntry(row, db));
+    } catch (err) {
+      console.error("[DictManager] queryByReading error:", err);
+      return [];
+    }
+  }
+
+  /**
+   * Map a DB row to a DictEntry. Fetches definitions via a separate query.
+   * @private
+   */
+  _rowToEntry(row, db) {
+    let reading = { primary: "", alternatives: [] };
+    let relationships = { homophones: [], synonyms: [], antonyms: [], related: [] };
+    let inflections = [];
+
+    try {
+      reading = JSON.parse(row.reading ?? "{}");
+    } catch {}
+    try {
+      const rel = JSON.parse(row.relations ?? "{}");
+      relationships = {
+        homophones: rel.homophones ?? [],
+        synonyms: rel.synonyms ?? [],
+        antonyms: rel.antonyms ?? [],
+        related: rel.related ?? [],
+      };
+    } catch {}
+    try {
+      inflections = JSON.parse(row.inflections ?? "[]");
+    } catch {}
+
+    // Fetch definitions (limited to 5 per entry to keep response size small)
+    let definitions = [];
+    try {
+      const defRows = db
+        .prepare(
+          `SELECT gloss, register, nuance, examples, collocations
+           FROM definitions
+           WHERE entry_id = ?
+           LIMIT 5`,
+        )
+        .all(row.id);
+
+      definitions = defRows.map((d) => ({
+        gloss: d.gloss ?? "",
+        register: d.register || undefined,
+        nuance: d.nuance || undefined,
+        examples: this._parseJsonArray(d.examples),
+        collocations: this._parseJsonArray(d.collocations),
+      }));
+    } catch {}
+
+    return {
+      id: row.id,
+      entry: row.entry,
+      reading,
+      partOfSpeech: row.part_of_speech || undefined,
+      inflections: inflections.length > 0 ? inflections : undefined,
+      definitions,
+      relationships,
+      source: PROVIDER_ID,
+    };
+  }
+
+  /** @private */
+  _parseJsonArray(value) {
+    if (!value) return undefined;
+    try {
+      const arr = JSON.parse(value);
+      return Array.isArray(arr) && arr.length > 0 ? arr : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public: status and version
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Returns the current installation status of the dictionary.
+   * @returns {{ status: string, installedVersion?: string, updateAvailable?: boolean }}
+   */
+  getStatus() {
+    const dbPath = this._getDbPath();
+    const installed = fs.existsSync(dbPath);
+    if (!installed) {
+      return { status: "not-installed" };
+    }
+
+    let installedVersion;
+    try {
+      installedVersion = fs.readFileSync(this._getVersionPath(), "utf8").trim();
+    } catch {}
+
+    return { status: "installed", installedVersion };
+  }
+
+  /**
+   * Check GitHub Releases for the latest version.
+   * @returns {Promise<{ latestVersion: string, installedVersion?: string, updateAvailable: boolean }>}
+   */
+  checkUpdate() {
+    return new Promise((resolve, reject) => {
+      const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`;
+      const req = https.get(
+        url,
+        {
+          headers: {
+            "User-Agent": "illusions-app",
+            Accept: "application/vnd.github.v3+json",
+          },
+        },
+        (res) => {
+          let data = "";
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => {
+            try {
+              const json = JSON.parse(data);
+              const latestVersion = json.tag_name ?? "";
+
+              let installedVersion;
+              try {
+                installedVersion = fs.readFileSync(this._getVersionPath(), "utf8").trim();
+              } catch {}
+
+              const updateAvailable =
+                !!latestVersion && (!installedVersion || installedVersion !== latestVersion);
+
+              // Cache asset download URL for later use
+              const asset = (json.assets ?? []).find(
+                (a) => a.name && a.name.endsWith(".db.gz"),
+              );
+              this._latestAssetUrl = asset?.browser_download_url ?? null;
+              this._latestVersion = latestVersion;
+
+              resolve({ latestVersion, installedVersion, updateAvailable });
+            } catch (err) {
+              reject(err);
+            }
+          });
+        },
+      );
+      req.on("error", reject);
+      req.setTimeout(10000, () => {
+        req.destroy(new Error("GitHub API request timed out"));
+      });
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public: download
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Download and install the latest dictionary database.
+   * Progress is reported via the onProgress callback (0–100).
+   * Protected by a mutex to prevent concurrent downloads.
+   *
+   * @param {(progress: number) => void} onProgress
+   * @returns {Promise<{ success: boolean, version?: string, error?: string }>}
+   */
+  async download(onProgress) {
+    if (this._downloadMutex.locked) {
+      return { success: false, error: "ダウンロードはすでに進行中です" };
+    }
+
+    const release = await this._downloadMutex.acquire();
+    try {
+      return await this._doDownload(onProgress);
+    } finally {
+      release();
+    }
+  }
+
+  /** @private */
+  async _doDownload(onProgress) {
+    try {
+      // Fetch release info if not cached
+      if (!this._latestAssetUrl) {
+        await this.checkUpdate();
+      }
+
+      if (!this._latestAssetUrl) {
+        return { success: false, error: "ダウンロードURLが取得できませんでした" };
+      }
+
+      this._ensureDictDir();
+      const tempPath = path.join(this._getDictDir(), DB_TEMP_FILENAME);
+      const finalPath = this._getDbPath();
+
+      // Download the .db.gz file
+      await this._downloadFile(this._latestAssetUrl, tempPath, onProgress);
+
+      // Report decompression start
+      onProgress?.(95);
+
+      // Decompress .gz in place
+      await this._decompressGzip(tempPath, finalPath + ".decompressing");
+
+      // Clean up temp file
+      fs.unlinkSync(tempPath);
+
+      // Close existing DB connection before replacing file
+      if (this._db) {
+        try {
+          this._db.close();
+        } catch {}
+        this._db = null;
+      }
+
+      // Atomically replace the database file
+      fs.renameSync(finalPath + ".decompressing", finalPath);
+
+      // Save version
+      if (this._latestVersion) {
+        fs.writeFileSync(this._getVersionPath(), this._latestVersion, "utf8");
+      }
+
+      onProgress?.(100);
+      console.log("[DictManager] Download complete:", this._latestVersion);
+      return { success: true, version: this._latestVersion };
+    } catch (err) {
+      console.error("[DictManager] Download failed:", err);
+      // Clean up partial files
+      for (const p of [
+        path.join(this._getDictDir(), DB_TEMP_FILENAME),
+        this._getDbPath() + ".decompressing",
+      ]) {
+        try {
+          if (fs.existsSync(p)) fs.unlinkSync(p);
+        } catch {}
+      }
+      return { success: false, error: String(err?.message ?? err) };
+    }
+  }
+
+  /**
+   * Download a URL to a local file path, reporting progress.
+   * Follows HTTP redirects (GitHub Releases uses S3 redirects).
+   * @private
+   */
+  _downloadFile(url, destPath, onProgress) {
+    return new Promise((resolve, reject) => {
+      const doRequest = (requestUrl, redirectCount = 0) => {
+        if (redirectCount > 5) {
+          reject(new Error("Too many redirects"));
+          return;
+        }
+
+        const parsedUrl = new URL(requestUrl);
+        const lib = parsedUrl.protocol === "https:" ? https : require("http");
+
+        lib
+          .get(requestUrl, { headers: { "User-Agent": "illusions-app" } }, (res) => {
+            // Handle redirects
+            if (res.statusCode === 301 || res.statusCode === 302 || res.statusCode === 307) {
+              const location = res.headers.location;
+              if (location) {
+                res.resume();
+                doRequest(location, redirectCount + 1);
+                return;
+              }
+            }
+
+            if (res.statusCode !== 200) {
+              reject(new Error(`HTTP ${res.statusCode}`));
+              return;
+            }
+
+            const totalBytes = parseInt(res.headers["content-length"] ?? "0", 10);
+            let receivedBytes = 0;
+            let lastReportedPct = 0;
+
+            const fileStream = fs.createWriteStream(destPath);
+            res.on("data", (chunk) => {
+              receivedBytes += chunk.length;
+              if (totalBytes > 0) {
+                const pct = Math.floor((receivedBytes / totalBytes) * 90); // 0–90%
+                if (pct > lastReportedPct) {
+                  lastReportedPct = pct;
+                  onProgress?.(pct);
+                }
+              }
+            });
+            res.pipe(fileStream);
+            fileStream.on("finish", resolve);
+            fileStream.on("error", reject);
+            res.on("error", reject);
+          })
+          .on("error", reject);
+      };
+
+      doRequest(url);
+    });
+  }
+
+  /**
+   * Decompress a .gz file to the given destination path.
+   * @private
+   */
+  _decompressGzip(srcPath, destPath) {
+    return new Promise((resolve, reject) => {
+      const src = fs.createReadStream(srcPath);
+      const dest = fs.createWriteStream(destPath);
+      const gunzip = zlib.createGunzip();
+
+      src.on("error", reject);
+      gunzip.on("error", reject);
+      dest.on("error", reject);
+      dest.on("finish", resolve);
+
+      src.pipe(gunzip).pipe(dest);
+    });
+  }
+}
+
+// Singleton
+let _manager = null;
+
+function getDictManager() {
+  if (!_manager) {
+    _manager = new DictManager();
+  }
+  return _manager;
+}
+
+module.exports = { getDictManager };

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -149,9 +149,7 @@ class DictManager {
 
       // Add indexes if not present
       const indexCheck = rwDb
-        .prepare(
-          "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_dict_entry_text'",
-        )
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name='idx_dict_entry_text'")
         .get();
       if (!indexCheck) {
         console.log("[DictManager] Creating indexes...");
@@ -366,9 +364,7 @@ class DictManager {
                 !!latestVersion && (!installedVersion || installedVersion !== latestVersion);
 
               // Cache asset download URL for later use
-              const asset = (json.assets ?? []).find(
-                (a) => a.name && a.name.endsWith(".db.gz"),
-              );
+              const asset = (json.assets ?? []).find((a) => a.name && a.name.endsWith(".db.gz"));
               this._latestAssetUrl = asset?.browser_download_url ?? null;
               this._latestVersion = latestVersion;
 

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -109,8 +109,14 @@ class DictManager {
     const dbPath = this._getDbPath();
     if (!fs.existsSync(dbPath)) return null;
 
-    // Ensure indexes exist before opening readonly — uses a separate writable connection
-    this._ensureIndexes(dbPath);
+    // Only attempt index creation / WAL if the file is writable
+    try {
+      fs.accessSync(dbPath, fs.constants.W_OK);
+      this._ensureIndexes(dbPath);
+    } catch {
+      // File is read-only on disk — skip index/WAL setup
+      console.warn("[DictManager] DB file is not writable; skipping index/WAL setup");
+    }
 
     try {
       const Database = require("better-sqlite3");
@@ -182,6 +188,8 @@ class DictManager {
    * @returns {import("../lib/dict/dict-types").DictEntry[]}
    */
   query(term, limit = 20) {
+    // Avoid opening the DB while a download/rename is in progress
+    if (this._downloadMutex.locked) return [];
     const db = this._openDb();
     if (!db) return [];
 
@@ -212,6 +220,8 @@ class DictManager {
    * @returns {import("../lib/dict/dict-types").DictEntry[]}
    */
   queryByReading(reading, limit = 20) {
+    // Avoid opening the DB while a download/rename is in progress
+    if (this._downloadMutex.locked) return [];
     const db = this._openDb();
     if (!db) return [];
 
@@ -524,7 +534,7 @@ class DictManager {
               }
             });
             res.pipe(fileStream);
-            fileStream.on("finish", resolve);
+            fileStream.on("close", resolve);
             fileStream.on("error", reject);
             res.on("error", reject);
           })
@@ -548,7 +558,7 @@ class DictManager {
       src.on("error", reject);
       gunzip.on("error", reject);
       dest.on("error", reject);
-      dest.on("finish", resolve);
+      dest.on("close", resolve);
 
       src.pipe(gunzip).pipe(dest);
     });

--- a/electron/ipc/dict-ipc.js
+++ b/electron/ipc/dict-ipc.js
@@ -10,10 +10,17 @@ const { getDictManager } = require("../dict-manager");
 function registerDictHandlers() {
   const mgr = getDictManager();
 
+  // Validate and clamp limit to a safe range (1–100)
+  const clampLimit = (raw) => {
+    const n = Number(raw ?? 20);
+    if (!Number.isFinite(n)) return 20;
+    return Math.max(1, Math.min(100, Math.floor(n)));
+  };
+
   // Query by headword
   ipcMain.handle("dict:query", async (_event, { term, limit }) => {
     try {
-      return mgr.query(String(term ?? ""), Number(limit ?? 20));
+      return mgr.query(String(term ?? ""), clampLimit(limit));
     } catch (err) {
       console.error("[Dict IPC] dict:query failed:", err);
       return [];
@@ -23,7 +30,7 @@ function registerDictHandlers() {
   // Query by kana reading (homophone lookup)
   ipcMain.handle("dict:query-reading", async (_event, { reading, limit }) => {
     try {
-      return mgr.queryByReading(String(reading ?? ""), Number(limit ?? 20));
+      return mgr.queryByReading(String(reading ?? ""), clampLimit(limit));
     } catch (err) {
       console.error("[Dict IPC] dict:query-reading failed:", err);
       return [];

--- a/electron/ipc/dict-ipc.js
+++ b/electron/ipc/dict-ipc.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-console */
+/**
+ * Dictionary IPC handlers — main process.
+ * Follows the same pattern as nlp-ipc.js and storage-ipc.js.
+ */
+
+const { ipcMain } = require("electron");
+const { getDictManager } = require("../dict-manager");
+
+function registerDictHandlers() {
+  const mgr = getDictManager();
+
+  // Query by headword
+  ipcMain.handle("dict:query", async (_event, { term, limit }) => {
+    try {
+      return mgr.query(String(term ?? ""), Number(limit ?? 20));
+    } catch (err) {
+      console.error("[Dict IPC] dict:query failed:", err);
+      return [];
+    }
+  });
+
+  // Query by kana reading (homophone lookup)
+  ipcMain.handle("dict:query-reading", async (_event, { reading, limit }) => {
+    try {
+      return mgr.queryByReading(String(reading ?? ""), Number(limit ?? 20));
+    } catch (err) {
+      console.error("[Dict IPC] dict:query-reading failed:", err);
+      return [];
+    }
+  });
+
+  // Get installation status and installed version
+  ipcMain.handle("dict:get-status", async () => {
+    try {
+      return mgr.getStatus();
+    } catch (err) {
+      console.error("[Dict IPC] dict:get-status failed:", err);
+      return { status: "error", error: String(err?.message ?? err) };
+    }
+  });
+
+  // Check GitHub Releases for the latest version
+  ipcMain.handle("dict:check-update", async () => {
+    try {
+      return await mgr.checkUpdate();
+    } catch (err) {
+      console.error("[Dict IPC] dict:check-update failed:", err);
+      return { error: String(err?.message ?? err) };
+    }
+  });
+
+  // Download and install the latest database, streaming progress back to the renderer
+  ipcMain.handle("dict:download", async (event) => {
+    try {
+      return await mgr.download((progress) => {
+        if (!event.sender.isDestroyed()) {
+          event.sender.send("dict:download-progress", { progress });
+        }
+      });
+    } catch (err) {
+      console.error("[Dict IPC] dict:download failed:", err);
+      return { success: false, error: String(err?.message ?? err) };
+    }
+  });
+}
+
+module.exports = { registerDictHandlers };

--- a/electron/main.js
+++ b/electron/main.js
@@ -42,6 +42,8 @@ const { registerPtyHandlers } = require("./ipc/pty-ipc");
 const { killAllSessions, killSessionsForWindow } = require("./ipc/terminal-session-registry");
 const { registerAuthHandlers, handleAuthCallback } = require("./ipc/auth-ipc");
 const { registerEditorHandlers } = require("./ipc/editor-ipc");
+const { registerDictHandlers } = require("./ipc/dict-ipc");
+const { getDictManager } = require("./dict-manager");
 
 process.on("uncaughtException", (err) => {
   console.error("[FATAL] Uncaught exception:", err);
@@ -162,6 +164,7 @@ app.whenReady().then(async () => {
   registerPtyHandlers();
   registerAuthHandlers();
   registerEditorHandlers();
+  registerDictHandlers();
 
   // Power state monitoring
   powerMonitor.on("on-ac", () => broadcastPowerState("ac"));
@@ -174,6 +177,35 @@ app.whenReady().then(async () => {
   setTimeout(() => {
     checkForUpdates(false);
   }, 3000);
+
+  // 辞典データ更新確認（AppState の dictAutoCheckUpdates が true の場合のみ）
+  setTimeout(async () => {
+    try {
+      const { ElectronStorageManager } = require("../lib/storage/electron-storage-manager");
+      const storageManager = new ElectronStorageManager();
+      const appState = await storageManager.loadAppState();
+      // Default to checking if not explicitly disabled
+      const shouldCheck = appState?.dictAutoCheckUpdates !== false;
+      if (shouldCheck) {
+        const mgr = getDictManager();
+        const status = mgr.getStatus();
+        if (status.status === "installed") {
+          const updateInfo = await mgr.checkUpdate().catch(() => null);
+          if (updateInfo?.updateAvailable) {
+            console.log("[Dict] Update available:", updateInfo.latestVersion);
+            // Notify the focused window
+            const { getMainWindow } = require("./window-manager");
+            const mainWin = getMainWindow();
+            if (mainWin && !mainWin.isDestroyed()) {
+              mainWin.webContents.send("dict:update-available", updateInfo);
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.error("[Dict] Auto update check failed:", err);
+    }
+  }, 5000);
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) void createMainWindow();

--- a/electron/main.js
+++ b/electron/main.js
@@ -191,11 +191,10 @@ app.whenReady().then(async () => {
           const updateInfo = await mgr.checkUpdate().catch(() => null);
           if (updateInfo?.updateAvailable) {
             console.log("[Dict] Update available:", updateInfo.latestVersion);
-            // Notify the focused window
-            const { getMainWindow } = require("./window-manager");
-            const mainWin = getMainWindow();
-            if (mainWin && !mainWin.isDestroyed()) {
-              mainWin.webContents.send("dict:update-available", updateInfo);
+            // Notify the focused window (if any)
+            const focusedWin = BrowserWindow.getFocusedWindow();
+            if (focusedWin && !focusedWin.isDestroyed()) {
+              focusedWin.webContents.send("dict:update-available", updateInfo);
             }
           }
         }

--- a/electron/main.js
+++ b/electron/main.js
@@ -25,7 +25,7 @@ if (app.isPackaged) {
 }
 
 const { registerNlpHandlers } = require("./ipc/nlp-ipc");
-const { registerStorageHandlers } = require("./ipc/storage-ipc");
+const { registerStorageHandlers, getStorageManager } = require("./ipc/storage-ipc");
 const { registerVFSHandlers } = require("./ipc/vfs-ipc");
 const { setupAutoUpdater, checkForUpdates } = require("./auto-updater");
 const { createMainWindow, broadcastPowerState } = require("./window-manager");
@@ -181,9 +181,7 @@ app.whenReady().then(async () => {
   // 辞典データ更新確認（AppState の dictAutoCheckUpdates が true の場合のみ）
   setTimeout(async () => {
     try {
-      const { ElectronStorageManager } = require("../lib/storage/electron-storage-manager");
-      const storageManager = new ElectronStorageManager();
-      const appState = await storageManager.loadAppState();
+      const appState = await getStorageManager().loadAppState();
       // Default to checking if not explicitly disabled
       const shouldCheck = appState?.dictAutoCheckUpdates !== false;
       if (shouldCheck) {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -248,6 +248,24 @@ contextBridge.exposeInMainWorld("electronAPI", {
       ipcRenderer.removeAllListeners("editor:buffer-close-broadcast");
     },
   },
+  dict: {
+    query: (term, limit) => ipcRenderer.invoke("dict:query", { term, limit }),
+    queryByReading: (reading, limit) =>
+      ipcRenderer.invoke("dict:query-reading", { reading, limit }),
+    getStatus: () => ipcRenderer.invoke("dict:get-status"),
+    checkUpdate: () => ipcRenderer.invoke("dict:check-update"),
+    download: () => ipcRenderer.invoke("dict:download"),
+    onDownloadProgress: (callback) => {
+      const handler = (_event, data) => callback(data);
+      ipcRenderer.on("dict:download-progress", handler);
+      return () => ipcRenderer.removeListener("dict:download-progress", handler);
+    },
+    onUpdateAvailable: (callback) => {
+      const handler = (_event, data) => callback(data);
+      ipcRenderer.on("dict:update-available", handler);
+      return () => ipcRenderer.removeListener("dict:update-available", handler);
+    },
+  },
   pty: {
     /** Spawn a new PTY session. Returns { sessionId } or { error }. */
     spawn: (options) => ipcRenderer.invoke("pty:spawn", options),

--- a/lib/dict/dict-service.ts
+++ b/lib/dict/dict-service.ts
@@ -1,0 +1,141 @@
+/**
+ * DictService — singleton that manages registered dictionary providers
+ * and aggregates query results across them.
+ *
+ * Usage:
+ *   import { getDictService } from "@/lib/dict/dict-service";
+ *   const results = await getDictService().query("雪");
+ */
+import type { IDictProvider, DictEntry, DictQueryResult, DictDownloadState } from "./dict-types";
+import { IllusionsDictProvider } from "./providers/illusions-dict-provider";
+
+// Deduplication key: (entry, reading.primary) — preserves homonyms that share
+// a surface form but differ in reading.
+function dedupKey(e: DictEntry): string {
+  return `${e.entry}\0${e.reading.primary}`;
+}
+
+function dedup(entries: DictEntry[]): DictEntry[] {
+  const seen = new Set<string>();
+  return entries.filter((e) => {
+    const k = dedupKey(e);
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+}
+
+class DictService {
+  private readonly providers: IDictProvider[] = [];
+
+  registerProvider(provider: IDictProvider): void {
+    if (this.providers.some((p) => p.id === provider.id)) return;
+    this.providers.push(provider);
+  }
+
+  /**
+   * Query all registered providers in parallel and merge results.
+   * Deduplicates by (entry, reading.primary).
+   */
+  async query(term: string, limit = 20): Promise<DictQueryResult> {
+    if (this.providers.length === 0) {
+      return { entries: [], noResults: false, providerUnavailable: true };
+    }
+
+    const results = await Promise.all(
+      this.providers.map(async (p) => {
+        const available = await p.isAvailable();
+        if (!available) {
+          const isWeb =
+            typeof window !== "undefined" &&
+            !(window as Window & { electronAPI?: unknown }).electronAPI;
+          return {
+            entries: [] as DictEntry[],
+            available: false,
+            webApiPending: isWeb,
+          };
+        }
+        const entries = await p.query(term, limit);
+        return { entries, available: true, webApiPending: false };
+      }),
+    );
+
+    const allEntries = dedup(results.flatMap((r) => r.entries));
+    const anyAvailable = results.some((r) => r.available);
+    const webApiPending = results.some((r) => r.webApiPending);
+
+    return {
+      entries: allEntries,
+      noResults: anyAvailable && allEntries.length === 0,
+      providerUnavailable: !anyAvailable,
+      webApiPending: webApiPending || undefined,
+    };
+  }
+
+  /**
+   * Query by kana reading for homophone lookup.
+   */
+  async queryByReading(reading: string, limit = 20): Promise<DictQueryResult> {
+    if (this.providers.length === 0) {
+      return { entries: [], noResults: false, providerUnavailable: true };
+    }
+
+    const results = await Promise.all(
+      this.providers.map(async (p) => {
+        const available = await p.isAvailable();
+        if (!available) return { entries: [] as DictEntry[], available: false };
+        const entries = await p.queryByReading(reading, limit);
+        return { entries, available: true };
+      }),
+    );
+
+    const allEntries = dedup(results.flatMap((r) => r.entries));
+    const anyAvailable = results.some((r) => r.available);
+
+    return {
+      entries: allEntries,
+      noResults: anyAvailable && allEntries.length === 0,
+      providerUnavailable: !anyAvailable,
+    };
+  }
+
+  /**
+   * Get download/install state for the given provider.
+   * Only works in Electron (IPC).
+   */
+  async getDownloadState(providerId: string): Promise<DictDownloadState> {
+    const electronAPI = (
+      window as Window & {
+        electronAPI?: {
+          dict?: { getStatus: () => Promise<Omit<DictDownloadState, "providerId">> };
+        };
+      }
+    ).electronAPI;
+
+    if (!electronAPI?.dict) {
+      return { providerId, status: "not-installed" };
+    }
+
+    try {
+      const raw = await electronAPI.dict.getStatus();
+      return { providerId, ...raw };
+    } catch {
+      return { providerId, status: "error", error: "Failed to get status" };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton
+// ---------------------------------------------------------------------------
+
+let _instance: DictService | null = null;
+
+export function getDictService(): DictService {
+  if (!_instance) {
+    _instance = new DictService();
+    // Auto-register the built-in illusionsDict provider
+    _instance.registerProvider(new IllusionsDictProvider());
+  }
+  return _instance;
+}

--- a/lib/dict/dict-service.ts
+++ b/lib/dict/dict-service.ts
@@ -120,7 +120,7 @@ class DictService {
       const raw = await electronAPI.dict.getStatus();
       return { providerId, ...raw };
     } catch {
-      return { providerId, status: "error", error: "Failed to get status" };
+      return { providerId, status: "error", error: "状態の取得に失敗しました" };
     }
   }
 }

--- a/lib/dict/dict-types.ts
+++ b/lib/dict/dict-types.ts
@@ -1,0 +1,106 @@
+/**
+ * Master dictionary types — provider-agnostic interfaces.
+ * All dictionary providers (illusionsDict, future sources) must conform to these types.
+ */
+
+// ---------------------------------------------------------------------------
+// Core entry types
+// ---------------------------------------------------------------------------
+
+export interface DictReading {
+  primary: string;
+  alternatives: string[];
+}
+
+export interface DictDefinition {
+  gloss: string;
+  register?: string;
+  nuance?: string;
+  examples?: string[];
+  collocations?: string[];
+}
+
+export interface DictRelationships {
+  homophones: string[];
+  synonyms: string[];
+  antonyms: string[];
+  related: string[];
+}
+
+export interface DictEntry {
+  /** Unique identifier within the provider */
+  id: string;
+  /** Headword (見出し語) */
+  entry: string;
+  reading: DictReading;
+  partOfSpeech?: string;
+  inflections?: string[];
+  definitions: DictDefinition[];
+  relationships: DictRelationships;
+  /** Provider that returned this entry */
+  source: string;
+}
+
+// ---------------------------------------------------------------------------
+// Provider interface
+// ---------------------------------------------------------------------------
+
+export interface IDictProvider {
+  /** Stable identifier used to tag results (e.g. "illusions-dict") */
+  readonly id: string;
+  /** Human-readable name shown in UI */
+  readonly displayName: string;
+
+  /** Returns true when this provider is ready to answer queries */
+  isAvailable(): Promise<boolean>;
+
+  /**
+   * Search by headword exact match or prefix.
+   * @param term   Search term
+   * @param limit  Max results (default: 20)
+   */
+  query(term: string, limit?: number): Promise<DictEntry[]>;
+
+  /**
+   * Find entries sharing the given kana reading (homophone lookup).
+   * @param reading  Kana reading
+   * @param limit    Max results (default: 20)
+   */
+  queryByReading(reading: string, limit?: number): Promise<DictEntry[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Download / update state
+// ---------------------------------------------------------------------------
+
+export type DictDownloadStatus =
+  | "not-installed"
+  | "downloading"
+  | "installing"
+  | "installed"
+  | "error";
+
+export interface DictDownloadState {
+  providerId: string;
+  status: DictDownloadStatus;
+  /** 0–100, only set when status === "downloading" */
+  progress?: number;
+  installedVersion?: string;
+  latestVersion?: string;
+  updateAvailable?: boolean;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Service query result
+// ---------------------------------------------------------------------------
+
+export interface DictQueryResult {
+  entries: DictEntry[];
+  /** True when the provider is installed but returned no matches */
+  noResults: boolean;
+  /** True when the provider is not installed / not available */
+  providerUnavailable: boolean;
+  /** True when running in web environment where the API is not yet available */
+  webApiPending?: boolean;
+}

--- a/lib/dict/providers/illusions-dict-provider.ts
+++ b/lib/dict/providers/illusions-dict-provider.ts
@@ -1,0 +1,69 @@
+/**
+ * IllusionsDictProvider
+ *
+ * Electron: delegates queries to the main process via IPC (window.electronAPI.dict).
+ * Web: returns stub results with webApiPending flag until a real API is available.
+ */
+import type { IDictProvider, DictEntry } from "../dict-types";
+
+const PROVIDER_ID = "illusions-dict";
+const DISPLAY_NAME = "illusions辞典";
+const DEFAULT_LIMIT = 20;
+
+function isElectronDict(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    !!(window as Window & { electronAPI?: { dict?: unknown } }).electronAPI?.dict
+  );
+}
+
+function getElectronDictAPI() {
+  const api = (
+    window as Window & {
+      electronAPI?: {
+        dict?: {
+          query: (term: string, limit: number) => Promise<DictEntry[]>;
+          queryByReading: (reading: string, limit: number) => Promise<DictEntry[]>;
+          getStatus: () => Promise<{ status: string; installedVersion?: string }>;
+        };
+      };
+    }
+  ).electronAPI?.dict;
+  if (!api) throw new Error("electronAPI.dict is not available");
+  return api;
+}
+
+export class IllusionsDictProvider implements IDictProvider {
+  readonly id = PROVIDER_ID;
+  readonly displayName = DISPLAY_NAME;
+
+  async isAvailable(): Promise<boolean> {
+    if (!isElectronDict()) return false;
+    try {
+      const status = await getElectronDictAPI().getStatus();
+      return status.status === "installed";
+    } catch {
+      return false;
+    }
+  }
+
+  async query(term: string, limit = DEFAULT_LIMIT): Promise<DictEntry[]> {
+    if (!isElectronDict()) return [];
+    try {
+      return await getElectronDictAPI().query(term, limit);
+    } catch (err) {
+      console.error(`[IllusionsDictProvider] query failed:`, err);
+      return [];
+    }
+  }
+
+  async queryByReading(reading: string, limit = DEFAULT_LIMIT): Promise<DictEntry[]> {
+    if (!isElectronDict()) return [];
+    try {
+      return await getElectronDictAPI().queryByReading(reading, limit);
+    } catch (err) {
+      console.error(`[IllusionsDictProvider] queryByReading failed:`, err);
+      return [];
+    }
+  }
+}

--- a/lib/editor-page/use-dict-settings.ts
+++ b/lib/editor-page/use-dict-settings.ts
@@ -1,0 +1,88 @@
+/**
+ * Dictionary settings hook — manages dict-related AppState fields.
+ * Follows the same pattern as use-ai-settings.ts.
+ */
+import { useCallback, useState } from "react";
+import { persistAppState } from "@/lib/storage/app-state-manager";
+
+export interface DictSettings {
+  dictAutoCheckUpdates: boolean;
+  dictAutoDownload: boolean;
+  dictInstalledVersion: string | undefined;
+  dictLastCheckedAt: string | undefined;
+}
+
+export interface DictSettingsHandlers {
+  handleDictAutoCheckUpdatesChange: (value: boolean) => void;
+  handleDictAutoDownloadChange: (value: boolean) => void;
+  handleDictInstalledVersionChange: (version: string | undefined) => void;
+  handleDictLastCheckedAtChange: (timestamp: string | undefined) => void;
+}
+
+export interface UseDictSettingsResult {
+  dictSettings: DictSettings;
+  dictHandlers: DictSettingsHandlers;
+  applyPersistedDictSettings: (appState: Record<string, unknown>) => void;
+}
+
+export function useDictSettings(): UseDictSettingsResult {
+  const [dictAutoCheckUpdates, setDictAutoCheckUpdates] = useState(true);
+  const [dictAutoDownload, setDictAutoDownload] = useState(false);
+  const [dictInstalledVersion, setDictInstalledVersion] = useState<string | undefined>(undefined);
+  const [dictLastCheckedAt, setDictLastCheckedAt] = useState<string | undefined>(undefined);
+
+  const applyPersistedDictSettings = useCallback((appState: Record<string, unknown>) => {
+    if (typeof appState.dictAutoCheckUpdates === "boolean") {
+      setDictAutoCheckUpdates(appState.dictAutoCheckUpdates);
+    }
+    if (typeof appState.dictAutoDownload === "boolean") {
+      setDictAutoDownload(appState.dictAutoDownload);
+    }
+    if (typeof appState.dictInstalledVersion === "string") {
+      setDictInstalledVersion(appState.dictInstalledVersion);
+    }
+    if (typeof appState.dictLastCheckedAt === "string") {
+      setDictLastCheckedAt(appState.dictLastCheckedAt);
+    }
+  }, []);
+
+  const handleDictAutoCheckUpdatesChange = useCallback((value: boolean) => {
+    setDictAutoCheckUpdates(value);
+    void persistAppState({ dictAutoCheckUpdates: value });
+  }, []);
+
+  const handleDictAutoDownloadChange = useCallback((value: boolean) => {
+    setDictAutoDownload(value);
+    void persistAppState({ dictAutoDownload: value });
+  }, []);
+
+  const handleDictInstalledVersionChange = useCallback((version: string | undefined) => {
+    setDictInstalledVersion(version);
+    if (version !== undefined) {
+      void persistAppState({ dictInstalledVersion: version });
+    }
+  }, []);
+
+  const handleDictLastCheckedAtChange = useCallback((timestamp: string | undefined) => {
+    setDictLastCheckedAt(timestamp);
+    if (timestamp !== undefined) {
+      void persistAppState({ dictLastCheckedAt: timestamp });
+    }
+  }, []);
+
+  const dictSettings: DictSettings = {
+    dictAutoCheckUpdates,
+    dictAutoDownload,
+    dictInstalledVersion,
+    dictLastCheckedAt,
+  };
+
+  const dictHandlers: DictSettingsHandlers = {
+    handleDictAutoCheckUpdatesChange,
+    handleDictAutoDownloadChange,
+    handleDictInstalledVersionChange,
+    handleDictLastCheckedAtChange,
+  };
+
+  return { dictSettings, dictHandlers, applyPersistedDictSettings };
+}

--- a/lib/editor-page/use-dict-settings.ts
+++ b/lib/editor-page/use-dict-settings.ts
@@ -48,25 +48,33 @@ export function useDictSettings(): UseDictSettingsResult {
 
   const handleDictAutoCheckUpdatesChange = useCallback((value: boolean) => {
     setDictAutoCheckUpdates(value);
-    void persistAppState({ dictAutoCheckUpdates: value });
+    void persistAppState({ dictAutoCheckUpdates: value }).catch((e: unknown) =>
+      console.error("辞書設定の保存に失敗しました", e),
+    );
   }, []);
 
   const handleDictAutoDownloadChange = useCallback((value: boolean) => {
     setDictAutoDownload(value);
-    void persistAppState({ dictAutoDownload: value });
+    void persistAppState({ dictAutoDownload: value }).catch((e: unknown) =>
+      console.error("辞書設定の保存に失敗しました", e),
+    );
   }, []);
 
   const handleDictInstalledVersionChange = useCallback((version: string | undefined) => {
     setDictInstalledVersion(version);
     if (version !== undefined) {
-      void persistAppState({ dictInstalledVersion: version });
+      void persistAppState({ dictInstalledVersion: version }).catch((e: unknown) =>
+        console.error("辞書設定の保存に失敗しました", e),
+      );
     }
   }, []);
 
   const handleDictLastCheckedAtChange = useCallback((timestamp: string | undefined) => {
     setDictLastCheckedAt(timestamp);
     if (timestamp !== undefined) {
-      void persistAppState({ dictLastCheckedAt: timestamp });
+      void persistAppState({ dictLastCheckedAt: timestamp }).catch((e: unknown) =>
+        console.error("辞書設定の保存に失敗しました", e),
+      );
     }
   }, []);
 

--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -10,16 +10,20 @@ import { useDisplaySettings } from "./use-display-settings";
 import type { DisplaySettings, DisplaySettingsHandlers } from "./use-display-settings";
 import { useAiSettings } from "./use-ai-settings";
 import type { AiSettings, AiSettingsHandlers } from "./use-ai-settings";
+import { useDictSettings } from "./use-dict-settings";
+import type { DictSettings, DictSettingsHandlers } from "./use-dict-settings";
 
 export type { DisplaySettings, DisplaySettingsHandlers } from "./use-display-settings";
 export type { AiSettings, AiSettingsHandlers } from "./use-ai-settings";
+export type { DictSettings, DictSettingsHandlers } from "./use-dict-settings";
 
-/** Combined editor settings from display and AI sub-hooks */
-export type EditorSettings = DisplaySettings & AiSettings;
+/** Combined editor settings from display, AI, and dictionary sub-hooks */
+export type EditorSettings = DisplaySettings & AiSettings & DictSettings;
 
-/** Combined handlers from display and AI sub-hooks */
+/** Combined handlers from display, AI, and dictionary sub-hooks */
 export type EditorSettingsHandlers = Omit<DisplaySettingsHandlers, "setShowSettingsModal"> &
-  Omit<AiSettingsHandlers, "setLintingEnabled" | "setLintingRuleConfigs" | "setLlmEnabled"> & {
+  Omit<AiSettingsHandlers, "setLintingEnabled" | "setLintingRuleConfigs" | "setLlmEnabled"> &
+  DictSettingsHandlers & {
     setShowSettingsModal: (value: boolean) => void;
     handleLintingEnabledChange: (value: boolean) => void;
     handleLintingRuleConfigChange: (
@@ -60,6 +64,7 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
     useDisplaySettings(incrementEditorKey);
 
   const { aiSettings, aiHandlers, applyPersistedAiSettings } = useAiSettings();
+  const { dictSettings, dictHandlers, applyPersistedDictSettings } = useDictSettings();
 
   // Load persisted settings on mount
   useEffect(() => {
@@ -72,6 +77,7 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
 
         applyPersistedDisplaySettings(appState as Record<string, unknown>);
         applyPersistedAiSettings(appState as Record<string, unknown>);
+        applyPersistedDictSettings(appState as Record<string, unknown>);
 
         // Force editor rebuild to apply restored settings (e.g. custom font)
         incrementEditorKey();
@@ -90,6 +96,7 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
   const settings: EditorSettings = {
     ...displaySettings,
     ...aiSettings,
+    ...dictSettings,
   };
 
   const handlers: EditorSettingsHandlers = {
@@ -106,6 +113,10 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
     handlePowerSaveModeChange: aiHandlers.handlePowerSaveModeChange,
     handleAutoPowerSaveOnBatteryChange: aiHandlers.handleAutoPowerSaveOnBatteryChange,
     handleCorrectionConfigChange: aiHandlers.handleCorrectionConfigChange,
+    handleDictAutoCheckUpdatesChange: dictHandlers.handleDictAutoCheckUpdatesChange,
+    handleDictAutoDownloadChange: dictHandlers.handleDictAutoDownloadChange,
+    handleDictInstalledVersionChange: dictHandlers.handleDictInstalledVersionChange,
+    handleDictLastCheckedAtChange: dictHandlers.handleDictLastCheckedAtChange,
   };
 
   return {

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -175,6 +175,16 @@ export interface AppState {
 
   // キーマップオーバーライド
   keymapOverrides?: Record<string, { modifiers: string[]; key: string } | null>;
+
+  // 辞典設定
+  /** 起動時に辞典データの更新を確認する（デフォルト: true） */
+  dictAutoCheckUpdates?: boolean;
+  /** 更新が見つかった場合に自動ダウンロードする（デフォルト: false） */
+  dictAutoDownload?: boolean;
+  /** インストール済み辞典データのバージョンタグ */
+  dictInstalledVersion?: string;
+  /** 最後に更新確認した ISO タイムスタンプ */
+  dictLastCheckedAt?: string;
 }
 
 /**

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -274,7 +274,9 @@ declare global {
       /** Subscribe to download progress events (0–100). Returns cleanup function. */
       onDownloadProgress: (callback: (data: { progress: number }) => void) => () => void;
       /** Subscribe to update-available notifications pushed from main process. */
-      onUpdateAvailable: (callback: (data: { latestVersion: string; updateAvailable: boolean }) => void) => () => void;
+      onUpdateAvailable: (
+        callback: (data: { latestVersion: string; updateAvailable: boolean }) => void,
+      ) => () => void;
     };
     /** PTY session management */
     pty?: {

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -9,6 +9,7 @@ import type {
 import type { Token, WordEntry, TokenizeProgress } from "@/lib/nlp-client/types";
 import type { VFSWatchEvent } from "@/lib/vfs/types";
 import type { KeymapOverrides } from "@/lib/keymap/keymap-types";
+import type { DictEntry, DictDownloadStatus } from "@/lib/dict/dict-types";
 
 export {};
 
@@ -249,6 +250,31 @@ declare global {
       onBufferClose: (callback: (bufferId: string) => void) => () => void;
       /** Remove all editor sync listeners */
       removeAllListeners: () => void;
+    };
+    /** Master dictionary IPC (illusionsDict and future providers) */
+    dict?: {
+      /** Query entries by headword (exact or prefix match) */
+      query: (term: string, limit?: number) => Promise<DictEntry[]>;
+      /** Query entries by kana reading (homophone lookup) */
+      queryByReading: (reading: string, limit?: number) => Promise<DictEntry[]>;
+      /** Get current installation status */
+      getStatus: () => Promise<{
+        status: DictDownloadStatus;
+        installedVersion?: string;
+      }>;
+      /** Check GitHub Releases for the latest version */
+      checkUpdate: () => Promise<{
+        latestVersion?: string;
+        installedVersion?: string;
+        updateAvailable?: boolean;
+        error?: string;
+      }>;
+      /** Download and install the latest database */
+      download: () => Promise<{ success: boolean; version?: string; error?: string }>;
+      /** Subscribe to download progress events (0–100). Returns cleanup function. */
+      onDownloadProgress: (callback: (data: { progress: number }) => void) => () => void;
+      /** Subscribe to update-available notifications pushed from main process. */
+      onUpdateAvailable: (callback: (data: { latestVersion: string; updateAvailable: boolean }) => void) => () => void;
     };
     /** PTY session management */
     pty?: {


### PR DESCRIPTION
## Summary

- `lib/dict/` モジュールを新規作成し、プロバイダー抽象化レイヤー (`IDictProvider`) を追加。将来の他辞典もこのインターフェイスで接続可能
- Electron では IPC 経由でローカル SQLite（illusionsDict-Word-Database）をクエリし、Web 環境ではスタブを返す実装
- 辞典データのダウンロード・更新機能を実装（GitHub Releases API + `zlib` 展開 + Promise ベース mutex で二重ダウンロード防止）
- 辞典設定（自動更新確認・自動ダウンロード）を既存 AppState フローに完全統合

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `lib/dict/dict-types.ts` | `IDictProvider`, `DictEntry`, `DictDownloadState` 型定義 |
| `lib/dict/providers/illusions-dict-provider.ts` | Electron IPC 委譲 / Web スタブ実装 |
| `lib/dict/dict-service.ts` | Singleton サービス、プロバイダー管理、(entry, reading.primary) による dedup |
| `electron/dict-manager.js` | SQLite クエリ（index 確認/作成）、GitHub Releases 更新確認、ダウンロード |
| `electron/ipc/dict-ipc.js` | IPC ハンドラー（nlp-ipc.js パターン） |
| `electron/main.js` | `registerDictHandlers()` + 起動時自動更新確認（5 秒遅延） |
| `electron/preload.js` | `dict` namespace 追加 |
| `types/electron.d.ts` | `ElectronAPI.dict` 型定義 |
| `lib/storage/storage-types.ts` | `AppState` に辞典設定フィールド追加 |
| `lib/editor-page/use-dict-settings.ts` | 設定 hook（use-ai-settings.ts パターン） |
| `lib/editor-page/use-editor-settings.ts` | `useDictSettings` を合成 |
| `contexts/EditorSettingsContext.tsx` | `useDictSettingsContext` セレクタフック追加 |
| `components/SettingsModal.tsx` | 「辞典」カテゴリ追加 |
| `components/settings/DictSettingsTab.tsx` | バージョン表示・ダウンロード・更新設定 UI |
| `components/Dictionary.tsx` | Web タブ上部にマスター辞典検索結果を統合（新タブなし） |

## Test plan

- [ ] Electron 起動 → 辞典パネル → 検索語入力 → Web タブ上部にマスター辞典カードが表示される
- [ ] 未インストール状態でバナー「辞典データ未インストール」＋ダウンロードボタンが表示される
- [ ] ダウンロードボタン押下 → 進捗バー表示 → インストール完了後に結果表示
- [ ] 設定 → 辞典 → autoCheckUpdates トグル → AppState に永続化される
- [ ] 複数ウィンドウで同時ダウンロードを試みても mutex により 1 件のみ実行される
- [ ] Web ビルド（`npm run build`）が通過し、辞典セクションは graceful fallback を表示する
- [ ] `npx tsc --noEmit` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)