### PR TITLE
fix(menu): remove duplicate separator in web file menu

### DIFF
--- a/lib/menu/menu-definitions.ts
+++ b/lib/menu/menu-definitions.ts
@@ -51,7 +51,6 @@ export const WEB_MENU_STRUCTURE: MenuSection[] = [
         ],
       },
       { type: "separator" },
-      { type: "separator" },
       { label: "新しいタブ", accelerator: "Ctrl+T", action: "new-tab" },
       { label: "タブを閉じる", accelerator: "Ctrl+W", action: "close-tab" },
     ],


### PR DESCRIPTION
## Summary

- Web版のファイルメニューで「エクスポート」と「新しいタブ」の間にセパレータが2つ連続で表示されていた問題を修正

## Changes

- `lib/menu/menu-definitions.ts`: 重複していた `{ type: "separator" }` エントリを1つ削除

## Test plan

- [ ] Web版でファイルメニューを開き、「エクスポート」と「新しいタブ」の間にセパレータが1本だけ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)