### PR TITLE
feat(export): add EPUB export, page sizes, and unify web download

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -690,14 +690,7 @@ export default function EditorPage() {
       });
       const baseName = (dialogState.metadata.title || "untitled").replace(/\.[^.]+$/, "");
       const { saveBlobFile } = await import("@/lib/export/save-blob-file");
-      const saved = await saveBlobFile(
-        blob,
-        `${baseName}.docx`,
-        {
-          "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [".docx"],
-        },
-        false,
-      );
+      const saved = await saveBlobFile(blob, `${baseName}.docx`, false);
 
       notificationManager.dismiss(progressId);
 
@@ -705,7 +698,6 @@ export default function EditorPage() {
         setExportDialogState(null);
         notificationManager.success("DOCXをエクスポートしました");
       }
-      // saved === false means user cancelled — keep dialog open
     } catch (error) {
       notificationManager.dismiss(progressId);
       const message = error instanceof Error ? error.message : "不明なエラー";
@@ -761,12 +753,7 @@ export default function EditorPage() {
         .replace(/[<>:"/\\|?*]/g, "_")
         .replace(/\.[^.]+$/, "");
       const { saveBlobFile } = await import("@/lib/export/save-blob-file");
-      const saved = await saveBlobFile(
-        blob,
-        `${baseName}.epub`,
-        { "application/epub+zip": [".epub"] },
-        false,
-      );
+      const saved = await saveBlobFile(blob, `${baseName}.epub`, false);
 
       notificationManager.dismiss(progressId);
 

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -12,7 +12,6 @@ import {
 } from "@/lib/export/export-settings";
 import { FontSelector } from "@/components/explorer/FontSelector";
 import { PageSizeSelector } from "@/components/PageSizeSelector";
-import { openWebPrintPreview } from "@/lib/export/web-print-preview";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
 import { useAuthSafe } from "@/contexts/AuthContext";
 
@@ -176,7 +175,6 @@ function ExportDialogInner({
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
-  const [popupBlocked, setPopupBlocked] = useState(false);
   const generationIdRef = useRef(0);
   const previewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -341,20 +339,6 @@ function ExportDialogInner({
       if (previewTimeoutRef.current) clearTimeout(previewTimeoutRef.current);
     };
   }, []);
-
-  // --- Web: print preview button handler ---
-  const handleWebPrintPreview = useCallback(async () => {
-    setPopupBlocked(false);
-    try {
-      const pdfSettings = toPdfExportSettings(settings);
-      const opened = await openWebPrintPreview(content, metadata, pdfSettings);
-      if (!opened) {
-        setPopupBlocked(true);
-      }
-    } catch {
-      setPreviewError("印刷プレビューの生成に失敗しました");
-    }
-  }, [settings, content, metadata]);
 
   // --- Action button label ---
   const actionLabel =
@@ -821,25 +805,14 @@ function ExportDialogInner({
                 <div className="flex flex-col items-center justify-center h-full gap-4 px-6">
                   <div className="text-center space-y-2">
                     <p className="text-sm text-foreground-secondary">
-                      ブラウザの印刷プレビューで確認できます
+                      エクスポートボタンをクリックすると印刷ダイアログが開きます。
+                      「PDFとして保存」を選択してください。
                     </p>
                     <p className="text-xs text-foreground-tertiary">
                       {settings.pageSize} · {settings.landscape ? "横置き" : "縦置き"} ·{" "}
                       {settings.verticalWriting ? "縦書き" : "横書き"} · {settings.fontFamily}
                     </p>
                   </div>
-                  <button
-                    type="button"
-                    className="px-4 py-2 rounded-lg text-sm bg-accent text-accent-foreground hover:bg-accent-hover transition-colors"
-                    onClick={handleWebPrintPreview}
-                  >
-                    印刷プレビューを開く
-                  </button>
-                  {popupBlocked && (
-                    <p className="text-xs text-danger">
-                      ポップアップがブロックされました。ブラウザの設定を確認してください。
-                    </p>
-                  )}
                 </div>
               ) : (
                 <div className="flex items-center justify-center h-full">

--- a/lib/export/__tests__/save-blob-file.test.ts
+++ b/lib/export/__tests__/save-blob-file.test.ts
@@ -2,9 +2,8 @@
  * save-blob-file unit tests
  *
  * Tests for the shared file-save helper covering:
- * - Blob URL download fallback (core Web DOCX path)
- * - User cancel handling (AbortError from showSaveFilePicker)
- * - Gesture expiry degradation (NotAllowedError/SecurityError → Blob URL fallback)
+ * - Blob URL download (core Web path — always fires, no cancel signal)
+ * - Electron TXT save via IPC (cancel returns false, error throws)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -16,7 +15,6 @@ const mockRevokeObjectURL = vi.fn();
 const mockClick = vi.fn();
 
 beforeEach(() => {
-  // Clear call history on standalone vi.fn() mocks (vi.restoreAllMocks only clears spies)
   mockCreateObjectURL.mockClear();
   mockRevokeObjectURL.mockClear();
   mockClick.mockClear();
@@ -26,7 +24,6 @@ beforeEach(() => {
     revokeObjectURL: mockRevokeObjectURL,
   });
 
-  // Mock document.createElement to return a controllable <a> element
   const mockAnchor = {
     href: "",
     download: "",
@@ -39,20 +36,16 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // Clean up showSaveFilePicker from window if set by a test
-  delete (window as unknown as Record<string, unknown>).showSaveFilePicker;
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
 describe("saveBlobFile", () => {
   const blob = new Blob(["test content"], { type: "text/plain" });
-  const accept = { "text/plain": [".txt"] };
 
-  describe("Blob URL download fallback", () => {
-    it("downloads via Blob URL when File System Access API is absent", async () => {
-      // No showSaveFilePicker on window
-      const result = await saveBlobFile(blob, "test.txt", accept, false);
+  describe("Web: Blob URL download", () => {
+    it("downloads via Blob URL and returns true", async () => {
+      const result = await saveBlobFile(blob, "test.txt", false);
 
       expect(result).toBe(true);
       expect(mockCreateObjectURL).toHaveBeenCalledWith(blob);
@@ -61,55 +54,39 @@ describe("saveBlobFile", () => {
     });
   });
 
-  describe("File System Access API", () => {
-    it("returns false on user cancel (AbortError)", async () => {
-      const error = new DOMException("User cancelled", "AbortError");
-      // Assign directly to window so `"showSaveFilePicker" in window` works in jsdom
-      (window as unknown as Record<string, unknown>).showSaveFilePicker = vi
-        .fn()
-        .mockRejectedValue(error);
+  describe("Electron: TXT save via IPC", () => {
+    const mockSaveFile = vi.fn();
 
-      const result = await saveBlobFile(blob, "test.txt", accept, false);
+    beforeEach(() => {
+      vi.stubGlobal("window", {
+        ...window,
+        electronAPI: { saveFile: mockSaveFile },
+      });
+    });
+
+    it("returns false when user cancels the save dialog", async () => {
+      mockSaveFile.mockResolvedValue(null);
+
+      const result = await saveBlobFile(blob, "test.txt", true, ".txt");
 
       expect(result).toBe(false);
-      // Should NOT fall through to download
+      expect(mockSaveFile).toHaveBeenCalledWith(null, "test content", ".txt");
       expect(mockClick).not.toHaveBeenCalled();
     });
 
-    it("falls through to Blob URL on NotAllowedError (gesture expired)", async () => {
-      const error = new DOMException("Gesture required", "NotAllowedError");
-      (window as unknown as Record<string, unknown>).showSaveFilePicker = vi
-        .fn()
-        .mockRejectedValue(error);
+    it("returns true on successful save", async () => {
+      mockSaveFile.mockResolvedValue("/path/to/test.txt");
 
-      const result = await saveBlobFile(blob, "test.txt", accept, false);
+      const result = await saveBlobFile(blob, "test.txt", true, ".txt");
 
       expect(result).toBe(true);
-      expect(mockCreateObjectURL).toHaveBeenCalledWith(blob);
-      expect(mockClick).toHaveBeenCalled();
+      expect(mockClick).not.toHaveBeenCalled();
     });
 
-    it("falls through to Blob URL on SecurityError (permission denied)", async () => {
-      const error = new DOMException("Permission denied", "SecurityError");
-      (window as unknown as Record<string, unknown>).showSaveFilePicker = vi
-        .fn()
-        .mockRejectedValue(error);
+    it("throws on IPC error result", async () => {
+      mockSaveFile.mockResolvedValue({ success: false, error: "disk full" });
 
-      const result = await saveBlobFile(blob, "test.txt", accept, false);
-
-      expect(result).toBe(true);
-      expect(mockClick).toHaveBeenCalled();
-    });
-
-    it("re-throws unexpected errors", async () => {
-      const error = new TypeError("Unexpected error");
-      (window as unknown as Record<string, unknown>).showSaveFilePicker = vi
-        .fn()
-        .mockRejectedValue(error);
-
-      await expect(saveBlobFile(blob, "test.txt", accept, false)).rejects.toThrow(
-        "Unexpected error",
-      );
+      await expect(saveBlobFile(blob, "test.txt", true, ".txt")).rejects.toThrow("disk full");
     });
   });
 });

--- a/lib/export/save-blob-file.ts
+++ b/lib/export/save-blob-file.ts
@@ -1,28 +1,28 @@
 /**
  * Shared file-save helper for browser and Electron.
  *
- * In Electron, delegates to the main-process IPC save dialog (TXT only).
- * In web browsers, tries the File System Access API (Chromium), then falls
- * back to a Blob URL download for other browsers or when the user gesture
- * has expired.
+ * - Electron (TXT only): delegates to the main-process IPC save dialog.
+ *   Returns false when the user cancels the save dialog.
+ * - Web: always triggers a browser download via a temporary Blob URL.
+ *   Returns true unconditionally (browser downloads have no cancel signal).
+ *
+ * Other Electron formats (PDF, DOCX, EPUB) use dedicated IPC export handlers
+ * and never reach this function.
  */
 
 /**
  * Save a Blob to a file.
  *
  * @param blob - Blob content to write
- * @param suggestedName - Default file name shown in the save dialog
- * @param accept - MIME type → extensions map for the file picker
+ * @param suggestedName - Default file name for the download / save dialog
  * @param isElectron - True when running inside Electron renderer
  * @param electronExt - File extension for Electron save dialog. Currently only
- *   ".txt" is routed through Electron IPC here; DOCX/EPUB/PDF use dedicated
- *   IPC export handlers and never reach this function in Electron mode.
- * @returns true if saved, false if user cancelled
+ *   ".txt" is routed through Electron IPC here.
+ * @returns true if saved/downloaded, false if user cancelled (Electron only)
  */
 export async function saveBlobFile(
   blob: Blob,
   suggestedName: string,
-  accept: Record<string, string[]>,
   isElectron: boolean,
   electronExt?: string,
 ): Promise<boolean> {
@@ -38,40 +38,7 @@ export async function saveBlobFile(
     return true;
   }
 
-  // Web: try File System Access API (Chromium browsers).
-  // showSaveFilePicker requires an active user gesture. When called after
-  // async work (dynamic import + blob generation), the gesture may have expired,
-  // causing AbortError, NotAllowedError, or SecurityError. AbortError means the
-  // user explicitly cancelled; the others mean the gesture expired — in that case
-  // we fall through to the Blob URL download fallback.
-  if (hasShowSaveFilePicker(window)) {
-    try {
-      const handle = await window.showSaveFilePicker({
-        suggestedName,
-        types: [
-          {
-            description: suggestedName.split(".").pop()?.toUpperCase() ?? "ファイル",
-            accept,
-          },
-        ],
-      });
-      const writable = await handle.createWritable();
-      await writable.write(blob);
-      await writable.close();
-      return true;
-    } catch (error) {
-      const name = (error as { name?: string }).name;
-      if (name === "AbortError") return false; // user explicitly cancelled
-      // Gesture expired or permission denied — fall through to download fallback
-      if (name === "NotAllowedError" || name === "SecurityError") {
-        // fall through below
-      } else {
-        throw error;
-      }
-    }
-  }
-
-  // Fallback: trigger download via Blob URL
+  // Web: trigger download via Blob URL
   downloadViaBlob(blob, suggestedName);
   return true;
 }
@@ -88,13 +55,4 @@ function downloadViaBlob(blob: Blob, suggestedName: string): void {
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
-}
-
-/**
- * Type guard: checks whether window has the File System Access API showSaveFilePicker method.
- */
-function hasShowSaveFilePicker(w: Window): w is Window & {
-  showSaveFilePicker: (options?: object) => Promise<FileSystemFileHandle>;
-} {
-  return "showSaveFilePicker" in w;
 }

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -84,13 +84,7 @@ export function useExport({
           const suggestedName = `${baseName}${suffix}.txt`;
 
           const blob = new Blob([converted], { type: "text/plain;charset=utf-8" });
-          const saved = await saveBlobFile(
-            blob,
-            suggestedName,
-            { "text/plain": [".txt"] },
-            isElectron,
-            ".txt",
-          );
+          const saved = await saveBlobFile(blob, suggestedName, isElectron, ".txt");
           notificationManager.dismiss(progressId);
 
           if (saved) {
@@ -249,23 +243,18 @@ async function exportAsWeb(
   try {
     let blob: Blob;
     let suggestedName: string;
-    let accept: Record<string, string[]>;
 
     switch (format) {
       case "docx": {
         const { generateDocxBlob } = await import("./docx-exporter");
         blob = await generateDocxBlob(content, { metadata });
         suggestedName = `${baseName}.docx`;
-        accept = {
-          "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [".docx"],
-        };
         break;
       }
       case "epub": {
         const { generateEpubBlob } = await import("./epub-web");
         blob = await generateEpubBlob(content, { metadata });
         suggestedName = `${baseName}.epub`;
-        accept = { "application/epub+zip": [".epub"] };
         break;
       }
       default:
@@ -273,7 +262,7 @@ async function exportAsWeb(
         return;
     }
 
-    const saved = await saveBlobFile(blob, suggestedName, accept, false);
+    const saved = await saveBlobFile(blob, suggestedName, false);
     notificationManager.dismiss(progressId);
 
     if (saved) {


### PR DESCRIPTION
## Summary

- EPUB エクスポート機能を追加（カバー画像、メタデータ編集、章分割、80+ページサイズ対応）
- Web 版の全エクスポート（TXT/PDF/DOCX/EPUB）を統一し、File System Access API を廃止してブラウザダウンロード方式に一本化
- B5/B6 ページサイズのレガシー互換性を維持（ISO → JIS キー名の衝突を解消）
- EPUB 著者名の非同期 autofill タイミングを修正

## Changes

| Area | Files | Description |
|---|---|---|
| EPUB export | `epub-shared.ts`, `epub-web.ts`, `epub-exporter.ts` | EPUB 生成（Node.js: archiver / Browser: fflate） |
| Page sizes | `page-sizes.ts`, `PageSizeSelector.tsx` | 80+サイズ、JIS-B*/ISO-B* キー分離、レガシーエイリアス |
| Export dialog | `ExportDialog.tsx` | EPUB タブ追加、Web PDF プレビュー簡素化 |
| Web download | `save-blob-file.ts` | `showSaveFilePicker` 除去、常に Blob URL ダウンロード |
| Export hook | `use-export.ts` | `accept` パラメータ除去、契約語意更新 |
| Export handlers | `app/page.tsx` | EPUB confirm handler、`saveBlobFile` 呼び出し簡素化 |
| IPC | `electron/ipc/file-ipc.js` | `export-epub` ハンドラ追加 |
| Tests | `save-blob-file.test.ts` | Electron TXT cancel/error テスト追加、FSA API テスト削除 |

## Test plan

- [ ] Web: TXT エクスポート → ブラウザダウンロード（`showSaveFilePicker` なし）
- [ ] Web: PDF エクスポート → ExportDialog → 設定 → 印刷ダイアログ表示
- [ ] Web: DOCX エクスポート → ExportDialog → 設定 → ダウンロード
- [ ] Web: EPUB エクスポート → ExportDialog → カバー/メタデータ設定 → ダウンロード
- [ ] Electron: 全フォーマットのリグレッションなし確認
- [ ] B5/B6 ページサイズが既存設定で ISO 寸法を維持
- [ ] `npm run type-check` パス
- [ ] `npm test` (save-blob-file) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)