### PR TITLE
fix(stats): 詳細スコアの進捗バーが黒くなる問題を修正

### DIFF
--- a/components/inspector/StatsPanel.tsx
+++ b/components/inspector/StatsPanel.tsx
@@ -305,10 +305,10 @@ export default function StatsPanel({
                           width: `${value}%`,
                           backgroundColor:
                             value >= 75
-                              ? "var(--color-success)"
+                              ? "rgb(var(--success))"
                               : value >= 50
-                                ? "var(--color-warning, #f59e0b)"
-                                : "var(--color-error)",
+                                ? "rgb(var(--warning))"
+                                : "rgb(var(--error))",
                         }}
                       />
                     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "illusions",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "illusions",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary

- `全体の統計` → `詳細スコア` の進捗バーが、定義されていない CSS 変数を参照しており透明になっていた問題を修正
- 結果として全 4 項目（文の負荷・語彙の難しさ・構文の複雑さ・段落の密度）のバーがダーク背景を透過し、真っ黒に見える状態だった
- `app/globals.css` に定義済みの `--success` / `--warning` / `--error`（RGB triplet）を正しく参照するよう修正、ライト／ダーク両モードで緑・黄・赤が表示される

## Changes

| ファイル | 変更内容 |
|---|---|
| `components/inspector/StatsPanel.tsx` | `var(--color-success/warning/error)` → `rgb(var(--success/warning/error))` |
| `package-lock.json` | 1.1.0 → 1.2.0 版号同期（インストール時の差分） |

## Test plan

- [ ] ダークモードで文章を開き `全体の統計` パネルの `詳細スコア` バーが緑（75+）／黄（50-74）／赤（<50）で描画されることを確認
- [ ] ライトモードでも同様に色分けされることを確認
- [ ] スコア境界値（75, 50）でしきい値が切り替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)