### PR TITLE
chore: add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ docs/.obsidian/
 
 # Git worktrees
 .worktrees/
+.claude/worktrees/
 
 # Review loop artifacts
 reviews/


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to `.gitignore` to prevent agent worktree artifacts from appearing in git status

## Test plan
- [x] Verify `.claude/worktrees/` no longer shows as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)