### PR TITLE
fix: post-release hotfixes (www TS error + Store retry)

### DIFF
--- a/.github/workflows/sync-ms-store-listing.yml
+++ b/.github/workflows/sync-ms-store-listing.yml
@@ -47,6 +47,7 @@ jobs:
     name: Submit to Microsoft Store (${{ inputs.mode }})
     runs-on: windows-latest
     environment: MicrosoftStore
+    timeout-minutes: 90
     env:
       MSSTORE_TENANT_ID: ${{ secrets.MSSTORE_TENANT_ID }}
       MSSTORE_CLIENT_ID: ${{ secrets.MSSTORE_CLIENT_ID }}
@@ -123,6 +124,26 @@ jobs:
           $appxFiles | ForEach-Object { Write-Host "  - $($_.Name)" }
 
       - name: Submit to Microsoft Store
+        shell: bash
         env:
           MSIX_DIR: msix-packages
-        run: node scripts/submit-store.mjs
+        run: |
+          MAX_ATTEMPTS=3
+          RETRY_DELAY=120  # 2 minutes between retries
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "=== Attempt $attempt / $MAX_ATTEMPTS ==="
+            node scripts/submit-store.mjs
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 0 ]; then
+              echo "Submission succeeded on attempt $attempt."
+              exit 0
+            fi
+            if [ $attempt -lt $MAX_ATTEMPTS ]; then
+              echo "Attempt $attempt failed (exit $EXIT_CODE). Retrying in ${RETRY_DELAY}s..."
+              sleep $RETRY_DELAY
+            fi
+          done
+
+          echo "::error::All $MAX_ATTEMPTS submission attempts failed."
+          exit 1

--- a/scripts/submit-store.mjs
+++ b/scripts/submit-store.mjs
@@ -44,7 +44,7 @@ const CLIENT_ID = process.env.MSSTORE_CLIENT_ID;
 const CLIENT_SECRET = process.env.MSSTORE_CLIENT_SECRET;
 const APP_ID = process.env.STORE_PRODUCT_ID;
 const MSIX_DIR = resolve(process.env.MSIX_DIR ?? "msix-packages");
-const POLL_TIMEOUT_MS = Number(process.env.POLL_TIMEOUT_MS ?? 600_000);
+const POLL_TIMEOUT_MS = Number(process.env.POLL_TIMEOUT_MS ?? 1_200_000);
 
 const API_BASE = "https://manage.devcenter.microsoft.com/v1.0/my";
 const STORE_METADATA_DIR = resolve(__dirname, "..", "store", "microsoft", "ja-JP");
@@ -317,7 +317,7 @@ async function uploadPackageToSas(sasUrl, zipPath) {
  */
 async function pollSubmissionStatus(token, submissionId) {
   const start = Date.now();
-  const intervalMs = 15_000;
+  const intervalMs = 30_000;
 
   while (Date.now() - start < POLL_TIMEOUT_MS) {
     const sub = await apiGet(token, `/applications/${APP_ID}/submissions/${submissionId}`);

--- a/www/src/downloads.ts
+++ b/www/src/downloads.ts
@@ -94,11 +94,18 @@ function formatDate(isoDate: string): string {
   });
 }
 
+type NavigatorWithUAData = Navigator & {
+  userAgentData?: {
+    getHighEntropyValues(hints: string[]): Promise<{ architecture?: string }>;
+  };
+};
+
 /** Async Windows architecture detection using User-Agent Client Hints (Chromium 93+) */
 async function detectWindowsArch(): Promise<"x64" | "arm64" | "unknown"> {
   try {
-    if (typeof navigator !== "undefined" && navigator.userAgentData) {
-      const ua = await navigator.userAgentData.getHighEntropyValues(["architecture"]);
+    const nav = navigator as NavigatorWithUAData;
+    if (typeof navigator !== "undefined" && nav.userAgentData) {
+      const ua = await nav.userAgentData.getHighEntropyValues(["architecture"]);
       if (ua.architecture === "arm") return "arm64";
       if (ua.architecture === "x86") return "x64";
     }


### PR DESCRIPTION
## Summary

- `www/src/downloads.ts`: `navigator.userAgentData` を `NavigatorWithUAData` 型でキャストし TS2551 エラーを修正 → GitHub Pages デプロイ復旧
- `scripts/submit-store.mjs`: polling タイムアウト 600s → 1200s、interval 15s → 30s
- `.github/workflows/sync-ms-store-listing.yml`: ジョブ timeout-minutes 90、最大 3 回リトライ（間隔 2 分）追加

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `www/src/downloads.ts` | `NavigatorWithUAData` 型を追加、直接アクセスをキャスト経由に変更 |
| `scripts/submit-store.mjs` | `POLL_TIMEOUT_MS` デフォルト値変更、polling interval 変更 |
| `.github/workflows/sync-ms-store-listing.yml` | job timeout・3 回リトライループ追加、EXIT_CODE バグ修正 |

## Test plan

- [ ] `Deploy www to GitHub Pages` CI が pass することを確認
- [ ] `Sync Microsoft Store Listing` が timeout せず完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)