### PR TITLE
docs: fix broken link to storage architecture doc

### DIFF
--- a/docs/guides/linting-rules.md
+++ b/docs/guides/linting-rules.md
@@ -496,4 +496,4 @@ messageJa: "ダッシュの使い方が間違っています"; // DO NOT do this
 
 - [Milkdown Plugin Development Guide](./milkdown-plugin.md) -- Plugin architecture and linting integration
 - [Keyboard Shortcuts Reference](./keyboard-shortcuts.md) -- Editor shortcuts and menu structure
-- [Storage Architecture](../architecture/storage-architecture.md) -- How linting settings are persisted
+- [Storage Architecture](../architecture/storage-system.md) -- How linting settings are persisted


### PR DESCRIPTION
## Summary

- Fix broken relative link in `docs/guides/linting-rules.md` — pointed to non-existent `storage-architecture.md`, corrected to `storage-system.md`

## Changes

| File | Change |
| --- | --- |
| `docs/guides/linting-rules.md` | `storage-architecture.md` → `storage-system.md` |

## Test plan

- [ ] Verify `docs/architecture/storage-system.md` exists
- [ ] Verify the link renders correctly in GitHub markdown preview

Closes #1272

🤖 Generated with [Claude Code](https://claude.com/claude-code)