### PR TITLE
chore: weekly-release fallback cron + idempotency guard

### DIFF
--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -3,7 +3,8 @@ name: Weekly Release
 on:
   schedule:
     - cron: "0 0 * * 1" # Monday 00:00 UTC = 09:00 JST
-    - cron: "0 1 * * 1" # Monday 01:00 UTC = 10:00 JST (fallback if 00:00 run delayed)
+    - cron: "0 1 * * 1" # Monday 01:00 UTC = 10:00 JST (retry 1)
+    - cron: "0 2 * * 1" # Monday 02:00 UTC = 11:00 JST (retry 2)
   workflow_dispatch: # Manual trigger
 
 permissions:

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -2,7 +2,8 @@ name: Weekly Release
 
 on:
   schedule:
-    - cron: "0 0 * * 1" # Every Monday 00:00 UTC = 09:00 JST
+    - cron: "0 0 * * 1" # Monday 00:00 UTC = 09:00 JST
+    - cron: "0 1 * * 1" # Monday 01:00 UTC = 10:00 JST (fallback if 00:00 run delayed)
   workflow_dispatch: # Manual trigger
 
 permissions:
@@ -31,9 +32,31 @@ jobs:
         run: |
           echo "No new commits in dev. Skipping weekly release."
 
+      - name: Check for existing weekly release PR
+        id: check-existing
+        if: steps.check-diff.outputs.ahead != '0'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: 'main',
+            });
+            const existing = prs.find(pr =>
+              pr.labels.some(l => l.name === 'weekly-release')
+            );
+            if (existing) {
+              console.log(`Weekly release PR #${existing.number} already exists. Skipping.`);
+              core.setOutput('exists', 'true');
+            } else {
+              core.setOutput('exists', 'false');
+            }
+
       - name: Check latest dev CI status
         id: check-ci
-        if: steps.check-diff.outputs.ahead != '0'
+        if: steps.check-diff.outputs.ahead != '0' && steps.check-existing.outputs.exists != 'true'
         uses: actions/github-script@v8
         with:
           script: |
@@ -54,7 +77,7 @@ jobs:
             core.setOutput('green', isGreen ? 'true' : 'false');
 
       - name: Close old weekly release PRs
-        if: steps.check-diff.outputs.ahead != '0' && steps.check-ci.outputs.green == 'true'
+        if: steps.check-diff.outputs.ahead != '0' && steps.check-existing.outputs.exists != 'true' && steps.check-ci.outputs.green == 'true'
         uses: actions/github-script@v8
         with:
           script: |
@@ -78,7 +101,7 @@ jobs:
             }
 
       - name: Create weekly release PR
-        if: steps.check-diff.outputs.ahead != '0' && steps.check-ci.outputs.green == 'true'
+        if: steps.check-diff.outputs.ahead != '0' && steps.check-existing.outputs.exists != 'true' && steps.check-ci.outputs.green == 'true'
         uses: actions/github-script@v8
         with:
           script: |
@@ -133,7 +156,7 @@ jobs:
             console.log(`Created PR #${pr.number}: ${pr.html_url}`);
 
       - name: Create issue on CI failure
-        if: steps.check-diff.outputs.ahead != '0' && steps.check-ci.outputs.green != 'true'
+        if: steps.check-diff.outputs.ahead != '0' && steps.check-existing.outputs.exists != 'true' && steps.check-ci.outputs.green != 'true'
         uses: actions/github-script@v8
         with:
           script: |

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ reviews/
 .claude/review-loop.log
 .claude/*.local.md
 .claude/settings.local.json
+.claude/*.lock
 
 # auto-generated files
 /generated/


### PR DESCRIPTION
## 概要

Weekly Release ワークフローの信頼性改善。

## 変更内容

### `.github/workflows/weekly-release.yml`
- **fallback cron 追加**: 月曜 01:00 UTC（10:00 JST）を追加。GitHub Actions のスケジュール遅延時に自動リトライ
- **冪等ガード追加**: `check-existing` ステップで既存の `weekly-release` ラベル付き open PR を確認し、存在する場合は後続ステップを全スキップ（重複 PR 作成防止）

### `.gitignore`
- `.claude/*.lock` を追加（Claude Code 内部ロックファイルを追跡対象外に）

## 動作フロー（修正後）

```
00:00 UTC: cron 実行 → PR #N 作成
01:00 UTC: fallback cron 実行 → 既存 PR #N を検出 → スキップ
```

手動トリガー時も同様にスキップされるため、二重実行が安全になります。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>