### PR TITLE
feat(export): add EPUB tab, 80+ page sizes, and export improvements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -757,7 +757,9 @@ export default function EditorPage() {
     try {
       const { generateEpubBlob } = await import("@/lib/export/epub-web");
       const blob = await generateEpubBlob(dialogState.content, options);
-      const baseName = (options.metadata.title || "untitled").replace(/\.[^.]+$/, "");
+      const baseName = (options.metadata.title || "untitled")
+        .replace(/[<>:"/\\|?*]/g, "_")
+        .replace(/\.[^.]+$/, "");
       const { saveBlobFile } = await import("@/lib/export/save-blob-file");
       const saved = await saveBlobFile(
         blob,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ import { openWebPrintPreview } from "@/lib/export/web-print-preview";
 import type { ExportMetadata } from "@/lib/export/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { DocxExportSettings } from "@/lib/export/docx-export-settings";
+import type { EpubExportOptions } from "@/lib/export/epub-shared";
 import { notificationManager } from "@/lib/services/notification-manager";
 import { useWebMenuHandlers } from "@/lib/menu/use-web-menu-handlers";
 import { useGlobalShortcuts } from "@/lib/hooks/use-global-shortcuts";
@@ -493,7 +494,7 @@ export default function EditorPage() {
 
   // Export dialog state (PDF / DOCX share a single state slot)
   interface ExportDialogState {
-    format: "pdf" | "docx";
+    format: "pdf" | "docx" | "epub";
     content: string;
     metadata: ExportMetadata;
   }
@@ -512,7 +513,7 @@ export default function EditorPage() {
   }, []);
 
   const handleExportDialogRequest = useCallback(
-    (format: "pdf" | "docx", content: string, metadata: ExportMetadata) => {
+    (format: "pdf" | "docx" | "epub", content: string, metadata: ExportMetadata) => {
       const state: ExportDialogState = { format, content, metadata };
       exportDialogStateRef.current = state;
       setExportDialogState(state);
@@ -709,6 +710,72 @@ export default function EditorPage() {
       notificationManager.dismiss(progressId);
       const message = error instanceof Error ? error.message : "不明なエラー";
       notificationManager.error(`DOCXのエクスポートに失敗しました: ${message}`);
+    }
+  }, []);
+
+  const handleEpubExportConfirm = useCallback(async (options: EpubExportOptions) => {
+    const dialogState = exportDialogStateRef.current;
+    if (!dialogState) return;
+
+    // Electron path: use IPC
+    if (window.electronAPI?.exportEPUB) {
+      setExportDialogState(null);
+
+      const progressId = notificationManager.showProgress("EPUBをエクスポート中...", {
+        type: "info",
+      });
+
+      try {
+        // Electron IPC serializes Uint8Array automatically
+        const result = await window.electronAPI.exportEPUB(dialogState.content, options);
+
+        notificationManager.dismiss(progressId);
+
+        if (result === null || result === undefined) return;
+
+        if (typeof result === "object" && "success" in result && !result.success) {
+          notificationManager.error(
+            `EPUBのエクスポートに失敗しました: ${(result as { error: string }).error}`,
+          );
+          return;
+        }
+
+        notificationManager.success("EPUBをエクスポートしました");
+      } catch (error) {
+        notificationManager.dismiss(progressId);
+        const message = error instanceof Error ? error.message : "不明なエラー";
+        notificationManager.error(`EPUBのエクスポートに失敗しました: ${message}`);
+      }
+      return;
+    }
+
+    // Web path: generate EPUB blob and download
+    const progressId = notificationManager.showProgress("EPUBをエクスポート中...", {
+      type: "info",
+    });
+
+    try {
+      const { generateEpubBlob } = await import("@/lib/export/epub-web");
+      const blob = await generateEpubBlob(dialogState.content, options);
+      const baseName = (options.metadata.title || "untitled").replace(/\.[^.]+$/, "");
+      const { saveBlobFile } = await import("@/lib/export/save-blob-file");
+      const saved = await saveBlobFile(
+        blob,
+        `${baseName}.epub`,
+        { "application/epub+zip": [".epub"] },
+        false,
+      );
+
+      notificationManager.dismiss(progressId);
+
+      if (saved) {
+        setExportDialogState(null);
+        notificationManager.success("EPUBをエクスポートしました");
+      }
+    } catch (error) {
+      notificationManager.dismiss(progressId);
+      const message = error instanceof Error ? error.message : "不明なエラー";
+      notificationManager.error(`EPUBのエクスポートに失敗しました: ${message}`);
     }
   }, []);
 
@@ -1100,6 +1167,7 @@ export default function EditorPage() {
           onClose: () => setExportDialogState(null),
           onPdfExport: handlePdfExportConfirm,
           onDocxExport: handleDocxExportConfirm,
+          onEpubExport: handleEpubExportConfirm,
           content: exportDialogState?.content ?? "",
           metadata: exportDialogState?.metadata ?? { title: "" },
         },

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -44,6 +44,7 @@ import type { ContextMenuState } from "@/lib/hooks/use-context-menu";
 import type { LintIssue } from "@/lib/linting/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { DocxExportSettings } from "@/lib/export/docx-export-settings";
+import type { EpubExportOptions } from "@/lib/export/epub-shared";
 import type { ExportMetadata } from "@/lib/export/types";
 import type { RuleRunner } from "@/lib/linting/rule-runner";
 import { DockviewReact } from "dockview-react";
@@ -97,10 +98,11 @@ interface EditorLayoutProps {
     rubySelectedText: string;
     handleApplyRuby: React.ComponentProps<typeof RubyDialog>["onApply"];
     exportDialog: {
-      state: { format: "pdf" | "docx"; content: string; metadata: ExportMetadata } | null;
+      state: { format: "pdf" | "docx" | "epub"; content: string; metadata: ExportMetadata } | null;
       onClose: () => void;
       onPdfExport: (settings: PdfExportSettings) => void;
       onDocxExport: (settings: DocxExportSettings) => void;
+      onEpubExport: (options: EpubExportOptions) => void;
       content: string;
       metadata: ExportMetadata;
     };
@@ -280,6 +282,7 @@ export default function EditorLayout({
               onClose={dialogs.exportDialog.onClose}
               onExportPdf={dialogs.exportDialog.onPdfExport}
               onExportDocx={dialogs.exportDialog.onDocxExport}
+              onExportEpub={dialogs.exportDialog.onEpubExport}
               content={dialogs.exportDialog.content}
               metadata={dialogs.exportDialog.metadata}
             />

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -14,7 +14,7 @@ import { FontSelector } from "@/components/explorer/FontSelector";
 import { PageSizeSelector } from "@/components/PageSizeSelector";
 import { openWebPrintPreview } from "@/lib/export/web-print-preview";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
-import { useAuth } from "@/contexts/AuthContext";
+import { useAuthSafe } from "@/contexts/AuthContext";
 
 import type {
   UnifiedExportSettings,
@@ -148,13 +148,8 @@ function ExportDialogInner({
   const hasPreviewApi = isElectron && !!window.electronAPI?.generatePdfPreview;
 
   // --- Author auto-fill from auth context ---
-  let authUserName: string | undefined;
-  try {
-    const { user } = useAuth();
-    authUserName = user?.name ?? undefined;
-  } catch {
-    // AuthProvider not available — ignore
-  }
+  const authContext = useAuthSafe();
+  const authUserName = authContext?.user?.name ?? undefined;
 
   // --- EPUB metadata state ---
   const [epubTitle, setEpubTitle] = useState(metadata.title || "");
@@ -172,6 +167,10 @@ function ExportDialogInner({
   const [coverMediaType, setCoverMediaType] = useState<string | null>(null);
   const [coverPreviewUrl, setCoverPreviewUrl] = useState<string | null>(null);
   const coverInputRef = useRef<HTMLInputElement>(null);
+
+  // --- Blob URL refs for cleanup (state captures stale values in [] effects) ---
+  const pdfUrlRef = useRef<string | null>(null);
+  const coverPreviewUrlRef = useRef<string | null>(null);
 
   // --- Electron PDF preview state ---
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
@@ -205,22 +204,27 @@ function ExportDialogInner({
       const buf = new Uint8Array(reader.result as ArrayBuffer);
       setCoverImage(buf);
       setCoverMediaType(file.type);
-      // Create preview URL
-      if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
       const blob = new Blob([buf], { type: file.type });
-      setCoverPreviewUrl(URL.createObjectURL(blob));
+      const newUrl = URL.createObjectURL(blob);
+      coverPreviewUrlRef.current = newUrl;
+      setCoverPreviewUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return newUrl;
+      });
     };
     reader.readAsArrayBuffer(file);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleCoverRemove = useCallback(() => {
     setCoverImage(null);
     setCoverMediaType(null);
-    if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
-    setCoverPreviewUrl(null);
+    setCoverPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return null;
+    });
+    coverPreviewUrlRef.current = null;
     if (coverInputRef.current) coverInputRef.current.value = "";
-  }, [coverPreviewUrl]);
+  }, []);
 
   const handleCoverDrop = useCallback(
     (e: React.DragEvent) => {
@@ -307,7 +311,9 @@ function ExportDialogInner({
 
           const bytes = Uint8Array.from(atob(result.data), (c) => c.charCodeAt(0));
           const blob = new Blob([bytes], { type: "application/pdf" });
-          setPdfUrl(URL.createObjectURL(blob) + "#view=FitH");
+          const newPdfUrl = URL.createObjectURL(blob) + "#view=FitH";
+          pdfUrlRef.current = newPdfUrl;
+          setPdfUrl(newPdfUrl);
         } else {
           setPreviewError(result.error);
         }
@@ -327,14 +333,13 @@ function ExportDialogInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasPreviewApi, settings, selectedFormat, content, metadata]);
 
-  // Cleanup blob URLs on unmount
+  // Cleanup blob URLs on unmount (refs always hold the latest values)
   useEffect(() => {
     return () => {
-      if (pdfUrl) URL.revokeObjectURL(pdfUrl);
-      if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
+      if (pdfUrlRef.current) URL.revokeObjectURL(pdfUrlRef.current);
+      if (coverPreviewUrlRef.current) URL.revokeObjectURL(coverPreviewUrlRef.current);
       if (previewTimeoutRef.current) clearTimeout(previewTimeoutRef.current);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // --- Web: print preview button handler ---

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -160,6 +160,13 @@ function ExportDialogInner({
   const [epubTitle, setEpubTitle] = useState(metadata.title || "");
   const [epubAuthor, setEpubAuthor] = useState(metadata.author || authUserName || "");
 
+  // Update author when auth finishes loading asynchronously
+  useEffect(() => {
+    if (authUserName && !epubAuthor) {
+      setEpubAuthor(authUserName);
+    }
+  }, [authUserName]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // --- Cover image state ---
   const [coverImage, setCoverImage] = useState<Uint8Array | null>(null);
   const [coverMediaType, setCoverMediaType] = useState<string | null>(null);

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -8,20 +8,29 @@ import {
   saveExportSettings,
   toPdfExportSettings,
   toDocxExportSettings,
+  toEpubExportOptions,
 } from "@/lib/export/export-settings";
 import { FontSelector } from "@/components/explorer/FontSelector";
+import { PageSizeSelector } from "@/components/PageSizeSelector";
 import { openWebPrintPreview } from "@/lib/export/web-print-preview";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
+import { useAuth } from "@/contexts/AuthContext";
 
 import type {
   UnifiedExportSettings,
-  ExportPageSize,
   PageNumberFormat,
   PageNumberPosition,
 } from "@/lib/export/export-settings";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { DocxExportSettings } from "@/lib/export/docx-export-settings";
+import type { EpubExportOptions, ChapterSplitLevel } from "@/lib/export/epub-shared";
 import type { ExportMetadata } from "@/lib/export/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ExportDialogFormat = "pdf" | "docx" | "epub";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -30,10 +39,11 @@ import type { ExportMetadata } from "@/lib/export/types";
 interface ExportDialogProps {
   isOpen: boolean;
   mode?: "export" | "print";
-  initialFormat: "pdf" | "docx";
+  initialFormat: ExportDialogFormat;
   onClose: () => void;
   onExportPdf: (settings: PdfExportSettings) => void;
   onExportDocx: (settings: DocxExportSettings) => void;
+  onExportEpub?: (options: EpubExportOptions) => void;
   content: string;
   metadata: ExportMetadata;
 }
@@ -41,13 +51,6 @@ interface ExportDialogProps {
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-
-const PAGE_SIZE_OPTIONS: { value: ExportPageSize; label: string }[] = [
-  { value: "A4", label: "A4 (210×297mm)" },
-  { value: "A5", label: "A5 (148×210mm)" },
-  { value: "B5", label: "B5 (176×250mm)" },
-  { value: "B6", label: "B6 (125×176mm)" },
-];
 
 const PAGE_NUMBER_FORMAT_OPTIONS: { value: PageNumberFormat; label: string }[] = [
   { value: "simple", label: "1" },
@@ -62,6 +65,13 @@ const PAGE_NUMBER_POSITION_OPTIONS: { value: PageNumberPosition; label: string }
   { value: "top-left", label: "左上" },
   { value: "top-center", label: "中央上" },
   { value: "top-right", label: "右上" },
+];
+
+const CHAPTER_SPLIT_OPTIONS: { value: ChapterSplitLevel; label: string }[] = [
+  { value: "h1", label: "見出し1（#）" },
+  { value: "h2", label: "見出し2（##）まで" },
+  { value: "h3", label: "見出し3（###）まで" },
+  { value: "none", label: "分割しない" },
 ];
 
 const inputClass =
@@ -101,6 +111,7 @@ export default function ExportDialog({
   onClose,
   onExportPdf,
   onExportDocx,
+  onExportEpub,
   content,
   metadata,
 }: ExportDialogProps): React.ReactNode {
@@ -112,6 +123,7 @@ export default function ExportDialog({
       onClose={onClose}
       onExportPdf={onExportPdf}
       onExportDocx={onExportDocx}
+      onExportEpub={onExportEpub}
       content={content}
       metadata={metadata}
     />
@@ -124,14 +136,35 @@ function ExportDialogInner({
   onClose,
   onExportPdf,
   onExportDocx,
+  onExportEpub,
   content,
   metadata,
 }: Omit<ExportDialogProps, "isOpen">) {
-  const [selectedFormat, setSelectedFormat] = useState<"pdf" | "docx">(initialFormat);
+  const [selectedFormat, setSelectedFormat] = useState<ExportDialogFormat>(initialFormat);
   const [settings, setSettings] = useState<UnifiedExportSettings>(() => loadExportSettings());
 
+  const isEpub = selectedFormat === "epub";
   const isElectron = typeof window !== "undefined" && isElectronRenderer();
   const hasPreviewApi = isElectron && !!window.electronAPI?.generatePdfPreview;
+
+  // --- Author auto-fill from auth context ---
+  let authUserName: string | undefined;
+  try {
+    const { user } = useAuth();
+    authUserName = user?.name ?? undefined;
+  } catch {
+    // AuthProvider not available — ignore
+  }
+
+  // --- EPUB metadata state ---
+  const [epubTitle, setEpubTitle] = useState(metadata.title || "");
+  const [epubAuthor, setEpubAuthor] = useState(metadata.author || authUserName || "");
+
+  // --- Cover image state ---
+  const [coverImage, setCoverImage] = useState<Uint8Array | null>(null);
+  const [coverMediaType, setCoverMediaType] = useState<string | null>(null);
+  const [coverPreviewUrl, setCoverPreviewUrl] = useState<string | null>(null);
+  const coverInputRef = useRef<HTMLInputElement>(null);
 
   // --- Electron PDF preview state ---
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
@@ -157,18 +190,82 @@ function ExportDialogInner({
     }));
   }, []);
 
+  // --- Cover image handling ---
+  const handleCoverFile = useCallback((file: File) => {
+    if (!file.type.match(/^image\/(jpeg|png)$/)) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const buf = new Uint8Array(reader.result as ArrayBuffer);
+      setCoverImage(buf);
+      setCoverMediaType(file.type);
+      // Create preview URL
+      if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
+      const blob = new Blob([buf], { type: file.type });
+      setCoverPreviewUrl(URL.createObjectURL(blob));
+    };
+    reader.readAsArrayBuffer(file);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleCoverRemove = useCallback(() => {
+    setCoverImage(null);
+    setCoverMediaType(null);
+    if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
+    setCoverPreviewUrl(null);
+    if (coverInputRef.current) coverInputRef.current.value = "";
+  }, [coverPreviewUrl]);
+
+  const handleCoverDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      const file = e.dataTransfer.files[0];
+      if (file) handleCoverFile(file);
+    },
+    [handleCoverFile],
+  );
+
+  // --- Export handler ---
   const handleExport = useCallback(() => {
     saveExportSettings(settings);
+
+    if (isEpub && onExportEpub) {
+      const options = toEpubExportOptions(
+        settings,
+        {
+          title: epubTitle || metadata.title,
+          author: epubAuthor || metadata.author,
+          language: metadata.language ?? "ja",
+        },
+        coverImage ?? undefined,
+        coverMediaType ?? undefined,
+      );
+      onExportEpub(options);
+      return;
+    }
+
     if (mode === "print" || selectedFormat === "pdf") {
       onExportPdf(toPdfExportSettings(settings));
     } else {
       onExportDocx(toDocxExportSettings(settings));
     }
-  }, [settings, selectedFormat, mode, onExportPdf, onExportDocx]);
+  }, [
+    settings,
+    selectedFormat,
+    mode,
+    isEpub,
+    onExportPdf,
+    onExportDocx,
+    onExportEpub,
+    epubTitle,
+    epubAuthor,
+    metadata,
+    coverImage,
+    coverMediaType,
+  ]);
 
   // --- Electron: debounced PDF preview generation ---
   useEffect(() => {
-    if (!hasPreviewApi) return;
+    if (!hasPreviewApi || isEpub) return;
 
     if (previewTimeoutRef.current) clearTimeout(previewTimeoutRef.current);
 
@@ -177,7 +274,6 @@ function ExportDialogInner({
       setPreviewLoading(true);
       setPreviewError(null);
 
-      // Use toPdfExportSettings to get properly resolved font CSS + googleFontFamily
       const previewSettings = toPdfExportSettings(settings);
 
       try {
@@ -197,11 +293,9 @@ function ExportDialogInner({
           googleFontFamily: previewSettings.googleFontFamily,
         });
 
-        // Discard stale result
         if (id !== generationIdRef.current) return;
 
         if (result.success) {
-          // Revoke previous blob URL
           if (pdfUrl) URL.revokeObjectURL(pdfUrl);
 
           const bytes = Uint8Array.from(atob(result.data), (c) => c.charCodeAt(0));
@@ -226,10 +320,11 @@ function ExportDialogInner({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasPreviewApi, settings, selectedFormat, content, metadata]);
 
-  // Cleanup blob URL on unmount
+  // Cleanup blob URLs on unmount
   useEffect(() => {
     return () => {
       if (pdfUrl) URL.revokeObjectURL(pdfUrl);
+      if (coverPreviewUrl) URL.revokeObjectURL(coverPreviewUrl);
       if (previewTimeoutRef.current) clearTimeout(previewTimeoutRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -249,16 +344,31 @@ function ExportDialogInner({
     }
   }, [settings, content, metadata]);
 
+  // --- Action button label ---
+  const actionLabel =
+    mode === "print"
+      ? "印刷"
+      : isEpub
+        ? "EPUBとしてエクスポート"
+        : selectedFormat === "pdf"
+          ? "PDFとしてエクスポート"
+          : "DOCXとしてエクスポート";
+
   return (
     <GlassDialog
       isOpen
       onBackdropClick={onClose}
       ariaLabel={mode === "print" ? "印刷設定" : "エクスポート設定"}
-      panelClassName="mx-4 w-full max-w-7xl p-0 overflow-hidden"
+      panelClassName={clsx("mx-4 w-full p-0 overflow-hidden", isEpub ? "max-w-2xl" : "max-w-7xl")}
     >
       <div className="flex max-h-[85vh]">
         {/* Left: Settings panel */}
-        <div className="w-80 flex-shrink-0 flex flex-col border-r border-border">
+        <div
+          className={clsx(
+            "flex-shrink-0 flex flex-col",
+            isEpub ? "w-full" : "w-80 border-r border-border",
+          )}
+        >
           <div className="px-6 pt-6 pb-4 border-b border-border">
             <h2 className="text-lg font-semibold text-foreground mb-3">
               {mode === "print" ? "印刷設定" : "エクスポート設定"}
@@ -266,87 +376,210 @@ function ExportDialogInner({
             {/* Format toggle (hidden in print mode) */}
             {mode !== "print" && (
               <div className="flex gap-1 p-1 bg-background-secondary rounded-lg">
-                <button
-                  type="button"
-                  className={clsx(
-                    "flex-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
-                    selectedFormat === "pdf"
-                      ? "bg-accent text-accent-foreground shadow-sm"
-                      : "text-foreground-secondary hover:text-foreground",
-                  )}
-                  onClick={() => setSelectedFormat("pdf")}
-                >
-                  PDF
-                </button>
-                <button
-                  type="button"
-                  className={clsx(
-                    "flex-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
-                    selectedFormat === "docx"
-                      ? "bg-accent text-accent-foreground shadow-sm"
-                      : "text-foreground-secondary hover:text-foreground",
-                  )}
-                  onClick={() => setSelectedFormat("docx")}
-                >
-                  DOCX
-                </button>
+                {(["pdf", "docx", "epub"] as const).map((fmt) => (
+                  <button
+                    key={fmt}
+                    type="button"
+                    className={clsx(
+                      "flex-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors",
+                      selectedFormat === fmt
+                        ? "bg-accent text-accent-foreground shadow-sm"
+                        : "text-foreground-secondary hover:text-foreground",
+                    )}
+                    onClick={() => setSelectedFormat(fmt)}
+                  >
+                    {fmt.toUpperCase()}
+                  </button>
+                ))}
               </div>
             )}
           </div>
 
-          <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
-            {/* ── Page layout section ── */}
-
-            {/* Paper size */}
-            <div>
-              <label className={labelClass}>用紙サイズ</label>
-              <select
-                className={inputClass}
-                value={settings.pageSize}
-                onChange={(e) => updateField("pageSize", e.target.value as ExportPageSize)}
-              >
-                {PAGE_SIZE_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* Page orientation */}
-            <div>
-              <label className={labelClass}>用紙の向き</label>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  className={clsx(
-                    "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
-                    !settings.landscape
-                      ? "bg-accent text-accent-foreground border-accent"
-                      : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+          <div
+            className={clsx(
+              "flex-1 overflow-y-auto px-6 py-4 space-y-4",
+              isEpub && "max-w-lg mx-auto w-full",
+            )}
+          >
+            {/* ══════════════════════════════════════════════════════════ */}
+            {/* EPUB-only: Metadata section                              */}
+            {/* ══════════════════════════════════════════════════════════ */}
+            {isEpub && (
+              <>
+                {/* Cover image upload */}
+                <div>
+                  <label className={labelClass}>表紙画像</label>
+                  <div
+                    className={clsx(
+                      "relative w-40 h-60 mx-auto border-2 border-dashed rounded-lg flex items-center justify-center cursor-pointer transition-colors",
+                      coverPreviewUrl
+                        ? "border-accent"
+                        : "border-border-secondary hover:border-foreground-tertiary",
+                    )}
+                    onClick={() => coverInputRef.current?.click()}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDrop={handleCoverDrop}
+                  >
+                    {coverPreviewUrl ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={coverPreviewUrl}
+                        alt="表紙プレビュー"
+                        className="w-full h-full object-contain rounded-lg"
+                      />
+                    ) : (
+                      <div className="text-center text-foreground-tertiary text-xs px-2">
+                        <p>クリックまたはドラッグ&amp;ドロップ</p>
+                        <p className="mt-1">JPEG / PNG</p>
+                      </div>
+                    )}
+                    <input
+                      ref={coverInputRef}
+                      type="file"
+                      accept="image/jpeg,image/png"
+                      className="hidden"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) handleCoverFile(file);
+                      }}
+                    />
+                  </div>
+                  {coverPreviewUrl && (
+                    <button
+                      type="button"
+                      className="block mx-auto mt-2 text-xs text-danger hover:underline"
+                      onClick={handleCoverRemove}
+                    >
+                      表紙を削除
+                    </button>
                   )}
-                  onClick={() => updateField("landscape", false)}
-                >
-                  縦置き
-                </button>
-                <button
-                  type="button"
-                  className={clsx(
-                    "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
-                    settings.landscape
-                      ? "bg-accent text-accent-foreground border-accent"
-                      : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
-                  )}
-                  onClick={() => updateField("landscape", true)}
-                >
-                  横置き
-                </button>
-              </div>
-            </div>
+                </div>
 
-            {/* Writing direction */}
+                {/* Title */}
+                <div>
+                  <label className={labelClass}>書名</label>
+                  <input
+                    type="text"
+                    className={inputClass}
+                    value={epubTitle}
+                    onChange={(e) => setEpubTitle(e.target.value)}
+                    placeholder={metadata.title || "タイトルを入力"}
+                  />
+                </div>
+
+                {/* Author */}
+                <div>
+                  <label className={labelClass}>著者名</label>
+                  <input
+                    type="text"
+                    className={inputClass}
+                    value={epubAuthor}
+                    onChange={(e) => setEpubAuthor(e.target.value)}
+                    placeholder="著者名を入力"
+                  />
+                </div>
+
+                {/* Publisher */}
+                <div>
+                  <label className={labelClass}>出版社</label>
+                  <input
+                    type="text"
+                    className={inputClass}
+                    value={settings.epubPublisher}
+                    onChange={(e) => updateField("epubPublisher", e.target.value)}
+                    placeholder="任意"
+                  />
+                </div>
+
+                {/* Identifier */}
+                <div>
+                  <label className={labelClass}>識別子（UUID/ISBN）</label>
+                  <input
+                    type="text"
+                    className={inputClass}
+                    value={settings.epubIdentifier}
+                    onChange={(e) => updateField("epubIdentifier", e.target.value)}
+                    placeholder="自動生成UUID"
+                  />
+                </div>
+
+                {/* Chapter split */}
+                <div>
+                  <label className={labelClass}>章の分割</label>
+                  <select
+                    className={inputClass}
+                    value={settings.epubChapterSplitLevel}
+                    onChange={(e) =>
+                      updateField("epubChapterSplitLevel", e.target.value as ChapterSplitLevel)
+                    }
+                  >
+                    {CHAPTER_SPLIT_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <hr className="border-border" />
+              </>
+            )}
+
+            {/* ══════════════════════════════════════════════════════════ */}
+            {/* Page layout section (hidden for EPUB)                     */}
+            {/* ══════════════════════════════════════════════════════════ */}
+            {!isEpub && (
+              <>
+                {/* Paper size */}
+                <div>
+                  <label className={labelClass}>用紙サイズ</label>
+                  <PageSizeSelector
+                    value={settings.pageSize}
+                    onChange={(size) => updateField("pageSize", size)}
+                  />
+                </div>
+
+                {/* Page orientation */}
+                <div>
+                  <label className={labelClass}>用紙の向き</label>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      className={clsx(
+                        "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                        !settings.landscape
+                          ? "bg-accent text-accent-foreground border-accent"
+                          : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                      )}
+                      onClick={() => updateField("landscape", false)}
+                    >
+                      縦置き
+                    </button>
+                    <button
+                      type="button"
+                      className={clsx(
+                        "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                        settings.landscape
+                          ? "bg-accent text-accent-foreground border-accent"
+                          : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                      )}
+                      onClick={() => updateField("landscape", true)}
+                    >
+                      横置き
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
+
+            {/* Writing direction (shared: PDF/DOCX/EPUB) */}
             <div>
               <label className={labelClass}>組方向</label>
+              {isEpub && (
+                <p className="text-xs text-foreground-tertiary mb-1">
+                  EPUBのCSS writing-modeに反映
+                </p>
+              )}
               <div className="flex gap-2">
                 <button
                   type="button"
@@ -379,35 +612,37 @@ function ExportDialogInner({
 
             {/* ── Typography section ── */}
 
-            {/* Chars per line + Lines per page */}
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className={labelClass}>一行の文字数</label>
-                <input
-                  type="number"
-                  className={numberInputClass + " w-full"}
-                  min={10}
-                  max={60}
-                  step={1}
-                  value={settings.charsPerLine}
-                  onChange={(e) => updateField("charsPerLine", clampInt(e.target.value, 10, 60))}
-                />
+            {/* Chars per line + Lines per page (PDF/DOCX only) */}
+            {!isEpub && (
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className={labelClass}>一行の文字数</label>
+                  <input
+                    type="number"
+                    className={numberInputClass + " w-full"}
+                    min={10}
+                    max={60}
+                    step={1}
+                    value={settings.charsPerLine}
+                    onChange={(e) => updateField("charsPerLine", clampInt(e.target.value, 10, 60))}
+                  />
+                </div>
+                <div>
+                  <label className={labelClass}>一頁の行数</label>
+                  <input
+                    type="number"
+                    className={numberInputClass + " w-full"}
+                    min={10}
+                    max={50}
+                    step={1}
+                    value={settings.linesPerPage}
+                    onChange={(e) => updateField("linesPerPage", clampInt(e.target.value, 10, 50))}
+                  />
+                </div>
               </div>
-              <div>
-                <label className={labelClass}>一頁の行数</label>
-                <input
-                  type="number"
-                  className={numberInputClass + " w-full"}
-                  min={10}
-                  max={50}
-                  step={1}
-                  value={settings.linesPerPage}
-                  onChange={(e) => updateField("linesPerPage", clampInt(e.target.value, 10, 50))}
-                />
-              </div>
-            </div>
+            )}
 
-            {/* Font */}
+            {/* Font (shared) */}
             <div>
               <label className={labelClass}>フォント</label>
               <FontSelector
@@ -416,7 +651,7 @@ function ExportDialogInner({
               />
             </div>
 
-            {/* Indent */}
+            {/* Indent (shared) */}
             <div>
               <label className={labelClass}>字下げ（em）</label>
               <input
@@ -430,100 +665,100 @@ function ExportDialogInner({
               />
             </div>
 
-            <hr className="border-border" />
+            {/* ── Page number section (PDF/DOCX only) ── */}
+            {!isEpub && (
+              <>
+                <hr className="border-border" />
 
-            {/* ── Page number section ── */}
-
-            {/* Page numbers toggle */}
-            <div className="flex items-center justify-between">
-              <label className={labelClass + " mb-0"}>ページ番号</label>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={settings.showPageNumbers}
-                onClick={() => updateField("showPageNumbers", !settings.showPageNumbers)}
-                className={clsx(
-                  "relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors",
-                  settings.showPageNumbers ? "bg-accent" : "bg-border-secondary",
-                )}
-              >
-                <span
-                  className={clsx(
-                    "inline-block h-5 w-5 transform rounded-full bg-background transition-transform",
-                    settings.showPageNumbers ? "translate-x-6" : "translate-x-1",
-                  )}
-                />
-              </button>
-            </div>
-            {showWebPageNumberHint && (
-              <p className="text-xs text-foreground-tertiary -mt-2">
-                Web版ではこの設定は適用されません。必要な場合はブラウザの印刷設定でヘッダー/フッターを有効にしてください。
-              </p>
-            )}
-
-            {/* Page number format and position (shown when page numbers enabled) */}
-            {settings.showPageNumbers && (
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className={labelClass}>形式</label>
-                  <select
-                    className={inputClass}
-                    value={settings.pageNumberFormat}
-                    onChange={(e) =>
-                      updateField("pageNumberFormat", e.target.value as PageNumberFormat)
-                    }
+                <div className="flex items-center justify-between">
+                  <label className={labelClass + " mb-0"}>ページ番号</label>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={settings.showPageNumbers}
+                    onClick={() => updateField("showPageNumbers", !settings.showPageNumbers)}
+                    className={clsx(
+                      "relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors",
+                      settings.showPageNumbers ? "bg-accent" : "bg-border-secondary",
+                    )}
                   >
-                    {PAGE_NUMBER_FORMAT_OPTIONS.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div>
-                  <label className={labelClass}>位置</label>
-                  <select
-                    className={inputClass}
-                    value={settings.pageNumberPosition}
-                    onChange={(e) =>
-                      updateField("pageNumberPosition", e.target.value as PageNumberPosition)
-                    }
-                  >
-                    {PAGE_NUMBER_POSITION_OPTIONS.map((opt) => (
-                      <option key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-            )}
-
-            <hr className="border-border" />
-
-            {/* ── Margins section ── */}
-
-            <div>
-              <label className={labelClass}>余白（mm）</label>
-              <div className="grid grid-cols-4 gap-2">
-                {(["top", "bottom", "left", "right"] as const).map((side) => (
-                  <div key={side}>
-                    <label className="block text-xs text-foreground-tertiary mb-1 text-center">
-                      {{ top: "上", bottom: "下", left: "左", right: "右" }[side]}
-                    </label>
-                    <input
-                      type="number"
-                      className={numberInputClass + " w-full"}
-                      min={0}
-                      max={50}
-                      step={1}
-                      value={settings.margins[side]}
-                      onChange={(e) => updateMargin(side, clampInt(e.target.value, 0, 50))}
+                    <span
+                      className={clsx(
+                        "inline-block h-5 w-5 transform rounded-full bg-background transition-transform",
+                        settings.showPageNumbers ? "translate-x-6" : "translate-x-1",
+                      )}
                     />
+                  </button>
+                </div>
+                {showWebPageNumberHint && (
+                  <p className="text-xs text-foreground-tertiary -mt-2">
+                    Web版ではこの設定は適用されません。必要な場合はブラウザの印刷設定でヘッダー/フッターを有効にしてください。
+                  </p>
+                )}
+
+                {settings.showPageNumbers && (
+                  <div className="grid grid-cols-2 gap-3">
+                    <div>
+                      <label className={labelClass}>形式</label>
+                      <select
+                        className={inputClass}
+                        value={settings.pageNumberFormat}
+                        onChange={(e) =>
+                          updateField("pageNumberFormat", e.target.value as PageNumberFormat)
+                        }
+                      >
+                        {PAGE_NUMBER_FORMAT_OPTIONS.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label className={labelClass}>位置</label>
+                      <select
+                        className={inputClass}
+                        value={settings.pageNumberPosition}
+                        onChange={(e) =>
+                          updateField("pageNumberPosition", e.target.value as PageNumberPosition)
+                        }
+                      >
+                        {PAGE_NUMBER_POSITION_OPTIONS.map((opt) => (
+                          <option key={opt.value} value={opt.value}>
+                            {opt.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
                   </div>
-                ))}
-              </div>
-            </div>
+                )}
+
+                <hr className="border-border" />
+
+                {/* ── Margins section (PDF/DOCX only) ── */}
+                <div>
+                  <label className={labelClass}>余白（mm）</label>
+                  <div className="grid grid-cols-4 gap-2">
+                    {(["top", "bottom", "left", "right"] as const).map((side) => (
+                      <div key={side}>
+                        <label className="block text-xs text-foreground-tertiary mb-1 text-center">
+                          {{ top: "上", bottom: "下", left: "左", right: "右" }[side]}
+                        </label>
+                        <input
+                          type="number"
+                          className={numberInputClass + " w-full"}
+                          min={0}
+                          max={50}
+                          step={1}
+                          value={settings.margins[side]}
+                          onChange={(e) => updateMargin(side, clampInt(e.target.value, 0, 50))}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
           </div>
 
           {/* Actions */}
@@ -533,11 +768,7 @@ function ExportDialogInner({
               className="w-full px-4 py-2 rounded-lg text-sm bg-accent text-accent-foreground hover:bg-accent-hover transition-colors"
               onClick={handleExport}
             >
-              {mode === "print"
-                ? "印刷"
-                : selectedFormat === "pdf"
-                  ? "PDFとしてエクスポート"
-                  : "DOCXとしてエクスポート"}
+              {actionLabel}
             </button>
             <button
               type="button"
@@ -549,64 +780,65 @@ function ExportDialogInner({
           </div>
         </div>
 
-        {/* Right: Preview panel */}
-        <div className="flex-1 flex flex-col bg-background-secondary min-w-0">
-          <div className="px-4 py-3 border-b border-border flex items-center justify-between flex-shrink-0">
-            <span className="text-sm font-medium text-foreground">プレビュー</span>
-            <span className="text-xs text-foreground-tertiary">
-              {settings.pageSize} · {settings.landscape ? "横置き" : "縦置き"} ·{" "}
-              {settings.verticalWriting ? "縦書き" : "横書き"}
-            </span>
-          </div>
+        {/* Right: Preview panel (hidden for EPUB) */}
+        {!isEpub && (
+          <div className="flex-1 flex flex-col bg-background-secondary min-w-0">
+            <div className="px-4 py-3 border-b border-border flex items-center justify-between flex-shrink-0">
+              <span className="text-sm font-medium text-foreground">プレビュー</span>
+              <span className="text-xs text-foreground-tertiary">
+                {settings.pageSize} · {settings.landscape ? "横置き" : "縦置き"} ·{" "}
+                {settings.verticalWriting ? "縦書き" : "横書き"}
+              </span>
+            </div>
 
-          <div className="flex-1 overflow-hidden">
-            {hasPreviewApi ? (
-              /* Electron: real PDF preview via <embed> */
-              pdfUrl ? (
-                <embed src={pdfUrl} type="application/pdf" className="w-full h-full" />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center">
-                  {previewLoading && (
-                    <span className="text-sm text-foreground-tertiary">プレビューを生成中...</span>
+            <div className="flex-1 overflow-hidden">
+              {hasPreviewApi ? (
+                pdfUrl ? (
+                  <embed src={pdfUrl} type="application/pdf" className="w-full h-full" />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center">
+                    {previewLoading && (
+                      <span className="text-sm text-foreground-tertiary">
+                        プレビューを生成中...
+                      </span>
+                    )}
+                    {previewError && <span className="text-sm text-danger">{previewError}</span>}
+                  </div>
+                )
+              ) : selectedFormat === "pdf" ? (
+                <div className="flex flex-col items-center justify-center h-full gap-4 px-6">
+                  <div className="text-center space-y-2">
+                    <p className="text-sm text-foreground-secondary">
+                      ブラウザの印刷プレビューで確認できます
+                    </p>
+                    <p className="text-xs text-foreground-tertiary">
+                      {settings.pageSize} · {settings.landscape ? "横置き" : "縦置き"} ·{" "}
+                      {settings.verticalWriting ? "縦書き" : "横書き"} · {settings.fontFamily}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="px-4 py-2 rounded-lg text-sm bg-accent text-accent-foreground hover:bg-accent-hover transition-colors"
+                    onClick={handleWebPrintPreview}
+                  >
+                    印刷プレビューを開く
+                  </button>
+                  {popupBlocked && (
+                    <p className="text-xs text-danger">
+                      ポップアップがブロックされました。ブラウザの設定を確認してください。
+                    </p>
                   )}
-                  {previewError && <span className="text-sm text-danger">{previewError}</span>}
                 </div>
-              )
-            ) : selectedFormat === "pdf" ? (
-              /* Web + PDF: info panel with print preview button */
-              <div className="flex flex-col items-center justify-center h-full gap-4 px-6">
-                <div className="text-center space-y-2">
-                  <p className="text-sm text-foreground-secondary">
-                    ブラウザの印刷プレビューで確認できます
-                  </p>
-                  <p className="text-xs text-foreground-tertiary">
-                    {settings.pageSize} · {settings.landscape ? "横置き" : "縦置き"} ·{" "}
-                    {settings.verticalWriting ? "縦書き" : "横書き"} · {settings.fontFamily}
+              ) : (
+                <div className="flex items-center justify-center h-full">
+                  <p className="text-sm text-foreground-tertiary">
+                    DOCXの内蔵プレビューはありません。エクスポートして確認してください。
                   </p>
                 </div>
-                <button
-                  type="button"
-                  className="px-4 py-2 rounded-lg text-sm bg-accent text-accent-foreground hover:bg-accent-hover transition-colors"
-                  onClick={handleWebPrintPreview}
-                >
-                  印刷プレビューを開く
-                </button>
-                {popupBlocked && (
-                  <p className="text-xs text-danger">
-                    ポップアップがブロックされました。ブラウザの設定を確認してください。
-                  </p>
-                )}
-              </div>
-            ) : (
-              /* Web + DOCX: no preview available */
-              <div className="flex items-center justify-center h-full">
-                <p className="text-sm text-foreground-tertiary">
-                  DOCXの内蔵プレビューはありません。エクスポートして確認してください。
-                </p>
-              </div>
-            )}
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </GlassDialog>
   );

--- a/components/PageSizeSelector.tsx
+++ b/components/PageSizeSelector.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
 import { ChevronRight, Check } from "lucide-react";
 import clsx from "clsx";
 import { PAGE_SIZE_CATEGORIES, formatDimensions } from "@/lib/export/page-sizes";
-import type { PageSizeEntry } from "@/lib/export/page-sizes";
+import type { PageSizeEntry, PageSizeCategory } from "@/lib/export/page-sizes";
 
 interface PageSizeSelectorProps {
   value: string;
@@ -12,7 +12,7 @@ interface PageSizeSelectorProps {
 }
 
 /** Resolve a page size key to its display label */
-function findEntry(key: string): PageSizeEntry | undefined {
+export function findEntry(key: string): PageSizeEntry | undefined {
   for (const cat of PAGE_SIZE_CATEGORIES) {
     const found = cat.sizes.find((s) => s.key === key);
     if (found) return found;
@@ -20,13 +20,77 @@ function findEntry(key: string): PageSizeEntry | undefined {
   return undefined;
 }
 
+/**
+ * Filter and deduplicate page sizes by search term.
+ * Deduplication always runs — a key that appears in an earlier category
+ * is removed from later categories (e.g. A4 in "おすすめ" shadows A4 in "ISO A").
+ */
+export function filterPageSizes(
+  categories: PageSizeCategory[],
+  searchTerm: string,
+): { name: string; sizes: PageSizeEntry[] }[] {
+  const term = searchTerm.toLowerCase();
+  const seen = new Set<string>();
+  const results: { name: string; sizes: PageSizeEntry[] }[] = [];
+
+  for (const cat of categories) {
+    const matched = cat.sizes.filter((s) => {
+      if (seen.has(s.key)) return false;
+      if (searchTerm) {
+        const match =
+          s.key.toLowerCase().includes(term) ||
+          s.label.toLowerCase().includes(term) ||
+          s.label.includes(searchTerm); // Japanese match
+        if (!match) return false;
+      }
+      seen.add(s.key);
+      return true;
+    });
+    if (matched.length > 0) {
+      results.push({ name: cat.name, sizes: matched });
+    }
+  }
+  return results;
+}
+
 /** Searchable dropdown for page sizes, grouped by category */
 export function PageSizeSelector({ value, onChange }: PageSizeSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
 
   const selectedEntry = useMemo(() => findEntry(value), [value]);
+
+  const filteredCategories = useMemo(
+    () => filterPageSizes(PAGE_SIZE_CATEGORIES, searchTerm),
+    [searchTerm],
+  );
+
+  // Flat list of all visible items for keyboard navigation
+  const flatItems = useMemo(() => {
+    const items: PageSizeEntry[] = [];
+    for (const cat of filteredCategories) {
+      for (const s of cat.sizes) {
+        items.push(s);
+      }
+    }
+    return items;
+  }, [filteredCategories]);
+
+  // Reset highlight when list changes
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [filteredCategories]);
+
+  // Scroll highlighted item into view
+  useEffect(() => {
+    if (highlightedIndex < 0 || !listRef.current) return;
+    const el = listRef.current.querySelector(`[data-flat-index="${highlightedIndex}"]`);
+    if (el) el.scrollIntoView({ block: "nearest" });
+  }, [highlightedIndex]);
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -39,43 +103,63 @@ export function PageSizeSelector({ value, onChange }: PageSizeSelectorProps) {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  const handleSelect = (key: string) => {
-    onChange(key);
-    setIsOpen(false);
-    setSearchTerm("");
-  };
+  const handleSelect = useCallback(
+    (key: string) => {
+      onChange(key);
+      setIsOpen(false);
+      setSearchTerm("");
+      setHighlightedIndex(-1);
+      triggerRef.current?.focus();
+    },
+    [onChange],
+  );
 
-  // Filter categories and sizes by search term
-  const filteredCategories = useMemo(() => {
-    if (!searchTerm) return PAGE_SIZE_CATEGORIES;
-
-    const term = searchTerm.toLowerCase();
-    const seen = new Set<string>();
-    const results: { name: string; sizes: PageSizeEntry[] }[] = [];
-
-    for (const cat of PAGE_SIZE_CATEGORIES) {
-      const matched = cat.sizes.filter((s) => {
-        if (seen.has(s.key)) return false;
-        const match =
-          s.key.toLowerCase().includes(term) ||
-          s.label.toLowerCase().includes(term) ||
-          s.label.includes(searchTerm); // Japanese match
-        if (match) seen.add(s.key);
-        return match;
-      });
-      if (matched.length > 0) {
-        results.push({ name: cat.name, sizes: matched });
+  const handleSearchKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "Escape":
+          e.preventDefault();
+          setIsOpen(false);
+          setSearchTerm("");
+          setHighlightedIndex(-1);
+          triggerRef.current?.focus();
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          setHighlightedIndex((prev) => Math.min(prev + 1, flatItems.length - 1));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+          break;
+        case "Enter":
+          e.preventDefault();
+          if (highlightedIndex >= 0 && highlightedIndex < flatItems.length) {
+            handleSelect(flatItems[highlightedIndex].key);
+          }
+          break;
       }
+    },
+    [flatItems, highlightedIndex, handleSelect],
+  );
+
+  const handleTriggerKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      setIsOpen(false);
     }
-    return results;
-  }, [searchTerm]);
+  }, []);
+
+  // Build a flat index counter for data-flat-index attributes
+  let flatIndex = 0;
 
   return (
     <div className="relative" ref={dropdownRef}>
       {/* Selected size display */}
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => setIsOpen(!isOpen)}
+        onKeyDown={handleTriggerKeyDown}
         className="w-full px-3 py-2 text-sm border border-border-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-accent bg-background text-foreground text-left flex items-center justify-between"
       >
         <span>
@@ -97,42 +181,49 @@ export function PageSizeSelector({ value, onChange }: PageSizeSelectorProps) {
               placeholder="検索..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
               className="w-full px-2 py-1 text-sm border border-border-secondary rounded bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
               autoFocus
             />
           </div>
 
           {/* Size list */}
-          <div className="overflow-y-auto flex-1">
+          <div className="overflow-y-auto flex-1" ref={listRef}>
             {filteredCategories.map((cat) => (
               <div key={cat.name}>
                 {/* Category header */}
                 <div className="sticky top-0 px-3 py-1.5 text-xs font-semibold text-foreground-secondary bg-background-secondary">
                   {cat.name}
                 </div>
-                {cat.sizes.map((entry) => (
-                  <button
-                    key={`${cat.name}-${entry.key}`}
-                    type="button"
-                    onClick={() => handleSelect(entry.key)}
-                    className={clsx(
-                      "w-full px-3 py-1.5 text-sm text-left flex items-center justify-between hover:bg-background-hover",
-                      entry.key === value && "bg-background-hover",
-                    )}
-                  >
-                    <span className="flex items-center gap-2">
-                      {entry.key === value ? (
-                        <Check className="w-3.5 h-3.5 text-accent" />
-                      ) : (
-                        <span className="w-3.5" />
+                {cat.sizes.map((entry) => {
+                  const idx = flatIndex++;
+                  return (
+                    <button
+                      key={`${cat.name}-${entry.key}`}
+                      type="button"
+                      data-flat-index={idx}
+                      onClick={() => handleSelect(entry.key)}
+                      onMouseEnter={() => setHighlightedIndex(idx)}
+                      className={clsx(
+                        "w-full px-3 py-1.5 text-sm text-left flex items-center justify-between hover:bg-background-hover",
+                        entry.key === value && "bg-background-hover",
+                        idx === highlightedIndex && "bg-background-hover",
                       )}
-                      {entry.label}
-                    </span>
-                    <span className="text-xs text-foreground-secondary">
-                      {entry.width}×{entry.height}
-                    </span>
-                  </button>
-                ))}
+                    >
+                      <span className="flex items-center gap-2">
+                        {entry.key === value ? (
+                          <Check className="w-3.5 h-3.5 text-accent" />
+                        ) : (
+                          <span className="w-3.5" />
+                        )}
+                        {entry.label}
+                      </span>
+                      <span className="text-xs text-foreground-secondary">
+                        {entry.width}×{entry.height}
+                      </span>
+                    </button>
+                  );
+                })}
               </div>
             ))}
             {filteredCategories.length === 0 && (

--- a/components/PageSizeSelector.tsx
+++ b/components/PageSizeSelector.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState, useEffect, useRef, useMemo } from "react";
+import { ChevronRight, Check } from "lucide-react";
+import clsx from "clsx";
+import { PAGE_SIZE_CATEGORIES, formatDimensions } from "@/lib/export/page-sizes";
+import type { PageSizeEntry } from "@/lib/export/page-sizes";
+
+interface PageSizeSelectorProps {
+  value: string;
+  onChange: (key: string) => void;
+}
+
+/** Resolve a page size key to its display label */
+function findEntry(key: string): PageSizeEntry | undefined {
+  for (const cat of PAGE_SIZE_CATEGORIES) {
+    const found = cat.sizes.find((s) => s.key === key);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/** Searchable dropdown for page sizes, grouped by category */
+export function PageSizeSelector({ value, onChange }: PageSizeSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const selectedEntry = useMemo(() => findEntry(value), [value]);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleSelect = (key: string) => {
+    onChange(key);
+    setIsOpen(false);
+    setSearchTerm("");
+  };
+
+  // Filter categories and sizes by search term
+  const filteredCategories = useMemo(() => {
+    if (!searchTerm) return PAGE_SIZE_CATEGORIES;
+
+    const term = searchTerm.toLowerCase();
+    const seen = new Set<string>();
+    const results: { name: string; sizes: PageSizeEntry[] }[] = [];
+
+    for (const cat of PAGE_SIZE_CATEGORIES) {
+      const matched = cat.sizes.filter((s) => {
+        if (seen.has(s.key)) return false;
+        const match =
+          s.key.toLowerCase().includes(term) ||
+          s.label.toLowerCase().includes(term) ||
+          s.label.includes(searchTerm); // Japanese match
+        if (match) seen.add(s.key);
+        return match;
+      });
+      if (matched.length > 0) {
+        results.push({ name: cat.name, sizes: matched });
+      }
+    }
+    return results;
+  }, [searchTerm]);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* Selected size display */}
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full px-3 py-2 text-sm border border-border-secondary rounded-lg focus:outline-none focus:ring-2 focus:ring-accent bg-background text-foreground text-left flex items-center justify-between"
+      >
+        <span>
+          {selectedEntry?.label || value}
+          <span className="ml-2 text-foreground-secondary text-xs">{formatDimensions(value)}</span>
+        </span>
+        <ChevronRight
+          className={clsx("w-4 h-4 transition-transform", isOpen ? "rotate-90" : "rotate-0")}
+        />
+      </button>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div className="absolute z-50 mt-1 w-full bg-background border border-border-secondary rounded-lg shadow-lg max-h-80 overflow-hidden flex flex-col">
+          {/* Search */}
+          <div className="p-2 border-b border-border">
+            <input
+              type="text"
+              placeholder="検索..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="w-full px-2 py-1 text-sm border border-border-secondary rounded bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
+              autoFocus
+            />
+          </div>
+
+          {/* Size list */}
+          <div className="overflow-y-auto flex-1">
+            {filteredCategories.map((cat) => (
+              <div key={cat.name}>
+                {/* Category header */}
+                <div className="sticky top-0 px-3 py-1.5 text-xs font-semibold text-foreground-secondary bg-background-secondary">
+                  {cat.name}
+                </div>
+                {cat.sizes.map((entry) => (
+                  <button
+                    key={`${cat.name}-${entry.key}`}
+                    type="button"
+                    onClick={() => handleSelect(entry.key)}
+                    className={clsx(
+                      "w-full px-3 py-1.5 text-sm text-left flex items-center justify-between hover:bg-background-hover",
+                      entry.key === value && "bg-background-hover",
+                    )}
+                  >
+                    <span className="flex items-center gap-2">
+                      {entry.key === value ? (
+                        <Check className="w-3.5 h-3.5 text-accent" />
+                      ) : (
+                        <span className="w-3.5" />
+                      )}
+                      {entry.label}
+                    </span>
+                    <span className="text-xs text-foreground-secondary">
+                      {entry.width}×{entry.height}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ))}
+            {filteredCategories.length === 0 && (
+              <div className="px-3 py-4 text-sm text-foreground-secondary text-center">
+                該当なし
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/__tests__/page-size-selector.test.ts
+++ b/components/__tests__/page-size-selector.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for PageSizeSelector's exported pure functions and keyboard behavior.
+ *
+ * Pure function tests: filterPageSizes, findEntry
+ * DOM keyboard tests: jsdom + react-dom/client + KeyboardEvent dispatching
+ */
+
+import { describe, it, expect } from "vitest";
+import { PAGE_SIZE_CATEGORIES } from "@/lib/export/page-sizes";
+import { filterPageSizes, findEntry } from "../PageSizeSelector";
+
+// ---------------------------------------------------------------------------
+// Pure function tests — filterPageSizes
+// ---------------------------------------------------------------------------
+
+describe("filterPageSizes", () => {
+  it("deduplicates in browse mode (no search term)", () => {
+    const results = filterPageSizes(PAGE_SIZE_CATEGORIES, "");
+    const allKeys = results.flatMap((cat) => cat.sizes.map((s) => s.key));
+    const uniqueKeys = new Set(allKeys);
+    expect(allKeys.length).toBe(uniqueKeys.size);
+  });
+
+  it("A4 appears exactly once, in the first category that contains it", () => {
+    const results = filterPageSizes(PAGE_SIZE_CATEGORIES, "");
+    let a4Count = 0;
+    let a4Category = "";
+    for (const cat of results) {
+      for (const s of cat.sizes) {
+        if (s.key === "A4") {
+          a4Count++;
+          a4Category = cat.name;
+        }
+      }
+    }
+    expect(a4Count).toBe(1);
+    // A4 should be in the first category (おすすめ), not ISO A
+    expect(a4Category).toBe("おすすめ");
+  });
+
+  it("deduplicates during search", () => {
+    const results = filterPageSizes(PAGE_SIZE_CATEGORIES, "A4");
+    const a4Entries = results.flatMap((cat) => cat.sizes.filter((s) => s.key === "A4"));
+    expect(a4Entries.length).toBe(1);
+  });
+
+  it("finds Japanese labels (文庫)", () => {
+    const results = filterPageSizes(PAGE_SIZE_CATEGORIES, "文庫");
+    const allKeys = results.flatMap((cat) => cat.sizes.map((s) => s.key));
+    expect(allKeys.length).toBeGreaterThan(0);
+    expect(allKeys.some((k) => k.toLowerCase().includes("bunko") || k.includes("文庫"))).toBe(true);
+  });
+
+  it("returns empty for non-matching search", () => {
+    const results = filterPageSizes(PAGE_SIZE_CATEGORIES, "xyz_no_match_999");
+    expect(results.length).toBe(0);
+  });
+
+  it("every output category has at least one size", () => {
+    const results = filterPageSizes(PAGE_SIZE_CATEGORIES, "");
+    for (const cat of results) {
+      expect(cat.sizes.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure function tests — findEntry
+// ---------------------------------------------------------------------------
+
+describe("findEntry", () => {
+  it("returns A4 with correct dimensions", () => {
+    const entry = findEntry("A4");
+    expect(entry).toBeDefined();
+    expect(entry!.width).toBe(210);
+    expect(entry!.height).toBe(297);
+  });
+
+  it("returns undefined for unknown key", () => {
+    expect(findEntry("NONEXISTENT_SIZE")).toBeUndefined();
+  });
+});

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -35,6 +35,14 @@ export function useAuth(): AuthContextValue {
   return ctx;
 }
 
+/**
+ * Safe variant that returns null when called outside an AuthProvider.
+ * Use in components that may render without auth context (e.g. export dialogs).
+ */
+export function useAuthSafe(): AuthContextValue | null {
+  return useContext(AuthContext);
+}
+
 // ---------------------------------------------------------------------------
 // Electron-only token persistence (safeStorage / IPC)
 // ---------------------------------------------------------------------------

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -559,10 +559,16 @@ function registerFileHandlers() {
       };
     }
     try {
-      // Convert ArrayBuffer cover image back to Uint8Array if present
+      // Defensive: ensure coverImage is Uint8Array regardless of IPC serialization quirks.
+      // Structured clone normally preserves Uint8Array, but guard against edge cases.
       const epubOptions = { ...options };
-      if (epubOptions.coverImage && epubOptions.coverImage instanceof ArrayBuffer) {
-        epubOptions.coverImage = new Uint8Array(epubOptions.coverImage);
+      if (epubOptions.coverImage && !(epubOptions.coverImage instanceof Uint8Array)) {
+        if (epubOptions.coverImage instanceof ArrayBuffer) {
+          epubOptions.coverImage = new Uint8Array(epubOptions.coverImage);
+        } else if (ArrayBuffer.isView(epubOptions.coverImage)) {
+          const view = epubOptions.coverImage;
+          epubOptions.coverImage = new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+        }
       }
 
       const { generateEpub } = require("../../lib/export/epub-exporter");

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -571,6 +571,15 @@ function registerFileHandlers() {
         }
       }
 
+      // Normalize coverMediaType to JPEG/PNG only; drop cover if unsupported
+      if (epubOptions.coverImage && epubOptions.coverMediaType) {
+        const validTypes = ["image/jpeg", "image/png"];
+        if (!validTypes.includes(epubOptions.coverMediaType)) {
+          epubOptions.coverImage = undefined;
+          epubOptions.coverMediaType = undefined;
+        }
+      }
+
       const { generateEpub } = require("../../lib/export/epub-exporter");
       const epubBuffer = await generateEpub(content, epubOptions);
 

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -559,12 +559,22 @@ function registerFileHandlers() {
       };
     }
     try {
+      // Convert ArrayBuffer cover image back to Uint8Array if present
+      const epubOptions = { ...options };
+      if (epubOptions.coverImage && epubOptions.coverImage instanceof ArrayBuffer) {
+        epubOptions.coverImage = new Uint8Array(epubOptions.coverImage);
+      }
+
       const { generateEpub } = require("../../lib/export/epub-exporter");
-      const epubBuffer = await generateEpub(content, options || {});
+      const epubBuffer = await generateEpub(content, epubOptions);
+
+      // Sanitize filename: remove characters invalid on Windows
+      const rawTitle = epubOptions?.metadata?.title || "untitled";
+      const safeTitle = rawTitle.replace(/[<>:"/\\|?*]/g, "_");
 
       const { filePath } = await dialog.showSaveDialog({
         title: "EPUBとしてエクスポート",
-        defaultPath: `${options?.metadata?.title || "untitled"}.epub`,
+        defaultPath: `${safeTitle}.epub`,
         filters: [{ name: "EPUB", extensions: ["epub"] }],
       });
 

--- a/lib/export/docx-export-settings.ts
+++ b/lib/export/docx-export-settings.ts
@@ -6,12 +6,10 @@
  * for proper Japanese font rendering in Word.
  */
 
-import { PAGE_DIMENSIONS } from "./pdf-export-settings";
-
-export type DocxPageSize = "A4" | "A5" | "B5" | "B6";
+import { PAGE_DIMENSIONS, ALL_PAGE_SIZE_KEYS } from "./page-sizes";
 
 export interface DocxExportSettings {
-  pageSize: DocxPageSize;
+  pageSize: string;
   landscape: boolean;
   verticalWriting: boolean;
   fontFamily: string;
@@ -105,10 +103,10 @@ function clamp(value: number, min: number, max: number): number {
 
 export function sanitizeSettings(raw: Partial<DocxExportSettings>): DocxExportSettings {
   const d = DEFAULT_DOCX_SETTINGS;
-  const validPageSizes: DocxPageSize[] = ["A4", "A5", "B5", "B6"];
-  const pageSize = validPageSizes.includes(raw.pageSize as DocxPageSize)
-    ? (raw.pageSize as DocxPageSize)
-    : d.pageSize;
+  const pageSize =
+    typeof raw.pageSize === "string" && ALL_PAGE_SIZE_KEYS.has(raw.pageSize)
+      ? raw.pageSize
+      : d.pageSize;
 
   const rawMargins = raw.margins;
   const hasMargins = typeof rawMargins === "object" && rawMargins !== null;

--- a/lib/export/epub-exporter.ts
+++ b/lib/export/epub-exporter.ts
@@ -31,10 +31,14 @@ export async function generateEpub(content: string, options: EpubExportOptions):
   passThrough.on("data", (chunk: Buffer) => buffers.push(chunk));
   archive.pipe(passThrough);
 
-  for (const [path, stringContent] of files) {
+  for (const [path, fileContent] of files) {
     // mimetype must be stored uncompressed per EPUB spec
     const store = path === "mimetype";
-    archive.append(stringContent, { name: path, store });
+    if (fileContent instanceof Uint8Array) {
+      archive.append(Buffer.from(fileContent), { name: path, store });
+    } else {
+      archive.append(fileContent, { name: path, store });
+    }
   }
 
   // Attach completion listeners BEFORE finalize to avoid race condition.

--- a/lib/export/epub-shared.ts
+++ b/lib/export/epub-shared.ts
@@ -8,8 +8,46 @@
 import { mdiToHtml, splitIntoChapters, getMdiStylesheet } from "./mdi-to-html";
 import type { ExportMetadata } from "./types";
 
+export type ChapterSplitLevel = "h1" | "h2" | "h3" | "none";
+
 export interface EpubExportOptions {
-  metadata: ExportMetadata;
+  metadata: ExportMetadata & {
+    publisher?: string;
+    identifier?: string;
+  };
+  verticalWriting?: boolean;
+  fontFamily?: string;
+  textIndent?: number;
+  chapterSplitLevel?: ChapterSplitLevel;
+  coverImage?: Uint8Array;
+  coverMediaType?: string;
+}
+
+/** Map chapter split level string to numeric value for splitIntoChapters() */
+function splitLevelToNumber(level: ChapterSplitLevel | undefined): number {
+  switch (level) {
+    case "h1":
+      return 1;
+    case "h2":
+      return 2;
+    case "h3":
+      return 3;
+    case "none":
+      return 0;
+    default:
+      return 1;
+  }
+}
+
+/** Detect cover image file extension from media type */
+function coverExtension(mediaType: string | undefined): string {
+  if (mediaType === "image/png") return "png";
+  return "jpg";
+}
+
+/** Sanitize a font-family string for safe inclusion in CSS */
+function sanitizeFontFamily(raw: string): string {
+  return raw.replace(/[{}<>;@\\]/g, "");
 }
 
 /**
@@ -18,25 +56,44 @@ export interface EpubExportOptions {
  * The Map preserves insertion order, guaranteeing that "mimetype" is
  * always the first entry — required by the EPUB 3 specification.
  *
- * @returns Map<zip-path, string-content>
+ * @returns Map<zip-path, string-or-binary-content>
  */
-export function buildEpubFiles(content: string, options: EpubExportOptions): Map<string, string> {
+export function buildEpubFiles(
+  content: string,
+  options: EpubExportOptions,
+): Map<string, string | Uint8Array> {
   const { metadata } = options;
   const title = metadata.title || "Untitled";
   const author = metadata.author || "";
   const language = metadata.language || "ja";
   const date = metadata.date || new Date().toISOString().split("T")[0];
-  const bookId = `illusions-${Date.now()}`;
+  const publisher = metadata.publisher || "";
+  const bookId = metadata.identifier || `illusions-${Date.now()}`;
 
-  const chapters = splitIntoChapters(content);
+  const verticalWriting = options.verticalWriting ?? false;
+  const fontFamily = sanitizeFontFamily(options.fontFamily || "serif");
+  const textIndent = options.textIndent ?? 1;
+  const hasCover = options.coverImage && options.coverImage.length > 0;
+  const coverExt = coverExtension(options.coverMediaType);
+  const coverFileName = hasCover ? `cover.${coverExt}` : undefined;
+  const coverMediaType = options.coverMediaType || "image/jpeg";
+
+  const splitLevel = splitLevelToNumber(options.chapterSplitLevel);
+  const chapters = splitIntoChapters(content, splitLevel);
   if (chapters.length === 0) {
     const html = mdiToHtml(content, { bodyOnly: true });
     chapters.push({ title, htmlContent: html, level: 1 });
   }
+  // When no splitting or single untitled chapter, use the book title
+  if (chapters.length === 1 && !chapters[0].title) {
+    chapters[0].title = title;
+  }
 
-  const stylesheet = getMdiStylesheet();
+  // Only get base MDI rules (.mdi-tcy, ruby, etc.) — body/typesetting styles
+  // are handled in generateEpubStylesheet() to avoid duplicate body blocks.
+  const mdiCss = getMdiStylesheet();
 
-  const files = new Map<string, string>();
+  const files = new Map<string, string | Uint8Array>();
 
   // 1. mimetype — MUST be first entry per EPUB spec
   files.set("mimetype", "application/epub+zip");
@@ -47,16 +104,35 @@ export function buildEpubFiles(content: string, options: EpubExportOptions): Map
   // 3. OEBPS/content.opf
   files.set(
     "OEBPS/content.opf",
-    generateContentOpf({ title, author, language, date, bookId, chapterCount: chapters.length }),
+    generateContentOpf({
+      title,
+      author,
+      language,
+      date,
+      bookId,
+      publisher,
+      chapterCount: chapters.length,
+      coverFileName,
+      coverMediaType,
+    }),
   );
 
   // 4. OEBPS/toc.xhtml
   files.set("OEBPS/toc.xhtml", generateTocXhtml(title, chapters, language));
 
   // 5. OEBPS/style.css
-  files.set("OEBPS/style.css", generateEpubStylesheet(stylesheet));
+  files.set(
+    "OEBPS/style.css",
+    generateEpubStylesheet(mdiCss, { verticalWriting, fontFamily, textIndent }),
+  );
 
-  // 6. Chapter XHTML files
+  // 6. Cover image + cover page (if provided)
+  if (hasCover && coverFileName && options.coverImage) {
+    files.set(`OEBPS/${coverFileName}`, options.coverImage);
+    files.set("OEBPS/cover.xhtml", generateCoverXhtml(coverFileName, title, language));
+  }
+
+  // 7. Chapter XHTML files
   for (let i = 0; i < chapters.length; i++) {
     const chapter = chapters[i];
     files.set(
@@ -85,15 +161,41 @@ function generateContentOpf(params: {
   language: string;
   date: string;
   bookId: string;
+  publisher: string;
   chapterCount: number;
+  coverFileName?: string;
+  coverMediaType?: string;
 }): string {
-  const { title, author, language, date, bookId, chapterCount } = params;
+  const {
+    title,
+    author,
+    language,
+    date,
+    bookId,
+    publisher,
+    chapterCount,
+    coverFileName,
+    coverMediaType,
+  } = params;
 
   const manifestItems: string[] = [
     '    <item id="toc" href="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>',
     '    <item id="style" href="style.css" media-type="text/css"/>',
   ];
-  const spineItems: string[] = ['    <itemref idref="toc"/>'];
+  const spineItems: string[] = [];
+
+  // Cover page + image in manifest/spine
+  if (coverFileName) {
+    manifestItems.push(
+      `    <item id="cover-image" href="${coverFileName}" media-type="${coverMediaType || "image/jpeg"}" properties="cover-image"/>`,
+    );
+    manifestItems.push(
+      '    <item id="cover" href="cover.xhtml" media-type="application/xhtml+xml"/>',
+    );
+    spineItems.push('    <itemref idref="cover"/>');
+  }
+
+  spineItems.push('    <itemref idref="toc"/>');
 
   for (let i = 1; i <= chapterCount; i++) {
     manifestItems.push(
@@ -104,14 +206,20 @@ function generateContentOpf(params: {
 
   const modifiedTimestamp = new Date().toISOString().replace(/\.\d{3}Z/, "Z");
 
+  const metadataLines = [
+    `    <dc:identifier id="bookid">${escapeXml(bookId)}</dc:identifier>`,
+    `    <dc:title>${escapeXml(title)}</dc:title>`,
+    `    <dc:language>${escapeXml(language)}</dc:language>`,
+    `    <dc:date>${escapeXml(date)}</dc:date>`,
+  ];
+  if (author) metadataLines.push(`    <dc:creator>${escapeXml(author)}</dc:creator>`);
+  if (publisher) metadataLines.push(`    <dc:publisher>${escapeXml(publisher)}</dc:publisher>`);
+  metadataLines.push(`    <meta property="dcterms:modified">${modifiedTimestamp}</meta>`);
+
   return `<?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="bookid">
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
-    <dc:identifier id="bookid">${escapeXml(bookId)}</dc:identifier>
-    <dc:title>${escapeXml(title)}</dc:title>
-    <dc:language>${escapeXml(language)}</dc:language>
-    <dc:date>${escapeXml(date)}</dc:date>${author ? `\n    <dc:creator>${escapeXml(author)}</dc:creator>` : ""}
-    <meta property="dcterms:modified">${modifiedTimestamp}</meta>
+${metadataLines.join("\n")}
   </metadata>
   <manifest>
 ${manifestItems.join("\n")}
@@ -168,13 +276,20 @@ function generateChapterXhtml(title: string, htmlContent: string, language: stri
 </html>`;
 }
 
-function generateEpubStylesheet(mdiCss: string): string {
+function generateEpubStylesheet(
+  mdiCss: string,
+  opts: { verticalWriting: boolean; fontFamily: string; textIndent: number },
+): string {
+  const writingModeCss = opts.verticalWriting
+    ? `  writing-mode: vertical-rl;\n  -webkit-writing-mode: vertical-rl;\n  -epub-writing-mode: vertical-rl;\n  text-orientation: mixed;\n`
+    : "";
+
   return `/* EPUB base styles */
 body {
-  font-family: serif;
+  font-family: ${opts.fontFamily};
   line-height: 1.8;
   margin: 1em;
-}
+${writingModeCss}}
 
 h1 {
   font-size: 1.5em;
@@ -188,12 +303,30 @@ h2 {
 }
 
 p {
-  text-indent: 1em;
+  text-indent: ${opts.textIndent}em;
   margin: 0.3em 0;
 }
 
 /* MDI-specific styles */
 ${mdiCss}`;
+}
+
+function generateCoverXhtml(coverFileName: string, title: string, language: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="${language}" lang="${language}">
+<head>
+  <meta charset="UTF-8"/>
+  <title>${escapeXml(title)}</title>
+  <style>
+    body { margin: 0; padding: 0; text-align: center; }
+    img { max-width: 100%; max-height: 100%; }
+  </style>
+</head>
+<body>
+  <img src="${coverFileName}" alt="${escapeXml(title)}"/>
+</body>
+</html>`;
 }
 
 /**

--- a/lib/export/epub-shared.ts
+++ b/lib/export/epub-shared.ts
@@ -73,10 +73,18 @@ export function buildEpubFiles(
   const verticalWriting = options.verticalWriting ?? false;
   const fontFamily = sanitizeFontFamily(options.fontFamily || "serif");
   const textIndent = options.textIndent ?? 1;
-  const hasCover = options.coverImage && options.coverImage.length > 0;
-  const coverExt = coverExtension(options.coverMediaType);
+  // Normalize coverMediaType to JPEG/PNG only; ignore cover if unsupported
+  const validCoverType =
+    options.coverMediaType === "image/png" || options.coverMediaType === "image/jpeg"
+      ? options.coverMediaType
+      : "image/jpeg";
+  const hasCover =
+    options.coverImage &&
+    options.coverImage.length > 0 &&
+    (options.coverMediaType === "image/png" || options.coverMediaType === "image/jpeg");
+  const coverExt = coverExtension(validCoverType);
   const coverFileName = hasCover ? `cover.${coverExt}` : undefined;
-  const coverMediaType = options.coverMediaType || "image/jpeg";
+  const coverMediaType = validCoverType;
 
   const splitLevel = splitLevelToNumber(options.chapterSplitLevel);
   const chapters = splitIntoChapters(content, splitLevel);

--- a/lib/export/epub-web.ts
+++ b/lib/export/epub-web.ts
@@ -36,10 +36,11 @@ export async function generateEpubBlob(content: string, options: EpubExportOptio
   // output may fail instanceof in jsdom/vitest environments.)
   const encode = (s: string): Uint8Array => new Uint8Array(new TextEncoder().encode(s));
 
-  for (const [path, strContent] of fileMap) {
+  for (const [path, fileContent] of fileMap) {
     // mimetype must be stored uncompressed (level: 0) per EPUB spec
     const isMimetype = path === "mimetype";
-    zipInput[path] = [encode(strContent), { level: isMimetype ? 0 : 9 }];
+    const data = fileContent instanceof Uint8Array ? fileContent : encode(fileContent);
+    zipInput[path] = [data, { level: isMimetype ? 0 : 9 }];
   }
 
   const zipped = zipSync(zipInput);

--- a/lib/export/export-settings.ts
+++ b/lib/export/export-settings.ts
@@ -1,5 +1,5 @@
 /**
- * Unified export settings for PDF and DOCX.
+ * Unified export settings for PDF, DOCX, and EPUB.
  *
  * Uses charsPerLine / linesPerPage as the canonical typesetting model
  * (more expressive than raw fontSize + lineSpacing). DOCX-specific values
@@ -8,17 +8,21 @@
  * Migrates from legacy per-format localStorage keys on first load.
  */
 
-import { calculateTypesetting, PAGE_DIMENSIONS } from "./pdf-export-settings";
+import { calculateTypesetting } from "./pdf-export-settings";
+import { PAGE_DIMENSIONS, ALL_PAGE_SIZE_KEYS } from "./page-sizes";
 import { ALL_JAPANESE_FONTS } from "@/lib/utils/fonts";
 
 import type { PdfExportSettings } from "./pdf-export-settings";
 import type { DocxExportSettings } from "./docx-export-settings";
+import type { ChapterSplitLevel, EpubExportOptions } from "./epub-shared";
+import type { ExportMetadata } from "./types";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type ExportPageSize = "A4" | "A5" | "B5" | "B6";
+/** Page size key — any key in PAGE_DIMENSIONS (e.g. "A4", "Bunko", "Letter") */
+export type ExportPageSize = string;
 
 export type PageNumberFormat = "simple" | "dash" | "fraction";
 export type PageNumberPosition =
@@ -41,6 +45,10 @@ export interface UnifiedExportSettings {
   pageNumberFormat: PageNumberFormat;
   pageNumberPosition: PageNumberPosition;
   textIndent: number;
+  // EPUB-specific
+  epubPublisher: string;
+  epubIdentifier: string;
+  epubChapterSplitLevel: ChapterSplitLevel;
 }
 
 export const DEFAULT_EXPORT_SETTINGS: UnifiedExportSettings = {
@@ -55,6 +63,9 @@ export const DEFAULT_EXPORT_SETTINGS: UnifiedExportSettings = {
   pageNumberFormat: "simple",
   pageNumberPosition: "bottom-center",
   textIndent: 1,
+  epubPublisher: "",
+  epubIdentifier: "",
+  epubChapterSplitLevel: "h1",
 };
 
 // ---------------------------------------------------------------------------
@@ -196,6 +207,27 @@ export function toDocxExportSettings(s: UnifiedExportSettings): DocxExportSettin
   };
 }
 
+export function toEpubExportOptions(
+  s: UnifiedExportSettings,
+  metadata: ExportMetadata,
+  coverImage?: Uint8Array,
+  coverMediaType?: string,
+): EpubExportOptions {
+  return {
+    metadata: {
+      ...metadata,
+      publisher: s.epubPublisher || undefined,
+      identifier: s.epubIdentifier || undefined,
+    },
+    verticalWriting: s.verticalWriting,
+    fontFamily: fontKeyToCss(s.fontFamily),
+    textIndent: s.textIndent,
+    chapterSplitLevel: s.epubChapterSplitLevel,
+    coverImage,
+    coverMediaType,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Persistence & migration
 // ---------------------------------------------------------------------------
@@ -204,7 +236,6 @@ const STORAGE_KEY = "illusions:export-settings";
 const LEGACY_PDF_KEY = "illusions:pdf-export-settings";
 const LEGACY_DOCX_KEY = "illusions:docx-export-settings";
 
-const VALID_PAGE_SIZES: ExportPageSize[] = ["A4", "A5", "B5", "B6"];
 const VALID_PAGE_NUMBER_FORMATS: PageNumberFormat[] = ["simple", "dash", "fraction"];
 const VALID_PAGE_NUMBER_POSITIONS: PageNumberPosition[] = [
   "bottom-left",
@@ -214,6 +245,7 @@ const VALID_PAGE_NUMBER_POSITIONS: PageNumberPosition[] = [
   "top-center",
   "top-right",
 ];
+const VALID_CHAPTER_SPLIT_LEVELS: ChapterSplitLevel[] = ["h1", "h2", "h3", "none"];
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
@@ -221,9 +253,10 @@ function clamp(value: number, min: number, max: number): number {
 
 function sanitize(raw: Partial<UnifiedExportSettings>): UnifiedExportSettings {
   const d = DEFAULT_EXPORT_SETTINGS;
-  const pageSize = VALID_PAGE_SIZES.includes(raw.pageSize as ExportPageSize)
-    ? (raw.pageSize as ExportPageSize)
-    : d.pageSize;
+  const pageSize =
+    typeof raw.pageSize === "string" && ALL_PAGE_SIZE_KEYS.has(raw.pageSize)
+      ? raw.pageSize
+      : d.pageSize;
 
   const rawMargins = raw.margins;
   const hasMargins = typeof rawMargins === "object" && rawMargins !== null;
@@ -271,6 +304,13 @@ function sanitize(raw: Partial<UnifiedExportSettings>): UnifiedExportSettings {
       ? (raw.pageNumberPosition as PageNumberPosition)
       : d.pageNumberPosition,
     textIndent: typeof raw.textIndent === "number" ? clamp(raw.textIndent, 0, 4) : d.textIndent,
+    epubPublisher: typeof raw.epubPublisher === "string" ? raw.epubPublisher : d.epubPublisher,
+    epubIdentifier: typeof raw.epubIdentifier === "string" ? raw.epubIdentifier : d.epubIdentifier,
+    epubChapterSplitLevel: VALID_CHAPTER_SPLIT_LEVELS.includes(
+      raw.epubChapterSplitLevel as ChapterSplitLevel,
+    )
+      ? (raw.epubChapterSplitLevel as ChapterSplitLevel)
+      : d.epubChapterSplitLevel,
   };
 }
 
@@ -351,3 +391,4 @@ export function saveExportSettings(settings: UnifiedExportSettings): void {
 }
 
 export { PAGE_DIMENSIONS };
+export type { ChapterSplitLevel, EpubExportOptions };

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -330,15 +330,22 @@ export function mdiToHtml(
 }
 
 /**
- * Split MDI markdown into chapters by top-level headings (# ).
+ * Split MDI markdown into chapters by headings.
  *
  * Content before the first heading becomes a chapter with an empty title.
  * Each chapter's htmlContent is generated with bodyOnly mode.
  *
  * @param markdown - Full MDI markdown document
+ * @param splitLevel - Max heading level to split on (1=H1, 2=H1+H2, 3=H1+H2+H3, 0=no split)
  * @returns Array of Chapter objects
  */
-export function splitIntoChapters(markdown: string): Chapter[] {
+export function splitIntoChapters(markdown: string, splitLevel: number = 1): Chapter[] {
+  // No splitting — entire document is one chapter
+  if (splitLevel <= 0) {
+    const html = mdiToHtml(markdown, { bodyOnly: true });
+    return [{ title: "", htmlContent: html, level: 1 }];
+  }
+
   const chapters: Chapter[] = [];
   const lines = markdown.split("\n");
 
@@ -348,10 +355,9 @@ export function splitIntoChapters(markdown: string): Chapter[] {
   let hasStarted = false;
 
   for (const line of lines) {
-    // Match top-level headings: "# Title"
     const headingMatch = /^(#{1,6})\s+(.+)$/.exec(line);
 
-    if (headingMatch && headingMatch[1] === "#") {
+    if (headingMatch && headingMatch[1].length <= splitLevel) {
       // Flush previous chapter
       if (hasStarted || currentLines.length > 0) {
         const content = currentLines.join("\n").trim();
@@ -363,7 +369,7 @@ export function splitIntoChapters(markdown: string): Chapter[] {
       }
 
       currentTitle = headingMatch[2].trim();
-      currentLevel = 1;
+      currentLevel = headingMatch[1].length;
       currentLines = [];
       hasStarted = true;
     } else {

--- a/lib/export/page-sizes.ts
+++ b/lib/export/page-sizes.ts
@@ -27,8 +27,8 @@ export const PAGE_SIZE_CATEGORIES: PageSizeCategory[] = [
     sizes: [
       { key: "A4", label: "A4", width: 210, height: 297 },
       { key: "A5", label: "A5", width: 148, height: 210 },
-      { key: "B5", label: "B5 (JIS)", width: 182, height: 257 },
-      { key: "B6", label: "B6 (JIS)", width: 128, height: 182 },
+      { key: "JIS-B5", label: "B5 (JIS)", width: 182, height: 257 },
+      { key: "JIS-B6", label: "B6 (JIS)", width: 128, height: 182 },
       { key: "Bunko", label: "文庫判", width: 105, height: 148 },
       { key: "Shinsho", label: "新書判", width: 103, height: 182 },
       { key: "Shirokuban", label: "四六判", width: 127, height: 188 },
@@ -54,17 +54,17 @@ export const PAGE_SIZE_CATEGORIES: PageSizeCategory[] = [
   {
     name: "JIS B",
     sizes: [
-      { key: "B0", label: "B0 (JIS)", width: 1030, height: 1456 },
-      { key: "B1", label: "B1 (JIS)", width: 728, height: 1030 },
-      { key: "B2", label: "B2 (JIS)", width: 515, height: 728 },
-      { key: "B3", label: "B3 (JIS)", width: 364, height: 515 },
-      { key: "B4", label: "B4 (JIS)", width: 257, height: 364 },
-      { key: "B5", label: "B5 (JIS)", width: 182, height: 257 },
-      { key: "B6", label: "B6 (JIS)", width: 128, height: 182 },
-      { key: "B7", label: "B7 (JIS)", width: 91, height: 128 },
-      { key: "B8", label: "B8 (JIS)", width: 64, height: 91 },
-      { key: "B9", label: "B9 (JIS)", width: 45, height: 64 },
-      { key: "B10", label: "B10 (JIS)", width: 32, height: 45 },
+      { key: "JIS-B0", label: "B0 (JIS)", width: 1030, height: 1456 },
+      { key: "JIS-B1", label: "B1 (JIS)", width: 728, height: 1030 },
+      { key: "JIS-B2", label: "B2 (JIS)", width: 515, height: 728 },
+      { key: "JIS-B3", label: "B3 (JIS)", width: 364, height: 515 },
+      { key: "JIS-B4", label: "B4 (JIS)", width: 257, height: 364 },
+      { key: "JIS-B5", label: "B5 (JIS)", width: 182, height: 257 },
+      { key: "JIS-B6", label: "B6 (JIS)", width: 128, height: 182 },
+      { key: "JIS-B7", label: "B7 (JIS)", width: 91, height: 128 },
+      { key: "JIS-B8", label: "B8 (JIS)", width: 64, height: 91 },
+      { key: "JIS-B9", label: "B9 (JIS)", width: 45, height: 64 },
+      { key: "JIS-B10", label: "B10 (JIS)", width: 32, height: 45 },
     ],
   },
   {
@@ -155,6 +155,13 @@ for (const cat of PAGE_SIZE_CATEGORIES) {
     ALL_PAGE_SIZE_KEYS.add(s.key);
   }
 }
+
+// Legacy aliases: "B5"/"B6" historically meant ISO dimensions in pdf-export-settings.
+// Preserve these so existing saved settings resolve correctly after upgrade.
+PAGE_DIMENSIONS["B5"] ??= PAGE_DIMENSIONS["ISO-B5"];
+PAGE_DIMENSIONS["B6"] ??= PAGE_DIMENSIONS["ISO-B6"];
+ALL_PAGE_SIZE_KEYS.add("B5");
+ALL_PAGE_SIZE_KEYS.add("B6");
 
 /** Format dimensions as "W×H mm" for display */
 export function formatDimensions(key: string): string {

--- a/lib/export/page-sizes.ts
+++ b/lib/export/page-sizes.ts
@@ -1,0 +1,164 @@
+/**
+ * Comprehensive page size definitions for export (PDF, DOCX, EPUB).
+ *
+ * 80+ sizes across 8 categories. Each size has a unique key,
+ * display label (Japanese), and dimensions in mm.
+ */
+
+export interface PageSizeEntry {
+  key: string;
+  label: string;
+  width: number; // mm
+  height: number; // mm
+}
+
+export interface PageSizeCategory {
+  name: string;
+  sizes: PageSizeEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Categories
+// ---------------------------------------------------------------------------
+
+export const PAGE_SIZE_CATEGORIES: PageSizeCategory[] = [
+  {
+    name: "おすすめ",
+    sizes: [
+      { key: "A4", label: "A4", width: 210, height: 297 },
+      { key: "A5", label: "A5", width: 148, height: 210 },
+      { key: "B5", label: "B5 (JIS)", width: 182, height: 257 },
+      { key: "B6", label: "B6 (JIS)", width: 128, height: 182 },
+      { key: "Bunko", label: "文庫判", width: 105, height: 148 },
+      { key: "Shinsho", label: "新書判", width: 103, height: 182 },
+      { key: "Shirokuban", label: "四六判", width: 127, height: 188 },
+      { key: "Letter", label: "Letter", width: 216, height: 279 },
+    ],
+  },
+  {
+    name: "ISO A",
+    sizes: [
+      { key: "A0", label: "A0", width: 841, height: 1189 },
+      { key: "A1", label: "A1", width: 594, height: 841 },
+      { key: "A2", label: "A2", width: 420, height: 594 },
+      { key: "A3", label: "A3", width: 297, height: 420 },
+      { key: "A4", label: "A4", width: 210, height: 297 },
+      { key: "A5", label: "A5", width: 148, height: 210 },
+      { key: "A6", label: "A6", width: 105, height: 148 },
+      { key: "A7", label: "A7", width: 74, height: 105 },
+      { key: "A8", label: "A8", width: 52, height: 74 },
+      { key: "A9", label: "A9", width: 37, height: 52 },
+      { key: "A10", label: "A10", width: 26, height: 37 },
+    ],
+  },
+  {
+    name: "JIS B",
+    sizes: [
+      { key: "B0", label: "B0 (JIS)", width: 1030, height: 1456 },
+      { key: "B1", label: "B1 (JIS)", width: 728, height: 1030 },
+      { key: "B2", label: "B2 (JIS)", width: 515, height: 728 },
+      { key: "B3", label: "B3 (JIS)", width: 364, height: 515 },
+      { key: "B4", label: "B4 (JIS)", width: 257, height: 364 },
+      { key: "B5", label: "B5 (JIS)", width: 182, height: 257 },
+      { key: "B6", label: "B6 (JIS)", width: 128, height: 182 },
+      { key: "B7", label: "B7 (JIS)", width: 91, height: 128 },
+      { key: "B8", label: "B8 (JIS)", width: 64, height: 91 },
+      { key: "B9", label: "B9 (JIS)", width: 45, height: 64 },
+      { key: "B10", label: "B10 (JIS)", width: 32, height: 45 },
+    ],
+  },
+  {
+    name: "ISO B",
+    sizes: [
+      { key: "ISO-B0", label: "B0 (ISO)", width: 1000, height: 1414 },
+      { key: "ISO-B1", label: "B1 (ISO)", width: 707, height: 1000 },
+      { key: "ISO-B2", label: "B2 (ISO)", width: 500, height: 707 },
+      { key: "ISO-B3", label: "B3 (ISO)", width: 353, height: 500 },
+      { key: "ISO-B4", label: "B4 (ISO)", width: 250, height: 353 },
+      { key: "ISO-B5", label: "B5 (ISO)", width: 176, height: 250 },
+      { key: "ISO-B6", label: "B6 (ISO)", width: 125, height: 176 },
+      { key: "ISO-B7", label: "B7 (ISO)", width: 88, height: 125 },
+      { key: "ISO-B8", label: "B8 (ISO)", width: 62, height: 88 },
+      { key: "ISO-B9", label: "B9 (ISO)", width: 44, height: 62 },
+      { key: "ISO-B10", label: "B10 (ISO)", width: 31, height: 44 },
+    ],
+  },
+  {
+    name: "日本出版・文芸",
+    sizes: [
+      { key: "Bunko", label: "文庫判", width: 105, height: 148 },
+      { key: "Shinsho", label: "新書判", width: 103, height: 182 },
+      { key: "Shirokuban", label: "四六判", width: 127, height: 188 },
+      { key: "Kikuban", label: "菊判", width: 150, height: 220 },
+      { key: "A5-ban", label: "A5判", width: 148, height: 210 },
+      { key: "B6-ban", label: "B6判", width: 128, height: 182 },
+      { key: "AB-ban", label: "AB判", width: 210, height: 257 },
+      { key: "Ju-ban", label: "重箱判", width: 182, height: 206 },
+      { key: "Kiku-tate", label: "菊判（変形）", width: 152, height: 218 },
+      { key: "Tankobon", label: "単行本判", width: 130, height: 188 },
+    ],
+  },
+  {
+    name: "北米・国際オフィス",
+    sizes: [
+      { key: "Letter", label: "Letter", width: 216, height: 279 },
+      { key: "Legal", label: "Legal", width: 216, height: 356 },
+      { key: "Tabloid", label: "Tabloid", width: 279, height: 432 },
+      { key: "Executive", label: "Executive", width: 184, height: 267 },
+      { key: "Statement", label: "Statement", width: 140, height: 216 },
+      { key: "Folio", label: "Folio", width: 210, height: 330 },
+      { key: "Quarto", label: "Quarto", width: 203, height: 254 },
+      { key: "10x14", label: "10×14", width: 254, height: 356 },
+    ],
+  },
+  {
+    name: "日本封筒",
+    sizes: [
+      { key: "Naga-3", label: "長形3号", width: 120, height: 235 },
+      { key: "Naga-4", label: "長形4号", width: 90, height: 205 },
+      { key: "Kaku-2", label: "角形2号", width: 240, height: 332 },
+      { key: "Kaku-3", label: "角形3号", width: 216, height: 277 },
+      { key: "Kaku-6", label: "角形6号", width: 162, height: 229 },
+      { key: "Kaku-8", label: "角形8号", width: 119, height: 197 },
+      { key: "You-4", label: "洋形4号", width: 105, height: 235 },
+      { key: "You-6", label: "洋形6号", width: 98, height: 190 },
+    ],
+  },
+  {
+    name: "郵便・新聞・写真",
+    sizes: [
+      { key: "Hagaki", label: "はがき", width: 100, height: 148 },
+      { key: "Ofuku-Hagaki", label: "往復はがき", width: 200, height: 148 },
+      { key: "L-ban", label: "L判", width: 89, height: 127 },
+      { key: "2L-ban", label: "2L判", width: 127, height: 178 },
+      { key: "KG", label: "KG判", width: 102, height: 152 },
+      { key: "Cabinet", label: "キャビネ判", width: 130, height: 180 },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Derived lookups
+// ---------------------------------------------------------------------------
+
+/** Flat map: key → { width, height } in mm */
+export const PAGE_DIMENSIONS: Record<string, { width: number; height: number }> = {};
+
+/** Set of all valid page size keys */
+export const ALL_PAGE_SIZE_KEYS: Set<string> = new Set();
+
+for (const cat of PAGE_SIZE_CATEGORIES) {
+  for (const s of cat.sizes) {
+    if (!PAGE_DIMENSIONS[s.key]) {
+      PAGE_DIMENSIONS[s.key] = { width: s.width, height: s.height };
+    }
+    ALL_PAGE_SIZE_KEYS.add(s.key);
+  }
+}
+
+/** Format dimensions as "W×H mm" for display */
+export function formatDimensions(key: string): string {
+  const d = PAGE_DIMENSIONS[key];
+  if (!d) return "";
+  return `${d.width}×${d.height} mm`;
+}

--- a/lib/export/pdf-export-settings.ts
+++ b/lib/export/pdf-export-settings.ts
@@ -6,7 +6,7 @@
  */
 
 export interface PdfExportSettings {
-  pageSize: "A4" | "A5" | "B5" | "B6";
+  pageSize: string;
   landscape: boolean;
   verticalWriting: boolean;
   charsPerLine: number;
@@ -41,13 +41,9 @@ export const DEFAULT_PDF_SETTINGS: PdfExportSettings = {
   textIndent: 1,
 };
 
-/** Page dimensions in mm */
-export const PAGE_DIMENSIONS: Record<string, { width: number; height: number }> = {
-  A4: { width: 210, height: 297 },
-  A5: { width: 148, height: 210 },
-  B5: { width: 176, height: 250 },
-  B6: { width: 125, height: 176 },
-};
+// Import and re-export comprehensive page dimensions from page-sizes module
+import { PAGE_DIMENSIONS } from "./page-sizes";
+export { PAGE_DIMENSIONS };
 
 const STORAGE_KEY = "illusions:pdf-export-settings";
 

--- a/lib/export/types.ts
+++ b/lib/export/types.ts
@@ -19,7 +19,7 @@ export interface ExportOptions {
 export interface PdfGenerationOptions {
   metadata: ExportMetadata;
   verticalWriting?: boolean;
-  pageSize?: "A4" | "A5" | "B5" | "B6";
+  pageSize?: string;
   landscape?: boolean;
   margins?: { top: number; bottom: number; left: number; right: number };
   charsPerLine?: number;

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -24,7 +24,7 @@ interface UseExportParams {
    * and later call the IPC with user-configured options.
    */
   onExportDialogRequest?: (
-    format: "pdf" | "docx",
+    format: "pdf" | "docx" | "epub",
     content: string,
     metadata: ExportMetadata,
   ) => void;
@@ -104,8 +104,8 @@ export function useExport({
         return;
       }
 
-      // PDF/DOCX export: delegate to settings dialog when callback is provided
-      if ((format === "pdf" || format === "docx") && onExportDialogRequest) {
+      // PDF/DOCX/EPUB export: delegate to settings dialog when callback is provided
+      if ((format === "pdf" || format === "docx" || format === "epub") && onExportDialogRequest) {
         onExportDialogRequest(format, content, metadata);
         return;
       }

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -80,7 +80,7 @@ declare global {
     ) => Promise<string | { success: false; error: string } | null>;
     exportEPUB?: (
       content: string,
-      options: { metadata: { title: string; author?: string; date?: string; language?: string } },
+      options: import("@/lib/export/epub-shared").EpubExportOptions,
     ) => Promise<string | { success: false; error: string } | null>;
     exportDOCX?: (
       content: string,


### PR DESCRIPTION
## Summary

- EPUBエクスポートタブを追加（カバー画像、メタデータ、章分割、縦書きCSS、フォント/字下げ設定）
- 用紙サイズを4種→80+種に拡張（8カテゴリ、検索可能ドロップダウン）
- PDF/DOCXのページ番号形式・位置オプションを追加
- セキュリティ修正: EPUB CSS fontFamily sanitization、カバー画像JPEG/PNG制限、ファイル名sanitization

## Changes

| Area | Files | Description |
|------|-------|-------------|
| EPUB generation | `epub-shared.ts`, `epub-exporter.ts`, `epub-web.ts` | Cover image, vertical writing CSS, font/indent, chapter split level, publisher/identifier metadata |
| Chapter splitting | `mdi-to-html.ts` | `splitIntoChapters(markdown, splitLevel)` — H1/H2/H3/none |
| Page sizes | `page-sizes.ts` (new), `PageSizeSelector.tsx` (new) | 80+ sizes across 8 categories with searchable dropdown |
| Unified settings | `export-settings.ts`, `pdf-export-settings.ts`, `docx-export-settings.ts` | EPUB fields, page number format/position, widened pageSize type |
| Dialog UI | `ExportDialog.tsx` | EPUB tab with cover upload, metadata, chapter split; `PageSizeSelector`; author auto-fill from AuthContext |
| Routing | `use-export.ts`, `app/page.tsx`, `EditorLayout.tsx` | Route EPUB through settings dialog (Electron + Web) |
| Electron | `file-ipc.js`, `electron.d.ts` | Expanded EPUB IPC options, ArrayBuffer→Uint8Array conversion |
| Menu | `menu.js`, `menu-definitions.ts` | Reorder: PDF → DOCX → EPUB |
| Helpers | `save-blob-file.ts` (new), `web-print-preview.ts` (new) | File save (File System Access API + fallback), web print preview |

## Test plan

- [ ] Click EPUB tab → paper settings hidden, metadata section shown, no PDF preview IPC fired
- [ ] Cover upload: drag JPEG/PNG → preview shows → remove works; WebP/SVG rejected
- [ ] Chapter split: change to H2 → exported EPUB splits on H1+H2
- [ ] Vertical writing: toggle → EPUB CSS has `writing-mode: vertical-rl`
- [ ] Edit title/author in EPUB tab → export → EPUB `content.opf` has edited values
- [ ] Page size selector: search "文庫" → shows 文庫判, select → settings update
- [ ] Switch EPUB → PDF → verify preview resumes normally
- [ ] Web export: menu → EPUB → dialog opens → settings shown → export downloads blob
- [ ] `npx tsc --noEmit` passes
- [ ] `node scripts/bundle-electron.mjs` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)