### PR TITLE
feat(dict): integrate Genji API as remote dictionary backend

### DIFF
--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -20,7 +20,7 @@ import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
 import { getUserDictionaryService } from "@/lib/services/user-dictionary-service";
 import DictionaryEntryDialog from "./Dictionary/DictionaryEntryDialog";
 import { getDictService } from "@/lib/dict/dict-service";
-import type { DictEntry, DictDownloadStatus } from "@/lib/dict/dict-types";
+import type { DictEntry } from "@/lib/dict/dict-types";
 
 // Web dictionary sources
 interface WebDictionarySource {
@@ -83,7 +83,9 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   // Master dict state
   const [masterResults, setMasterResults] = useState<DictEntry[]>([]);
   const [masterLoading, setMasterLoading] = useState(false);
-  const [masterStatus, setMasterStatus] = useState<DictDownloadStatus>("not-installed");
+  const [localInstallStatus, setLocalInstallStatus] = useState<
+    "not-installed" | "downloading" | "installing" | "installed" | "error"
+  >("not-installed");
   const [expandedMasterId, setExpandedMasterId] = useState<string | null>(null);
 
   // Persistence
@@ -123,11 +125,12 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
     void loadEntries();
   }, [loadEntries]);
 
-  // Check master dict status on mount
+  // Check local install status on mount (Electron only)
   useEffect(() => {
+    if (!isElectron()) return;
     getDictService()
       .getDownloadState("genji")
-      .then((state) => setMasterStatus(state.status))
+      .then((state) => setLocalInstallStatus(state.status))
       .catch(() => {});
   }, []);
 
@@ -151,9 +154,6 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
       .query(activeSearchQuery.trim())
       .then((result) => {
         setMasterResults(result.entries);
-        if (result.providerUnavailable && !result.webApiPending) {
-          setMasterStatus("not-installed");
-        }
       })
       .catch(() => setMasterResults([]))
       .finally(() => setMasterLoading(false));
@@ -260,14 +260,14 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
     ).electronAPI?.dict;
     if (!api) return;
 
-    setMasterStatus("downloading");
+    setLocalInstallStatus("downloading");
     void api
       .download()
       .then((result) => {
-        setMasterStatus(result.success ? "installed" : "error");
+        setLocalInstallStatus(result.success ? "installed" : "error");
       })
       .catch(() => {
-        setMasterStatus("error");
+        setLocalInstallStatus("error");
       });
   }, []);
 
@@ -497,7 +497,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                   )}
 
                   {/* Not installed banner (Electron only) */}
-                  {!masterLoading && masterStatus === "not-installed" && isElectron() && (
+                  {!masterLoading && localInstallStatus === "not-installed" && isElectron() && (
                     <div className="bg-background-elevated border border-border rounded-lg p-3 flex items-center justify-between gap-3">
                       <span className="text-sm text-foreground-secondary">
                         辞典データ未インストール
@@ -513,7 +513,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                   )}
 
                   {/* Downloading indicator */}
-                  {masterStatus === "downloading" && (
+                  {localInstallStatus === "downloading" && (
                     <div className="flex items-center gap-2 text-sm text-foreground-secondary">
                       <Loader2 className="w-4 h-4 animate-spin" />
                       ダウンロード中...
@@ -524,7 +524,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                   {!masterLoading && masterResults.length > 0 && (
                     <div className="space-y-2">
                       <div className="text-xs font-semibold text-foreground-tertiary">
-                        illusions辞典 ({masterResults.length} 件)
+                        幻辞 ({masterResults.length} 件)
                       </div>
                       {masterResults.map((entry) => (
                         <MasterDictCard
@@ -538,7 +538,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                   )}
 
                   {/* No results */}
-                  {!masterLoading && masterResults.length === 0 && masterStatus === "installed" && (
+                  {!masterLoading && masterResults.length === 0 && activeSearchQuery.trim() && (
                     <p className="text-sm text-foreground-secondary">
                       「{activeSearchQuery}」の辞典結果なし
                     </p>

--- a/components/settings/DictSettingsTab.tsx
+++ b/components/settings/DictSettingsTab.tsx
@@ -237,7 +237,8 @@ export default function DictSettingsTab() {
 
         {!isElectron() && (
           <p className="text-xs text-foreground-tertiary">
-            辞典データはデスクトップ版でのみ利用できます。
+            Web版ではオンライン辞典（Genji API）を使用しています。
+            ローカル辞典のダウンロードはデスクトップ版でのみ利用できます。
           </p>
         )}
       </div>

--- a/lib/dict/dict-service.ts
+++ b/lib/dict/dict-service.ts
@@ -46,29 +46,20 @@ class DictService {
       this.providers.map(async (p) => {
         const available = await p.isAvailable();
         if (!available) {
-          const isWeb =
-            typeof window !== "undefined" &&
-            !(window as Window & { electronAPI?: unknown }).electronAPI;
-          return {
-            entries: [] as DictEntry[],
-            available: false,
-            webApiPending: isWeb,
-          };
+          return { entries: [] as DictEntry[], available: false };
         }
         const entries = await p.query(term, limit);
-        return { entries, available: true, webApiPending: false };
+        return { entries, available: true };
       }),
     );
 
     const allEntries = dedup(results.flatMap((r) => r.entries));
     const anyAvailable = results.some((r) => r.available);
-    const webApiPending = results.some((r) => r.webApiPending);
 
     return {
       entries: allEntries,
       noResults: anyAvailable && allEntries.length === 0,
       providerUnavailable: !anyAvailable,
-      webApiPending: webApiPending || undefined,
     };
   }
 

--- a/lib/dict/dict-types.ts
+++ b/lib/dict/dict-types.ts
@@ -101,6 +101,4 @@ export interface DictQueryResult {
   noResults: boolean;
   /** True when the provider is not installed / not available */
   providerUnavailable: boolean;
-  /** True when running in web environment where the API is not yet available */
-  webApiPending?: boolean;
 }

--- a/lib/dict/providers/__tests__/genji-api-backend.test.ts
+++ b/lib/dict/providers/__tests__/genji-api-backend.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mapRawJsonToDictEntry, queryByEntry, queryByReading } from "../genji-api-backend";
+
+// ---------------------------------------------------------------------------
+// Sample raw_json fixture
+// ---------------------------------------------------------------------------
+
+const SAMPLE_RAW = {
+  uuid: "dde85894-4cca-592d-bdfe-c1c7789e4e18",
+  entry: "雪",
+  reading: {
+    primary: "ゆき",
+    alternatives: ["せつ"],
+    is_heteronym: false,
+  },
+  grammar: {
+    pos: ["名詞"],
+    ctype: null,
+    inflections: null,
+  },
+  definitions: [
+    {
+      index: 1,
+      gloss: "snow",
+      register: "standard",
+      nuance: null,
+      collocations: ["積雪", "降雪"],
+      examples: {
+        standard: [
+          { text: "雪が降る。", source: "幻辞" },
+          { text: "雪の日。", source: "幻辞" },
+        ],
+        literary: [
+          {
+            text: "記憶は雪のふるやうなもの",
+            citation: { source: "記憶", author: "萩原朔太郎", note: "青空文庫" },
+          },
+        ],
+      },
+    },
+    {
+      index: 2,
+      gloss: "something white",
+      register: "literary",
+      nuance: "poetic usage",
+      collocations: [],
+      examples: { standard: [], literary: [] },
+    },
+  ],
+  relations: {
+    homophones: ["行き"],
+    synonyms: [],
+    antonyms: [],
+    related: ["吹雪", "雪崩"],
+  },
+  meta: {
+    version: "1.0.0",
+    source: "JMdict",
+    updated_at: "2026-04-05T00:00:00Z",
+    freq_rank: 1675,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// mapRawJsonToDictEntry
+// ---------------------------------------------------------------------------
+
+describe("mapRawJsonToDictEntry", () => {
+  it("maps core fields correctly", () => {
+    const entry = mapRawJsonToDictEntry(SAMPLE_RAW);
+
+    expect(entry.id).toBe("dde85894-4cca-592d-bdfe-c1c7789e4e18");
+    expect(entry.entry).toBe("雪");
+    expect(entry.source).toBe("genji");
+    expect(entry.reading.primary).toBe("ゆき");
+    expect(entry.reading.alternatives).toEqual(["せつ"]);
+    expect(entry.partOfSpeech).toBe("名詞");
+    expect(entry.inflections).toBeUndefined();
+  });
+
+  it("flattens examples from standard + literary", () => {
+    const entry = mapRawJsonToDictEntry(SAMPLE_RAW);
+
+    expect(entry.definitions[0].examples).toEqual([
+      "雪が降る。",
+      "雪の日。",
+      "記憶は雪のふるやうなもの",
+    ]);
+  });
+
+  it("maps multiple definitions", () => {
+    const entry = mapRawJsonToDictEntry(SAMPLE_RAW);
+
+    expect(entry.definitions).toHaveLength(2);
+    expect(entry.definitions[0].gloss).toBe("snow");
+    expect(entry.definitions[0].register).toBe("standard");
+    expect(entry.definitions[0].collocations).toEqual(["積雪", "降雪"]);
+    expect(entry.definitions[1].gloss).toBe("something white");
+    expect(entry.definitions[1].nuance).toBe("poetic usage");
+  });
+
+  it("maps relationships", () => {
+    const entry = mapRawJsonToDictEntry(SAMPLE_RAW);
+
+    expect(entry.relationships.homophones).toEqual(["行き"]);
+    expect(entry.relationships.related).toEqual(["吹雪", "雪崩"]);
+  });
+
+  it("handles null/missing optional fields gracefully", () => {
+    const minimal = {
+      uuid: "abc-123",
+      entry: "テスト",
+      reading: { primary: "てすと", alternatives: [] },
+      grammar: { pos: null, ctype: null, inflections: null },
+      definitions: [],
+      relations: { homophones: [], synonyms: [], antonyms: [], related: [] },
+    };
+
+    const entry = mapRawJsonToDictEntry(minimal);
+
+    expect(entry.partOfSpeech).toBeUndefined();
+    expect(entry.inflections).toBeUndefined();
+    expect(entry.definitions).toEqual([]);
+  });
+
+  it("joins multiple pos with ・", () => {
+    const raw = {
+      ...SAMPLE_RAW,
+      grammar: { pos: ["名詞", "副詞"], ctype: null, inflections: null },
+    };
+    const entry = mapRawJsonToDictEntry(raw);
+    expect(entry.partOfSpeech).toBe("名詞・副詞");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queryByEntry / queryByReading (mock fetch)
+// ---------------------------------------------------------------------------
+
+describe("queryByEntry", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("returns mapped DictEntry[] on success", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ rows: [{ raw_json: JSON.stringify(SAMPLE_RAW) }] }),
+    });
+
+    const results = await queryByEntry("雪", 20);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].entry).toBe("雪");
+    expect(results[0].definitions[0].gloss).toBe("snow");
+  });
+
+  it("returns [] on network error", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+
+    const results = await queryByEntry("雪", 20);
+    expect(results).toEqual([]);
+  });
+
+  it("returns [] on non-ok HTTP response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+
+    const results = await queryByEntry("雪", 20);
+    expect(results).toEqual([]);
+  });
+
+  it("handles raw_json as already-parsed object", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ rows: [{ raw_json: SAMPLE_RAW }] }),
+    });
+
+    const results = await queryByEntry("雪", 20);
+    expect(results).toHaveLength(1);
+    expect(results[0].entry).toBe("雪");
+  });
+});
+
+describe("queryByReading", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns mapped entries for reading search", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ rows: [{ raw_json: JSON.stringify(SAMPLE_RAW) }] }),
+    });
+
+    const results = await queryByReading("ゆき", 20);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].reading.primary).toBe("ゆき");
+  });
+});

--- a/lib/dict/providers/__tests__/genji-provider.test.ts
+++ b/lib/dict/providers/__tests__/genji-provider.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { DictEntry } from "../../dict-types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockQueryByEntry = vi.fn<(term: string, limit: number) => Promise<DictEntry[]>>();
+const mockQueryByReading = vi.fn<(reading: string, limit: number) => Promise<DictEntry[]>>();
+
+vi.mock("../genji-api-backend", () => ({
+  queryByEntry: (...args: [string, number]) => mockQueryByEntry(...args),
+  queryByReading: (...args: [string, number]) => mockQueryByReading(...args),
+}));
+
+const SAMPLE_ENTRY: DictEntry = {
+  id: "abc-123",
+  entry: "雪",
+  reading: { primary: "ゆき", alternatives: [] },
+  partOfSpeech: "名詞",
+  definitions: [{ gloss: "snow" }],
+  relationships: { homophones: [], synonyms: [], antonyms: [], related: [] },
+  source: "genji",
+};
+
+const SAMPLE_LOCAL_ENTRY: DictEntry = {
+  ...SAMPLE_ENTRY,
+  id: "local-123",
+};
+
+// Save original window state
+const originalWindow = { ...globalThis.window };
+
+function setupElectronEnv(installed: boolean, entries: DictEntry[] = []) {
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      ...originalWindow,
+      process: { type: "renderer" },
+      electronAPI: {
+        dict: {
+          query: vi.fn().mockResolvedValue(entries),
+          queryByReading: vi.fn().mockResolvedValue(entries),
+          getStatus: vi.fn().mockResolvedValue({
+            status: installed ? "installed" : "not-installed",
+          }),
+        },
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function setupWebEnv() {
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      ...originalWindow,
+      process: undefined,
+      electronAPI: undefined,
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GenjiProvider", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockQueryByEntry.mockReset();
+    mockQueryByReading.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      value: originalWindow,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  async function createProvider() {
+    const { GenjiProvider } = await import("../genji-provider");
+    return new GenjiProvider();
+  }
+
+  describe("isAvailable", () => {
+    it("returns true in web environment", async () => {
+      setupWebEnv();
+      const provider = await createProvider();
+      expect(await provider.isAvailable()).toBe(true);
+    });
+
+    it("returns true in Electron environment", async () => {
+      setupElectronEnv(true);
+      const provider = await createProvider();
+      expect(await provider.isAvailable()).toBe(true);
+    });
+  });
+
+  describe("query — web environment", () => {
+    it("uses remote backend", async () => {
+      setupWebEnv();
+      mockQueryByEntry.mockResolvedValue([SAMPLE_ENTRY]);
+
+      const provider = await createProvider();
+      const results = await provider.query("雪");
+
+      expect(mockQueryByEntry).toHaveBeenCalledWith("雪", 20);
+      expect(results).toEqual([SAMPLE_ENTRY]);
+    });
+  });
+
+  describe("query — Electron with installed dict", () => {
+    it("uses local backend when results found", async () => {
+      setupElectronEnv(true, [SAMPLE_LOCAL_ENTRY]);
+
+      const provider = await createProvider();
+      const results = await provider.query("雪");
+
+      expect(results).toEqual([SAMPLE_LOCAL_ENTRY]);
+      expect(mockQueryByEntry).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("query — Electron without installed dict", () => {
+    it("falls back to remote backend", async () => {
+      setupElectronEnv(false);
+      mockQueryByEntry.mockResolvedValue([SAMPLE_ENTRY]);
+
+      const provider = await createProvider();
+      const results = await provider.query("雪");
+
+      expect(mockQueryByEntry).toHaveBeenCalledWith("雪", 20);
+      expect(results).toEqual([SAMPLE_ENTRY]);
+    });
+  });
+
+  describe("query — Electron local returns empty", () => {
+    it("falls back to remote when local returns empty", async () => {
+      setupElectronEnv(true, []);
+      mockQueryByEntry.mockResolvedValue([SAMPLE_ENTRY]);
+
+      const provider = await createProvider();
+      const results = await provider.query("雪");
+
+      expect(mockQueryByEntry).toHaveBeenCalled();
+      expect(results).toEqual([SAMPLE_ENTRY]);
+    });
+  });
+
+  describe("query — Electron local throws", () => {
+    it("falls back to remote on local error", async () => {
+      setupElectronEnv(true);
+      // Override query to throw
+      (
+        window as Window & { electronAPI?: { dict?: { query: ReturnType<typeof vi.fn> } } }
+      ).electronAPI!.dict!.query.mockRejectedValue(new Error("IPC failed"));
+      mockQueryByEntry.mockResolvedValue([SAMPLE_ENTRY]);
+
+      const provider = await createProvider();
+      const results = await provider.query("雪");
+
+      expect(mockQueryByEntry).toHaveBeenCalled();
+      expect(results).toEqual([SAMPLE_ENTRY]);
+    });
+  });
+
+  describe("queryByReading — web environment", () => {
+    it("uses remote backend", async () => {
+      setupWebEnv();
+      mockQueryByReading.mockResolvedValue([SAMPLE_ENTRY]);
+
+      const provider = await createProvider();
+      const results = await provider.queryByReading("ゆき");
+
+      expect(mockQueryByReading).toHaveBeenCalledWith("ゆき", 20);
+      expect(results).toEqual([SAMPLE_ENTRY]);
+    });
+  });
+});

--- a/lib/dict/providers/genji-api-backend.ts
+++ b/lib/dict/providers/genji-api-backend.ts
@@ -1,0 +1,199 @@
+/**
+ * GenjiApiBackend — HTTP client for the Genji Datasette API.
+ *
+ * Provides remote dictionary queries using the `raw_json` field from the
+ * `entries` table.  Used as a fallback backend inside GenjiProvider when
+ * the local Electron IPC backend is unavailable.
+ */
+import type { DictEntry, DictDefinition, DictRelationships, DictReading } from "../dict-types";
+
+const GENJI_API_BASE = "https://api.dict.illusions.app";
+const FETCH_TIMEOUT_MS = 5000;
+
+// ---------------------------------------------------------------------------
+// raw_json shape (mirrors the Genji database schema)
+// ---------------------------------------------------------------------------
+
+interface RawExample {
+  text: string;
+  source?: string;
+  citation?: { source?: string; author?: string; note?: string };
+}
+
+interface RawDefinition {
+  index: number;
+  gloss: string;
+  register?: string;
+  nuance?: string | null;
+  collocations?: string[];
+  examples?: {
+    standard?: RawExample[];
+    literary?: RawExample[];
+  };
+}
+
+interface RawJson {
+  uuid: string;
+  entry: string;
+  reading: {
+    primary: string;
+    alternatives: string[];
+    is_heteronym?: boolean;
+  };
+  grammar: {
+    pos: string[] | null;
+    ctype?: string | null;
+    inflections?: string[] | null;
+  };
+  definitions: RawDefinition[];
+  relations: {
+    homophones: string[];
+    synonyms: string[];
+    antonyms: string[];
+    related: string[];
+  };
+  meta?: {
+    version?: string;
+    source?: string;
+    updated_at?: string;
+    freq_rank?: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mapping
+// ---------------------------------------------------------------------------
+
+function flattenExamples(def: RawDefinition): string[] {
+  const out: string[] = [];
+  if (def.examples?.standard) {
+    for (const ex of def.examples.standard) {
+      if (ex.text) out.push(ex.text);
+    }
+  }
+  if (def.examples?.literary) {
+    for (const ex of def.examples.literary) {
+      if (ex.text) out.push(ex.text);
+    }
+  }
+  return out;
+}
+
+export function mapRawJsonToDictEntry(raw: RawJson): DictEntry {
+  const reading: DictReading = {
+    primary: raw.reading.primary,
+    alternatives: raw.reading.alternatives ?? [],
+  };
+
+  const definitions: DictDefinition[] = (raw.definitions ?? []).map((d) => ({
+    gloss: d.gloss,
+    register: d.register ?? undefined,
+    nuance: d.nuance ?? undefined,
+    collocations: d.collocations?.length ? d.collocations : undefined,
+    examples: flattenExamples(d),
+  }));
+
+  const relationships: DictRelationships = {
+    homophones: raw.relations?.homophones ?? [],
+    synonyms: raw.relations?.synonyms ?? [],
+    antonyms: raw.relations?.antonyms ?? [],
+    related: raw.relations?.related ?? [],
+  };
+
+  return {
+    id: raw.uuid,
+    entry: raw.entry,
+    reading,
+    partOfSpeech: raw.grammar?.pos?.join("・") ?? undefined,
+    inflections: raw.grammar?.inflections ?? undefined,
+    definitions,
+    relationships,
+    source: "genji",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SQL helpers
+// ---------------------------------------------------------------------------
+
+function buildSqlUrl(sql: string, params: Record<string, string>): string {
+  const url = new URL(`${GENJI_API_BASE}/genji.json`);
+  url.searchParams.set("sql", sql);
+  url.searchParams.set("_shape", "objects");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return url.toString();
+}
+
+interface DatasetteResponse {
+  rows: Array<{ raw_json: string }>;
+}
+
+async function executeSql(sql: string, params: Record<string, string>): Promise<RawJson[]> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(buildSqlUrl(sql, params), {
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.warn(`[GenjiApiBackend] HTTP ${res.status} for query`);
+      return [];
+    }
+    const data = (await res.json()) as DatasetteResponse;
+    return data.rows.map((row) => {
+      const parsed = typeof row.raw_json === "string" ? JSON.parse(row.raw_json) : row.raw_json;
+      return parsed as RawJson;
+    });
+  } catch (err) {
+    if ((err as Error).name === "AbortError") {
+      console.warn("[GenjiApiBackend] request timed out");
+    } else {
+      console.warn("[GenjiApiBackend] fetch failed:", err);
+    }
+    return [];
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Search by headword — exact match first, then prefix, ordered by length.
+ */
+export async function queryByEntry(term: string, limit: number): Promise<DictEntry[]> {
+  const sql = `
+    SELECT raw_json FROM entries
+    WHERE entry = :term OR entry LIKE :prefix
+    ORDER BY (entry = :term) DESC, length(entry)
+    LIMIT :limit
+  `;
+  const raws = await executeSql(sql, {
+    term,
+    prefix: `${term}%`,
+    limit: String(limit),
+  });
+  return raws.map(mapRawJsonToDictEntry);
+}
+
+/**
+ * Find entries sharing the given kana reading (exact match).
+ */
+export async function queryByReading(reading: string, limit: number): Promise<DictEntry[]> {
+  const sql = `
+    SELECT raw_json FROM entries
+    WHERE reading_primary = :reading
+    ORDER BY length(entry)
+    LIMIT :limit
+  `;
+  const raws = await executeSql(sql, {
+    reading,
+    limit: String(limit),
+  });
+  return raws.map(mapRawJsonToDictEntry);
+}

--- a/lib/dict/providers/genji-provider.ts
+++ b/lib/dict/providers/genji-provider.ts
@@ -1,14 +1,19 @@
 /**
- * GenjiProvider
+ * GenjiProvider — dual-backend dictionary provider.
  *
- * Electron: delegates queries to the main process via IPC (window.electronAPI.dict).
- * Web: returns stub results with webApiPending flag until a real API is available.
+ * Electron (local dict installed): queries via IPC to the main-process SQLite.
+ * Otherwise (web, or Electron without local dict): falls back to Genji REST API.
  */
 import type { IDictProvider, DictEntry } from "../dict-types";
+import * as GenjiApiBackend from "./genji-api-backend";
 
 const PROVIDER_ID = "genji";
 const DISPLAY_NAME = "幻辞";
 const DEFAULT_LIMIT = 20;
+
+// ---------------------------------------------------------------------------
+// Electron IPC helpers
+// ---------------------------------------------------------------------------
 
 function isElectronDict(): boolean {
   return (
@@ -33,37 +38,65 @@ function getElectronDictAPI() {
   return api;
 }
 
+/** Check whether the local Electron dict is installed and ready. */
+async function isLocalAvailable(): Promise<boolean> {
+  if (!isElectronDict()) return false;
+  try {
+    const status = await getElectronDictAPI().getStatus();
+    return status.status === "installed";
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
 export class GenjiProvider implements IDictProvider {
   readonly id = PROVIDER_ID;
   readonly displayName = DISPLAY_NAME;
 
+  /**
+   * Always available — local IPC or remote API.
+   * Does NOT hit the network; remote availability is assumed and errors
+   * are handled gracefully in query methods.
+   */
   async isAvailable(): Promise<boolean> {
-    if (!isElectronDict()) return false;
-    try {
-      const status = await getElectronDictAPI().getStatus();
-      return status.status === "installed";
-    } catch {
-      return false;
-    }
+    return true;
   }
 
   async query(term: string, limit = DEFAULT_LIMIT): Promise<DictEntry[]> {
-    if (!isElectronDict()) return [];
-    try {
-      return await getElectronDictAPI().query(term, limit);
-    } catch (err) {
-      console.error(`[GenjiProvider] query failed:`, err);
-      return [];
+    // Try local backend first (Electron with installed dict)
+    if (isElectronDict()) {
+      try {
+        if (await isLocalAvailable()) {
+          const results = await getElectronDictAPI().query(term, limit);
+          if (results.length > 0) return results;
+        }
+      } catch {
+        // Fall through to remote
+      }
     }
+
+    // Remote fallback
+    return GenjiApiBackend.queryByEntry(term, limit);
   }
 
   async queryByReading(reading: string, limit = DEFAULT_LIMIT): Promise<DictEntry[]> {
-    if (!isElectronDict()) return [];
-    try {
-      return await getElectronDictAPI().queryByReading(reading, limit);
-    } catch (err) {
-      console.error(`[GenjiProvider] queryByReading failed:`, err);
-      return [];
+    // Try local backend first
+    if (isElectronDict()) {
+      try {
+        if (await isLocalAvailable()) {
+          const results = await getElectronDictAPI().queryByReading(reading, limit);
+          if (results.length > 0) return results;
+        }
+      } catch {
+        // Fall through to remote
+      }
     }
+
+    // Remote fallback
+    return GenjiApiBackend.queryByReading(reading, limit);
   }
 }


### PR DESCRIPTION
## Summary

- Genji REST API をリモートバックエンドとして統合し、Web版でも辞典検索を可能に
- Desktop版ではローカルSQLite優先、未インストール時はGenji APIにフォールバック
- UI状態マシンを修正：ローカルインストール状態と検索結果状態を分離

## Changes

| File | Description |
|------|-------------|
| `lib/dict/providers/genji-api-backend.ts` | **New** — Genji Datasette API HTTP client (`raw_json` + exact/prefix SQL) |
| `lib/dict/providers/genji-provider.ts` | Dual-backend: local IPC → remote API fallback |
| `lib/dict/dict-types.ts` | Remove `webApiPending` from `DictQueryResult` |
| `lib/dict/dict-service.ts` | Remove `webApiPending` logic |
| `components/Dictionary.tsx` | Separate `localInstallStatus` from query state, fix no-results |
| `components/settings/DictSettingsTab.tsx` | Update web fallback message |
| `lib/dict/providers/__tests__/*` | **New** — 19 unit tests for backend + provider |

## Test plan

- [ ] Web版: 「雪」を検索 → Genji API から結果が返る
- [ ] Web版: prefix検索で「雪国」「雪崩」なども表示される
- [ ] Web版: 存在しない語を検索 → 「結果なし」メッセージが表示される（従来は表示されなかった）
- [ ] Desktop版（ローカル辞典インストール済み）: ローカルIPC経由で結果を返す
- [ ] Desktop版（ローカル辞典未インストール）: Genji APIフォールバックで結果を返す
- [ ] `npx tsc --noEmit` パス済み
- [ ] `vitest run lib/dict/providers/__tests__/` — 19テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)