### PR TITLE
feat(workspace): restore project tabs and dockview layout from workspace.json

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -259,6 +259,7 @@ export default function EditorPage() {
     handleCloseTabDiscard,
     handleCloseTabCancel,
     flushTabState,
+    restoreProjectTabs,
   } = tabManager;
 
   // Keep a live tabs ref for dockview panel renderers captured by stale closures.
@@ -295,6 +296,11 @@ export default function EditorPage() {
   const [searchOpenTrigger, setSearchOpenTrigger] = useState(0);
   const [searchInitialTerm, setSearchInitialTerm] = useState<string | undefined>(undefined);
 
+  // Derive project dockview layout from workspace state (already loaded at project open)
+  const projectDockviewLayout = isProjectMode(editorMode)
+    ? editorMode.workspaceState.dockviewLayout
+    : null;
+
   // --- Dockview adapter (bridges useTabManager ↔ dockview layout) ---
   const { handleDockviewReady, dockviewApi, splitEditor } = useDockviewAdapter({
     tabManager: tabManagerWithPtyCleanup,
@@ -302,11 +308,13 @@ export default function EditorPage() {
     searchOpenTrigger,
     searchInitialTerm,
     windowKey,
+    projectLayout: projectDockviewLayout,
   });
   const { flushLayoutState } = useDockviewPersistence({
     dockviewApi,
     tabs: tabManagerWithPtyCleanup.tabs,
     windowKey,
+    isProject: isProjectMode(editorMode),
   });
   flushLayoutStateRef.current = flushLayoutState;
 
@@ -374,6 +382,7 @@ export default function EditorPage() {
     skipAutoRestore,
     lastSavedTime,
     onVfsReady: vfsGate.resolve,
+    restoreProjectTabs,
   });
   const {
     state: {

--- a/lib/dockview/index.ts
+++ b/lib/dockview/index.ts
@@ -40,5 +40,8 @@ export {
   type UseDockviewAdapterReturn,
 } from "./use-dockview-adapter";
 
+// Stable key utility
+export { stableKeyForTab } from "./stable-key";
+
 // Persistence
 export { useDockviewPersistence, loadDockviewLayout } from "./use-dockview-persistence";

--- a/lib/dockview/stable-key.ts
+++ b/lib/dockview/stable-key.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared stable-key utility for dockview layout persistence and restoration.
+ */
+
+import type { TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab, isTerminalTab, isDiffTab } from "@/lib/tab-manager/tab-types";
+
+/**
+ * Build a stable, ID-independent key for a tab that survives session restarts.
+ * Supports same-file clones via `#N` suffix (e.g. "chapter1.mdi", "chapter1.mdi#1").
+ *
+ * Key formats:
+ *   - First editor tab for a file: file path
+ *   - Subsequent clones of same file: "filePath#1", "filePath#2", etc.
+ *   - Unsaved editor tab: "unsaved:<tabId>"
+ *   - Terminal tab: "terminal:<sessionId>"
+ *   - Diff tab: "diff:<sourceTabId>"
+ *
+ * @param tab - The tab to generate a key for
+ * @param occurrences - Mutable map tracking how many times each base path has been seen.
+ *   Pass the same map across all tabs in a single serialization pass for correct indexing.
+ */
+export function stableKeyForTab(tab: TabState, occurrences?: Map<string, number>): string | null {
+  if (isEditorTab(tab)) {
+    const basePath = tab.file?.path ?? `unsaved:${tab.id}`;
+    if (occurrences) {
+      const count = occurrences.get(basePath) ?? 0;
+      occurrences.set(basePath, count + 1);
+      return count === 0 ? basePath : `${basePath}#${count}`;
+    }
+    return basePath;
+  }
+  if (isTerminalTab(tab)) {
+    return `terminal:${tab.sessionId}`;
+  }
+  if (isDiffTab(tab)) {
+    return `diff:${tab.sourceTabId}`;
+  }
+  return null;
+}

--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -22,6 +22,8 @@ import type {
   DiffPanelParams,
   SimplifiedGroupLayout,
 } from "./types";
+import type { WorkspaceDockviewLayout } from "@/lib/project/project-types";
+import { toAbsolutePath } from "@/lib/project/workspace-persistence";
 import { loadDockviewLayout } from "./use-dockview-persistence";
 
 // ---------------------------------------------------------------------------
@@ -41,6 +43,12 @@ export interface UseDockviewAdapterOptions {
    * multiple windows with different projects do not share the same layout record.
    */
   windowKey?: string | null;
+  /**
+   * Dockview layout from workspace.json (project mode).
+   * When provided, this is used instead of loading from SQLite.
+   * Paths are relative to project root and will be converted to absolute.
+   */
+  projectLayout?: WorkspaceDockviewLayout | null;
 }
 
 export interface UseDockviewAdapterReturn {
@@ -103,10 +111,17 @@ function buildTerminalPanelPosition(
  * Build the stable key for a tab to match against saved layout keys.
  *
  * Must mirror the logic in use-dockview-persistence.ts:stableKeyForTab().
+ * Uses occurrence tracking for same-file clone disambiguation (#N suffix).
  */
-function stableKeyForTab(tab: TabState): string | null {
+function stableKeyForTab(tab: TabState, occurrences?: Map<string, number>): string | null {
   if (isEditorTab(tab)) {
-    return tab.file?.path ?? `unsaved:${tab.id}`;
+    const basePath = tab.file?.path ?? `unsaved:${tab.id}`;
+    if (occurrences) {
+      const count = occurrences.get(basePath) ?? 0;
+      occurrences.set(basePath, count + 1);
+      return count === 0 ? basePath : `${basePath}#${count}`;
+    }
+    return basePath;
   }
   if (isTerminalTab(tab)) {
     return `terminal:${tab.sessionId}`;
@@ -134,9 +149,11 @@ function applySimplifiedLayout(
   tabs: TabState[],
 ): void {
   // Build stable-key → panelId lookup from current tabs (all tab kinds)
+  // Uses occurrence tracking to match same-file clones via #N suffix.
+  const occurrences = new Map<string, number>();
   const panelIdByKey = new Map<string, string>();
   for (const tab of tabs) {
-    const key = stableKeyForTab(tab);
+    const key = stableKeyForTab(tab, occurrences);
     if (key) {
       panelIdByKey.set(key, tab.id);
     }
@@ -230,6 +247,22 @@ function applySimplifiedLayout(
       }
     }
   }
+
+  // Restore active tab per group
+  for (let i = 0; i < layout.groups.length; i++) {
+    const savedGroup = layout.groups[i];
+    if (!savedGroup.activeTabPath) continue;
+    const activePanelId = panelIdByKey.get(savedGroup.activeTabPath);
+    if (!activePanelId) continue;
+    const panel = api.getPanel(activePanelId);
+    if (panel) {
+      try {
+        panel.api.setActive();
+      } catch {
+        // Panel may not be in this group anymore
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -242,6 +275,7 @@ export function useDockviewAdapter({
   searchOpenTrigger,
   searchInitialTerm,
   windowKey,
+  projectLayout,
 }: UseDockviewAdapterOptions): UseDockviewAdapterReturn {
   const [dockviewApi, setDockviewApi] = useState<DockviewApi | null>(null);
   const apiRef = useRef<DockviewApi | null>(null);
@@ -337,13 +371,41 @@ export function useDockviewAdapter({
     [],
   );
 
+  // -- Reset layout state on project change ----------------------------------
+  const prevWindowKeyRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    const newKey = windowKey ?? null;
+    if (prevWindowKeyRef.current !== undefined && prevWindowKeyRef.current !== newKey) {
+      layoutAppliedRef.current = false;
+      savedLayoutRef.current = null;
+    }
+    prevWindowKeyRef.current = newKey;
+  }, [windowKey]);
+
   // -- Pre-load saved layout for restoration --------------------------------
-  // Re-runs when windowKey changes from null to a real value (project loaded).
-  // layoutAppliedRef ensures the layout is only applied once even if this
-  // effect fires multiple times.
+  // In project mode, uses the projectLayout prop (from workspace.json, already
+  // loaded). In standalone mode, loads from SQLite via loadDockviewLayout().
 
   useEffect(() => {
-    if (layoutAppliedRef.current) return; // Already applied; do not override
+    if (layoutAppliedRef.current) return;
+
+    // Project mode: use workspace.json layout (convert relative → absolute paths)
+    if (projectLayout && projectLayout.groups.length > 1) {
+      const rootPath = windowKey ?? null;
+      const absoluteLayout: SimplifiedGroupLayout = {
+        groups: projectLayout.groups.map((g) => ({
+          tabPaths: g.tabPaths.map((p) => (p ? toAbsolutePath(p, rootPath) : null)),
+          activeTabPath: g.activeTabPath ? toAbsolutePath(g.activeTabPath, rootPath) : null,
+        })),
+        orientation: projectLayout.orientation,
+        sizes: projectLayout.sizes,
+      };
+      savedLayoutRef.current = absoluteLayout;
+      setLayoutReadyTick((t) => t + 1);
+      return;
+    }
+
+    // Standalone mode: load from SQLite
     let cancelled = false;
     void loadDockviewLayout(windowKey).then((state) => {
       if (cancelled) return;
@@ -355,7 +417,7 @@ export function useDockviewAdapter({
     return () => {
       cancelled = true;
     };
-  }, [windowKey]);
+  }, [windowKey, projectLayout]);
 
   // -- Pending split tracking -----------------------------------------------
 

--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { DockviewApi, IDockviewPanel } from "dockview-react";
 import type { TabId, TabState } from "@/lib/tab-manager/tab-types";
 import { isEditorTab, isTerminalTab, isDiffTab } from "@/lib/tab-manager/tab-types";
+import { stableKeyForTab } from "./stable-key";
 import type { UseTabManagerReturn } from "@/lib/tab-manager/types";
 import type {
   EditorPanelParams,
@@ -106,31 +107,6 @@ function buildTerminalPanelPosition(
 // ---------------------------------------------------------------------------
 // Layout restoration helper
 // ---------------------------------------------------------------------------
-
-/**
- * Build the stable key for a tab to match against saved layout keys.
- *
- * Must mirror the logic in use-dockview-persistence.ts:stableKeyForTab().
- * Uses occurrence tracking for same-file clone disambiguation (#N suffix).
- */
-function stableKeyForTab(tab: TabState, occurrences?: Map<string, number>): string | null {
-  if (isEditorTab(tab)) {
-    const basePath = tab.file?.path ?? `unsaved:${tab.id}`;
-    if (occurrences) {
-      const count = occurrences.get(basePath) ?? 0;
-      occurrences.set(basePath, count + 1);
-      return count === 0 ? basePath : `${basePath}#${count}`;
-    }
-    return basePath;
-  }
-  if (isTerminalTab(tab)) {
-    return `terminal:${tab.sessionId}`;
-  }
-  if (isDiffTab(tab)) {
-    return `diff:${tab.sourceTabId}`;
-  }
-  return null;
-}
 
 /**
  * Apply a saved simplified layout to the current dockview state.

--- a/lib/dockview/use-dockview-persistence.ts
+++ b/lib/dockview/use-dockview-persistence.ts
@@ -19,6 +19,8 @@ import {
   fetchWindowState,
 } from "@/lib/storage/app-state-manager";
 import { getStorageService } from "@/lib/storage/storage-service";
+import { persistWorkspaceJson, toRelativePath } from "@/lib/project/workspace-persistence";
+import type { WorkspaceDockviewLayout } from "@/lib/project/project-types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -32,15 +34,28 @@ const LAYOUT_PERSIST_DEBOUNCE = 2000;
 
 /**
  * Build a stable, ID-independent key for a tab that survives session restarts.
+ * Supports same-file clones via `#N` suffix (e.g. "chapter1.mdi", "chapter1.mdi#1").
  *
- * - Editor tab with saved file: the file path (e.g. "/home/user/novel.mdi")
- * - Editor tab without file (unsaved): "unsaved:<tabId>"
- * - Terminal tab: "terminal:<sessionId>"
- * - Diff tab: "diff:<sourceTabId>"
+ * Key formats:
+ *   - First editor tab for a file: file path
+ *   - Subsequent clones of same file: "filePath#1", "filePath#2", etc.
+ *   - Unsaved editor tab: "unsaved:<tabId>"
+ *   - Terminal tab: "terminal:<sessionId>"
+ *   - Diff tab: "diff:<sourceTabId>"
+ *
+ * @param tab - The tab to generate a key for
+ * @param occurrences - Mutable map tracking how many times each base path has been seen.
+ *   Pass the same map across all tabs in a single serialization pass for correct indexing.
  */
-function stableKeyForTab(tab: TabState): string | null {
+function stableKeyForTab(tab: TabState, occurrences?: Map<string, number>): string | null {
   if (isEditorTab(tab)) {
-    return tab.file?.path ?? `unsaved:${tab.id}`;
+    const basePath = tab.file?.path ?? `unsaved:${tab.id}`;
+    if (occurrences) {
+      const count = occurrences.get(basePath) ?? 0;
+      occurrences.set(basePath, count + 1);
+      return count === 0 ? basePath : `${basePath}#${count}`;
+    }
+    return basePath;
   }
   if (isTerminalTab(tab)) {
     return `terminal:${tab.sessionId}`;
@@ -54,12 +69,7 @@ function stableKeyForTab(tab: TabState): string | null {
 /**
  * Extract a simplified, ID-independent layout from the current dockview state.
  * Uses stable keys so the layout survives tab ID regeneration.
- *
- * Stable key formats:
- *   - Saved editor tab: file path
- *   - Unsaved editor tab: "unsaved:<tabId>"
- *   - Terminal tab: "terminal:<sessionId>"
- *   - Diff tab: "diff:<sourceTabId>"
+ * Same-file clones are disambiguated with `#N` suffix.
  */
 function extractSimplifiedLayout(
   api: DockviewApi,
@@ -69,9 +79,11 @@ function extractSimplifiedLayout(
   if (groups.length <= 1) return undefined; // Single group = default layout, no need to save
 
   // Build panelId → stable key lookup (covers all tab kinds)
+  // Use occurrence tracking for same-file clone disambiguation
+  const occurrences = new Map<string, number>();
   const pathByPanelId = new Map<string, string | null>();
   for (const tab of tabs) {
-    pathByPanelId.set(tab.id, stableKeyForTab(tab));
+    pathByPanelId.set(tab.id, stableKeyForTab(tab, occurrences));
   }
 
   // Extract orientation from serialized JSON (the API doesn't expose it directly)
@@ -125,6 +137,8 @@ export interface UseDockviewPersistenceOptions {
    * 互いの状態を上書きしないようにする。
    */
   windowKey?: string | null;
+  /** Whether the app is currently in project mode. */
+  isProject?: boolean;
 }
 
 export interface UseDockviewPersistenceReturn {
@@ -137,6 +151,7 @@ export function useDockviewPersistence({
   tabs = [],
   enabled = true,
   windowKey,
+  isProject = false,
 }: UseDockviewPersistenceOptions): UseDockviewPersistenceReturn {
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const apiRef = useRef<DockviewApi | null>(null);
@@ -145,14 +160,40 @@ export function useDockviewPersistence({
   tabsRef.current = tabs;
   const windowKeyRef = useRef(windowKey ?? null);
   windowKeyRef.current = windowKey ?? null;
+  const isProjectRef = useRef(isProject);
+  isProjectRef.current = isProject;
 
   /** Serialize and persist the current layout immediately. */
   const persistLayoutNow = useCallback(async () => {
     const api = apiRef.current;
     if (!api) return;
     try {
-      const layoutJson = api.toJSON();
       const simplified = extractSimplifiedLayout(api, tabsRef.current);
+
+      // --- Project mode: write to workspace.json ---
+      if (isProjectRef.current && simplified) {
+        const rootPath = windowKeyRef.current;
+        // Convert absolute paths → relative for workspace.json storage.
+        // Filter out terminal/diff keys (ephemeral, not restored).
+        const workspaceLayout: WorkspaceDockviewLayout = {
+          groups: simplified.groups.map((g) => ({
+            tabPaths: g.tabPaths.map((p) => {
+              if (!p || p.startsWith("terminal:") || p.startsWith("diff:")) return null;
+              return toRelativePath(p, rootPath) ?? p;
+            }),
+            activeTabPath: g.activeTabPath
+              ? (toRelativePath(g.activeTabPath, rootPath) ?? g.activeTabPath)
+              : null,
+          })),
+          orientation: simplified.orientation,
+          sizes: simplified.sizes,
+        };
+        await persistWorkspaceJson({ dockviewLayout: workspaceLayout });
+        return;
+      }
+
+      // --- Standalone mode: write to SQLite ---
+      const layoutJson = api.toJSON();
       const layoutState: DockviewLayoutState = {
         dockviewJson: layoutJson,
         buffers: [],
@@ -162,7 +203,6 @@ export function useDockviewPersistence({
       if (key) {
         await persistWindowState(key, { dockviewLayout: layoutState });
       } else {
-        // Fallback: no per-window key yet — write to global AppState.
         await persistAppState({ dockviewLayout: layoutState });
       }
     } catch (err) {

--- a/lib/dockview/use-dockview-persistence.ts
+++ b/lib/dockview/use-dockview-persistence.ts
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useRef } from "react";
 import type { DockviewApi } from "dockview-react";
 import type { DockviewLayoutState, SimplifiedGroupLayout } from "./types";
 import type { TabState } from "@/lib/tab-manager/tab-types";
-import { isEditorTab, isTerminalTab, isDiffTab } from "@/lib/tab-manager/tab-types";
+import { stableKeyForTab } from "./stable-key";
 import {
   persistAppState,
   persistWindowState,
@@ -31,40 +31,6 @@ const LAYOUT_PERSIST_DEBOUNCE = 2000;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Build a stable, ID-independent key for a tab that survives session restarts.
- * Supports same-file clones via `#N` suffix (e.g. "chapter1.mdi", "chapter1.mdi#1").
- *
- * Key formats:
- *   - First editor tab for a file: file path
- *   - Subsequent clones of same file: "filePath#1", "filePath#2", etc.
- *   - Unsaved editor tab: "unsaved:<tabId>"
- *   - Terminal tab: "terminal:<sessionId>"
- *   - Diff tab: "diff:<sourceTabId>"
- *
- * @param tab - The tab to generate a key for
- * @param occurrences - Mutable map tracking how many times each base path has been seen.
- *   Pass the same map across all tabs in a single serialization pass for correct indexing.
- */
-function stableKeyForTab(tab: TabState, occurrences?: Map<string, number>): string | null {
-  if (isEditorTab(tab)) {
-    const basePath = tab.file?.path ?? `unsaved:${tab.id}`;
-    if (occurrences) {
-      const count = occurrences.get(basePath) ?? 0;
-      occurrences.set(basePath, count + 1);
-      return count === 0 ? basePath : `${basePath}#${count}`;
-    }
-    return basePath;
-  }
-  if (isTerminalTab(tab)) {
-    return `terminal:${tab.sessionId}`;
-  }
-  if (isDiffTab(tab)) {
-    return `diff:${tab.sourceTabId}`;
-  }
-  return null;
-}
 
 /**
  * Extract a simplified, ID-independent layout from the current dockview state.

--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -6,7 +6,7 @@ import { getDefaultWorkspaceState } from "@/lib/project/project-types";
 import { getVFS } from "@/lib/vfs";
 import { notificationManager } from "@/lib/services/notification-manager";
 
-import type { ProjectMode, StandaloneMode } from "@/lib/project/project-types";
+import type { ProjectMode, StandaloneMode, WorkspaceTab } from "@/lib/project/project-types";
 import { ensureProjectJson, readProjectJson, readFileHandle } from "./project-file-utils";
 
 interface UseFileOpeningParams {
@@ -28,6 +28,11 @@ interface UseFileOpeningParams {
   tabLoadSystemFile: (path: string, content: string) => void;
   /** Increment editor key to force editor remount */
   incrementEditorKey: () => void;
+  /** Restore tabs from workspace.json data loaded during project open */
+  restoreProjectTabs: (
+    savedTabs: { tabs: WorkspaceTab[]; activeIndex: number } | undefined,
+    rootPath: string | null,
+  ) => Promise<boolean>;
 }
 
 export interface UseFileOpeningResult {
@@ -59,13 +64,22 @@ export function useFileOpening({
   openRestoredProject,
   tabLoadSystemFile,
   incrementEditorKey,
+  restoreProjectTabs,
 }: UseFileOpeningParams): UseFileOpeningResult {
   const handleOpenProject = useCallback(async () => {
     try {
       const projectService = getProjectService();
       const project = await projectService.openProject();
       setProjectMode(project);
-      await loadProjectContent(project);
+
+      // Restore tabs from workspace.json; fall back to loading main file
+      const restored = await restoreProjectTabs(
+        project.workspaceState.openTabs,
+        project.rootPath ?? null,
+      );
+      if (!restored) {
+        await loadProjectContent(project);
+      }
 
       if (isElectron && project.rootPath) {
         const storage = getStorageService();
@@ -81,7 +95,7 @@ export function useFileOpening({
       if (error instanceof Error && error.message.includes("cancelled")) return;
       console.error("Failed to open project:", error);
     }
-  }, [setProjectMode, isElectron, loadProjectContent]);
+  }, [setProjectMode, isElectron, loadProjectContent, restoreProjectTabs]);
 
   const handleOpenStandaloneFile = useCallback(async () => {
     try {
@@ -123,7 +137,9 @@ export function useFileOpening({
                 project.rootPath,
               );
             }
-            signalVfsReady();
+            // NOTE: signalVfsReady() is deferred to AFTER tab restore so that the
+            // mount-time standalone restore (use-tab-persistence.ts) does not race
+            // with the explicit project tab restore.
             const rootDirHandle = await vfs.getDirectoryHandle("");
             const projectJsonResult = await readProjectJson(rootDirHandle);
             if (!projectJsonResult) {
@@ -168,12 +184,19 @@ export function useFileOpening({
             };
 
             setProjectMode(restoredProject);
-            // Skip loading main file during auto-restore on Electron — tab persistence
-            // will restore the previously open tabs (or empty state).
-            // On Web, always load so the main file is available.
-            if (!isAutoRestoringRef.current || !isElectron) {
+
+            // Restore tabs from workspace.json; fall back to loading main file
+            const restored = await restoreProjectTabs(
+              restoredProject.workspaceState.openTabs,
+              restoredProject.rootPath ?? null,
+            );
+            if (!restored) {
               await loadProjectContent(restoredProject);
             }
+
+            // Signal VFS ready AFTER tab restore — this ensures the standalone
+            // mount-time restore sees projectTabsRestoredRef=true and skips.
+            signalVfsReady();
             return true;
           } catch (error) {
             signalVfsReady();
@@ -248,6 +271,7 @@ export function useFileOpening({
       setConfirmRemoveRecent,
       setPermissionPromptData,
       setShowPermissionPrompt,
+      restoreProjectTabs,
     ],
   );
 
@@ -287,7 +311,15 @@ export function useFileOpening({
         };
 
         setProjectMode(project);
-        await loadProjectContent(project);
+
+        // Restore tabs from workspace.json; fall back to loading main file
+        const restored = await restoreProjectTabs(
+          project.workspaceState.openTabs,
+          project.rootPath ?? null,
+        );
+        if (!restored) {
+          await loadProjectContent(project);
+        }
 
         const storage = getStorageService();
         await storage.addRecentProject({
@@ -303,7 +335,7 @@ export function useFileOpening({
         );
       }
     },
-    [setProjectMode, loadProjectContent],
+    [setProjectMode, loadProjectContent, restoreProjectTabs],
   );
 
   return {

--- a/lib/editor-page/use-project-initialization.ts
+++ b/lib/editor-page/use-project-initialization.ts
@@ -4,7 +4,7 @@ import { getProjectService } from "@/lib/project/project-service";
 import { getDefaultWorkspaceState } from "@/lib/project/project-types";
 import { notificationManager } from "@/lib/services/notification-manager";
 
-import type { ProjectMode } from "@/lib/project/project-types";
+import type { ProjectMode, WorkspaceTab } from "@/lib/project/project-types";
 import { readProjectJson, readFileHandle } from "./project-file-utils";
 
 interface UseProjectInitializationParams {
@@ -15,6 +15,11 @@ interface UseProjectInitializationParams {
   /** Increment editor key to force editor remount */
   incrementEditorKey: () => void;
   setProjectMode: (project: ProjectMode) => void;
+  /** Restore tabs from workspace.json data loaded during project open */
+  restoreProjectTabs: (
+    savedTabs: { tabs: WorkspaceTab[]; activeIndex: number } | undefined,
+    rootPath: string | null,
+  ) => Promise<boolean>;
 }
 
 export interface UseProjectInitializationResult {
@@ -38,6 +43,7 @@ export function useProjectInitialization({
   tabLoadSystemFile,
   incrementEditorKey,
   setProjectMode,
+  restoreProjectTabs,
 }: UseProjectInitializationParams): UseProjectInitializationResult {
   /** Load a project's main file content into the editor */
   const loadProjectContent = useCallback(
@@ -103,10 +109,13 @@ export function useProjectInitialization({
         };
 
         setProjectMode(project);
-        // Skip loading main file during auto-restore on Electron — tab persistence
-        // will restore the previously open tabs (or empty state).
-        // On Web, always load so the main file is available.
-        if (!isAutoRestoringRef.current || !isElectron) {
+
+        // Restore tabs from workspace.json; fall back to loading main file
+        const restored = await restoreProjectTabs(
+          project.workspaceState.openTabs,
+          project.rootPath ?? null,
+        );
+        if (!restored) {
           await loadProjectContent(project);
         }
       } catch (error) {
@@ -114,7 +123,7 @@ export function useProjectInitialization({
         notificationManager.error("プロジェクトを開けませんでした。");
       }
     },
-    [setProjectMode, loadProjectContent, isElectron, isAutoRestoringRef],
+    [setProjectMode, loadProjectContent, isElectron, isAutoRestoringRef, restoreProjectTabs],
   );
 
   return { loadProjectContent, openRestoredProject };

--- a/lib/editor-page/use-project-lifecycle.ts
+++ b/lib/editor-page/use-project-lifecycle.ts
@@ -4,7 +4,12 @@ import { getStorageService } from "@/lib/storage/storage-service";
 import { getProjectUpgradeService } from "@/lib/project/project-upgrade";
 import { isStandaloneMode } from "@/lib/project/project-types";
 
-import type { EditorMode, ProjectMode, StandaloneMode } from "@/lib/project/project-types";
+import type {
+  EditorMode,
+  ProjectMode,
+  StandaloneMode,
+  WorkspaceTab,
+} from "@/lib/project/project-types";
 import { useUpgradeBanner } from "./use-upgrade-banner";
 import { useRecentProjects } from "./use-recent-projects";
 import { useAutoRestore } from "./use-auto-restore";
@@ -31,6 +36,11 @@ interface UseProjectLifecycleParams {
   lastSavedTime: number | null;
   /** Called once after the VFS root has been set (or when no project to restore) */
   onVfsReady?: () => void;
+  /** Restore tabs from workspace.json data loaded during project open */
+  restoreProjectTabs: (
+    savedTabs: { tabs: WorkspaceTab[]; activeIndex: number } | undefined,
+    rootPath: string | null,
+  ) => Promise<boolean>;
 }
 
 export interface ProjectLifecycleState {
@@ -94,6 +104,7 @@ export function useProjectLifecycle(params: UseProjectLifecycleParams): UseProje
     skipAutoRestore,
     lastSavedTime,
     onVfsReady,
+    restoreProjectTabs,
   } = params;
 
   // UI state
@@ -143,6 +154,7 @@ export function useProjectLifecycle(params: UseProjectLifecycleParams): UseProje
     tabLoadSystemFile,
     incrementEditorKey,
     setProjectMode,
+    restoreProjectTabs,
   });
 
   // Permission prompt state and handlers
@@ -174,6 +186,7 @@ export function useProjectLifecycle(params: UseProjectLifecycleParams): UseProje
     openRestoredProject,
     tabLoadSystemFile,
     incrementEditorKey,
+    restoreProjectTabs,
   });
 
   // Auto-restore the last opened project on startup

--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -331,11 +331,14 @@ export class ProjectService {
     };
     await projectJsonHandle.write(JSON.stringify(updatedMetadata, null, 2));
 
-    // Update workspace.json (create: true to handle legacy projects without workspace.json)
-    const workspaceJsonHandle = await illusionsDir.getFileHandle("workspace.json", {
-      create: true,
+    // Update workspace.json via merge writer (preserves openTabs/dockviewLayout
+    // written by tab persistence — see workspace-persistence.ts).
+    const { persistWorkspaceJson } = await import("./workspace-persistence");
+    await persistWorkspaceJson({
+      editorState: project.workspaceState.editorState,
+      lastOpenedAt: project.workspaceState.lastOpenedAt,
+      viewState: project.workspaceState.viewState,
     });
-    await workspaceJsonHandle.write(JSON.stringify(project.workspaceState, null, 2));
   }
 
   /**

--- a/lib/project/project-types.ts
+++ b/lib/project/project-types.ts
@@ -44,6 +44,26 @@ export interface ProjectConfig {
   editorSettings: EditorSettings;
 }
 
+/** Serialized tab entry stored in workspace.json with project-relative paths. */
+export interface WorkspaceTab {
+  /** Path relative to project root (null for unsaved tabs) */
+  relativePath: string | null;
+  fileName: string;
+  isPreview?: boolean;
+  fileType?: SupportedFileExtension;
+}
+
+/** Simplified, ID-independent dockview layout for workspace.json persistence. */
+export interface WorkspaceDockviewLayout {
+  groups: Array<{
+    /** Stable keys: relative file paths, with `#N` suffix for same-file clones */
+    tabPaths: (string | null)[];
+    activeTabPath: string | null;
+  }>;
+  orientation: "HORIZONTAL" | "VERTICAL";
+  sizes: number[];
+}
+
 /**
  * Workspace state stored in .illusions/workspace.json.
  * エディタのカーソル位置やパネル状態など、作業状態を保持する。
@@ -62,6 +82,13 @@ export interface WorkspaceState {
     isLeftPanelCollapsed: boolean;
     isRightPanelCollapsed: boolean;
   };
+  /** Open editor tabs persisted for session restore. */
+  openTabs?: {
+    tabs: WorkspaceTab[];
+    activeIndex: number;
+  };
+  /** Dockview split layout (simplified, ID-independent). */
+  dockviewLayout?: WorkspaceDockviewLayout;
 }
 
 /**

--- a/lib/project/workspace-persistence.ts
+++ b/lib/project/workspace-persistence.ts
@@ -1,0 +1,105 @@
+/**
+ * Mutex-protected read-modify-write for .illusions/workspace.json.
+ *
+ * All writes to workspace.json MUST go through persistWorkspaceJson()
+ * to prevent TOCTOU races and partial overwrites.
+ *
+ * workspace.json への書き込みはすべて persistWorkspaceJson() を通す。
+ * TOCTOU レースコンディションと部分上書きを防止する。
+ */
+
+import { AsyncMutex } from "@/lib/utils/async-mutex";
+import { getVFS } from "@/lib/vfs";
+import { isAbsolutePath, joinPath } from "@/lib/vfs/path-utils";
+import type { WorkspaceState } from "./project-types";
+import { getDefaultWorkspaceState } from "./project-types";
+
+const workspaceMutex = new AsyncMutex();
+const WORKSPACE_JSON_PATH = ".illusions/workspace.json";
+
+/**
+ * Merge partial updates into .illusions/workspace.json atomically.
+ * Reads the current file, shallow-merges the given fields, and writes back.
+ * No-ops silently if VFS root is not set (standalone mode).
+ *
+ * @param updates - Partial workspace state fields to merge
+ */
+export async function persistWorkspaceJson(updates: Partial<WorkspaceState>): Promise<void> {
+  const release = await workspaceMutex.acquire();
+  try {
+    const vfs = getVFS();
+    // Guard: VFS root must be set (project mode)
+    if ("isReady" in vfs && typeof vfs.isReady === "function" && !vfs.isReady()) return;
+
+    let current: WorkspaceState;
+    try {
+      const text = await vfs.readFile(WORKSPACE_JSON_PATH);
+      current = JSON.parse(text) as WorkspaceState;
+    } catch {
+      current = getDefaultWorkspaceState();
+    }
+    const merged: WorkspaceState = { ...current, ...updates };
+    await vfs.writeFile(WORKSPACE_JSON_PATH, JSON.stringify(merged, null, 2));
+  } catch {
+    // Non-fatal: workspace.json write failure should not crash the app
+  } finally {
+    release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an absolute file path to a project-relative path.
+ * Returns null if the path is outside the project root.
+ *
+ * Handles:
+ * - Unix absolute paths (/Users/x/project/file.mdi)
+ * - Windows drive paths (C:\Users\x\project\file.mdi)
+ * - Already-relative paths (returned as-is)
+ * - Separator normalization (backslash → forward slash)
+ *
+ * @param absolutePath - The file path to convert
+ * @param rootPath - Project root path (null for Web mode where paths are already relative)
+ */
+export function toRelativePath(absolutePath: string, rootPath: string | null): string | null {
+  if (!rootPath) {
+    // Web mode: paths are already relative
+    return absolutePath;
+  }
+  // Normalize separators
+  const normalizedPath = absolutePath.replace(/\\/g, "/");
+  const normalizedRoot = rootPath.replace(/\\/g, "/").replace(/\/+$/, "");
+
+  if (!isAbsolutePath(normalizedPath)) {
+    // Already relative
+    return normalizedPath;
+  }
+
+  // Case-insensitive prefix check on Windows (drive letters)
+  const pathLower = normalizedPath.toLowerCase();
+  const rootLower = normalizedRoot.toLowerCase();
+
+  if (!pathLower.startsWith(rootLower + "/") && pathLower !== rootLower) {
+    // Path is outside the project root
+    return null;
+  }
+
+  return normalizedPath.slice(normalizedRoot.length + 1);
+}
+
+/**
+ * Convert a project-relative path to an absolute path.
+ *
+ * @param relativePath - Path relative to project root
+ * @param rootPath - Project root path (null for Web mode)
+ */
+export function toAbsolutePath(relativePath: string, rootPath: string | null): string {
+  if (!rootPath) {
+    // Web mode: paths stay relative
+    return relativePath;
+  }
+  return joinPath(rootPath, relativePath);
+}

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -137,7 +137,11 @@ export function useTabManager(options?: {
 
   // --- Tab persistence (save/restore to AppState) -------------------------
 
-  const { wasAutoRecovered, flushTabState: _flushTabState } = useTabPersistence({
+  const {
+    wasAutoRecovered,
+    flushTabState: _flushTabState,
+    restoreProjectTabs,
+  } = useTabPersistence({
     tabs: tabState.tabs,
     setTabs: tabState.setTabs,
     activeTabId: tabState.activeTabId,
@@ -211,5 +215,8 @@ export function useTabManager(options?: {
 
     // Persistence flush
     flushTabState: _flushTabState,
+
+    // Project tab restore
+    restoreProjectTabs,
   };
 }

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -2,7 +2,7 @@
 
 import type { MutableRefObject, Dispatch, SetStateAction } from "react";
 import type { MdiFileDescriptor } from "../project/mdi-file";
-import type { SupportedFileExtension } from "../project/project-types";
+import type { SupportedFileExtension, WorkspaceTab } from "../project/project-types";
 import type { TabId, TabState, EditorTabState, TerminalTabState } from "./tab-types";
 
 // ---------------------------------------------------------------------------
@@ -79,6 +79,15 @@ export interface UseTabManagerReturn {
   // Persistence flush (for save-before-close)
   /** Immediately flush pending tab state to storage. */
   flushTabState: () => Promise<void>;
+
+  /**
+   * Restore tabs from workspace.json data (already loaded during project open).
+   * Returns true if any tabs were restored.
+   */
+  restoreProjectTabs: (
+    savedTabs: { tabs: WorkspaceTab[]; activeIndex: number } | undefined,
+    rootPath: string | null,
+  ) => Promise<boolean>;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -9,6 +9,12 @@ import { isEditorTab } from "./tab-types";
 import type { TabManagerCore } from "./types";
 import { TAB_PERSIST_DEBOUNCE, createNewTab, generateTabId, inferFileType } from "./types";
 import { getVFS } from "../vfs";
+import type { WorkspaceTab } from "../project/project-types";
+import {
+  persistWorkspaceJson,
+  toRelativePath,
+  toAbsolutePath,
+} from "../project/workspace-persistence";
 
 // ---------------------------------------------------------------------------
 // Params
@@ -47,6 +53,21 @@ export interface UseTabPersistenceReturn {
   wasAutoRecovered: boolean;
   /** Immediately flush pending tab state to storage (cancels debounce). */
   flushTabState: () => Promise<void>;
+  /**
+   * Restore tabs from workspace.json data that was already loaded during project open.
+   * Called explicitly by project-open handlers — replaces the mount-time restore for
+   * project mode. Returns true if any tabs were restored.
+   *
+   * プロジェクトオープン時に読み込み済みの workspace.json データからタブを復元する。
+   * プロジェクトモードではマウント時復元の代わりにこの関数を明示的に呼ぶ。
+   *
+   * @param savedTabs - The openTabs data from WorkspaceState (may be undefined)
+   * @param rootPath  - Project root path for converting relative → absolute paths (null for Web)
+   */
+  restoreProjectTabs: (
+    savedTabs: { tabs: WorkspaceTab[]; activeIndex: number } | undefined,
+    rootPath: string | null,
+  ) => Promise<boolean>;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,12 +76,13 @@ export interface UseTabPersistenceReturn {
 
 /**
  * Handles two responsibilities:
- * 1. Persist open tabs to AppState (debounced, Electron only).
- * 2. Restore tabs from AppState / storage on mount.
+ * 1. Persist open tabs to workspace.json (project mode) or AppState (standalone).
+ * 2. Restore tabs from workspace.json (explicit, via restoreProjectTabs) or
+ *    AppState/storage on mount (standalone mode only).
  *
- * Coordinates with useTabState which starts with an empty tabs array.
- * This hook is responsible for populating the first tab after determining
- * the correct initial state (saved tabs, Web buffer restore, or a blank default).
+ * In project mode, the mount-time Electron restore is REPLACED by explicit
+ * restoreProjectTabs() calls from project-open handlers. This eliminates
+ * the race condition where windowKey was null during mount-time restore.
  */
 export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersistenceReturn {
   const {
@@ -70,6 +92,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     setActiveTabId,
     tabsRef,
     activeTabIdRef,
+    isProjectRef,
     isElectron,
     skipAutoRestore,
     vfsReadyPromise,
@@ -89,7 +112,11 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
   // before the async restore path (which may wait on vfsReadyPromise) runs.
   const storageInitializedRef = useRef(false);
 
-  // --- Persist open tabs to AppState (debounced) --------------------------
+  // Tracks whether restoreProjectTabs was called (prevents mount-time
+  // restore from running redundantly when a project is being auto-restored).
+  const projectTabsRestoredRef = useRef(false);
+
+  // --- Persist open tabs (debounced) -------------------------------------
 
   const tabPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -98,13 +125,33 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     const currentTabs = tabsRef.current;
     const currentActiveId = activeTabIdRef.current;
     const editorTabs = currentTabs.filter(isEditorTab);
+    const activeEditorIndex = editorTabs.findIndex((t) => t.id === currentActiveId);
+
+    // --- Project mode: write to workspace.json ---
+    if (isProjectRef.current) {
+      const rootPath = windowKeyRef.current; // rootPath for Electron, null for Web
+      const workspaceTabs: WorkspaceTab[] = editorTabs.map((t) => ({
+        relativePath: t.file?.path ? toRelativePath(t.file.path, rootPath) : null,
+        fileName: t.file?.name ?? "新規ファイル",
+        isPreview: t.isPreview || undefined,
+        fileType: t.fileType,
+      }));
+      await persistWorkspaceJson({
+        openTabs: {
+          tabs: workspaceTabs,
+          activeIndex: Math.max(0, activeEditorIndex),
+        },
+      });
+      return;
+    }
+
+    // --- Standalone mode: write to SQLite / global AppState ---
     const serializedTabs: SerializedTab[] = editorTabs.map((t) => ({
       filePath: t.file?.path ?? null,
       fileName: t.file?.name ?? "新規ファイル",
       isPreview: t.isPreview || undefined,
       fileType: t.fileType,
     }));
-    const activeEditorIndex = editorTabs.findIndex((t) => t.id === currentActiveId);
     const state: TabPersistenceState = {
       tabs: serializedTabs,
       activeIndex: Math.max(0, activeEditorIndex),
@@ -112,19 +159,11 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     const key = windowKeyRef.current;
     if (key) {
       await persistWindowState(key, { openTabs: state });
-    }
-    // Always also write to global AppState as a single-window fallback and for
-    // tools (e.g. crash-recovery) that still read from there.
-    // NOTE: We intentionally do NOT import/call persistAppState here to avoid a
-    // circular-import risk; the global write is handled by the dockview persistence
-    // path which also writes the combined state. For the tab-only path, we just
-    // use the per-window store when a key is available, and still write global when
-    // no key is set (legacy / web mode).
-    if (!key) {
+    } else {
       const { persistAppState } = await import("../storage/app-state-manager");
       await persistAppState({ openTabs: state });
     }
-  }, [tabsRef, activeTabIdRef]);
+  }, [tabsRef, activeTabIdRef, isProjectRef]);
 
   /** Flush pending tab state: cancel debounce and persist immediately. */
   const flushTabState = useCallback(async () => {
@@ -137,9 +176,6 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
 
   useEffect(() => {
     // Skip persisting empty state until after storage has been initialized.
-    // This prevents a race on Electron where the 1s debounce fires before
-    // restoreTabs finishes awaiting vfsReadyPromise (up to 5s), which would
-    // overwrite the saved tabs with [] and cause a blank editor on next open.
     if (!storageInitializedRef.current && tabs.length === 0) return;
 
     if (tabPersistTimerRef.current) {
@@ -167,11 +203,74 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     };
   }, [flushTabState]);
 
+  // --- restoreProjectTabs (explicit, called by project-open handlers) ----
+
+  const restoreProjectTabs = useCallback(
+    async (
+      savedTabs: { tabs: WorkspaceTab[]; activeIndex: number } | undefined,
+      rootPath: string | null,
+    ): Promise<boolean> => {
+      projectTabsRestoredRef.current = true;
+
+      if (!savedTabs || savedTabs.tabs.length === 0) return false;
+
+      const restoredTabs: EditorTabState[] = [];
+      for (const saved of savedTabs.tabs) {
+        if (!saved.relativePath) {
+          // Unsaved tab — restore as blank
+          restoredTabs.push(createNewTab(undefined, saved.fileType ?? ".mdi"));
+          continue;
+        }
+        try {
+          const absolutePath = toAbsolutePath(saved.relativePath, rootPath);
+          const vfs = getVFS();
+          const fileContent = await vfs.readFile(absolutePath);
+          restoredTabs.push({
+            tabKind: "editor",
+            id: generateTabId(),
+            file: {
+              path: absolutePath,
+              handle: null,
+              name: saved.fileName,
+            },
+            content: fileContent,
+            lastSavedContent: fileContent,
+            isDirty: false,
+            lastSavedTime: Date.now(),
+            lastSaveWasAuto: false,
+            isSaving: false,
+            isPreview: saved.isPreview ?? false,
+            fileType: saved.fileType ?? inferFileType(saved.fileName),
+            fileSyncStatus: "clean",
+            conflictDiskContent: null,
+          });
+        } catch (error) {
+          console.warn(`タブの復元に失敗しました (${saved.relativePath}):`, error);
+        }
+      }
+
+      if (restoredTabs.length > 0) {
+        setTabs(restoredTabs);
+        const activeIdx = Math.min(savedTabs.activeIndex, restoredTabs.length - 1);
+        setActiveTabId(restoredTabs[Math.max(0, activeIdx)].id);
+        storageInitializedRef.current = true;
+        return true;
+      }
+
+      // All file-backed tabs failed to restore
+      const hadFileBacked = savedTabs.tabs.some((t) => Boolean(t.relativePath));
+      if (hadFileBacked) {
+        setRestoreError?.(
+          "前回開いていたファイルを復元できませんでした。ファイルが移動または削除された可能性があります。",
+        );
+      }
+      storageInitializedRef.current = true;
+      return false;
+    },
+    [setTabs, setActiveTabId, setRestoreError],
+  );
+
   // --- Storage initialization & Web file restore --------------------------
-  //
-  // This effect always ensures at least one tab exists after storage loads.
-  // For Electron, restoreTabs (below) may override the tab set here when
-  // file-backed saved tabs are found.
 
   useEffect(() => {
     const initializeStorage = async () => {
@@ -179,26 +278,16 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
         const storage = getStorageService();
         await storage.initialize();
 
-        // Use per-window storage when a key is available.
-        // For Web, the key may not yet be set on first mount; fall back to global.
         const key = windowKeyRef.current;
         const windowState = key ? await fetchWindowState(key) : null;
         const appState = windowState ? null : await storage.loadAppState();
 
-        // Check if we have previously saved tab state
         const savedOpenTabs = windowState?.openTabs ?? appState?.openTabs;
-
-        // If saved state explicitly has 0 tabs, restore empty state — no tab needed.
         const savedEmpty = savedOpenTabs && savedOpenTabs.tabs.length === 0;
 
-        // Determine the initial tab using a local variable to make the
-        // fallback logic explicit and avoid multiple setTabs calls.
         let initialTab: EditorTabState | null = null;
 
         if (!skipAutoRestore && !isElectron && !savedEmpty) {
-          // Web: restore file handle from editor buffer.
-          // Look up the file key this tab last saved with to avoid loading
-          // another tab's buffer (cross-tab collision fix for #1064).
           const lastFileKey = await storage.getItem("last_editor_buffer_key");
           const buffer = await storage.loadEditorBuffer(lastFileKey ?? undefined);
           if (buffer?.fileHandle) {
@@ -228,31 +317,21 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
           }
         }
 
-        // Fallback: create a default blank tab when no restore path fired.
-        // Skip if saved state was explicitly empty (user closed all tabs).
-        // For Electron (non-skipAutoRestore), restoreTabs handles the case where
-        // file-backed tabs were previously saved; skip creating a fallback here
-        // to avoid a visible flash before restoreTabs completes.
         if (!initialTab && !savedEmpty && (!isElectron || skipAutoRestore)) {
           initialTab = createNewTab();
         }
 
         if (initialTab) {
           const tab = initialTab;
-          // Use functional updates so a concurrently-running restoreTabs (Electron)
-          // that already set tabs is not overridden.
           setTabs((prev) => (prev.length > 0 ? prev : [tab]));
           setActiveTabId((prev) => (prev === "" ? tab.id : prev));
         }
       } catch (error) {
         console.error("ストレージの初期化に失敗しました:", error);
-        // Ensure at least one tab even on storage error
         const errorTab = createNewTab();
         setTabs((prev) => (prev.length > 0 ? prev : [errorTab]));
         setActiveTabId((prev) => (prev === "" ? errorTab.id : prev));
       } finally {
-        // For Web (and Electron with skipAutoRestore), restore is complete here.
-        // Electron's restoreTabs sets this flag after vfsReadyPromise resolves.
         if (!isElectron || skipAutoRestore) {
           storageInitializedRef.current = true;
         }
@@ -262,9 +341,10 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     void initializeStorage();
   }, [isElectron, skipAutoRestore, setTabs, setActiveTabId]);
 
-  // --- Restore tabs from AppState on mount (Electron only) ----------------
-  // Wait for VFS root to be set so that the main process has a registered
-  // allowed root before we attempt vfs:read-file IPC calls.
+  // --- Standalone-mode restore from AppState (Electron only) -------------
+  // This ONLY handles standalone mode (no project). In project mode,
+  // restoreProjectTabs() is called explicitly by the project-open handler,
+  // replacing the old mount-time restore that had a race condition with windowKey.
 
   useEffect(() => {
     if (!isElectron || skipAutoRestore) return;
@@ -272,26 +352,27 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
 
     const restoreTabs = async () => {
       try {
-        // Wait for VFS root to be set before reading files (prevents race condition)
         if (vfsReadyPromise) {
           await Promise.race([vfsReadyPromise, new Promise<void>((r) => setTimeout(r, 5000))]);
         }
 
-        // Use per-window storage when a key is available; fall back to global
-        // AppState for legacy sessions (migration handled inside fetchWindowState).
+        // If project tabs were explicitly restored (via restoreProjectTabs),
+        // this mount-time path is redundant — skip to prevent double-restore.
+        if (projectTabsRestoredRef.current) {
+          storageInitializedRef.current = true;
+          return;
+        }
+
+        // Standalone mode: restore from global AppState / per-window SQLite
         const key = windowKeyRef.current;
         const windowState = await fetchWindowState(key ?? "__global__");
         const openTabs = windowState?.openTabs;
-        // No saved state at all: first use — initializeStorage handles default tab.
         if (!openTabs) return;
-
-        // Saved state is explicitly empty (user closed all tabs last session).
         if (openTabs.tabs.length === 0) return;
 
         const restoredTabs: EditorTabState[] = [];
         for (const serialized of openTabs.tabs) {
           if (!serialized.filePath) {
-            // Restore unsaved (new) tabs as blank tabs so they are not silently dropped.
             restoredTabs.push(createNewTab(undefined, serialized.fileType ?? ".mdi"));
             continue;
           }
@@ -327,19 +408,13 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
           const activeIdx = Math.min(openTabs.activeIndex, restoredTabs.length - 1);
           setActiveTabId(restoredTabs[activeIdx].id);
         } else {
-          // Check whether any of the saved tabs had a file path.
           const hadFileBacked = openTabs.tabs.some((t) => Boolean(t.filePath));
           if (hadFileBacked) {
-            // All file-backed tabs failed to restore — do NOT create a blank
-            // default tab, as that would overwrite the saved session on the
-            // next debounced persist. Surface an error instead so the UI can
-            // inform the user.
             setRestoreError?.(
               "前回開いていたファイルを復元できませんでした。ファイルが移動または削除された可能性があります。",
             );
             return;
           }
-          // Saved tabs were all untitled (no file path) — create a default tab.
           const defaultTab = createNewTab();
           setTabs((prev) => (prev.length > 0 ? prev : [defaultTab]));
           setActiveTabId((prev) => (prev === "" ? defaultTab.id : prev));
@@ -347,7 +422,6 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
       } catch (error) {
         console.error("タブの復元に失敗しました:", error);
       } finally {
-        // Allow tab persistence after Electron restore completes (or errors).
         storageInitializedRef.current = true;
       }
     };
@@ -355,5 +429,5 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     void restoreTabs();
   }, [isElectron, skipAutoRestore, setTabs, setActiveTabId, vfsReadyPromise, setRestoreError]);
 
-  return { wasAutoRecovered, flushTabState };
+  return { wasAutoRecovered, flushTabState, restoreProjectTabs };
 }


### PR DESCRIPTION
## Summary

- プロジェクトを開く際に、前回のタブ状態とdockview分割レイアウトを `.illusions/workspace.json` から復元するようにした
- プロジェクト単位でタブ/レイアウト状態を保持し、アプリ再起動後も復元可能に
- `signalVfsReady()` と `setProjectMode()` の競合状態を、明示的なライフサイクルバインド復元で解消

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `lib/project/project-types.ts` | `WorkspaceState` に `openTabs` + `dockviewLayout` フィールドを追加 |
| `lib/project/workspace-persistence.ts` | **新規** — mutex付き workspace.json マージライター + パスヘルパー |
| `lib/project/project-service.ts` | `saveProject()` をマージライターに変更（タブ/レイアウトデータを保持） |
| `lib/tab-manager/use-tab-persistence.ts` | プロジェクトモード時 workspace.json に書込み + `restoreProjectTabs` 公開 |
| `lib/tab-manager/index.ts` / `types.ts` | `restoreProjectTabs` をインターフェースに追加 |
| `lib/editor-page/use-file-opening.ts` | 全プロジェクトオープンパスで `restoreProjectTabs` 呼出し |
| `lib/editor-page/use-project-lifecycle.ts` | `restoreProjectTabs` パラメータをスレッド |
| `lib/editor-page/use-project-initialization.ts` | Web復元パスで `restoreProjectTabs` 使用 |
| `lib/dockview/use-dockview-persistence.ts` | プロジェクトモード時 workspace.json にレイアウト保存 |
| `lib/dockview/use-dockview-adapter.ts` | `projectLayout` prop + windowKey変更時リセット |
| `app/page.tsx` | `restoreProjectTabs` + `projectLayout` 接続 |

## Test plan

- [ ] プロジェクトを開く → 複数ファイルをタブで開く → dockviewペインを分割 → アプリを閉じる
- [ ] アプリを再起動 → タブと分割レイアウトが復元されることを確認
- [ ] `.illusions/workspace.json` を確認 → `openTabs`（相対パス）と `dockviewLayout` が存在すること
- [ ] 別のプロジェクトを開く → そのプロジェクト固有のタブが復元されること（前のプロジェクトのタブではない）
- [ ] 初めて開くプロジェクト → メインファイルがデフォルトで読み込まれること
- [ ] スタンドアロンモード（プロジェクトなし） → 既存のSQLiteタブ永続化が機能すること
- [ ] `npx tsc --noEmit` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)