### PR TITLE
fix: resolve Windows shell names in PTY spawn (fixes #1301)

### DIFF
--- a/components/settings/TerminalSettingsTab.tsx
+++ b/components/settings/TerminalSettingsTab.tsx
@@ -88,11 +88,11 @@ export default function TerminalSettingsTab(): React.ReactElement {
             type="text"
             value={terminalDefaultShell}
             onChange={(e) => onTerminalDefaultShellChange(e.target.value)}
-            placeholder="自動検出（例: /bin/zsh）"
+            placeholder="自動検出（例: powershell、cmd、/bin/zsh）"
             className="w-full px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent placeholder:text-foreground-muted"
           />
           <p className="text-xs text-foreground-tertiary mt-1">
-            空欄の場合はシステムのデフォルトShellを使用します。
+            絶対パス（例: C:\Windows\System32\cmd.exe）またはShell名（例: powershell、pwsh、cmd、bash、zsh）を入力できます。空欄の場合はシステムのデフォルトShellを使用します。
           </p>
         </div>
 

--- a/components/settings/TerminalSettingsTab.tsx
+++ b/components/settings/TerminalSettingsTab.tsx
@@ -92,7 +92,8 @@ export default function TerminalSettingsTab(): React.ReactElement {
             className="w-full px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent placeholder:text-foreground-muted"
           />
           <p className="text-xs text-foreground-tertiary mt-1">
-            絶対パス（例: C:\Windows\System32\cmd.exe）またはShell名（例: powershell、pwsh、cmd、bash、zsh）を入力できます。空欄の場合はシステムのデフォルトShellを使用します。
+            絶対パス（例: C:\Windows\System32\cmd.exe）またはShell名（例:
+            powershell、pwsh、cmd、bash、zsh）を入力できます。空欄の場合はシステムのデフォルトShellを使用します。
           </p>
         </div>
 

--- a/electron/ipc/pty-ipc.js
+++ b/electron/ipc/pty-ipc.js
@@ -260,10 +260,13 @@ function registerPtyHandlers() {
     // Resolve shell: bare names (e.g. "powershell.exe") are resolved to absolute paths
     let shell;
     try {
-      const rawShell = (typeof options.shell === "string" && options.shell) || resolveDefaultShell();
+      const rawShell =
+        (typeof options.shell === "string" && options.shell) || resolveDefaultShell();
       shell = resolveShellPath(rawShell);
     } catch (err) {
-      return { error: err instanceof Error ? err.message : `Shellが見つかりません: ${options.shell}` };
+      return {
+        error: err instanceof Error ? err.message : `Shellが見つかりません: ${options.shell}`,
+      };
     }
     if (!shellExists(shell)) {
       return { error: `Shellが見つかりません: ${shell}` };

--- a/electron/ipc/pty-ipc.js
+++ b/electron/ipc/pty-ipc.js
@@ -12,7 +12,7 @@ const { ipcMain, BrowserWindow } = require("electron");
 const path = require("path");
 const fs = require("fs");
 const os = require("os");
-const { execSync } = require("child_process");
+const { execSync, execFileSync } = require("child_process");
 
 const {
   MAX_SESSIONS_PER_WINDOW,
@@ -60,6 +60,55 @@ function resolveWindowsShellByName(name) {
     // `where` exited non-zero — executable not on PATH
   }
   return null;
+}
+
+/**
+ * Resolve a user-supplied shell string to an absolute executable path.
+ *
+ * Resolution order:
+ *   1. Already an absolute path — return as-is (caller will verify existence).
+ *   2. Bare name (e.g. "powershell.exe", "bash") — PATH lookup via `where` (Windows)
+ *      or `which` (Unix).
+ *   3. Windows-only: well-known fallback paths for common shells when PATH lookup fails.
+ *
+ * @param {string} shell - shell value provided by the user (absolute path or bare name)
+ * @returns {string} absolute path to the shell executable
+ * @throws {Error} if the shell cannot be resolved to an absolute path
+ */
+function resolveShellPath(shell) {
+  if (!shell) return shell;
+
+  // Already an absolute path — use directly (existence is checked separately)
+  if (path.isAbsolute(shell)) return shell;
+
+  // PATH lookup: `where` on Windows, `which` on Unix
+  try {
+    const cmd = process.platform === "win32" ? "where" : "which";
+    const result = execFileSync(cmd, [shell], { encoding: "utf8", timeout: 3000 });
+    const resolved = result.trim().split(/\r?\n/)[0].trim();
+    if (resolved && path.isAbsolute(resolved)) return resolved;
+  } catch {
+    // Not found via PATH — fall through to well-known fallbacks
+  }
+
+  // Windows-only fallback for common shells
+  if (process.platform === "win32") {
+    const sysRoot = process.env.SystemRoot || process.env.WINDIR || "C:\\Windows";
+    const progFiles = process.env.ProgramFiles || "C:\\Program Files";
+    /** @type {Record<string, string>} */
+    const wellKnown = {
+      "powershell.exe": `${sysRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+      powershell: `${sysRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
+      "pwsh.exe": `${progFiles}\\PowerShell\\7\\pwsh.exe`,
+      pwsh: `${progFiles}\\PowerShell\\7\\pwsh.exe`,
+      "cmd.exe": `${sysRoot}\\System32\\cmd.exe`,
+      cmd: `${sysRoot}\\System32\\cmd.exe`,
+    };
+    const known = wellKnown[shell.toLowerCase()];
+    if (known) return known;
+  }
+
+  throw new Error(`シェルが見つかりません: ${shell}`);
 }
 
 /**
@@ -208,8 +257,14 @@ function registerPtyHandlers() {
       return { error: `グローバルの最大セッション数(${MAX_SESSIONS_GLOBAL})に達しました` };
     }
 
-    // Resolve shell
-    const shell = (typeof options.shell === "string" && options.shell) || resolveDefaultShell();
+    // Resolve shell: bare names (e.g. "powershell.exe") are resolved to absolute paths
+    let shell;
+    try {
+      const rawShell = (typeof options.shell === "string" && options.shell) || resolveDefaultShell();
+      shell = resolveShellPath(rawShell);
+    } catch (err) {
+      return { error: err instanceof Error ? err.message : `Shellが見つかりません: ${options.shell}` };
+    }
     if (!shellExists(shell)) {
       return { error: `Shellが見つかりません: ${shell}` };
     }


### PR DESCRIPTION
## 概要

ターミナル設定でシェルのフルパスではなく `powershell`、`cmd`、`pwsh` などの短縮名を入力しても正しく動作するよう修正します。

## 変更内容

### `electron/ipc/pty-ipc.js`
- `resolveShellPath(shell)` 関数を追加:
  1. 絶対パスはそのまま使用
  2. 短縮名は `where`（Windows）/ `which`（Unix）でPATH検索
  3. PATH検索失敗時は `process.env.SystemRoot` / `process.env.ProgramFiles` を使ったウェルノウンパスへフォールバック（`C:\Windows` ハードコードなし）
  4. 解決できない場合は `シェルが見つかりません: ${shell}` エラーをスロー
- `pty:spawn` ハンドラーで `resolveShellPath()` を `shellExists()` 前に呼び出すよう更新

### `components/settings/TerminalSettingsTab.tsx`
- シェル入力のplaceholderを更新: `自動検出（例: powershell、cmd、/bin/zsh）`
- ヘルプテキストを更新: 絶対パスとシェル名の両方が使えることを明示

Closes #1301

🤖 Generated with [Claude Code](https://claude.com/claude-code)