### PR TITLE
fix(www): cast navigator for userAgentData TS strict mode

### DIFF
--- a/www/src/downloads.ts
+++ b/www/src/downloads.ts
@@ -94,11 +94,18 @@ function formatDate(isoDate: string): string {
   });
 }
 
+type NavigatorWithUAData = Navigator & {
+  userAgentData?: {
+    getHighEntropyValues(hints: string[]): Promise<{ architecture?: string }>;
+  };
+};
+
 /** Async Windows architecture detection using User-Agent Client Hints (Chromium 93+) */
 async function detectWindowsArch(): Promise<"x64" | "arm64" | "unknown"> {
   try {
-    if (typeof navigator !== "undefined" && navigator.userAgentData) {
-      const ua = await navigator.userAgentData.getHighEntropyValues(["architecture"]);
+    const nav = navigator as NavigatorWithUAData;
+    if (typeof navigator !== "undefined" && nav.userAgentData) {
+      const ua = await nav.userAgentData.getHighEntropyValues(["architecture"]);
       if (ua.architecture === "arm") return "arm64";
       if (ua.architecture === "x86") return "x64";
     }


### PR DESCRIPTION
## Summary

- `www/src/downloads.ts`: `Navigator.userAgentData` は `lib: ["ES2022", "DOM"]` の型定義に含まれていないため `TS2551` エラーが発生
- `NavigatorWithUAData` ローカル型を定義してキャスト、型安全を保持

## Why

PR #1316 マージ後の `Deploy www to GitHub Pages` CI が失敗。

🤖 Generated with [Claude Code](https://claude.com/claude-code)