### PR TITLE
fix(ci): build native modules per-arch for Windows ARM64 packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -404,7 +404,7 @@ jobs:
           retention-days: 1
 
   package-windows-nsis:
-    name: Build (Windows NSIS)
+    name: Build (Windows NSIS ${{ matrix.arch }})
     needs: [detect-changes, compute-version, build-windows-core]
     # Allow PRs to run (build-windows-core runs in type-check-only mode on PRs; compute-version is skipped),
     # but require successful compute-version and build-windows-core for non-PR events before packaging.
@@ -418,6 +418,9 @@ jobs:
       &&
       needs.detect-changes.outputs.desktop_changed == 'true'
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'windows-latest' }}
+    strategy:
+      matrix:
+        arch: [x64, arm64]
     env:
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
@@ -440,9 +443,9 @@ jobs:
           path: |
             ${{ env.ELECTRON_CACHE }}
             ${{ env.ELECTRON_BUILDER_CACHE }}
-          key: electron-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
+          key: electron-${{ runner.os }}-${{ matrix.arch }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            electron-${{ runner.os }}-${{ runner.arch }}-
+            electron-${{ runner.os }}-${{ matrix.arch }}-
 
       - name: Install dependencies
         shell: bash
@@ -470,19 +473,58 @@ jobs:
         with:
           name: windows-build-output
 
+      - name: Rebuild native modules for target arch
+        if: github.event_name != 'pull_request'
+        run: npm run bundle:electron -- --target-arch ${{ matrix.arch }}
+
+      - name: Verify native module architecture
+        if: github.event_name != 'pull_request'
+        shell: pwsh
+        run: |
+          $expectedArch = "${{ matrix.arch }}"
+
+          # Check better-sqlite3.node PE header
+          $bsql = "dist-main/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+          if (Test-Path $bsql) {
+            $bytes = [System.IO.File]::ReadAllBytes($bsql)
+            $peOffset = [BitConverter]::ToInt32($bytes, 0x3C)
+            $machine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
+            # 0x8664 = AMD64 (x64), 0xAA64 = ARM64
+            $expectedMachine = if ($expectedArch -eq "x64") { 0x8664 } else { 0xAA64 }
+            if ($machine -ne $expectedMachine) {
+              Write-Error "better_sqlite3.node architecture mismatch: expected $expectedArch (0x$($expectedMachine.ToString('X4'))) but got 0x$($machine.ToString('X4'))"
+              exit 1
+            }
+          }
+
+          # Verify node-pty build/ was removed for cross-arch (should use prebuilds/)
+          if ($expectedArch -ne "x64" -and (Test-Path "dist-main/node_modules/node-pty/build/Release")) {
+            Write-Error "node-pty/build/Release still exists — ARM64 would load wrong binary"
+            exit 1
+          }
+
+          # Verify prebuilds for target arch exist
+          $prebuildsDir = "dist-main/node_modules/node-pty/prebuilds/win32-$expectedArch"
+          if (-not (Test-Path $prebuildsDir)) {
+            Write-Error "node-pty prebuilds for win32-$expectedArch not found"
+            exit 1
+          }
+
+          Write-Host "✅ Native modules verified for $expectedArch"
+
       - name: Build NSIS installer
         if: github.event_name != 'pull_request'
-        run: npx electron-builder --win nsis --x64 --arm64 --publish never
+        run: npx electron-builder --win nsis --${{ matrix.arch }} --publish never
 
       - name: Upload NSIS artifacts
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
-          name: illusions-windows-${{ needs.compute-version.outputs.full }}
+          name: illusions-windows-${{ matrix.arch }}-${{ needs.compute-version.outputs.full }}
           path: dist-electron/**
 
   package-windows-msix:
-    name: Build (Windows Store)
+    name: Build (Windows Store ${{ matrix.arch }})
     needs: [detect-changes, compute-version, build-windows-core]
     # Allow PRs to run: build-windows-core runs on PRs (type-check-only mode; compute-version is skipped).
     # For non-PR events, require successful compute-version and build-windows-core before packaging.
@@ -496,6 +538,9 @@ jobs:
       &&
       needs.detect-changes.outputs.desktop_changed == 'true'
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'windows-latest' }}
+    strategy:
+      matrix:
+        arch: [x64, arm64]
     outputs:
       version: ${{ needs.compute-version.outputs.full }}
     env:
@@ -520,9 +565,9 @@ jobs:
           path: |
             ${{ env.ELECTRON_CACHE }}
             ${{ env.ELECTRON_BUILDER_CACHE }}
-          key: electron-${{ runner.os }}-msix-${{ hashFiles('package-lock.json') }}
+          key: electron-${{ runner.os }}-msix-${{ matrix.arch }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
-            electron-${{ runner.os }}-msix-
+            electron-${{ runner.os }}-msix-${{ matrix.arch }}-
 
       - name: Install dependencies
         shell: bash
@@ -550,15 +595,51 @@ jobs:
         with:
           name: windows-build-output
 
+      - name: Rebuild native modules for target arch
+        if: github.event_name != 'pull_request'
+        run: npm run bundle:electron -- --target-arch ${{ matrix.arch }}
+
+      - name: Verify native module architecture
+        if: github.event_name != 'pull_request'
+        shell: pwsh
+        run: |
+          $expectedArch = "${{ matrix.arch }}"
+
+          # Check better-sqlite3.node PE header
+          $bsql = "dist-main/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+          if (Test-Path $bsql) {
+            $bytes = [System.IO.File]::ReadAllBytes($bsql)
+            $peOffset = [BitConverter]::ToInt32($bytes, 0x3C)
+            $machine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
+            $expectedMachine = if ($expectedArch -eq "x64") { 0x8664 } else { 0xAA64 }
+            if ($machine -ne $expectedMachine) {
+              Write-Error "better_sqlite3.node architecture mismatch: expected $expectedArch (0x$($expectedMachine.ToString('X4'))) but got 0x$($machine.ToString('X4'))"
+              exit 1
+            }
+          }
+
+          if ($expectedArch -ne "x64" -and (Test-Path "dist-main/node_modules/node-pty/build/Release")) {
+            Write-Error "node-pty/build/Release still exists — ARM64 would load wrong binary"
+            exit 1
+          }
+
+          $prebuildsDir = "dist-main/node_modules/node-pty/prebuilds/win32-$expectedArch"
+          if (-not (Test-Path $prebuildsDir)) {
+            Write-Error "node-pty prebuilds for win32-$expectedArch not found"
+            exit 1
+          }
+
+          Write-Host "✅ Native modules verified for $expectedArch"
+
       - name: Build MSIX package
         if: github.event_name != 'pull_request'
-        run: npx electron-builder --win appx --x64 --arm64 --publish never
+        run: npx electron-builder --win appx --${{ matrix.arch }} --publish never
 
       - name: Upload MSIX artifacts
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7
         with:
-          name: illusions-windows-msix-${{ needs.compute-version.outputs.full }}
+          name: illusions-windows-msix-${{ matrix.arch }}-${{ needs.compute-version.outputs.full }}
           path: |
             dist-electron/*.appx
             dist-electron/*.appx.blockmap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -485,16 +485,18 @@ jobs:
 
           # Check better-sqlite3.node PE header
           $bsql = "dist-main/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
-          if (Test-Path $bsql) {
-            $bytes = [System.IO.File]::ReadAllBytes($bsql)
-            $peOffset = [BitConverter]::ToInt32($bytes, 0x3C)
-            $machine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
-            # 0x8664 = AMD64 (x64), 0xAA64 = ARM64
-            $expectedMachine = if ($expectedArch -eq "x64") { 0x8664 } else { 0xAA64 }
-            if ($machine -ne $expectedMachine) {
-              Write-Error "better_sqlite3.node architecture mismatch: expected $expectedArch (0x$($expectedMachine.ToString('X4'))) but got 0x$($machine.ToString('X4'))"
-              exit 1
-            }
+          if (-not (Test-Path $bsql)) {
+            Write-Error "better_sqlite3.node not found at $bsql — native module build may have failed"
+            exit 1
+          }
+          $bytes = [System.IO.File]::ReadAllBytes($bsql)
+          $peOffset = [BitConverter]::ToInt32($bytes, 0x3C)
+          $machine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
+          # 0x8664 = AMD64 (x64), 0xAA64 = ARM64
+          $expectedMachine = if ($expectedArch -eq "x64") { 0x8664 } else { 0xAA64 }
+          if ($machine -ne $expectedMachine) {
+            Write-Error "better_sqlite3.node architecture mismatch: expected $expectedArch (0x$($expectedMachine.ToString('X4'))) but got 0x$($machine.ToString('X4'))"
+            exit 1
           }
 
           # Verify node-pty build/ was removed for cross-arch (should use prebuilds/)
@@ -607,15 +609,17 @@ jobs:
 
           # Check better-sqlite3.node PE header
           $bsql = "dist-main/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
-          if (Test-Path $bsql) {
-            $bytes = [System.IO.File]::ReadAllBytes($bsql)
-            $peOffset = [BitConverter]::ToInt32($bytes, 0x3C)
-            $machine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
-            $expectedMachine = if ($expectedArch -eq "x64") { 0x8664 } else { 0xAA64 }
-            if ($machine -ne $expectedMachine) {
-              Write-Error "better_sqlite3.node architecture mismatch: expected $expectedArch (0x$($expectedMachine.ToString('X4'))) but got 0x$($machine.ToString('X4'))"
-              exit 1
-            }
+          if (-not (Test-Path $bsql)) {
+            Write-Error "better_sqlite3.node not found at $bsql — native module build may have failed"
+            exit 1
+          }
+          $bytes = [System.IO.File]::ReadAllBytes($bsql)
+          $peOffset = [BitConverter]::ToInt32($bytes, 0x3C)
+          $machine = [BitConverter]::ToUInt16($bytes, $peOffset + 4)
+          $expectedMachine = if ($expectedArch -eq "x64") { 0x8664 } else { 0xAA64 }
+          if ($machine -ne $expectedMachine) {
+            Write-Error "better_sqlite3.node architecture mismatch: expected $expectedArch (0x$($expectedMachine.ToString('X4'))) but got 0x$($machine.ToString('X4'))"
+            exit 1
           }
 
           if ($expectedArch -ne "x64" -and (Test-Path "dist-main/node_modules/node-pty/build/Release")) {

--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -14,6 +14,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "..");
 
+const targetArchIndex = process.argv.indexOf("--target-arch");
+const targetArch = targetArchIndex !== -1 ? process.argv[targetArchIndex + 1] : process.arch;
+console.log(`🏗️  Target architecture: ${targetArch}`);
+
 const outDir = join(projectRoot, "dist-main");
 
 // Ensure output directory exists
@@ -70,9 +74,12 @@ console.log("✅ Preload script bundled to dist-main/preload.js");
 console.log("📦 Copying runtime dependencies for external modules...");
 
 const nodeModulesDest = join(outDir, "node_modules");
-if (!fs.existsSync(nodeModulesDest)) {
-  fs.mkdirSync(nodeModulesDest, { recursive: true });
+
+// Clean destination to prevent stale binaries from a previous arch
+if (fs.existsSync(nodeModulesDest)) {
+  fs.rmSync(nodeModulesDest, { recursive: true });
 }
+fs.mkdirSync(nodeModulesDest, { recursive: true });
 
 /**
  * Collect a package and all its production dependencies (transitive).
@@ -162,6 +169,41 @@ function resolvePackageDir(dep) {
   if (fs.existsSync(hoisted)) return hoisted;
   return null;
 }
+
+// When cross-compiling for a different architecture, swap native binaries
+// so the packaged app contains the correct arch-specific modules.
+async function prepareNativeModulesForArch(arch) {
+  if (arch === process.arch) return;
+
+  const { execSync } = await import("child_process");
+
+  // --- better-sqlite3: download correct prebuild for target arch ---
+  const bsqlDir = resolvePackageDir("better-sqlite3");
+  if (bsqlDir) {
+    const electronPkgPath = join(projectRoot, "node_modules", "electron", "package.json");
+    const electronPkg = JSON.parse(fs.readFileSync(electronPkgPath, "utf-8"));
+    console.log(`  📥 Downloading better-sqlite3 prebuild for win32-${arch}...`);
+    execSync(
+      `npx prebuild-install --arch ${arch} --platform win32 --runtime electron --target ${electronPkg.version}`,
+      { cwd: bsqlDir, stdio: "inherit" },
+    );
+    console.log(`  ✅ better-sqlite3 prebuild ready for ${arch}`);
+  }
+
+  // --- node-pty: remove build/Release so runtime uses prebuilds/win32-<arch> ---
+  // node-pty's loadNativeModule() resolves build/Release BEFORE prebuilds/.
+  // By removing build/, the runtime falls through to the correct prebuilds/win32-<arch>/.
+  const ptyDir = resolvePackageDir("node-pty");
+  if (ptyDir) {
+    const buildDir = join(ptyDir, "build");
+    if (fs.existsSync(buildDir)) {
+      fs.rmSync(buildDir, { recursive: true });
+      console.log(`  🗑️  Removed node-pty/build/ (will use prebuilds/win32-${arch}/)`);
+    }
+  }
+}
+
+await prepareNativeModulesForArch(targetArch);
 
 for (const dep of runtimeDeps) {
   const src = resolvePackageDir(dep);


### PR DESCRIPTION
## Summary

Fixes #1299

- **Root cause**: `bundle:electron` ran once on x64, copying x64 native binaries (`better-sqlite3`, `node-pty`) into `dist-main/node_modules/`. Both x64 and ARM64 installers shared this output, causing ARM64 packages to crash at runtime.
- Add `--target-arch` flag to `scripts/bundle-electron.mjs` — downloads correct `better-sqlite3` prebuild for target arch and strips `node-pty/build/` so runtime falls through to `prebuilds/win32-<arch>/`
- Split NSIS and MSIX packaging jobs into per-arch matrix (`x64`, `arm64`), each re-running `bundle:electron --target-arch <arch>` before packaging
- Add PowerShell PE header verification step to catch arch mismatches before packaging

## Test plan

- [ ] CI passes for all 4 matrix jobs (NSIS×2, MSIX×2)
- [ ] x64 NSIS artifact contains x64 `better_sqlite3.node` (PE header 0x8664)
- [ ] ARM64 NSIS artifact has no `node-pty/build/Release/` and has `prebuilds/win32-arm64/`
- [ ] PowerShell verification step catches deliberate mismatch (manual test)
- [ ] x64 path regression: no `--target-arch` = `process.arch` default, no stripping

🤖 Generated with [Claude Code](https://claude.com/claude-code)