### PR TITLE
fix(export): address missed Copilot findings on DOCX export

### DIFF
--- a/components/DocxExportDialog.tsx
+++ b/components/DocxExportDialog.tsx
@@ -208,6 +208,7 @@ function DocxExportDialogInner({ onClose, onExport }: Omit<DocxExportDialogProps
               <button
                 type="button"
                 role="switch"
+                aria-label="ページ番号"
                 aria-checked={settings.showPageNumbers}
                 onClick={() => updateField("showPageNumbers", !settings.showPageNumbers)}
                 className={clsx(

--- a/lib/export/docx-export-settings.ts
+++ b/lib/export/docx-export-settings.ts
@@ -91,7 +91,7 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function sanitizeSettings(raw: Partial<DocxExportSettings>): DocxExportSettings {
+export function sanitizeSettings(raw: Partial<DocxExportSettings>): DocxExportSettings {
   const d = DEFAULT_DOCX_SETTINGS;
   const validPageSizes: DocxPageSize[] = ["A4", "A5", "B5", "B6"];
   const pageSize = validPageSizes.includes(raw.pageSize as DocxPageSize)

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -25,6 +25,7 @@ import {
   emToTwips,
   ptToHalfPoints,
   lineSpacingToTwips,
+  sanitizeSettings,
 } from "./docx-export-settings";
 
 import type { DocxExportSettings, DocxFontConfig } from "./docx-export-settings";
@@ -40,7 +41,7 @@ export interface DocxExportOptions {
  */
 function buildDocxDocument(content: string, options: DocxExportOptions): Document {
   const { metadata } = options;
-  const settings = options.settings ?? DEFAULT_DOCX_SETTINGS;
+  const settings = options.settings ? sanitizeSettings(options.settings) : DEFAULT_DOCX_SETTINGS;
   const fontConfig = toDocxFont(settings.fontFamily);
   const paragraphs = parseMarkdownToDocxParagraphs(content, settings, fontConfig);
 


### PR DESCRIPTION
## Summary

- #1247 マージ時に見落とした Copilot レビュー指摘を修正

## Changes

- `docx-exporter.ts`: `sanitizeSettings()` で partial な `DocxExportSettings` をマージ・クランプしてから使用（runtime crash 防止）
- `docx-export-settings.ts`: `sanitizeSettings()` を export
- `DocxExportDialog.tsx`: ページ番号トグルに `aria-label` を追加（アクセシビリティ）

## Test plan

- [ ] `npx tsc --noEmit` — 型エラーなし
- [ ] DOCX エクスポートダイアログを開いて設定変更 → エクスポートが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)