### PR TITLE
chore(ci): enforce dev as base branch for bot-generated PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,16 @@
 # Illusions Project - GitHub Copilot Instructions
 
+> **⚠️ CRITICAL — READ BEFORE OPENING ANY PULL REQUEST ⚠️**
+>
+> **All PRs MUST target the `dev` branch. NEVER target `main`.**
+>
+> - Default repository branch is `main` for historical reasons, but **do not use it as the PR base**.
+> - `main` only receives merges via the weekly release PR (`dev → main`, every Monday).
+> - When opening a PR via `gh pr create`, always pass `--base dev` explicitly.
+> - If you open a PR against `main`, it will be rebased onto `dev` or closed.
+>
+> Full rules in the [Branch Strategy](#branch-strategy-critical) section below.
+
 ## Project Overview
 
 **Illusions** is a Japanese novel writing application with advanced typesetting support.
@@ -153,9 +164,15 @@ hotfix/<name>   →  main  (emergency only, then cherry-pick to dev)
 
 When creating a PR:
 
-- Base branch: `dev` (default)
+- Base branch: **always** `dev` (the repo default branch is `main`, but that is NOT the PR target)
+- Use `gh pr create --base dev ...` — never rely on the default
 - Only use `main` as base for emergency hotfixes
 - Include `Closes #<issue>` in PR body for auto-closing
+
+Enforcement:
+
+- Dependabot is configured via `.github/dependabot.yml` with `target-branch: dev`
+- PRs opened against `main` by Copilot/agents will be rebased to `dev` during the patrol sweep
 
 ## Build & Development
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,46 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "npm"
+    directory: "/www"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "www"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      www_npm:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/milkdown-plugin-japanese-novel"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "milkdown-plugin"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      milkdown_plugin_npm:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "dev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+
+# ----------------------------------------------------------------------------
+# Base branch policy (see .github/copilot-instructions.md § Branch Strategy):
+#   All bot-generated PRs MUST target `dev`, never `main`.
+#   `main` receives merges only via the weekly release PR.
+# ----------------------------------------------------------------------------
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm_and_yarn:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

- Add \`.github/dependabot.yml\` with \`target-branch: dev\` for npm and github-actions ecosystems — Dependabot was defaulting to \`main\` because that is the repo default branch.
- Strengthen \`.github/copilot-instructions.md\` with a prominent top-of-file callout so Copilot SWE agent and other bots stop opening PRs against \`main\`.

## Why

During today's PR patrol, #1346 (Copilot docs update) and #1359 (Dependabot) both targeted \`main\`, violating the \`dev → main\` weekly release flow defined in \`CLAUDE.md\`. Their base branches have been rebased to \`dev\` manually; this PR prevents the issue from recurring.

## Test plan

- [ ] Dependabot's next weekly run opens PRs against \`dev\`
- [ ] Next Copilot SWE task respects the base-branch callout