### PR TITLE
fix(ci): make Store submission workflow retry actually execute

### DIFF
--- a/.github/workflows/sync-ms-store-listing.yml
+++ b/.github/workflows/sync-ms-store-listing.yml
@@ -136,18 +136,21 @@ jobs:
           RETRY_DELAY=120  # 2 minutes between retries
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
-            echo "=== Attempt $attempt / $MAX_ATTEMPTS ==="
+            echo "=== Workflow attempt $attempt / $MAX_ATTEMPTS ==="
+            set +e
             node scripts/submit-store.mjs
             EXIT_CODE=$?
+            set -e
             if [ $EXIT_CODE -eq 0 ]; then
-              echo "Submission succeeded on attempt $attempt."
+              echo "Submission succeeded on workflow attempt $attempt."
               exit 0
             fi
+            echo "::warning::Workflow attempt $attempt failed (exit code $EXIT_CODE)."
             if [ $attempt -lt $MAX_ATTEMPTS ]; then
-              echo "Attempt $attempt failed (exit $EXIT_CODE). Retrying in ${RETRY_DELAY}s..."
+              echo "Retrying in ${RETRY_DELAY}s..."
               sleep $RETRY_DELAY
             fi
           done
 
-          echo "::error::All $MAX_ATTEMPTS submission attempts failed."
+          echo "::error::All $MAX_ATTEMPTS workflow-level submission attempts failed."
           exit 1

--- a/scripts/submit-store.mjs
+++ b/scripts/submit-store.mjs
@@ -422,11 +422,23 @@ async function main() {
         await apiDelete(token, `/applications/${APP_ID}/submissions/${pendingId}`);
         break;
       } catch (deleteErr) {
-        if (deleteErr.status !== 409 || attempt === DELETE_MAX_ATTEMPTS) {
+        if (deleteErr.status !== 409) {
+          throw deleteErr;
+        }
+        if (attempt === DELETE_MAX_ATTEMPTS) {
+          console.error(
+            `\n  *** Persistent 409: submission ${pendingId} cannot be deleted after ${DELETE_MAX_ATTEMPTS} attempts. ***\n` +
+              `  This usually means the submission is stuck in a non-deletable state\n` +
+              `  (e.g., InProgress, PreProcessing, or under certification review).\n` +
+              `  Action required: go to https://partner.microsoft.com/dashboard\n` +
+              `  and manually cancel or wait for submission ${pendingId} to complete.`,
+          );
           throw deleteErr;
         }
         const delay = DELETE_BASE_DELAY_MS * attempt;
-        console.log(`  DELETE failed with transient 409: ${deleteErr.message}`);
+        console.log(
+          `  [DELETE retry ${attempt}/${DELETE_MAX_ATTEMPTS}] 409 for submission ${pendingId}: ${deleteErr.message}`,
+        );
         console.log(`  Retrying in ${delay / 1000}s...`);
         await new Promise((r) => setTimeout(r, delay));
       }


### PR DESCRIPTION
## Summary
- GitHub Actions の bash は `set -eo pipefail` がデフォルトのため、`node scripts/submit-store.mjs` が失敗すると即座にシェルが終了し、`EXIT_CODE=$?` に到達しない → 3回の workflow retry ループは実質的に動作していなかった
- `set +e` / `set -e` で囲むことで exit code を正しくキャプチャし、retry を機能させる
- persistent 409 状態のエラーメッセージを改善：Partner Center での手動対応が必要であることを明示

## Changes
1. **`.github/workflows/sync-ms-store-listing.yml`**: `set +e` で node コマンドの exit code をキャプチャ、workflow retry が実際に動作するように修正
2. **`scripts/submit-store.mjs`**: DELETE 409 の最終失敗時に actionable なエラーメッセージ（Partner Center URL + submission ID）を出力。retry ログに submission ID と attempt 番号を追加

## Root Cause
`set -eo pipefail` (GitHub Actions bash default) + non-zero exit from `node scripts/submit-store.mjs` = shell exits before `$?` capture → retry loop was dead code since it was written.

## Test plan
- [ ] `sync-ms-store-listing.yml` の bash を手動で trace: `set +e` → node 失敗 → `$?` キャプチャ → retry loop 継続を確認
- [ ] Script 側: 409 persistent 時のエラーメッセージに Partner Center URL と submission ID が含まれることを確認
- [ ] Concurrency group (`ms-store-submission`, `cancel-in-progress: false`) は変更なし

Closes #1349

🤖 Generated with [Claude Code](https://claude.com/claude-code)