### PR TITLE
fix: QA security fixes — XSS, LLM race conditions, IPC size/validation (#1303–#1307)

### DIFF
--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -118,6 +118,9 @@ function isSavePathDenied(normalizedPath) {
 
 const VALID_SAVE_FILE_TYPES = [".mdi", ".md", ".txt"];
 
+/** Maximum allowed content size in bytes (50 MB) */
+const MAX_CONTENT_BYTES = 50 * 1024 * 1024;
+
 /**
  * Validate a file path provided by the renderer for the save-file IPC handler.
  * Returns an error object if validation fails, or null if the path is valid.
@@ -297,6 +300,13 @@ function registerFileHandlers() {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content", code: "INVALID_INPUT" };
     }
+    if (content.length > MAX_CONTENT_BYTES) {
+      return {
+        success: false,
+        error: "ファイルサイズが上限を超えています（50 MB）",
+        code: "CONTENT_TOO_LARGE",
+      };
+    }
     if (fileType != null && !VALID_SAVE_FILE_TYPES.includes(fileType)) {
       return { success: false, error: `Invalid file type: ${fileType}`, code: "INVALID_INPUT" };
     }
@@ -381,6 +391,13 @@ function registerFileHandlers() {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content" };
     }
+    if (content.length > MAX_CONTENT_BYTES) {
+      return {
+        success: false,
+        error: "コンテンツが大きすぎてエクスポートできません（50 MB）",
+        code: "CONTENT_TOO_LARGE",
+      };
+    }
     try {
       const { generatePdf } = require("../../lib/export/pdf-exporter");
       const pdfBuffer = await generatePdf(content, options || {});
@@ -405,6 +422,13 @@ function registerFileHandlers() {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content" };
     }
+    if (content.length > MAX_CONTENT_BYTES) {
+      return {
+        success: false,
+        error: "コンテンツが大きすぎてエクスポートできません（50 MB）",
+        code: "CONTENT_TOO_LARGE",
+      };
+    }
     try {
       const { generateEpub } = require("../../lib/export/epub-exporter");
       const epubBuffer = await generateEpub(content, options || {});
@@ -428,6 +452,13 @@ function registerFileHandlers() {
   ipcMain.handle("export-docx", async (_event, content, options) => {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content" };
+    }
+    if (content.length > MAX_CONTENT_BYTES) {
+      return {
+        success: false,
+        error: "コンテンツが大きすぎてエクスポートできません（50 MB）",
+        code: "CONTENT_TOO_LARGE",
+      };
     }
     try {
       const { generateDocx } = require("../../lib/export/docx-exporter");

--- a/electron/ipc/storage-ipc.js
+++ b/electron/ipc/storage-ipc.js
@@ -21,6 +21,9 @@ function registerStorageHandlers() {
 
   // セッション保存
   ipcMain.handle("storage:save-session", async (_event, session) => {
+    if (typeof session !== "object" || session === null) {
+      throw new Error("Invalid session: expected object");
+    }
     try {
       await manager.saveSession(session);
     } catch (error) {
@@ -41,6 +44,9 @@ function registerStorageHandlers() {
 
   // AppState 保存
   ipcMain.handle("storage:save-app-state", async (_event, appState) => {
+    if (typeof appState !== "object" || appState === null) {
+      throw new Error("Invalid appState: expected object");
+    }
     try {
       await manager.saveAppState(appState);
     } catch (error) {
@@ -61,6 +67,14 @@ function registerStorageHandlers() {
 
   // Recent Files 追加
   ipcMain.handle("storage:add-to-recent", async (_event, file) => {
+    if (
+      typeof file !== "object" ||
+      file === null ||
+      typeof file.name !== "string" ||
+      typeof file.path !== "string"
+    ) {
+      throw new Error("Invalid file: expected { name: string, path: string, ... }");
+    }
     try {
       await manager.addToRecent(file);
     } catch (error) {
@@ -81,6 +95,9 @@ function registerStorageHandlers() {
 
   // Recent Files から削除
   ipcMain.handle("storage:remove-from-recent", async (_event, path) => {
+    if (typeof path !== "string") {
+      throw new Error("Invalid path: expected string");
+    }
     try {
       await manager.removeFromRecent(path);
     } catch (error) {
@@ -101,6 +118,9 @@ function registerStorageHandlers() {
 
   // Editor Buffer 保存
   ipcMain.handle("storage:save-editor-buffer", async (_event, buffer) => {
+    if (typeof buffer !== "object" || buffer === null) {
+      throw new Error("Invalid buffer: expected object");
+    }
     try {
       await manager.saveEditorBuffer(buffer);
     } catch (error) {
@@ -141,6 +161,9 @@ function registerStorageHandlers() {
 
   // Recent Projects 追加
   ipcMain.handle("storage:add-recent-project", async (_event, project) => {
+    if (typeof project !== "object" || project === null) {
+      throw new Error("Invalid project: expected object");
+    }
     try {
       await manager.addRecentProject(project);
     } catch (error) {
@@ -161,6 +184,9 @@ function registerStorageHandlers() {
 
   // Recent Projects 削除
   ipcMain.handle("storage:remove-recent-project", async (_event, projectId) => {
+    if (typeof projectId !== "string") {
+      throw new Error("Invalid projectId: expected string");
+    }
     try {
       await manager.removeRecentProject(projectId);
     } catch (error) {
@@ -171,6 +197,9 @@ function registerStorageHandlers() {
 
   // KV Store: set
   ipcMain.handle("storage:set-item", async (_event, key, value) => {
+    if (typeof key !== "string") {
+      throw new Error("Invalid key: expected string");
+    }
     try {
       manager.setItem(key, value);
     } catch (error) {
@@ -181,6 +210,9 @@ function registerStorageHandlers() {
 
   // KV Store: get
   ipcMain.handle("storage:get-item", async (_event, key) => {
+    if (typeof key !== "string") {
+      throw new Error("Invalid key: expected string");
+    }
     try {
       return manager.getItem(key);
     } catch (error) {
@@ -191,6 +223,9 @@ function registerStorageHandlers() {
 
   // KV Store: remove
   ipcMain.handle("storage:remove-item", async (_event, key) => {
+    if (typeof key !== "string") {
+      throw new Error("Invalid key: expected string");
+    }
     try {
       manager.removeItem(key);
     } catch (error) {

--- a/llm-service/llm-engine.js
+++ b/llm-service/llm-engine.js
@@ -1,33 +1,33 @@
 // @ts-check
-'use strict';
+"use strict";
 
-const path = require('path');
-const fs = require('fs/promises');
-const { createWriteStream, createReadStream } = require('fs');
-const crypto = require('crypto');
+const path = require("path");
+const fs = require("fs/promises");
+const { createWriteStream, createReadStream } = require("fs");
+const crypto = require("crypto");
 
 // Model registry data (duplicated from TS for CJS compatibility)
 const MODEL_REGISTRY = [
   {
-    id: 'qwen3-0.6b-q8',
-    fileName: 'Qwen3-0.6B-Q8_0.gguf',
-    url: 'https://huggingface.co/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf',
+    id: "qwen3-0.6b-q8",
+    fileName: "Qwen3-0.6B-Q8_0.gguf",
+    url: "https://huggingface.co/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf",
     size: 639_446_688,
-    sha256: '9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031',
+    sha256: "9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031",
   },
   {
-    id: 'qwen3-1.7b-q8',
-    fileName: 'Qwen3-1.7B-Q8_0.gguf',
-    url: 'https://huggingface.co/Qwen/Qwen3-1.7B-GGUF/resolve/main/Qwen3-1.7B-Q8_0.gguf',
+    id: "qwen3-1.7b-q8",
+    fileName: "Qwen3-1.7B-Q8_0.gguf",
+    url: "https://huggingface.co/Qwen/Qwen3-1.7B-GGUF/resolve/main/Qwen3-1.7B-Q8_0.gguf",
     size: 1_834_426_016,
-    sha256: '061b54daade076b5d3362dac252678d17da8c68f07560be70818cace6590cb1a',
+    sha256: "061b54daade076b5d3362dac252678d17da8c68f07560be70818cace6590cb1a",
   },
   {
-    id: 'qwen3-4b-q4km',
-    fileName: 'Qwen3-4B-Q4_K_M.gguf',
-    url: 'https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf',
+    id: "qwen3-4b-q4km",
+    fileName: "Qwen3-4B-Q4_K_M.gguf",
+    url: "https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf",
     size: 2_497_280_256,
-    sha256: '7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5',
+    sha256: "7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5",
   },
 ];
 
@@ -59,15 +59,15 @@ class LlmEngine {
 
   async init() {
     if (this.#initialized) return;
-    const { app } = require('electron');
-    this.#modelsDir = path.join(app.getPath('userData'), 'models');
+    const { app } = require("electron");
+    this.#modelsDir = path.join(app.getPath("userData"), "models");
     await fs.mkdir(this.#modelsDir, { recursive: true });
     this.#initialized = true;
   }
 
   #ensureInit() {
     if (!this.#initialized || !this.#modelsDir) {
-      throw new Error('LlmEngine not initialized. Call init() first.');
+      throw new Error("LlmEngine not initialized. Call init() first.");
     }
   }
 
@@ -85,30 +85,30 @@ class LlmEngine {
     const results = [];
     for (const entry of MODEL_REGISTRY) {
       const filePath = path.join(this.#modelsDir, entry.fileName);
-      let status = 'not-downloaded';
+      let status = "not-downloaded";
       try {
         const stat = await fs.stat(filePath);
         // Check if file size roughly matches (within 1% tolerance for metadata)
         if (stat.size > 0) {
-          status = 'ready';
+          status = "ready";
         }
       } catch {
         // Check for partial download
         try {
-          await fs.stat(filePath + '.tmp');
-          status = 'downloading';
+          await fs.stat(filePath + ".tmp");
+          status = "downloading";
         } catch {
           // not downloaded
         }
       }
       // Override if currently loaded
       if (this.#modelId === entry.id && this.#model) {
-        status = 'loaded';
+        status = "loaded";
       }
       results.push({
         id: entry.id,
         status,
-        filePath: status === 'ready' || status === 'loaded' ? filePath : undefined,
+        filePath: status === "ready" || status === "loaded" ? filePath : undefined,
       });
     }
     return results;
@@ -123,7 +123,7 @@ class LlmEngine {
     this.#ensureInit();
     const entry = this.#getEntry(modelId);
     const targetPath = path.join(this.#modelsDir, entry.fileName);
-    const tmpPath = targetPath + '.tmp';
+    const tmpPath = targetPath + ".tmp";
 
     // Check if already downloaded
     try {
@@ -144,7 +144,7 @@ class LlmEngine {
 
     const headers = {};
     if (startByte > 0) {
-      headers['Range'] = `bytes=${startByte}-`;
+      headers["Range"] = `bytes=${startByte}-`;
     }
 
     // Download using native fetch (available in Node 18+)
@@ -153,11 +153,11 @@ class LlmEngine {
       throw new Error(`Download failed: HTTP ${response.status}`);
     }
 
-    const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
+    const contentLength = parseInt(response.headers.get("content-length") || "0", 10);
     const totalSize = startByte + contentLength;
     let downloaded = startByte;
 
-    const fileStream = createWriteStream(tmpPath, { flags: startByte > 0 ? 'a' : 'w' });
+    const fileStream = createWriteStream(tmpPath, { flags: startByte > 0 ? "a" : "w" });
 
     const reader = response.body.getReader();
     try {
@@ -168,7 +168,7 @@ class LlmEngine {
         const buf = Buffer.from(value);
         if (!fileStream.write(buf)) {
           // Backpressure: wait for drain before reading more
-          await new Promise((resolve) => fileStream.once('drain', resolve));
+          await new Promise((resolve) => fileStream.once("drain", resolve));
         }
         downloaded += value.byteLength;
 
@@ -181,7 +181,7 @@ class LlmEngine {
       }
     } finally {
       fileStream.end();
-      await new Promise((resolve) => fileStream.on('finish', resolve));
+      await new Promise((resolve) => fileStream.on("finish", resolve));
     }
 
     // SHA256 integrity verification — reject empty hashes as a security measure
@@ -189,22 +189,21 @@ class LlmEngine {
       await fs.unlink(tmpPath);
       throw new Error(
         `SHA-256 hash is missing for ${entry.fileName}. ` +
-        'Refusing to accept an unverified model file.'
+          "Refusing to accept an unverified model file.",
       );
     }
-    const hash = crypto.createHash('sha256');
+    const hash = crypto.createHash("sha256");
     await new Promise((resolve, reject) => {
       const stream = createReadStream(tmpPath);
-      stream.on('data', (chunk) => hash.update(chunk));
-      stream.on('end', resolve);
-      stream.on('error', reject);
+      stream.on("data", (chunk) => hash.update(chunk));
+      stream.on("end", resolve);
+      stream.on("error", reject);
     });
-    const digest = hash.digest('hex');
+    const digest = hash.digest("hex");
     if (digest !== entry.sha256) {
       await fs.unlink(tmpPath);
       throw new Error(
-        `SHA-256 mismatch for ${entry.fileName}: ` +
-        `expected ${entry.sha256}, got ${digest}`
+        `SHA-256 mismatch for ${entry.fileName}: ` + `expected ${entry.sha256}, got ${digest}`,
       );
     }
 
@@ -230,7 +229,7 @@ class LlmEngine {
     }
     // Also clean up partial downloads
     try {
-      await fs.unlink(filePath + '.tmp');
+      await fs.unlink(filePath + ".tmp");
     } catch {
       // no partial file
     }
@@ -258,7 +257,7 @@ class LlmEngine {
       }
 
       // Dynamic import for ESM module
-      const { getLlama } = await import('node-llama-cpp');
+      const { getLlama } = await import("node-llama-cpp");
       const llama = await getLlama();
       this.#model = await llama.loadModel({ modelPath });
       this.#context = await this.#model.createContext();
@@ -273,7 +272,7 @@ class LlmEngine {
    */
   async unloadModel() {
     if (this.#inferring > 0 || this.#pendingInfers > 0) {
-      console.log('[LlmEngine] Skipping unload — inference in progress or queued');
+      console.log("[LlmEngine] Skipping unload — inference in progress or queued");
       return;
     }
     if (this.#idleTimer) {
@@ -310,7 +309,7 @@ class LlmEngine {
    */
   async infer(prompt, options = {}) {
     if (!this.#model || !this.#context) {
-      throw new Error('Model not loaded. Call loadModel() first.');
+      throw new Error("Model not loaded. Call loadModel() first.");
     }
 
     this.#pendingInfers++; // synchronous increment before queue entry
@@ -320,7 +319,7 @@ class LlmEngine {
       this.#pendingInfers--; // starting: transfer from pending to active
       // Guard: context may have been disposed between queue entry and execution
       if (!this.#context) {
-        throw new Error('Model was unloaded before inference could start.');
+        throw new Error("Model was unloaded before inference could start.");
       }
 
       this.#inferring++;
@@ -330,7 +329,7 @@ class LlmEngine {
         this.#idleTimer = null;
       }
 
-      const { LlamaChatSession } = await import('node-llama-cpp');
+      const { LlamaChatSession } = await import("node-llama-cpp");
       const sequence = this.#context.getSequence();
       const session = new LlamaChatSession({
         contextSequence: sequence,
@@ -342,7 +341,9 @@ class LlmEngine {
       try {
         const text = await session.prompt(prompt, {
           maxTokens,
-          onToken: () => { tokenCount++; },
+          onToken: () => {
+            tokenCount++;
+          },
         });
         return { text, tokenCount };
       } finally {
@@ -404,7 +405,7 @@ class LlmEngine {
     this.#idleTimer = setTimeout(async () => {
       this.#idleTimer = null;
       if (this.isLoaded()) {
-        console.log('[LlmEngine] Idle timeout — unloading model');
+        console.log("[LlmEngine] Idle timeout — unloading model");
         await this.unloadModel();
       }
     }, this.#IDLE_TIMEOUT_MS);

--- a/llm-service/llm-engine.js
+++ b/llm-service/llm-engine.js
@@ -1,0 +1,426 @@
+// @ts-check
+'use strict';
+
+const path = require('path');
+const fs = require('fs/promises');
+const { createWriteStream, createReadStream } = require('fs');
+const crypto = require('crypto');
+
+// Model registry data (duplicated from TS for CJS compatibility)
+const MODEL_REGISTRY = [
+  {
+    id: 'qwen3-0.6b-q8',
+    fileName: 'Qwen3-0.6B-Q8_0.gguf',
+    url: 'https://huggingface.co/Qwen/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q8_0.gguf',
+    size: 639_446_688,
+    sha256: '9465e63a22add5354d9bb4b99e90117043c7124007664907259bd16d043bb031',
+  },
+  {
+    id: 'qwen3-1.7b-q8',
+    fileName: 'Qwen3-1.7B-Q8_0.gguf',
+    url: 'https://huggingface.co/Qwen/Qwen3-1.7B-GGUF/resolve/main/Qwen3-1.7B-Q8_0.gguf',
+    size: 1_834_426_016,
+    sha256: '061b54daade076b5d3362dac252678d17da8c68f07560be70818cace6590cb1a',
+  },
+  {
+    id: 'qwen3-4b-q4km',
+    fileName: 'Qwen3-4B-Q4_K_M.gguf',
+    url: 'https://huggingface.co/Qwen/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf',
+    size: 2_497_280_256,
+    sha256: '7485fe6f11af29433bc51cab58009521f205840f5b4ae3a32fa7f92e8534fdf5',
+  },
+];
+
+class LlmEngine {
+  /** @type {import('node-llama-cpp').LlamaModel | null} */
+  #model = null;
+  /** @type {import('node-llama-cpp').LlamaContext | null} */
+  #context = null;
+  /** @type {string | null} */
+  #modelId = null;
+  /** @type {string | null} */
+  #modelsDir = null;
+  /** @type {boolean} */
+  #initialized = false;
+  /** @type {Promise<any>} Serialization queue for load/unload operations */
+  #loadQueue = Promise.resolve();
+  /** @type {Promise<any>} Serialization queue — ensures only one inference runs at a time */
+  #inferQueue = Promise.resolve();
+  /** @type {number} Number of active inferences (guards against concurrent unload) */
+  #inferring = 0;
+  /** @type {number} Number of inferences queued but not yet started (guards against TOCTOU unload) */
+  #pendingInfers = 0;
+  /** @type {boolean} Whether to auto-unload model after idle timeout */
+  #idlingStopEnabled = false;
+  /** @type {ReturnType<typeof setTimeout> | null} */
+  #idleTimer = null;
+  /** Idle timeout before auto-unloading (30 seconds) */
+  #IDLE_TIMEOUT_MS = 30_000;
+
+  async init() {
+    if (this.#initialized) return;
+    const { app } = require('electron');
+    this.#modelsDir = path.join(app.getPath('userData'), 'models');
+    await fs.mkdir(this.#modelsDir, { recursive: true });
+    this.#initialized = true;
+  }
+
+  #ensureInit() {
+    if (!this.#initialized || !this.#modelsDir) {
+      throw new Error('LlmEngine not initialized. Call init() first.');
+    }
+  }
+
+  #getEntry(modelId) {
+    const entry = MODEL_REGISTRY.find((m) => m.id === modelId);
+    if (!entry) throw new Error(`Unknown model: ${modelId}`);
+    return entry;
+  }
+
+  /**
+   * Get all models with their download status
+   */
+  async getModels() {
+    this.#ensureInit();
+    const results = [];
+    for (const entry of MODEL_REGISTRY) {
+      const filePath = path.join(this.#modelsDir, entry.fileName);
+      let status = 'not-downloaded';
+      try {
+        const stat = await fs.stat(filePath);
+        // Check if file size roughly matches (within 1% tolerance for metadata)
+        if (stat.size > 0) {
+          status = 'ready';
+        }
+      } catch {
+        // Check for partial download
+        try {
+          await fs.stat(filePath + '.tmp');
+          status = 'downloading';
+        } catch {
+          // not downloaded
+        }
+      }
+      // Override if currently loaded
+      if (this.#modelId === entry.id && this.#model) {
+        status = 'loaded';
+      }
+      results.push({
+        id: entry.id,
+        status,
+        filePath: status === 'ready' || status === 'loaded' ? filePath : undefined,
+      });
+    }
+    return results;
+  }
+
+  /**
+   * Download a model with resume support
+   * @param {string} modelId
+   * @param {(progress: { modelId: string; progress: number }) => void} [onProgress]
+   */
+  async downloadModel(modelId, onProgress) {
+    this.#ensureInit();
+    const entry = this.#getEntry(modelId);
+    const targetPath = path.join(this.#modelsDir, entry.fileName);
+    const tmpPath = targetPath + '.tmp';
+
+    // Check if already downloaded
+    try {
+      const stat = await fs.stat(targetPath);
+      if (stat.size > 0) return; // already exists
+    } catch {
+      // not downloaded yet
+    }
+
+    // Check for partial download (resume support)
+    let startByte = 0;
+    try {
+      const stat = await fs.stat(tmpPath);
+      startByte = stat.size;
+    } catch {
+      // no partial file
+    }
+
+    const headers = {};
+    if (startByte > 0) {
+      headers['Range'] = `bytes=${startByte}-`;
+    }
+
+    // Download using native fetch (available in Node 18+)
+    const response = await fetch(entry.url, { headers });
+    if (!response.ok && response.status !== 206) {
+      throw new Error(`Download failed: HTTP ${response.status}`);
+    }
+
+    const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
+    const totalSize = startByte + contentLength;
+    let downloaded = startByte;
+
+    const fileStream = createWriteStream(tmpPath, { flags: startByte > 0 ? 'a' : 'w' });
+
+    const reader = response.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const buf = Buffer.from(value);
+        if (!fileStream.write(buf)) {
+          // Backpressure: wait for drain before reading more
+          await new Promise((resolve) => fileStream.once('drain', resolve));
+        }
+        downloaded += value.byteLength;
+
+        if (onProgress && totalSize > 0) {
+          onProgress({
+            modelId,
+            progress: Math.round((downloaded / totalSize) * 100),
+          });
+        }
+      }
+    } finally {
+      fileStream.end();
+      await new Promise((resolve) => fileStream.on('finish', resolve));
+    }
+
+    // SHA256 integrity verification — reject empty hashes as a security measure
+    if (!entry.sha256) {
+      await fs.unlink(tmpPath);
+      throw new Error(
+        `SHA-256 hash is missing for ${entry.fileName}. ` +
+        'Refusing to accept an unverified model file.'
+      );
+    }
+    const hash = crypto.createHash('sha256');
+    await new Promise((resolve, reject) => {
+      const stream = createReadStream(tmpPath);
+      stream.on('data', (chunk) => hash.update(chunk));
+      stream.on('end', resolve);
+      stream.on('error', reject);
+    });
+    const digest = hash.digest('hex');
+    if (digest !== entry.sha256) {
+      await fs.unlink(tmpPath);
+      throw new Error(
+        `SHA-256 mismatch for ${entry.fileName}: ` +
+        `expected ${entry.sha256}, got ${digest}`
+      );
+    }
+
+    // Atomic rename
+    await fs.rename(tmpPath, targetPath);
+  }
+
+  /**
+   * Delete a downloaded model
+   * @param {string} modelId
+   */
+  async deleteModel(modelId) {
+    this.#ensureInit();
+    if (this.#modelId === modelId) {
+      await this.unloadModel();
+    }
+    const entry = this.#getEntry(modelId);
+    const filePath = path.join(this.#modelsDir, entry.fileName);
+    try {
+      await fs.unlink(filePath);
+    } catch {
+      // file doesn't exist, that's fine
+    }
+    // Also clean up partial downloads
+    try {
+      await fs.unlink(filePath + '.tmp');
+    } catch {
+      // no partial file
+    }
+  }
+
+  /**
+   * Load model into memory.
+   * Serialized via #loadQueue to prevent concurrent calls from leaking model instances.
+   * @param {string} modelId
+   */
+  async loadModel(modelId) {
+    this.#ensureInit();
+    this.#loadQueue = this.#loadQueue.then(async () => {
+      if (this.#modelId === modelId && this.#model) return; // already loaded
+      if (this.#model) await this.unloadModel(); // unload previous
+
+      const entry = this.#getEntry(modelId);
+      const modelPath = path.join(this.#modelsDir, entry.fileName);
+
+      // Verify file exists
+      try {
+        await fs.stat(modelPath);
+      } catch {
+        throw new Error(`Model file not found: ${entry.fileName}. Download it first.`);
+      }
+
+      // Dynamic import for ESM module
+      const { getLlama } = await import('node-llama-cpp');
+      const llama = await getLlama();
+      this.#model = await llama.loadModel({ modelPath });
+      this.#context = await this.#model.createContext();
+      this.#modelId = modelId;
+    });
+    return this.#loadQueue;
+  }
+
+  /**
+   * Unload model from memory, freeing VRAM/RAM.
+   * Skips unload if inference is currently in progress or queued.
+   */
+  async unloadModel() {
+    if (this.#inferring > 0 || this.#pendingInfers > 0) {
+      console.log('[LlmEngine] Skipping unload — inference in progress or queued');
+      return;
+    }
+    if (this.#idleTimer) {
+      clearTimeout(this.#idleTimer);
+      this.#idleTimer = null;
+    }
+    if (this.#context) {
+      await this.#context.dispose();
+      this.#context = null;
+    }
+    if (this.#model) {
+      await this.#model.dispose();
+      this.#model = null;
+    }
+    this.#modelId = null;
+    // Hint to GC to reclaim native memory
+    if (global.gc) global.gc();
+  }
+
+  /**
+   * Check if a model is currently loaded
+   */
+  isLoaded() {
+    return this.#model !== null;
+  }
+
+  /**
+   * Run inference on the loaded model.
+   * Requests are serialized via a queue because the LlamaContext has only
+   * one sequence slot — concurrent getSequence() calls would throw
+   * "No sequences left".
+   * @param {string} prompt
+   * @param {{ maxTokens?: number }} [options]
+   */
+  async infer(prompt, options = {}) {
+    if (!this.#model || !this.#context) {
+      throw new Error('Model not loaded. Call loadModel() first.');
+    }
+
+    this.#pendingInfers++; // synchronous increment before queue entry
+
+    // Chain onto the queue so only one inference occupies the sequence at a time
+    const result = this.#inferQueue.then(async () => {
+      this.#pendingInfers--; // starting: transfer from pending to active
+      // Guard: context may have been disposed between queue entry and execution
+      if (!this.#context) {
+        throw new Error('Model was unloaded before inference could start.');
+      }
+
+      this.#inferring++;
+      // Cancel idle timer while inference is active
+      if (this.#idleTimer) {
+        clearTimeout(this.#idleTimer);
+        this.#idleTimer = null;
+      }
+
+      const { LlamaChatSession } = await import('node-llama-cpp');
+      const sequence = this.#context.getSequence();
+      const session = new LlamaChatSession({
+        contextSequence: sequence,
+      });
+
+      const maxTokens = options.maxTokens || 512;
+      let tokenCount = 0;
+
+      try {
+        const text = await session.prompt(prompt, {
+          maxTokens,
+          onToken: () => { tokenCount++; },
+        });
+        return { text, tokenCount };
+      } finally {
+        session.dispose({ disposeSequence: true });
+        this.#inferring--;
+        this.#resetIdleTimer();
+      }
+    });
+
+    // Update queue — swallow errors so subsequent requests still run
+    this.#inferQueue = result.catch(() => {});
+
+    return result;
+  }
+
+  /**
+   * Get storage usage for downloaded models
+   */
+  async getStorageUsage() {
+    this.#ensureInit();
+    const models = [];
+    let totalUsed = 0;
+    for (const entry of MODEL_REGISTRY) {
+      const filePath = path.join(this.#modelsDir, entry.fileName);
+      try {
+        const stat = await fs.stat(filePath);
+        models.push({ id: entry.id, size: stat.size });
+        totalUsed += stat.size;
+      } catch {
+        // not downloaded
+      }
+    }
+    return { used: totalUsed, models };
+  }
+
+  /**
+   * Enable or disable automatic model unloading after idle timeout.
+   * @param {boolean} enabled
+   */
+  setIdlingStop(enabled) {
+    this.#idlingStopEnabled = enabled;
+    if (!enabled) {
+      if (this.#idleTimer) {
+        clearTimeout(this.#idleTimer);
+        this.#idleTimer = null;
+      }
+    } else if (this.isLoaded()) {
+      // Model already loaded — start the idle timer immediately
+      this.#resetIdleTimer();
+    }
+  }
+
+  /**
+   * Reset the idle timer. If the timer fires, the model is automatically unloaded.
+   */
+  #resetIdleTimer() {
+    if (!this.#idlingStopEnabled) return;
+    if (this.#idleTimer) clearTimeout(this.#idleTimer);
+    this.#idleTimer = setTimeout(async () => {
+      this.#idleTimer = null;
+      if (this.isLoaded()) {
+        console.log('[LlmEngine] Idle timeout — unloading model');
+        await this.unloadModel();
+      }
+    }, this.#IDLE_TIMEOUT_MS);
+  }
+
+  /**
+   * Full cleanup — call on app quit
+   */
+  async dispose() {
+    if (this.#idleTimer) {
+      clearTimeout(this.#idleTimer);
+      this.#idleTimer = null;
+    }
+    await this.unloadModel();
+    this.#initialized = false;
+  }
+}
+
+module.exports = { LlmEngine };

--- a/www/src/downloads.ts
+++ b/www/src/downloads.ts
@@ -312,7 +312,7 @@ function renderPage(release: GitHubRelease | null, error: string | null): void {
         <h1 class="page-title">ダウンロード</h1>
         <div class="error-card">
           <p>リリース情報の取得に失敗しました。</p>
-          <p class="error-detail">${error}</p>
+          <p class="error-detail">${esc(error)}</p>
           <a href="https://github.com/${REPO}/releases" class="btn btn-secondary" target="_blank" rel="noopener">
             GitHubで直接確認する →
           </a>
@@ -376,7 +376,7 @@ function renderPage(release: GitHubRelease | null, error: string | null): void {
           (asset) => `
         <a href="${safeUrl(asset.url)}" class="download-item" data-platform="${key}" data-filename="${esc(asset.name)}" download>
           <div class="download-item-info">
-            <span class="download-item-label">${asset.label}</span>
+            <span class="download-item-label">${esc(asset.label)}</span>
             <span class="download-item-filename">${esc(asset.name)}</span>
           </div>
           <div class="download-item-meta">
@@ -438,7 +438,7 @@ function renderPage(release: GitHubRelease | null, error: string | null): void {
       <div class="hero-download">
         <a href="${safeUrl(heroCta.href)}" class="btn-hero-download" data-platform="${currentOS}" data-filename="${heroCta.isExternal ? "Microsoft Store" : esc(bestAsset?.name || "unknown")}" ${heroCta.isExternal ? 'target="_blank" rel="noopener noreferrer"' : "download"}>
           <span class="btn-hero-download-icon">${heroCta.icon}</span>
-          <span class="btn-hero-download-label">${heroCta.label}</span>
+          <span class="btn-hero-download-label">${esc(heroCta.label)}</span>
           ${heroCta.meta ? `<span class="btn-hero-download-meta">${esc(heroCta.meta)}</span>` : ""}
         </a>
         <p class="hero-download-hint">他のプラットフォームは下記をご覧ください</p>


### PR DESCRIPTION
## 概要

QAオーディットで発見された5件のバグを修正します。

## 修正内容

### セキュリティ
- **#1303** `www/src/downloads.ts` — GitHub APIレスポンスをinnerHTMLに挿入する際のXSS脆弱性を修正（`esc()` / `safeUrl()` をすべての動的値に適用）

### LLMエンジン競合
- **#1304** `llm-service/llm-engine.js` — `loadModel()` に `#loadQueue` ミューテックスを追加し、並列ロードによるモデルインスタンスリークを防止
- **#1305** `llm-service/llm-engine.js` — `#pendingInfers` カウンターをキューエントリ前に同期的にインクリメントし、`unloadModel()` のTOCTOU競合を解消

### IPCバリデーション
- **#1306** `electron/ipc/file-ipc.js` — `save-file` / `export-*` ハンドラーに50 MBコンテンツサイズ上限を追加
- **#1307** `electron/ipc/storage-ipc.js` — すべての書き込みハンドラーにオブジェクト型バリデーションを追加（CLAUDE.md IPC規則準拠）

## 変更ファイル

| ファイル | 対応Issue |
|---|---|
| `www/src/downloads.ts` | #1303 |
| `llm-service/llm-engine.js` | #1304, #1305 |
| `electron/ipc/file-ipc.js` | #1306 |
| `electron/ipc/storage-ipc.js` | #1307 |

> **注記:** `llm-service/llm-engine.js` はまだ `dev` ブランチに存在しないため、このPRで追加されます（修正済みバージョン）。

Closes #1303
Closes #1304
Closes #1305
Closes #1306
Closes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)