### PR TITLE
refactor(dict): rename illusionsDict to Genji

### DIFF
--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -126,7 +126,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   // Check master dict status on mount
   useEffect(() => {
     getDictService()
-      .getDownloadState("illusions-dict")
+      .getDownloadState("genji")
       .then((state) => setMasterStatus(state.status))
       .catch(() => {});
   }, []);

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -3,7 +3,7 @@
  * DictManager — Electron main process dictionary manager.
  *
  * Responsibilities:
- *  - Open and cache the illusionsDict SQLite database
+ *  - Open and cache the Genji SQLite database
  *  - Ensure indexes exist for fast prefix search
  *  - Query entries and definitions
  *  - Check for updates via GitHub Releases API
@@ -17,12 +17,12 @@ const https = require("https");
 const zlib = require("zlib");
 const { app } = require("electron");
 
-const PROVIDER_ID = "illusions-dict";
+const PROVIDER_ID = "genji";
 const GITHUB_OWNER = "Iktahana";
-const GITHUB_REPO = "illusionsDict-Word-Database";
-const DB_FILENAME = "illusions_dict.db";
-const DB_TEMP_FILENAME = "illusions_dict.db.tmp";
-const VERSION_FILENAME = "illusions_dict_version.txt";
+const GITHUB_REPO = "Genji";
+const DB_FILENAME = "genji.db";
+const DB_TEMP_FILENAME = "genji.db.tmp";
+const VERSION_FILENAME = "genji_version.txt";
 
 // ---------------------------------------------------------------------------
 // Simple promise-chain mutex (main-process, no module import needed)

--- a/lib/dict/dict-service.ts
+++ b/lib/dict/dict-service.ts
@@ -7,7 +7,7 @@
  *   const results = await getDictService().query("雪");
  */
 import type { IDictProvider, DictEntry, DictQueryResult, DictDownloadState } from "./dict-types";
-import { IllusionsDictProvider } from "./providers/illusions-dict-provider";
+import { GenjiProvider } from "./providers/genji-provider";
 
 // Deduplication key: (entry, reading.primary) — preserves homonyms that share
 // a surface form but differ in reading.
@@ -134,8 +134,8 @@ let _instance: DictService | null = null;
 export function getDictService(): DictService {
   if (!_instance) {
     _instance = new DictService();
-    // Auto-register the built-in illusionsDict provider
-    _instance.registerProvider(new IllusionsDictProvider());
+    // Auto-register the built-in Genji provider
+    _instance.registerProvider(new GenjiProvider());
   }
   return _instance;
 }

--- a/lib/dict/dict-types.ts
+++ b/lib/dict/dict-types.ts
@@ -1,6 +1,6 @@
 /**
  * Master dictionary types — provider-agnostic interfaces.
- * All dictionary providers (illusionsDict, future sources) must conform to these types.
+ * All dictionary providers (Genji, future sources) must conform to these types.
  */
 
 // ---------------------------------------------------------------------------
@@ -46,7 +46,7 @@ export interface DictEntry {
 // ---------------------------------------------------------------------------
 
 export interface IDictProvider {
-  /** Stable identifier used to tag results (e.g. "illusions-dict") */
+  /** Stable identifier used to tag results (e.g. "genji") */
   readonly id: string;
   /** Human-readable name shown in UI */
   readonly displayName: string;

--- a/lib/dict/providers/genji-provider.ts
+++ b/lib/dict/providers/genji-provider.ts
@@ -1,13 +1,13 @@
 /**
- * IllusionsDictProvider
+ * GenjiProvider
  *
  * Electron: delegates queries to the main process via IPC (window.electronAPI.dict).
  * Web: returns stub results with webApiPending flag until a real API is available.
  */
 import type { IDictProvider, DictEntry } from "../dict-types";
 
-const PROVIDER_ID = "illusions-dict";
-const DISPLAY_NAME = "illusions辞典";
+const PROVIDER_ID = "genji";
+const DISPLAY_NAME = "幻辞";
 const DEFAULT_LIMIT = 20;
 
 function isElectronDict(): boolean {
@@ -33,7 +33,7 @@ function getElectronDictAPI() {
   return api;
 }
 
-export class IllusionsDictProvider implements IDictProvider {
+export class GenjiProvider implements IDictProvider {
   readonly id = PROVIDER_ID;
   readonly displayName = DISPLAY_NAME;
 
@@ -52,7 +52,7 @@ export class IllusionsDictProvider implements IDictProvider {
     try {
       return await getElectronDictAPI().query(term, limit);
     } catch (err) {
-      console.error(`[IllusionsDictProvider] query failed:`, err);
+      console.error(`[GenjiProvider] query failed:`, err);
       return [];
     }
   }
@@ -62,7 +62,7 @@ export class IllusionsDictProvider implements IDictProvider {
     try {
       return await getElectronDictAPI().queryByReading(reading, limit);
     } catch (err) {
-      console.error(`[IllusionsDictProvider] queryByReading failed:`, err);
+      console.error(`[GenjiProvider] queryByReading failed:`, err);
       return [];
     }
   }

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -263,7 +263,7 @@ declare global {
       /** Remove all editor sync listeners */
       removeAllListeners: () => void;
     };
-    /** Master dictionary IPC (illusionsDict and future providers) */
+    /** Master dictionary IPC (Genji and future providers) */
     dict?: {
       /** Query entries by headword (exact or prefix match) */
       query: (term: string, limit?: number) => Promise<DictEntry[]>;


### PR DESCRIPTION
## Summary

- 辞典データベースのリポジトリ名変更に伴い、プロジェクト内の全参照を統一的にリネーム
- `illusionsDict` / `IllusionsDict` / `illusions_dict` / `illusions-dict` → `Genji` / `genji`

## Changes

| File | Change |
|------|--------|
| `electron/dict-manager.js` | PROVIDER_ID, GITHUB_REPO, DB ファイル名、コメント |
| `lib/dict/providers/illusions-dict-provider.ts` → `genji-provider.ts` | ファイルリネーム、クラス名 `GenjiProvider`、表示名「幻辞」 |
| `lib/dict/dict-service.ts` | import パスとクラス名 |
| `lib/dict/dict-types.ts` | コメント |
| `types/electron.d.ts` | コメント |
| `components/Dictionary.tsx` | Provider ID 文字列 |

**保持不変:** 「幻辞」表示名、`dict.illusions.app` / `dict-api.illusions.app` ドメイン

## Test plan

- [ ] `npx tsc --noEmit` — TypeScript コンパイルエラーなし
- [ ] Electron ビルドで辞典ダウンロード・検索が正常動作
- [ ] GitHub Releases API が `Iktahana/Genji` から正しく取得可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)