### PR TITLE
chore(deps): ignore eslint 10.x until React ecosystem catches up

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      # ESLint 10 breaks eslint-plugin-react (peer: ^9.7 as of 7.37.5).
+      # Revisit once the React ESLint ecosystem catches up.
+      - dependency-name: "eslint"
+        versions: ["10.x"]
     groups:
       npm_and_yarn:
         patterns:


### PR DESCRIPTION
## Summary

- ESLint 10 の API 変更（`getFilename`）で `eslint-plugin-react` が壊れ、毎週の Dependabot group PR が Lint → 依存する Build を全滅させていた
- `eslint-plugin-react@7.37.5`（最新）の peer は `^eslint 9.7` まで、`eslint-config-next` も同プラグインをバンドル
- `.github/dependabot.yml` に ESLint 10.x を ignore するルールを追加し、週次 group PR が ESLint 10 を除いて再生成されるようにする

## Changes

| ファイル | 変更内容 |
|---|---|
| `.github/dependabot.yml` | `/` ecosystem に `ignore: eslint 10.x` を追加 |

## Context

- 既存の #1380 は同じ理由で close 済み
- 次の weekly cycle（月曜 09:00 JST）で ESLint 10 を除いた 45 件の新規 PR が自動生成される想定
- 上流（eslint-plugin-react の ESLint 10 対応版）がリリースされたらこの ignore ルールを削除

## Test plan

- [ ] YAML syntax チェック（`yamllint` 等）
- [ ] dev マージ後、次の weekly cycle で ESLint 10 を含まない PR が生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)