### PR TITLE
chore(vercel): only deploy on main branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `vercel.json` を追加し、`main` ブランチへのプッシュ時のみ Vercel デプロイを実行するよう設定
- `dev` ブランチや feature ブランチへのプッシュでは不要なビルドが走らなくなる

## Changes

- `vercel.json` 新規作成 — `git.deploymentEnabled.main: true` のみ設定

## Test plan

- [ ] `dev` ブランチへの PR マージ後、Vercel でビルドがスキップされることを確認
- [ ] `main` ブランチへのマージ後、Vercel でデプロイが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)