### PR TITLE
fix: increase Store polling timeout and add 3-attempt retry

### DIFF
--- a/.github/workflows/sync-ms-store-listing.yml
+++ b/.github/workflows/sync-ms-store-listing.yml
@@ -47,6 +47,7 @@ jobs:
     name: Submit to Microsoft Store (${{ inputs.mode }})
     runs-on: windows-latest
     environment: MicrosoftStore
+    timeout-minutes: 90
     env:
       MSSTORE_TENANT_ID: ${{ secrets.MSSTORE_TENANT_ID }}
       MSSTORE_CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
@@ -123,6 +124,25 @@ jobs:
           $appxFiles | ForEach-Object { Write-Host "  - $($_.Name)" }
 
       - name: Submit to Microsoft Store
+        shell: bash
         env:
           MSIX_DIR: msix-packages
-        run: node scripts/submit-store.mjs
+        run: |
+          MAX_ATTEMPTS=3
+          RETRY_DELAY=120  # 2 minutes between retries
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "=== Attempt $attempt / $MAX_ATTEMPTS ==="
+            if node scripts/submit-store.mjs; then
+              echo "Submission succeeded on attempt $attempt."
+              exit 0
+            fi
+            EXIT_CODE=$?
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "Attempt $attempt failed (exit $EXIT_CODE). Retrying in ${RETRY_DELAY}s..."
+              sleep $RETRY_DELAY
+            fi
+          done
+
+          echo "::error::All $MAX_ATTEMPTS submission attempts failed."
+          exit 1

--- a/.github/workflows/sync-ms-store-listing.yml
+++ b/.github/workflows/sync-ms-store-listing.yml
@@ -133,11 +133,12 @@ jobs:
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             echo "=== Attempt $attempt / $MAX_ATTEMPTS ==="
-            if node scripts/submit-store.mjs; then
+            node scripts/submit-store.mjs
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 0 ]; then
               echo "Submission succeeded on attempt $attempt."
               exit 0
             fi
-            EXIT_CODE=$?
             if [ $attempt -lt $MAX_ATTEMPTS ]; then
               echo "Attempt $attempt failed (exit $EXIT_CODE). Retrying in ${RETRY_DELAY}s..."
               sleep $RETRY_DELAY

--- a/scripts/submit-store.mjs
+++ b/scripts/submit-store.mjs
@@ -44,7 +44,7 @@ const CLIENT_ID = process.env.MSSTORE_CLIENT_ID;
 const CLIENT_SECRET = process.env.MSSTORE_CLIENT_SECRET;
 const APP_ID = process.env.STORE_PRODUCT_ID;
 const MSIX_DIR = resolve(process.env.MSIX_DIR ?? "msix-packages");
-const POLL_TIMEOUT_MS = Number(process.env.POLL_TIMEOUT_MS ?? 600_000);
+const POLL_TIMEOUT_MS = Number(process.env.POLL_TIMEOUT_MS ?? 1_200_000);
 
 const API_BASE = "https://manage.devcenter.microsoft.com/v1.0/my";
 const STORE_METADATA_DIR = resolve(__dirname, "..", "store", "microsoft", "ja-JP");
@@ -317,7 +317,7 @@ async function uploadPackageToSas(sasUrl, zipPath) {
  */
 async function pollSubmissionStatus(token, submissionId) {
   const start = Date.now();
-  const intervalMs = 15_000;
+  const intervalMs = 30_000;
 
   while (Date.now() - start < POLL_TIMEOUT_MS) {
     const sub = await apiGet(token, `/applications/${APP_ID}/submissions/${submissionId}`);


### PR DESCRIPTION
## Summary

- `scripts/submit-store.mjs`: デフォルト polling タイムアウトを 600 秒 → **1200 秒**（20 分）、polling 間隔を 15 秒 → **30 秒**に変更
- `.github/workflows/sync-ms-store-listing.yml`:
  - ジョブ全体の `timeout-minutes: 90` を追加
  - "Submit to Microsoft Store" ステップを **最大 3 回**リトライするループに変更（失敗時 2 分待機）

## Why

PR #1316 マージ後の `Sync Microsoft Store Listing` が polling 600 秒でタイムアウト。Microsoft Store の submission commit は処理に 15〜20 分かかることがある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)