### PR TITLE
fix: resolve ESLint errors blocking weekly release CI

### DIFF
--- a/lib/tab-manager/use-tab-state.ts
+++ b/lib/tab-manager/use-tab-state.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { MdiFileDescriptor } from "../project/mdi-file";
 import type { SupportedFileExtension } from "../project/project-types";
 import type { TabId, TabState, EditorTabState, TerminalTabState, DiffTabState } from "./tab-types";
@@ -125,7 +125,9 @@ export function useTabState(): UseTabStateReturn {
   const lastSaveWasAuto = editorActiveTab?.lastSaveWasAuto ?? false;
 
   const contentRef = useRef(content);
-  contentRef.current = content;
+  useEffect(() => {
+    contentRef.current = content;
+  });
 
   // --- Helpers ------------------------------------------------------------
 

--- a/llm-service/llm-engine.js
+++ b/llm-service/llm-engine.js
@@ -1,4 +1,5 @@
 // @ts-check
+/* eslint-disable @typescript-eslint/no-require-imports */
 "use strict";
 
 const path = require("path");


### PR DESCRIPTION
## Summary

- `llm-service/llm-engine.js`: Add `eslint-disable @typescript-eslint/no-require-imports` — this is an intentional CJS-only file (Electron main process, cannot use ESM `require()`)
- `lib/tab-manager/use-tab-state.ts`: Wrap `contentRef.current = content` in `useEffect` to fix `react-hooks/refs` violation

## Why

These lint errors are blocking PR #1316 (weekly release `dev → main`) from merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)