### PR TITLE
feat(export): add typesetting settings dialog for DOCX export

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import { useElectronMenuHandlers } from "@/lib/menu/use-electron-menu-handlers";
 import { useExport } from "@/lib/export/use-export";
 import type { ExportMetadata } from "@/lib/export/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
+import type { DocxExportSettings } from "@/lib/export/docx-export-settings";
 import { notificationManager } from "@/lib/services/notification-manager";
 import { useWebMenuHandlers } from "@/lib/menu/use-web-menu-handlers";
 import { useGlobalShortcuts } from "@/lib/hooks/use-global-shortcuts";
@@ -480,36 +481,42 @@ export default function EditorPage() {
     return name.replace(/\.[^.]+$/, "");
   }, [tabs, activeTabId]);
 
-  // PDF export dialog state
-  const [showPdfExportDialog, setShowPdfExportDialog] = useState(false);
-  const [pdfExportContent, setPdfExportContent] = useState("");
-  const [pdfExportMetadata, setPdfExportMetadata] = useState<ExportMetadata>({ title: "" });
-  const pdfExportContentRef = useRef("");
-  const pdfExportMetadataRef = useRef<ExportMetadata>({ title: "" });
+  // Export dialog state (PDF / DOCX share a single state slot)
+  interface ExportDialogState {
+    format: "pdf" | "docx";
+    content: string;
+    metadata: ExportMetadata;
+  }
+  const [exportDialogState, setExportDialogState] = useState<ExportDialogState | null>(null);
+  const exportDialogStateRef = useRef<ExportDialogState | null>(null);
 
-  const handlePdfExportRequest = useCallback((pdfContent: string, metadata: ExportMetadata) => {
-    pdfExportContentRef.current = pdfContent;
-    pdfExportMetadataRef.current = metadata;
-    setPdfExportContent(pdfContent);
-    setPdfExportMetadata(metadata);
-    setShowPdfExportDialog(true);
-  }, []);
+  const handleExportDialogRequest = useCallback(
+    (format: "pdf" | "docx", content: string, metadata: ExportMetadata) => {
+      const state: ExportDialogState = { format, content, metadata };
+      exportDialogStateRef.current = state;
+      setExportDialogState(state);
+    },
+    [],
+  );
 
   const handlePdfExportConfirm = useCallback(async (settings: PdfExportSettings) => {
-    setShowPdfExportDialog(false);
+    setExportDialogState(null);
 
     if (!window.electronAPI?.exportPDF) {
       notificationManager.error("PDFエクスポートはデスクトップアプリでのみ利用可能です");
       return;
     }
 
+    const dialogState = exportDialogStateRef.current;
+    if (!dialogState) return;
+
     const progressId = notificationManager.showProgress("PDFをエクスポート中...", {
       type: "info",
     });
 
     try {
-      const result = await window.electronAPI.exportPDF(pdfExportContentRef.current, {
-        metadata: pdfExportMetadataRef.current,
+      const result = await window.electronAPI.exportPDF(dialogState.content, {
+        metadata: dialogState.metadata,
         verticalWriting: settings.verticalWriting,
         pageSize: settings.pageSize,
         landscape: settings.landscape,
@@ -540,11 +547,51 @@ export default function EditorPage() {
     }
   }, []);
 
+  const handleDocxExportConfirm = useCallback(async (settings: DocxExportSettings) => {
+    setExportDialogState(null);
+
+    if (!window.electronAPI?.exportDOCX) {
+      notificationManager.error("DOCXエクスポートはデスクトップアプリでのみ利用可能です");
+      return;
+    }
+
+    const dialogState = exportDialogStateRef.current;
+    if (!dialogState) return;
+
+    const progressId = notificationManager.showProgress("DOCXをエクスポート中...", {
+      type: "info",
+    });
+
+    try {
+      const result = await window.electronAPI.exportDOCX(dialogState.content, {
+        metadata: dialogState.metadata,
+        settings,
+      });
+
+      notificationManager.dismiss(progressId);
+
+      if (result === null || result === undefined) return;
+
+      if (typeof result === "object" && "success" in result && !result.success) {
+        notificationManager.error(
+          `DOCXのエクスポートに失敗しました: ${(result as { error: string }).error}`,
+        );
+        return;
+      }
+
+      notificationManager.success("DOCXをエクスポートしました");
+    } catch (error) {
+      notificationManager.dismiss(progressId);
+      const message = error instanceof Error ? error.message : "Unknown error";
+      notificationManager.error(`DOCXのエクスポートに失敗しました: ${message}`);
+    }
+  }, []);
+
   const { exportAs } = useExport({
     getContent: getExportContent,
     getTitle: getExportTitle,
     getIsEditorTabActive: useCallback(() => isEditorTabActiveRef.current, []),
-    onPdfExportRequest: handlePdfExportRequest,
+    onExportDialogRequest: handleExportDialogRequest,
   });
 
   // System file open: tab manager handles loading; we just update editor key
@@ -921,11 +968,14 @@ export default function EditorPage() {
         setShowRubyDialog,
         rubySelectedText,
         handleApplyRuby,
-        showPdfExportDialog,
-        setShowPdfExportDialog,
-        handlePdfExportConfirm,
-        pdfExportContent,
-        pdfExportMetadata,
+        exportDialog: {
+          state: exportDialogState,
+          onClose: () => setExportDialogState(null),
+          onPdfExport: handlePdfExportConfirm,
+          onDocxExport: handleDocxExportConfirm,
+          content: exportDialogState?.content ?? "",
+          metadata: exportDialogState?.metadata ?? { title: "" },
+        },
       }}
       recovery={{
         wasAutoRecovered,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -542,7 +542,7 @@ export default function EditorPage() {
       notificationManager.success("PDFをエクスポートしました");
     } catch (error) {
       notificationManager.dismiss(progressId);
-      const message = error instanceof Error ? error.message : "Unknown error";
+      const message = error instanceof Error ? error.message : "不明なエラー";
       notificationManager.error(`PDFのエクスポートに失敗しました: ${message}`);
     }
   }, []);
@@ -582,7 +582,7 @@ export default function EditorPage() {
       notificationManager.success("DOCXをエクスポートしました");
     } catch (error) {
       notificationManager.dismiss(progressId);
-      const message = error instanceof Error ? error.message : "Unknown error";
+      const message = error instanceof Error ? error.message : "不明なエラー";
       notificationManager.error(`DOCXのエクスポートに失敗しました: ${message}`);
     }
   }, []);

--- a/components/DocxExportDialog.tsx
+++ b/components/DocxExportDialog.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { useState, useCallback, type KeyboardEvent } from "react";
+import clsx from "clsx";
+import GlassDialog from "./GlassDialog";
+import {
+  loadDocxExportSettings,
+  saveDocxExportSettings,
+  PAGE_DIMENSIONS,
+} from "@/lib/export/docx-export-settings";
+
+import type { DocxExportSettings, DocxPageSize } from "@/lib/export/docx-export-settings";
+
+interface DocxExportDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onExport: (settings: DocxExportSettings) => void;
+}
+
+const PAGE_SIZE_OPTIONS: { value: DocxPageSize; label: string }[] = [
+  { value: "A4", label: "A4 (210×297mm)" },
+  { value: "A5", label: "A5 (148×210mm)" },
+  { value: "B5", label: "B5 (176×250mm)" },
+  { value: "B6", label: "B6 (125×176mm)" },
+];
+
+const FONT_OPTIONS: { value: string; label: string }[] = [
+  { value: "Yu Mincho", label: "游明朝" },
+  { value: "Hiragino Mincho ProN", label: "ヒラギノ明朝" },
+  { value: "Noto Serif JP", label: "Noto Serif JP" },
+  { value: "Yu Gothic", label: "游ゴシック" },
+];
+
+const inputClass =
+  "w-full px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-accent";
+const numberInputClass =
+  "w-24 px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground text-sm text-center focus:outline-none focus:ring-2 focus:ring-accent";
+const labelClass = "block text-sm font-medium text-foreground mb-1";
+
+/**
+ * Wrapper that unmounts the inner form when closed,
+ * so useState initializer reloads settings each time the dialog opens.
+ */
+export default function DocxExportDialog({ isOpen, onClose, onExport }: DocxExportDialogProps) {
+  if (!isOpen) return null;
+  return <DocxExportDialogInner onClose={onClose} onExport={onExport} />;
+}
+
+function DocxExportDialogInner({ onClose, onExport }: Omit<DocxExportDialogProps, "isOpen">) {
+  const [settings, setSettings] = useState<DocxExportSettings>(() => loadDocxExportSettings());
+
+  const updateField = useCallback(
+    <K extends keyof DocxExportSettings>(key: K, value: DocxExportSettings[K]) => {
+      setSettings((prev) => ({ ...prev, [key]: value }));
+    },
+    [],
+  );
+
+  const updateMargin = useCallback((side: "top" | "bottom" | "left" | "right", value: number) => {
+    setSettings((prev) => ({
+      ...prev,
+      margins: { ...prev.margins, [side]: value },
+    }));
+  }, []);
+
+  const handleExport = useCallback(() => {
+    saveDocxExportSettings(settings);
+    onExport(settings);
+  }, [settings, onExport]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    },
+    [onClose],
+  );
+
+  const dims = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
+  const displayW = settings.landscape ? dims.height : dims.width;
+  const displayH = settings.landscape ? dims.width : dims.height;
+
+  return (
+    <GlassDialog
+      isOpen
+      onBackdropClick={onClose}
+      ariaLabel="DOCXエクスポート設定"
+      panelClassName="mx-4 w-full max-w-md p-0 overflow-hidden"
+    >
+      <div onKeyDown={handleKeyDown} className="flex flex-col max-h-[85vh]">
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 border-b border-border">
+          <h2 className="text-lg font-semibold text-foreground">DOCXエクスポート設定</h2>
+          <p className="text-xs text-foreground-tertiary mt-1">
+            {settings.pageSize} ({displayW}×{displayH}mm) ·{" "}
+            {settings.landscape ? "横置き" : "縦置き"}
+          </p>
+        </div>
+
+        {/* Settings */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+          {/* Paper size */}
+          <div>
+            <label className={labelClass}>用紙サイズ</label>
+            <select
+              className={inputClass}
+              value={settings.pageSize}
+              onChange={(e) => updateField("pageSize", e.target.value as DocxPageSize)}
+            >
+              {PAGE_SIZE_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Page orientation */}
+          <div>
+            <label className={labelClass}>用紙の向き</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className={clsx(
+                  "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                  !settings.landscape
+                    ? "bg-accent text-accent-foreground border-accent"
+                    : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                )}
+                onClick={() => updateField("landscape", false)}
+              >
+                縦置き
+              </button>
+              <button
+                type="button"
+                className={clsx(
+                  "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                  settings.landscape
+                    ? "bg-accent text-accent-foreground border-accent"
+                    : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                )}
+                onClick={() => updateField("landscape", true)}
+              >
+                横置き
+              </button>
+            </div>
+          </div>
+
+          {/* Font */}
+          <div>
+            <label className={labelClass}>フォント</label>
+            <select
+              className={inputClass}
+              value={settings.fontFamily}
+              onChange={(e) => updateField("fontFamily", e.target.value)}
+            >
+              {FONT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Font size + Line spacing */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClass}>文字サイズ（pt）</label>
+              <input
+                type="number"
+                className={numberInputClass + " w-full"}
+                min={8}
+                max={20}
+                step={0.5}
+                value={settings.fontSize}
+                onChange={(e) => updateField("fontSize", clampFloat(e.target.value, 8, 20))}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>行間隔</label>
+              <input
+                type="number"
+                className={numberInputClass + " w-full"}
+                min={1.0}
+                max={3.0}
+                step={0.1}
+                value={settings.lineSpacing}
+                onChange={(e) => updateField("lineSpacing", clampFloat(e.target.value, 1.0, 3.0))}
+              />
+            </div>
+          </div>
+
+          {/* Indent + Page numbers */}
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className={labelClass}>字下げ（em）</label>
+              <input
+                type="number"
+                className={numberInputClass + " w-full"}
+                min={0}
+                max={4}
+                step={0.5}
+                value={settings.textIndent}
+                onChange={(e) => updateField("textIndent", clampFloat(e.target.value, 0, 4))}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>ページ番号</label>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={settings.showPageNumbers}
+                onClick={() => updateField("showPageNumbers", !settings.showPageNumbers)}
+                className={clsx(
+                  "relative inline-flex h-9 w-16 shrink-0 items-center rounded-full transition-colors mt-0.5",
+                  settings.showPageNumbers ? "bg-accent" : "bg-border-secondary",
+                )}
+              >
+                <span
+                  className={clsx(
+                    "inline-block h-5 w-5 transform rounded-full bg-background transition-transform",
+                    settings.showPageNumbers ? "translate-x-9" : "translate-x-2",
+                  )}
+                />
+              </button>
+            </div>
+          </div>
+
+          {/* Margins */}
+          <div>
+            <label className={labelClass}>余白（mm）</label>
+            <div className="grid grid-cols-4 gap-2">
+              {(["top", "bottom", "left", "right"] as const).map((side) => (
+                <div key={side}>
+                  <label className="block text-xs text-foreground-tertiary mb-1 text-center">
+                    {{ top: "上", bottom: "下", left: "左", right: "右" }[side]}
+                  </label>
+                  <input
+                    type="number"
+                    className={numberInputClass + " w-full"}
+                    min={0}
+                    max={50}
+                    step={1}
+                    value={settings.margins[side]}
+                    onChange={(e) => updateMargin(side, clampInt(e.target.value, 0, 50))}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-border flex-shrink-0">
+          <button
+            type="button"
+            className="px-4 py-2 rounded-lg text-sm text-foreground-secondary hover:bg-hover transition-colors"
+            onClick={onClose}
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            className="px-4 py-2 rounded-lg text-sm bg-accent text-accent-foreground hover:bg-accent-hover transition-colors"
+            onClick={handleExport}
+          >
+            エクスポート
+          </button>
+        </div>
+      </div>
+    </GlassDialog>
+  );
+}
+
+function clampInt(raw: string, min: number, max: number): number {
+  const n = parseInt(raw, 10);
+  if (isNaN(n)) return min;
+  return Math.min(max, Math.max(min, n));
+}
+
+function clampFloat(raw: string, min: number, max: number): number {
+  const n = parseFloat(raw);
+  if (isNaN(n)) return min;
+  return Math.min(max, Math.max(min, n));
+}

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -11,6 +11,7 @@ import Inspector from "@/components/Inspector";
 import NovelEditor from "@/components/Editor";
 import ResizablePanel from "@/components/ResizablePanel";
 import PdfExportDialog from "@/components/PdfExportDialog";
+import DocxExportDialog from "@/components/DocxExportDialog";
 import RubyDialog from "@/components/RubyDialog";
 import SettingsModal from "@/components/SettingsModal";
 import SidebarPanel from "@/components/SidebarPanel";
@@ -43,6 +44,7 @@ import { isEditorTab, type EditorTabState, type TabState } from "@/lib/tab-manag
 import type { ContextMenuState } from "@/lib/hooks/use-context-menu";
 import type { LintIssue } from "@/lib/linting/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
+import type { DocxExportSettings } from "@/lib/export/docx-export-settings";
 import type { ExportMetadata } from "@/lib/export/types";
 import type { RuleRunner } from "@/lib/linting/rule-runner";
 import { DockviewReact } from "dockview-react";
@@ -95,11 +97,14 @@ interface EditorLayoutProps {
     setShowRubyDialog: (show: boolean) => void;
     rubySelectedText: string;
     handleApplyRuby: React.ComponentProps<typeof RubyDialog>["onApply"];
-    showPdfExportDialog: boolean;
-    setShowPdfExportDialog: (show: boolean) => void;
-    handlePdfExportConfirm: (settings: PdfExportSettings) => void;
-    pdfExportContent: string;
-    pdfExportMetadata: ExportMetadata;
+    exportDialog: {
+      state: { format: "pdf" | "docx"; content: string; metadata: ExportMetadata } | null;
+      onClose: () => void;
+      onPdfExport: (settings: PdfExportSettings) => void;
+      onDocxExport: (settings: DocxExportSettings) => void;
+      content: string;
+      metadata: ExportMetadata;
+    };
   };
   recovery: {
     wasAutoRecovered?: boolean;
@@ -264,11 +269,17 @@ export default function EditorLayout({
             />
 
             <PdfExportDialog
-              isOpen={dialogs.showPdfExportDialog}
-              onClose={() => dialogs.setShowPdfExportDialog(false)}
-              onExport={dialogs.handlePdfExportConfirm}
-              content={dialogs.pdfExportContent}
-              metadata={dialogs.pdfExportMetadata}
+              isOpen={dialogs.exportDialog.state?.format === "pdf"}
+              onClose={dialogs.exportDialog.onClose}
+              onExport={dialogs.exportDialog.onPdfExport}
+              content={dialogs.exportDialog.content}
+              metadata={dialogs.exportDialog.metadata}
+            />
+
+            <DocxExportDialog
+              isOpen={dialogs.exportDialog.state?.format === "docx"}
+              onClose={dialogs.exportDialog.onClose}
+              onExport={dialogs.exportDialog.onDocxExport}
             />
 
             {!chrome.isElectron && recovery.wasAutoRecovered && !recovery.dismissedRecovery && (

--- a/lib/export/docx-export-settings.ts
+++ b/lib/export/docx-export-settings.ts
@@ -1,0 +1,159 @@
+/**
+ * DOCX export settings persistence.
+ *
+ * Uses localStorage with deep merge and range sanitization.
+ * Font mapping handles Office-style ascii/eastAsia/hAnsi slots
+ * for proper Japanese font rendering in Word.
+ */
+
+import { PAGE_DIMENSIONS } from "./pdf-export-settings";
+
+export type DocxPageSize = "A4" | "A5" | "B5" | "B6";
+
+export interface DocxExportSettings {
+  pageSize: DocxPageSize;
+  landscape: boolean;
+  fontFamily: string;
+  fontSize: number;
+  lineSpacing: number;
+  margins: { top: number; bottom: number; left: number; right: number };
+  textIndent: number;
+  showPageNumbers: boolean;
+}
+
+export const DEFAULT_DOCX_SETTINGS: DocxExportSettings = {
+  pageSize: "A5",
+  landscape: false,
+  fontFamily: "Yu Mincho",
+  fontSize: 12,
+  lineSpacing: 1.5,
+  margins: { top: 20, bottom: 20, left: 20, right: 20 },
+  textIndent: 1,
+  showPageNumbers: false,
+};
+
+/** Office font descriptor for docx library's run font property */
+export interface DocxFontConfig {
+  ascii: string;
+  eastAsia: string;
+  hAnsi: string;
+}
+
+/**
+ * Map a display font name to Office-style font slots.
+ *
+ * eastAsia receives the Japanese name so Word resolves the font
+ * correctly on Japanese OS locales. ascii/hAnsi receive the
+ * Latin-script name for Western character fallback.
+ */
+const FONT_MAP: Record<string, DocxFontConfig> = {
+  "Yu Mincho": { ascii: "Yu Mincho", eastAsia: "游明朝", hAnsi: "Yu Mincho" },
+  "Yu Gothic": { ascii: "Yu Gothic", eastAsia: "游ゴシック", hAnsi: "Yu Gothic" },
+  "Hiragino Mincho ProN": {
+    ascii: "Hiragino Mincho ProN",
+    eastAsia: "ヒラギノ明朝 ProN",
+    hAnsi: "Hiragino Mincho ProN",
+  },
+  "Noto Serif JP": { ascii: "Noto Serif JP", eastAsia: "Noto Serif JP", hAnsi: "Noto Serif JP" },
+};
+
+export function toDocxFont(fontFamily: string): DocxFontConfig {
+  return FONT_MAP[fontFamily] ?? { ascii: fontFamily, eastAsia: fontFamily, hAnsi: fontFamily };
+}
+
+// --- Unit conversion ---
+
+/** 1 mm = 56.692913… twips (1 inch = 25.4 mm, 1 inch = 1440 twips) */
+export function mmToTwips(mm: number): number {
+  return Math.round(mm * (1440 / 25.4));
+}
+
+/** 1 em at a given font size in pt → twips (1 pt = 20 twips) */
+export function emToTwips(em: number, fontSizePt: number): number {
+  return Math.round(em * fontSizePt * 20);
+}
+
+/** Font size in pt → half-points (docx library uses half-points for run.size) */
+export function ptToHalfPoints(pt: number): number {
+  return Math.round(pt * 2);
+}
+
+/** Line spacing multiplier → twips (240 twips = single spacing) */
+export function lineSpacingToTwips(multiplier: number): number {
+  return Math.round(multiplier * 240);
+}
+
+// --- Persistence ---
+
+const STORAGE_KEY = "illusions:docx-export-settings";
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function sanitizeSettings(raw: Partial<DocxExportSettings>): DocxExportSettings {
+  const d = DEFAULT_DOCX_SETTINGS;
+  const validPageSizes: DocxPageSize[] = ["A4", "A5", "B5", "B6"];
+  const pageSize = validPageSizes.includes(raw.pageSize as DocxPageSize)
+    ? (raw.pageSize as DocxPageSize)
+    : d.pageSize;
+
+  const rawMargins = raw.margins;
+  const hasMargins = typeof rawMargins === "object" && rawMargins !== null;
+
+  return {
+    pageSize,
+    landscape: typeof raw.landscape === "boolean" ? raw.landscape : d.landscape,
+    fontFamily:
+      typeof raw.fontFamily === "string" && raw.fontFamily ? raw.fontFamily : d.fontFamily,
+    fontSize: typeof raw.fontSize === "number" ? clamp(raw.fontSize, 8, 20) : d.fontSize,
+    lineSpacing:
+      typeof raw.lineSpacing === "number" ? clamp(raw.lineSpacing, 1.0, 3.0) : d.lineSpacing,
+    margins: {
+      top:
+        hasMargins && typeof rawMargins.top === "number"
+          ? clamp(rawMargins.top, 0, 50)
+          : d.margins.top,
+      bottom:
+        hasMargins && typeof rawMargins.bottom === "number"
+          ? clamp(rawMargins.bottom, 0, 50)
+          : d.margins.bottom,
+      left:
+        hasMargins && typeof rawMargins.left === "number"
+          ? clamp(rawMargins.left, 0, 50)
+          : d.margins.left,
+      right:
+        hasMargins && typeof rawMargins.right === "number"
+          ? clamp(rawMargins.right, 0, 50)
+          : d.margins.right,
+    },
+    textIndent: typeof raw.textIndent === "number" ? clamp(raw.textIndent, 0, 4) : d.textIndent,
+    showPageNumbers:
+      typeof raw.showPageNumbers === "boolean" ? raw.showPageNumbers : d.showPageNumbers,
+  };
+}
+
+export function loadDocxExportSettings(): DocxExportSettings {
+  if (typeof window === "undefined") return { ...DEFAULT_DOCX_SETTINGS };
+
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_DOCX_SETTINGS };
+    const parsed = JSON.parse(raw) as Partial<DocxExportSettings>;
+    return sanitizeSettings(parsed);
+  } catch {
+    return { ...DEFAULT_DOCX_SETTINGS };
+  }
+}
+
+export function saveDocxExportSettings(settings: DocxExportSettings): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // localStorage quota exceeded — silently ignore
+  }
+}
+
+export { PAGE_DIMENSIONS };

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -5,12 +5,33 @@
  * Handles headings, paragraphs, bold, italic, and ruby (as parenthesized fallback).
  */
 
-import { Document, Packer, Paragraph, TextRun, HeadingLevel, AlignmentType } from "docx";
+import {
+  Document,
+  Packer,
+  Paragraph,
+  TextRun,
+  HeadingLevel,
+  AlignmentType,
+  Footer,
+  PageNumber,
+} from "docx";
 import type { ExportMetadata } from "./types";
 import { replaceMdiWithRubyText } from "./mdi-parser";
+import {
+  DEFAULT_DOCX_SETTINGS,
+  PAGE_DIMENSIONS,
+  toDocxFont,
+  mmToTwips,
+  emToTwips,
+  ptToHalfPoints,
+  lineSpacingToTwips,
+} from "./docx-export-settings";
+
+import type { DocxExportSettings, DocxFontConfig } from "./docx-export-settings";
 
 export interface DocxExportOptions {
   metadata: ExportMetadata;
+  settings?: DocxExportSettings;
 }
 
 /**
@@ -22,7 +43,34 @@ export interface DocxExportOptions {
  */
 export async function generateDocx(content: string, options: DocxExportOptions): Promise<Buffer> {
   const { metadata } = options;
-  const paragraphs = parseMarkdownToDocxParagraphs(content);
+  const settings = options.settings ?? DEFAULT_DOCX_SETTINGS;
+  const fontConfig = toDocxFont(settings.fontFamily);
+  const paragraphs = parseMarkdownToDocxParagraphs(content, settings, fontConfig);
+
+  // Page dimensions (swap for landscape)
+  const baseDims = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];
+  const pageWidth = settings.landscape ? baseDims.height : baseDims.width;
+  const pageHeight = settings.landscape ? baseDims.width : baseDims.height;
+
+  // Footer with centered page number
+  const footers = settings.showPageNumbers
+    ? {
+        default: new Footer({
+          children: [
+            new Paragraph({
+              alignment: AlignmentType.CENTER,
+              children: [
+                new TextRun({
+                  children: [PageNumber.CURRENT],
+                  font: fontConfig,
+                  size: ptToHalfPoints(settings.fontSize - 2),
+                }),
+              ],
+            }),
+          ],
+        }),
+      }
+    : undefined;
 
   const doc = new Document({
     creator: metadata.author || "",
@@ -32,29 +80,31 @@ export async function generateDocx(content: string, options: DocxExportOptions):
       default: {
         document: {
           run: {
-            font: "Yu Mincho",
-            size: 24, // 12pt in half-points
+            font: fontConfig,
+            size: ptToHalfPoints(settings.fontSize),
           },
           paragraph: {
-            spacing: { line: 360 }, // 1.5x line spacing
+            spacing: { line: lineSpacingToTwips(settings.lineSpacing) },
           },
         },
       },
     },
     sections: [
       {
+        ...(footers ? { footers } : {}),
         properties: {
           page: {
             size: {
-              width: 10206, // A5 width in twips (148mm)
-              height: 14400, // A5 height in twips
+              width: mmToTwips(pageWidth),
+              height: mmToTwips(pageHeight),
             },
             margin: {
-              top: 1134, // ~20mm
-              bottom: 1134,
-              left: 1134,
-              right: 1134,
+              top: mmToTwips(settings.margins.top),
+              bottom: mmToTwips(settings.margins.bottom),
+              left: mmToTwips(settings.margins.left),
+              right: mmToTwips(settings.margins.right),
             },
+            ...(settings.showPageNumbers ? { pageNumbers: { start: 1 } } : {}),
           },
         },
         children: paragraphs,
@@ -71,7 +121,11 @@ export async function generateDocx(content: string, options: DocxExportOptions):
 /**
  * Parse MDI markdown content into docx Paragraph objects
  */
-function parseMarkdownToDocxParagraphs(content: string): Paragraph[] {
+function parseMarkdownToDocxParagraphs(
+  content: string,
+  settings: DocxExportSettings,
+  fontConfig: DocxFontConfig,
+): Paragraph[] {
   const lines = content.split("\n");
   const paragraphs: Paragraph[] = [];
   let currentParagraphLines: string[] = [];
@@ -80,7 +134,7 @@ function parseMarkdownToDocxParagraphs(content: string): Paragraph[] {
     if (currentParagraphLines.length === 0) return;
     const text = currentParagraphLines.join("\n").trim();
     if (text) {
-      paragraphs.push(createParagraph(text));
+      paragraphs.push(createParagraph(text, settings, fontConfig));
     }
     currentParagraphLines = [];
   };
@@ -100,21 +154,20 @@ function parseMarkdownToDocxParagraphs(content: string): Paragraph[] {
       flushParagraph();
       const level = headingMatch[1].length;
       const headingText = headingMatch[2];
-      paragraphs.push(createHeading(headingText, level));
+      paragraphs.push(createHeading(headingText, level, fontConfig));
       continue;
     }
 
     // Horizontal rule
     if (/^(-{3,}|\*{3,}|_{3,})$/.test(trimmed)) {
       flushParagraph();
-      // Add a centered separator for horizontal rules
       paragraphs.push(
         new Paragraph({
           spacing: { before: 200, after: 200 },
           children: [
             new TextRun({
               text: "\uFF0A\u3000\uFF0A\u3000\uFF0A",
-              font: "Yu Mincho",
+              font: fontConfig,
             }),
           ],
           alignment: AlignmentType.CENTER,
@@ -133,7 +186,7 @@ function parseMarkdownToDocxParagraphs(content: string): Paragraph[] {
 /**
  * Create a heading paragraph
  */
-function createHeading(text: string, level: number): Paragraph {
+function createHeading(text: string, level: number, fontConfig: DocxFontConfig): Paragraph {
   const headingLevels: Record<number, (typeof HeadingLevel)[keyof typeof HeadingLevel]> = {
     1: HeadingLevel.HEADING_1,
     2: HeadingLevel.HEADING_2,
@@ -146,18 +199,22 @@ function createHeading(text: string, level: number): Paragraph {
   return new Paragraph({
     heading: headingLevels[level] || HeadingLevel.HEADING_1,
     spacing: { before: 400, after: 200 },
-    children: parseInlineFormatting(text),
+    children: parseInlineFormatting(text, fontConfig),
   });
 }
 
 /**
  * Create a body paragraph with inline formatting
  */
-function createParagraph(text: string): Paragraph {
+function createParagraph(
+  text: string,
+  settings: DocxExportSettings,
+  fontConfig: DocxFontConfig,
+): Paragraph {
   return new Paragraph({
     spacing: { before: 0, after: 120 },
-    indent: { firstLine: 480 }, // ~1em indent for Japanese prose
-    children: parseInlineFormatting(text),
+    indent: { firstLine: emToTwips(settings.textIndent, settings.fontSize) },
+    children: parseInlineFormatting(text, fontConfig),
   });
 }
 
@@ -166,7 +223,7 @@ function createParagraph(text: string): Paragraph {
  *
  * Handles: **bold**, *italic*, {ruby|text}, ^tcy^, [[no-break:text]], [[kern:val:text]]
  */
-function parseInlineFormatting(text: string): TextRun[] {
+function parseInlineFormatting(text: string, fontConfig: DocxFontConfig): TextRun[] {
   const runs: TextRun[] = [];
 
   // Process all MDI inline syntax via shared parser (ruby → fullwidth parens)
@@ -184,19 +241,19 @@ function parseInlineFormatting(text: string): TextRun[] {
     if (match.index > lastIndex) {
       const before = processed.slice(lastIndex, match.index);
       if (before) {
-        runs.push(new TextRun({ text: before }));
+        runs.push(new TextRun({ text: before, font: fontConfig }));
       }
     }
 
     if (match[2]) {
       // Bold italic: ***text***
-      runs.push(new TextRun({ text: match[2], bold: true, italics: true }));
+      runs.push(new TextRun({ text: match[2], bold: true, italics: true, font: fontConfig }));
     } else if (match[3]) {
       // Bold: **text**
-      runs.push(new TextRun({ text: match[3], bold: true }));
+      runs.push(new TextRun({ text: match[3], bold: true, font: fontConfig }));
     } else if (match[4]) {
       // Italic: *text*
-      runs.push(new TextRun({ text: match[4], italics: true }));
+      runs.push(new TextRun({ text: match[4], italics: true, font: fontConfig }));
     }
 
     lastIndex = match.index + match[0].length;
@@ -206,13 +263,13 @@ function parseInlineFormatting(text: string): TextRun[] {
   if (lastIndex < processed.length) {
     const remaining = processed.slice(lastIndex);
     if (remaining) {
-      runs.push(new TextRun({ text: remaining }));
+      runs.push(new TextRun({ text: remaining, font: fontConfig }));
     }
   }
 
   // If no runs were created, add the full text
   if (runs.length === 0) {
-    runs.push(new TextRun({ text: processed }));
+    runs.push(new TextRun({ text: processed, font: fontConfig }));
   }
 
   return runs;

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -15,11 +15,16 @@ interface UseExportParams {
    *  Export operations no-op when false (e.g. terminal or diff tab is active). */
   getIsEditorTabActive: () => boolean;
   /**
-   * When provided, PDF export opens a settings dialog instead of exporting directly.
-   * The callback receives the content and metadata so the parent can show the dialog
+   * When provided, export formats with settings dialogs (PDF, DOCX) open the
+   * dialog instead of exporting directly. The callback receives the format,
+   * content and metadata so the parent can show the appropriate dialog
    * and later call the IPC with user-configured options.
    */
-  onPdfExportRequest?: (content: string, metadata: ExportMetadata) => void;
+  onExportDialogRequest?: (
+    format: "pdf" | "docx",
+    content: string,
+    metadata: ExportMetadata,
+  ) => void;
 }
 
 /**
@@ -95,7 +100,7 @@ export function useExport({
   getContent,
   getTitle,
   getIsEditorTabActive,
-  onPdfExportRequest,
+  onExportDialogRequest,
 }: UseExportParams): {
   exportAs: (format: ExportFormat) => Promise<void>;
 } {
@@ -151,9 +156,13 @@ export function useExport({
         return;
       }
 
-      // PDF export: delegate to settings dialog when callback is provided
-      if (format === "pdf" && onPdfExportRequest && isElectronRenderer()) {
-        onPdfExportRequest(content, metadata);
+      // PDF/DOCX export: delegate to settings dialog when callback is provided
+      if (
+        (format === "pdf" || format === "docx") &&
+        onExportDialogRequest &&
+        isElectronRenderer()
+      ) {
+        onExportDialogRequest(format, content, metadata);
         return;
       }
 
@@ -206,7 +215,7 @@ export function useExport({
         notificationManager.error(`${label}のエクスポートに失敗しました: ${message}`);
       }
     },
-    [getContent, getTitle, getIsEditorTabActive, isElectron, onPdfExportRequest],
+    [getContent, getTitle, getIsEditorTabActive, isElectron, onExportDialogRequest],
   );
 
   // Register Electron menu event handlers

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -89,7 +89,19 @@ declare global {
     ) => Promise<string | { success: false; error: string } | null>;
     exportDOCX?: (
       content: string,
-      options: { metadata: { title: string; author?: string; date?: string; language?: string } },
+      options: {
+        metadata: { title: string; author?: string; date?: string; language?: string };
+        settings?: {
+          pageSize?: string;
+          landscape?: boolean;
+          fontFamily?: string;
+          fontSize?: number;
+          lineSpacing?: number;
+          margins?: { top: number; bottom: number; left: number; right: number };
+          textIndent?: number;
+          showPageNumbers?: boolean;
+        };
+      },
     ) => Promise<string | { success: false; error: string } | null>;
     onMenuExportTxt?: (callback: () => void) => (() => void) | void;
     onMenuExportTxtRuby?: (callback: () => void) => (() => void) | void;


### PR DESCRIPTION
## Summary

- DOCX エクスポートに PDF と同等の組版設定ダイアログを追加
- 用紙サイズ、向き、フォント（Office eastAsia/ascii/hAnsi スロット対応）、文字サイズ、行間隔、字下げ、ページ番号、余白を設定可能
- 設定は localStorage に深いマージ + 範囲バリデーション付きで永続化
- PDF 専用だったエクスポートダイアログ配線を汎用パターンに統一（prop drilling 削減）

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `lib/export/docx-export-settings.ts` | **NEW** — 設定型・デフォルト・永続化・`toDocxFont()`・単位変換ヘルパー |
| `components/DocxExportDialog.tsx` | **NEW** — 設定専用ダイアログ（プレビューなし） |
| `lib/export/docx-exporter.ts` | settings を全段落/見出し/区切り線生成関数に流す、ページ番号対応 |
| `lib/export/use-export.ts` | `onPdfExportRequest` → 汎用 `onExportDialogRequest(format, ...)` |
| `app/page.tsx` | PDF 専用 state 4 つ → `ExportDialogState \| null` に統合 + DOCX ハンドラー追加 |
| `components/EditorLayout.tsx` | PDF 専用 props → `exportDialog` グループに統合、`DocxExportDialog` レンダリング追加 |
| `types/electron.d.ts` | `exportDOCX` options に settings フィールドを追加 |

## Test plan

- [ ] メニュー → エクスポート → DOCX → 設定ダイアログが開くことを確認
- [ ] 用紙サイズ・フォント・余白などを変更してエクスポート → Word/LibreOffice で反映確認
- [ ] ページ番号 ON/OFF を切り替えてエクスポート → フッターに番号が表示されることを確認
- [ ] ダイアログを閉じて再度開く → 設定が localStorage から復元されることを確認
- [ ] PDF エクスポートのリグレッションがないことを確認（設定ダイアログ・エクスポート両方）
- [ ] `npx tsc --noEmit` がエラーなしで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)