### PR TITLE
fix(export): remove blank lines between paragraphs in TXT export

### DIFF
--- a/lib/export/__tests__/txt-exporter.test.ts
+++ b/lib/export/__tests__/txt-exporter.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import {
-  mdiToPlainText,
-  mdiToRubyText,
-  stripMarkdown,
-} from "../txt-exporter";
+import { mdiToPlainText, mdiToRubyText, stripMarkdown } from "../txt-exporter";
 
 // ---------------------------------------------------------------------------
 // stripMarkdown
@@ -101,13 +97,9 @@ describe("mdiToPlainText", () => {
       "Next section.",
     ].join("\n");
 
-    const expected = [
-      "Chapter One",
-      "漢字のテスト。",
-      "「台詞だ」",
-      "",
-      "Next section.",
-    ].join("\n");
+    const expected = ["Chapter One", "漢字のテスト。", "「台詞だ」", "", "Next section."].join(
+      "\n",
+    );
 
     expect(mdiToPlainText(input)).toBe(expected);
   });
@@ -119,16 +111,9 @@ describe("mdiToPlainText", () => {
 
 describe("mdiToRubyText", () => {
   it("should render ruby in parentheses and collapse blank lines", () => {
-    const input = [
-      "{漢字|かんじ}のテスト。",
-      "",
-      "「{台詞|せりふ}だ」",
-    ].join("\n");
+    const input = ["{漢字|かんじ}のテスト。", "", "「{台詞|せりふ}だ」"].join("\n");
 
-    const expected = [
-      "漢字（かんじ）のテスト。",
-      "「台詞（せりふ）だ」",
-    ].join("\n");
+    const expected = ["漢字（かんじ）のテスト。", "「台詞（せりふ）だ」"].join("\n");
 
     expect(mdiToRubyText(input)).toBe(expected);
   });

--- a/lib/export/__tests__/txt-exporter.test.ts
+++ b/lib/export/__tests__/txt-exporter.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  mdiToPlainText,
+  mdiToRubyText,
+  stripMarkdown,
+} from "../txt-exporter";
+
+// ---------------------------------------------------------------------------
+// stripMarkdown
+// ---------------------------------------------------------------------------
+
+describe("stripMarkdown", () => {
+  it("should strip heading markers", () => {
+    expect(stripMarkdown("# Title")).toBe("Title");
+    expect(stripMarkdown("## Subtitle")).toBe("Subtitle");
+  });
+
+  it("should strip bold and italic markers", () => {
+    expect(stripMarkdown("**bold** and *italic*")).toBe("bold and italic");
+    expect(stripMarkdown("***both***")).toBe("both");
+  });
+
+  it("should convert horizontal rules to scene break markers", () => {
+    const result = stripMarkdown("before\n\n---\n\nafter");
+    // Scene break marker is internal; verify it does not appear as literal "---"
+    expect(result).not.toContain("---");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Blank line collapsing (tested via mdiToPlainText)
+// ---------------------------------------------------------------------------
+
+describe("blank line collapsing", () => {
+  it("should remove blank lines between paragraphs", () => {
+    const input = "first paragraph\n\nsecond paragraph";
+    expect(mdiToPlainText(input)).toBe("first paragraph\nsecond paragraph");
+  });
+
+  it("should collapse multiple consecutive blank lines", () => {
+    const input = "first\n\n\n\nsecond";
+    expect(mdiToPlainText(input)).toBe("first\nsecond");
+  });
+
+  it("should preserve scene break as a single blank line", () => {
+    const input = "before\n\n---\n\nafter";
+    expect(mdiToPlainText(input)).toBe("before\n\nafter");
+  });
+
+  it("should preserve dialogue lines unchanged", () => {
+    const input = "narration\n\n\u300Cdialogue\u300D\n\nnext";
+    expect(mdiToPlainText(input)).toBe("narration\n\u300Cdialogue\u300D\nnext");
+  });
+
+  it("should handle content with no blank lines", () => {
+    const input = "line one\nline two\nline three";
+    expect(mdiToPlainText(input)).toBe("line one\nline two\nline three");
+  });
+
+  it("should handle empty input", () => {
+    expect(mdiToPlainText("")).toBe("");
+  });
+
+  it("should handle multiple scene breaks", () => {
+    const input = "part one\n\n---\n\npart two\n\n***\n\npart three";
+    expect(mdiToPlainText(input)).toBe("part one\n\npart two\n\npart three");
+  });
+
+  it("should handle heading followed by paragraph without extra blank lines", () => {
+    const input = "# Chapter\n\nFirst paragraph.\n\nSecond paragraph.";
+    expect(mdiToPlainText(input)).toBe("Chapter\nFirst paragraph.\nSecond paragraph.");
+  });
+
+  it("should handle consecutive scene breaks", () => {
+    const input = "before\n\n---\n\n---\n\nafter";
+    expect(mdiToPlainText(input)).toBe("before\n\n\nafter");
+  });
+
+  it("should handle scene break at start and end of content", () => {
+    const input = "---\n\nonly paragraph\n\n---";
+    expect(mdiToPlainText(input)).toBe("\nonly paragraph\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: mdiToPlainText
+// ---------------------------------------------------------------------------
+
+describe("mdiToPlainText", () => {
+  it("should strip MDI syntax and collapse blank lines", () => {
+    const input = [
+      "# Chapter One",
+      "",
+      "{漢字|かんじ}のテスト。",
+      "",
+      "「{台詞|せりふ}だ」",
+      "",
+      "---",
+      "",
+      "Next section.",
+    ].join("\n");
+
+    const expected = [
+      "Chapter One",
+      "漢字のテスト。",
+      "「台詞だ」",
+      "",
+      "Next section.",
+    ].join("\n");
+
+    expect(mdiToPlainText(input)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: mdiToRubyText
+// ---------------------------------------------------------------------------
+
+describe("mdiToRubyText", () => {
+  it("should render ruby in parentheses and collapse blank lines", () => {
+    const input = [
+      "{漢字|かんじ}のテスト。",
+      "",
+      "「{台詞|せりふ}だ」",
+    ].join("\n");
+
+    const expected = [
+      "漢字（かんじ）のテスト。",
+      "「台詞（せりふ）だ」",
+    ].join("\n");
+
+    expect(mdiToRubyText(input)).toBe(expected);
+  });
+});

--- a/lib/export/txt-exporter.ts
+++ b/lib/export/txt-exporter.ts
@@ -8,6 +8,9 @@
 
 import { stripMdiInlineSyntax, replaceMdiWithRubyText } from "./mdi-parser";
 
+/** Sentinel to distinguish scene breaks from paragraph-separation blank lines */
+const SCENE_BREAK_MARKER = "\x00SCENE_BREAK\x00";
+
 /**
  * Convert MDI markdown to plain text without ruby annotations.
  * Strips all MDI syntax and markdown formatting.
@@ -20,6 +23,7 @@ export function mdiToPlainText(content: string): string {
 
   // Strip markdown formatting
   result = stripMarkdown(result);
+  result = collapseBlankLines(result);
 
   return result;
 }
@@ -36,6 +40,7 @@ export function mdiToRubyText(content: string): string {
 
   // Strip markdown formatting
   result = stripMarkdown(result);
+  result = collapseBlankLines(result);
 
   return result;
 }
@@ -56,7 +61,7 @@ export function stripMarkdown(text: string): string {
 
     // Horizontal rules: --- / *** / ___ → empty line
     if (/^(-{3,}|\*{3,}|_{3,})$/.test(processed.trim())) {
-      result.push("");
+      result.push(SCENE_BREAK_MARKER);
       continue;
     }
 
@@ -73,6 +78,30 @@ export function stripMarkdown(text: string): string {
     processed = processed.replace(/\\([{^[\]])/g, "$1");
 
     result.push(processed);
+  }
+
+  return result.join("\n");
+}
+
+/**
+ * Remove blank lines between paragraphs for Japanese typesetting (組版).
+ * Scene breaks are preserved as a single blank line separator.
+ */
+function collapseBlankLines(text: string): string {
+  const lines = text.split("\n");
+  const result: string[] = [];
+
+  for (const line of lines) {
+    if (line === SCENE_BREAK_MARKER) {
+      result.push("");
+      continue;
+    }
+
+    if (line.trim() === "") {
+      continue;
+    }
+
+    result.push(line);
   }
 
   return result.join("\n");


### PR DESCRIPTION
## Summary

- TXT エクスポートで段落間の空行を削除し、日本語の組版慣習に準拠
- シーンブレイク（`---`/`***`/`___`）は空行1行として保持

## Changes

| File | Change |
|------|--------|
| `lib/export/txt-exporter.ts` | `SCENE_BREAK_MARKER` センチネル追加、`collapseBlankLines()` 関数追加、両エクスポート関数に組み込み |
| `lib/export/__tests__/txt-exporter.test.ts` | 新規：15テストケース（空行削除、シーンブレイク保持、E2E） |

## Test plan

- [ ] `npx vitest run lib/export/__tests__/txt-exporter.test.ts` — 15テスト全パス
- [ ] エディタでサンプル MDI ファイルを TXT エクスポートし、段落間に空行がないことを確認
- [ ] シーンブレイク（`---`）が空行1行として出力されることを確認
- [ ] TXT（ルビ付き）エクスポートでも同様の動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)