### PR TITLE
feat(mdi): add [[br]] explicit line break for .mdi round-trip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,4 +98,4 @@ Types: `feat`, `fix`, `refactor`, `docs`, `style`, `test`, `chore`
 | `lib/vfs/`                            | Filesystem abstraction              |
 | `electron/preload.js`                 | IPC security boundary               |
 
-Key references: `docs/architecture/storage-system.md`, `MDI.md`, `types/electron.d.ts`
+Key references: `docs/architecture/storage-system.md`, `docs/MDI/spec.md`, `MDI.md`, `types/electron.d.ts`

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -227,12 +227,18 @@ export default function MilkdownEditor({
       }
 
       // MDI extensions: conditionally loaded
+      // NOTE: enableNoBreak / enableKern are not explicitly passed here, so
+      //   they default to `true` (always enabled, even in .md files).
+      //   enableMdiBreak is explicitly gated on mdiExtensionsEnabled so that
+      //   `[[br]]` is only active in .mdi files. Aligning nobreak/kern with
+      //   the same gating is tracked separately.
       editor = editor.use(
         japaneseNovel({
           isVertical,
           showManuscriptLine: false,
           enableRuby: mdiExtensionsEnabled,
           enableTcy: mdiExtensionsEnabled,
+          enableMdiBreak: mdiExtensionsEnabled,
         }),
       );
 

--- a/docs/MDI/implementation.md
+++ b/docs/MDI/implementation.md
@@ -3,7 +3,7 @@ title: MDI 実装ノート
 slug: mdi-implementation
 type: spec
 status: active
-updated: 2026-04-03
+updated: 2026-04-18
 tags:
   - mdi
   - implementation
@@ -24,18 +24,28 @@ tags:
 - `packages/milkdown-plugin-japanese-novel/`
   MDI 記法に対応する ProseMirror node / remark plugin / decoration 群。
 
+### Explicit Line Break (`[[br]]`)
+
+- `packages/milkdown-plugin-japanese-novel/syntax.ts`
+  `MDI_BREAK_RE`、`remarkMdiBreakPlugin` — text node を走査し `[[br]]` を mdibreak インライン node に変換。
+- `packages/milkdown-plugin-japanese-novel/nodes/mdibreak.ts`
+  `mdibreakSchema` — ProseMirror の atom inline node、`<br class="mdi-break">` を出力。
+- `packages/milkdown-plugin-japanese-novel/plugins/hardbreak-indent.ts`
+  CommonMark の hardbreak と MDI の mdibreak の両方にインデント用スペーサー装飾を適用。
+
 ## Parsing / Export
 
 - `lib/export/mdi-parser.ts`
-  inline 構文の共通パーサ。
+  inline 構文の共通パーサ。`[[br]]` を改行（`\n`）として strip する処理を含む。
 - `lib/export/mdi-to-html.ts`
-  MDI を安全な HTML に変換する中核。
+  MDI を安全な HTML に変換する中核。`[[br]]` → `<br class="mdi-break">`。`getMdiStylesheet()` に `br.mdi-break` ルールを含む。
 - `lib/export/txt-exporter.ts`
-  MDI 構文を plain text / ruby 付きテキストに変換。
+  MDI 構文を plain text / ruby 付きテキストに変換。`[[br]]` は `\n` として出力される。
 - `lib/export/pdf-exporter.ts`
 - `lib/export/epub-exporter.ts`
+  EPUB は `mdi-to-html.ts` を経由するため、`[[br]]` の処理は自動的に共有される。
 - `lib/export/docx-exporter.ts`
-  MDI を各出力形式へ変換。
+  `parseInlineFormatting` で `[[br]]` を境界としてテキストを分割し、`TextRun({ break: 1 })` として出力。
 
 ## File / Project Integration
 

--- a/docs/MDI/roadmap.md
+++ b/docs/MDI/roadmap.md
@@ -3,7 +3,7 @@ title: MDI ロードマップ
 slug: mdi-roadmap
 type: spec
 status: draft
-updated: 2026-04-03
+updated: 2026-04-18
 tags:
   - mdi
   - roadmap
@@ -19,6 +19,7 @@ tags:
 - 縦中横: `^...^`
 - no-break: `[[no-break:...]]`
 - kern: `[[kern:<量>:<文字列>]]`
+- explicit line break: `[[br]]`（Issue #1235）
 - `.mdi` ファイル拡張子
 - HTML / TXT / PDF / EPUB / DOCX への出力経路
 

--- a/docs/MDI/spec.md
+++ b/docs/MDI/spec.md
@@ -204,7 +204,8 @@ CommonMark の hardbreak（行末 2 スペース + `\n`、または `Shift+Enter
 - CommonMark の hardbreak（`  \n` or `Shift+Enter`）とは独立しており、同一文書内での共存が可能。
 - 連続した `[[br]][[br]]` は複数回の改行として扱う。
 - **ルビ構文内（`{base[[br]]|ruby}` など）では `[[br]]` はリテラル文字として扱われる**。ルビの正規表現 `{[^|]+\|[^}]+}` はブラケット文字を属性値として取り込むため、`remark` 変換は発火しない。
-- **コードブロック・インラインコード内では無効**。`remark` が先に code node として隔離するため、`[[br]]` はリテラル文字として保持される。
+- **コードブロック・インラインコード内では無効（エディタ / `remark` 経路）**。`remark` が先に code node として隔離するため、その経路では `[[br]]` はリテラル文字として保持される。
+- **エクスポート経路（`mdi-to-html.ts`）との差異**：現状のエクスポートは文字列置換ベース（ruby/tcy/nobr/kern と同じ前処理パイプライン）のため、コードブロック・インラインコードの除外は `remark` 経路と同等には保証されない。本件は `[[br]]` 固有ではなく MDI inline 構文全般に共通する既知のギャップで、別 Issue でトークン/AST レベル置換への移行を追跡する。
 - **エスケープ `\[[br]]`**：エクスポート経路（`mdi-to-html.ts`）のみでリテラル化される。エディタの `remark` 経路ではエスケープ未対応（既存の bracket macro 全般の既知の差で、`docs/MDI/roadmap.md` の escape handling 項目で追跡中）。
 
 ### 6.4 HTML Conversion (Recommended)

--- a/docs/MDI/spec.md
+++ b/docs/MDI/spec.md
@@ -3,7 +3,7 @@ title: MDI 構文仕様
 slug: mdi-spec
 type: spec
 status: draft
-updated: 2026-04-03
+updated: 2026-04-18
 tags:
   - mdi
   - syntax
@@ -17,7 +17,7 @@ tags:
 ## Original Draft (English)
 
 MDI files are Markdown documents with illusions-specific extensions for Japanese typography.
-This specification defines _inline_ syntaxes that are difficult to express in standard Markdown (ruby, tate-chu-yoko, no-break, kerning).
+This specification defines _inline_ syntaxes that are difficult to express in standard Markdown (ruby, tate-chu-yoko, no-break, kerning, explicit line break).
 
 ## 1. Purpose & Assumptions
 
@@ -37,7 +37,7 @@ A recommended order is:
 1. Handle escapes (see 3.2)
 2. Ruby: `{base|ruby}`
 3. Tate-chu-yoko: `^...^`
-4. Bracket macros: `[[no-break:...]]`, `[[kern:...:...]]`
+4. Bracket macros: `[[br]]`, `[[no-break:...]]`, `[[kern:...:...]]`
 
 ### 2.2 Escapes (Recommended)
 
@@ -175,23 +175,81 @@ Output (example):
 }
 ```
 
-## 6. Kerning / Letter-spacing (字間調整)
+## 6. Explicit Line Break (改行)
+
+段落内に強制改行を挿入するための MDI 独自の構文です。
+CommonMark の hardbreak（行末 2 スペース + `\n`、または `Shift+Enter` で挿入）に依存しない、明示的な改行マーカーを提供します。
 
 ### 6.1 Syntax
+
+`[[br]]`
+
+- 引数を取らない bracket macro です。
+- 段落の途中、文字列の途中、どこにでも挿入できます。
+- `.mdi` 固有の構文です。`.md` ファイルでは通常のリテラル文字列として扱われます。
+
+### 6.2 Examples
+
+```markdown
+春は曙。[[br]]
+やうやう白くなりゆく山ぎは。
+
+[[br]][[br]]は連続した 2 回の改行として扱う。
+```
+
+### 6.3 Semantics
+
+- `.mdi` 固有の構文。`.md` には適用しない。
+- 段落（inline context）内でのみ有効。ブロックレベルでは無視される。
+- CommonMark の hardbreak（`  \n` or `Shift+Enter`）とは独立しており、同一文書内での共存が可能。
+- 連続した `[[br]][[br]]` は複数回の改行として扱う。
+- **ルビ構文内（`{base[[br]]|ruby}` など）では `[[br]]` はリテラル文字として扱われる**。ルビの正規表現 `{[^|]+\|[^}]+}` はブラケット文字を属性値として取り込むため、`remark` 変換は発火しない。
+- **コードブロック・インラインコード内では無効**。`remark` が先に code node として隔離するため、`[[br]]` はリテラル文字として保持される。
+- **エスケープ `\[[br]]`**：エクスポート経路（`mdi-to-html.ts`）のみでリテラル化される。エディタの `remark` 経路ではエスケープ未対応（既存の bracket macro 全般の既知の差で、`docs/MDI/roadmap.md` の escape handling 項目で追跡中）。
+
+### 6.4 HTML Conversion (Recommended)
+
+Input:
+
+```markdown
+春は曙。[[br]]やうやう白くなりゆく山ぎは。
+```
+
+Output (example):
+
+```html
+春は曙。<br class="mdi-break">やうやう白くなりゆく山ぎは。
+```
+
+### 6.5 CSS Example
+
+- エディタ内部の表示では既存の `.mdi-hardbreak-indent` クラスがインデント用スペーサーを挿入する（`<br>` 直後に `display: inline-block; width: <text-indent>em;` の空 span をデコレーションとして付加する）。
+- エクスポート経路では専用の CSS ルールを追加する：
+
+```css
+br.mdi-break {
+  /* 横書・縦書とも、ブラウザ既定の <br> 改行挙動を踏襲する。 */
+  /* 追加のマージンや特殊処理は不要。将来的なカスタム余地として明示的なルールを置く。 */
+}
+```
+
+## 7. Kerning / Letter-spacing (字間調整)
+
+### 7.1 Syntax
 
 `[[kern:<量>:<文字列>]]`
 
 - `<量>` is typically an `em` value, e.g. `-0.1em`, `+0.2em`, `0em`.
 - `<文字列>` is the affected text.
 
-### 6.2 Examples
+### 7.2 Examples
 
 ```markdown
 彼は[[kern:-0.1em:確実]]にそう言った。
 [[kern:+0.3em:沈黙]]が落ちた。
 ```
 
-### 6.3 HTML Conversion (Recommended)
+### 7.3 HTML Conversion (Recommended)
 
 To reduce CSS/HTML injection risk, using a CSS custom property is recommended.
 
@@ -207,7 +265,7 @@ Output (example):
 <span class="mdi-kern" style="--mdi-kern:-0.1em;">言葉</span>
 ```
 
-### 6.4 CSS Example
+### 7.4 CSS Example
 
 ```css
 .mdi-kern {
@@ -215,7 +273,7 @@ Output (example):
 }
 ```
 
-### 6.5 Validation (Recommended)
+### 7.5 Validation (Recommended)
 
 Implementations should validate `<量>`.
 A conservative rule is:
@@ -223,19 +281,20 @@ A conservative rule is:
 - Accept only `^[+-]?\d+(\.\d+)?em$`
 - If invalid, treat the whole macro as plain text (recommended) or fallback to `0em`.
 
-## 7. Design Notes
+## 8. Design Notes
 
 - MDI chooses delimiter forms that avoid common Markdown collisions.
 - Markup should remain human-readable: the meaning should be guessable from the text.
 - The final appearance is controlled by HTML + CSS; MDI provides semantics.
 
-## 8. Minimal Implementation Set
+## 9. Minimal Implementation Set
 
 At minimum, implementing the following significantly improves Japanese prose readability:
 
 - Ruby: `{漢字|かん.じ}`
 - Tate-chu-yoko: `^12^`
 - No-break: `[[no-break:文字列]]`
+- Explicit line break: `[[br]]`
 
 (Optionally) add kerning:
 

--- a/docs/MDI/spec.md
+++ b/docs/MDI/spec.md
@@ -218,7 +218,7 @@ Input:
 Output (example):
 
 ```html
-春は曙。<br class="mdi-break">やうやう白くなりゆく山ぎは。
+春は曙。<br class="mdi-break" />やうやう白くなりゆく山ぎは。
 ```
 
 ### 6.5 CSS Example

--- a/lib/export/__tests__/mdi-parser.test.ts
+++ b/lib/export/__tests__/mdi-parser.test.ts
@@ -8,6 +8,7 @@ import {
   MDI_NOBR_RE,
   MDI_KERN_RE,
   MDI_KERN_AMOUNT_RE,
+  MDI_BREAK_RE,
 } from "../mdi-parser";
 
 // ---------------------------------------------------------------------------
@@ -45,6 +46,22 @@ describe("MDI regex patterns", () => {
   describe("MDI_KERN_RE", () => {
     it("should match [[kern:amount:text]]", () => {
       expect("a [[kern:0.5em:text]] b").toMatch(MDI_KERN_RE);
+    });
+  });
+
+  describe("MDI_BREAK_RE", () => {
+    it("should match [[br]]", () => {
+      expect("line1[[br]]line2").toMatch(MDI_BREAK_RE);
+    });
+
+    it("should match consecutive [[br]][[br]]", () => {
+      const input = "a[[br]][[br]]b";
+      const matches = input.match(MDI_BREAK_RE);
+      expect(matches).toHaveLength(2);
+    });
+
+    it("should not match partial [[br", () => {
+      expect("a[[br").not.toMatch(MDI_BREAK_RE);
     });
   });
 
@@ -94,6 +111,14 @@ describe("stripMdiInlineSyntax", () => {
   it("should pass through plain text unchanged", () => {
     expect(stripMdiInlineSyntax("普通のテキスト")).toBe("普通のテキスト");
   });
+
+  it("should convert [[br]] to newline", () => {
+    expect(stripMdiInlineSyntax("春は曙。[[br]]やうやう")).toBe("春は曙。\nやうやう");
+  });
+
+  it("should convert consecutive [[br]][[br]] to two newlines", () => {
+    expect(stripMdiInlineSyntax("a[[br]][[br]]b")).toBe("a\n\nb");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -125,5 +150,9 @@ describe("replaceMdiWithRubyText", () => {
     const input = "{東京|とうきょう}の^12^月";
     const expected = "東京（とうきょう）の12月";
     expect(replaceMdiWithRubyText(input)).toBe(expected);
+  });
+
+  it("should convert [[br]] to newline", () => {
+    expect(replaceMdiWithRubyText("春は曙。[[br]]やうやう")).toBe("春は曙。\nやうやう");
   });
 });

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -18,7 +18,7 @@ import {
   TextDirection,
 } from "docx";
 import type { ExportMetadata } from "./types";
-import { replaceMdiWithRubyText } from "./mdi-parser";
+import { replaceMdiWithRubyText, MDI_BREAK_RE } from "./mdi-parser";
 import {
   DEFAULT_DOCX_SETTINGS,
   PAGE_DIMENSIONS,
@@ -280,15 +280,50 @@ function createParagraph(
 }
 
 /**
+ * Sentinel used to preserve `[[br]]` through replaceMdiWithRubyText without
+ * colliding with CommonMark softbreak newlines that originate from paragraph
+ * line-wrapping. Uses U+E001 (Unicode Private Use Area) which will not appear
+ * in user content and survives the generic MDI text transform.
+ */
+const DOCX_MDI_BREAK_SENTINEL = "\uE001";
+
+/**
+ * Push a text span as TextRuns, splitting on the MDI break sentinel and
+ * inserting `TextRun({ break: 1 })` at each boundary. Empty segments are
+ * skipped. CommonMark softbreaks (literal `\n`) are preserved as text and
+ * are NOT treated as explicit breaks.
+ */
+function pushRunWithBreaks(
+  runs: TextRun[],
+  text: string,
+  props: { bold?: boolean; italics?: boolean; font: DocxFontConfig },
+): void {
+  const parts = text.split(DOCX_MDI_BREAK_SENTINEL);
+  parts.forEach((part, i) => {
+    if (i > 0) {
+      runs.push(new TextRun({ break: 1, font: props.font }));
+    }
+    if (part) {
+      runs.push(new TextRun({ text: part, ...props }));
+    }
+  });
+}
+
+/**
  * Parse inline markdown/MDI formatting into TextRun objects
  *
- * Handles: **bold**, *italic*, {ruby|text}, ^tcy^, [[no-break:text]], [[kern:val:text]]
+ * Handles: **bold**, *italic*, {ruby|text}, ^tcy^, [[no-break:text]],
+ * [[kern:val:text]], [[br]] (as `<w:br/>`)
  */
 function parseInlineFormatting(text: string, fontConfig: DocxFontConfig): TextRun[] {
   const runs: TextRun[] = [];
 
-  // Process all MDI inline syntax via shared parser (ruby → fullwidth parens)
-  const processed = replaceMdiWithRubyText(text);
+  // Reserve `[[br]]` with a sentinel before the shared parser so that it is
+  // distinguishable from CommonMark softbreak newlines. replaceMdiWithRubyText
+  // otherwise converts `[[br]]` to `\n`, which would be indistinguishable from
+  // paragraph line-wrap newlines for the purpose of emitting `<w:br/>`.
+  const reserved = text.replace(MDI_BREAK_RE, DOCX_MDI_BREAK_SENTINEL);
+  const processed = replaceMdiWithRubyText(reserved);
 
   // Now parse bold/italic markdown
   // Split by bold-italic (***text***), bold (**text**), and italic (*text*) markers
@@ -298,37 +333,31 @@ function parseInlineFormatting(text: string, fontConfig: DocxFontConfig): TextRu
   let match: RegExpExecArray | null;
 
   while ((match = regex.exec(processed)) !== null) {
-    // Add text before this match
     if (match.index > lastIndex) {
       const before = processed.slice(lastIndex, match.index);
       if (before) {
-        runs.push(new TextRun({ text: before, font: fontConfig }));
+        pushRunWithBreaks(runs, before, { font: fontConfig });
       }
     }
 
     if (match[2]) {
-      // Bold italic: ***text***
-      runs.push(new TextRun({ text: match[2], bold: true, italics: true, font: fontConfig }));
+      pushRunWithBreaks(runs, match[2], { bold: true, italics: true, font: fontConfig });
     } else if (match[3]) {
-      // Bold: **text**
-      runs.push(new TextRun({ text: match[3], bold: true, font: fontConfig }));
+      pushRunWithBreaks(runs, match[3], { bold: true, font: fontConfig });
     } else if (match[4]) {
-      // Italic: *text*
-      runs.push(new TextRun({ text: match[4], italics: true, font: fontConfig }));
+      pushRunWithBreaks(runs, match[4], { italics: true, font: fontConfig });
     }
 
     lastIndex = match.index + match[0].length;
   }
 
-  // Add remaining text
   if (lastIndex < processed.length) {
     const remaining = processed.slice(lastIndex);
     if (remaining) {
-      runs.push(new TextRun({ text: remaining, font: fontConfig }));
+      pushRunWithBreaks(runs, remaining, { font: fontConfig });
     }
   }
 
-  // If no runs were created, add the full text
   if (runs.length === 0) {
     runs.push(new TextRun({ text: processed, font: fontConfig }));
   }

--- a/lib/export/mdi-parser.ts
+++ b/lib/export/mdi-parser.ts
@@ -9,6 +9,7 @@
  * - Tate-chu-yoko: ^text^
  * - No-break:      [[no-break:text]]
  * - Kerning:       [[kern:amount:text]]
+ * - Line break:    [[br]]
  * - Escaped:       \{  \^  \[
  */
 
@@ -27,6 +28,9 @@ export const MDI_NOBR_RE = /\[\[no-break:([^\]]+)\]\]/g;
 
 /** Kerning: [[kern:amount:text]] */
 export const MDI_KERN_RE = /\[\[kern:([^:\]]+):([^\]]+)\]\]/g;
+
+/** MDI explicit line break: [[br]] */
+export const MDI_BREAK_RE = /\[\[br\]\]/g;
 
 /** Escaped MDI opening brace: \{ */
 export const MDI_ESC_BRACE_RE = /\\(\{)/g;
@@ -63,6 +67,9 @@ export function stripMdiInlineSyntax(text: string): string {
   // Kerning: keep text
   result = result.replace(MDI_KERN_RE, "$2");
 
+  // Explicit line break: newline
+  result = result.replace(MDI_BREAK_RE, "\n");
+
   return result;
 }
 
@@ -92,6 +99,9 @@ export function replaceMdiWithRubyText(text: string): string {
 
   // Kerning: keep text
   result = result.replace(MDI_KERN_RE, "$2");
+
+  // Explicit line break: newline
+  result = result.replace(MDI_BREAK_RE, "\n");
 
   return result;
 }

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -17,6 +17,7 @@ import {
   MDI_TCY_RE,
   MDI_NOBR_RE,
   MDI_KERN_RE,
+  MDI_BREAK_RE,
   MDI_ESC_BRACE_RE,
   MDI_ESC_CARET_RE,
   MDI_ESC_BRACKET_RE,
@@ -83,6 +84,7 @@ interface MdiPreProcessResult {
  * 3. Tate-chu-yoko: ^text^ -> <span class="mdi-tcy">text</span>
  * 4. No-break: [[no-break:text]] -> <span class="mdi-nobr">text</span>
  * 5. Kerning: [[kern:amount:text]] -> <span class="mdi-kern" style="--mdi-kern:amount;">text</span>
+ * 6. Line break: [[br]] -> <br class="mdi-break">
  */
 function preProcessMdiSyntax(markdown: string): MdiPreProcessResult {
   // Store replacements to avoid double-processing
@@ -130,6 +132,9 @@ function preProcessMdiSyntax(markdown: string): MdiPreProcessResult {
       `<span class="mdi-kern" style="--mdi-kern:${amount};">${escapeHtml(text)}</span>`,
     );
   });
+
+  // 6. Explicit line break: [[br]]
+  result = result.replace(MDI_BREAK_RE, () => addPlaceholder(`<br class="mdi-break">`));
 
   return { text: result, placeholders };
 }
@@ -193,6 +198,7 @@ export function getMdiStylesheet(options?: MdiStylesheetOptions): string {
     ".mdi-tcy { text-combine-upright: all; }",
     ".mdi-nobr { white-space: nowrap; word-break: keep-all; }",
     ".mdi-kern { letter-spacing: var(--mdi-kern, 0em); }",
+    "br.mdi-break { /* inherits writing-mode; explicit rule for future customization */ }",
     "ruby rt { font-size: 0.5em; }",
   ];
 

--- a/packages/milkdown-plugin-japanese-novel/__tests__/mdibreak.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/mdibreak.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { remarkMdiBreakPlugin } from "../syntax";
+
+type TextNode = { type: "text"; value: string };
+type MdiBreakNode = { type: "mdibreak" };
+type InlineNode = TextNode | MdiBreakNode;
+type Paragraph = { type: "paragraph"; children: InlineNode[] };
+type Root = { type: "root"; children: Paragraph[] };
+
+function makeTree(paragraphText: string): Root {
+  return {
+    type: "root",
+    children: [
+      {
+        type: "paragraph",
+        children: [{ type: "text", value: paragraphText }],
+      },
+    ],
+  };
+}
+
+function runPlugin(tree: Root, options?: { enable?: boolean }): Root {
+  const factory = remarkMdiBreakPlugin as unknown as (
+    opts?: { enable?: boolean },
+  ) => (t: Root) => void;
+  factory(options)(tree);
+  return tree;
+}
+
+describe("remarkMdiBreakPlugin", () => {
+  it("converts [[br]] to a mdibreak node", () => {
+    const tree = runPlugin(makeTree("春は曙。[[br]]やうやう"));
+    const children = tree.children[0]!.children;
+    const types = children.map((n) => n.type);
+    expect(types).toContain("mdibreak");
+  });
+
+  it("splits surrounding text correctly", () => {
+    const tree = runPlugin(makeTree("a[[br]]b"));
+    const children = tree.children[0]!.children;
+    expect(children).toHaveLength(3);
+    expect(children[0]).toEqual({ type: "text", value: "a" });
+    expect(children[1]).toEqual({ type: "mdibreak" });
+    expect(children[2]).toEqual({ type: "text", value: "b" });
+  });
+
+  it("handles consecutive [[br]][[br]] as two breaks", () => {
+    const tree = runPlugin(makeTree("a[[br]][[br]]b"));
+    const children = tree.children[0]!.children;
+    const breakCount = children.filter((n) => n.type === "mdibreak").length;
+    expect(breakCount).toBe(2);
+  });
+
+  it("does not convert when disabled", () => {
+    const tree = runPlugin(makeTree("a[[br]]b"), { enable: false });
+    const children = tree.children[0]!.children;
+    const breakCount = children.filter((n) => n.type === "mdibreak").length;
+    expect(breakCount).toBe(0);
+    expect(children[0]).toEqual({ type: "text", value: "a[[br]]b" });
+  });
+
+  it("leaves text with no [[br]] untouched", () => {
+    const tree = runPlugin(makeTree("plain text"));
+    const children = tree.children[0]!.children;
+    expect(children).toHaveLength(1);
+    expect(children[0]).toEqual({ type: "text", value: "plain text" });
+  });
+
+  it("handles [[br]] at start of paragraph", () => {
+    const tree = runPlugin(makeTree("[[br]]hello"));
+    const children = tree.children[0]!.children;
+    expect(children[0]).toEqual({ type: "mdibreak" });
+    expect(children[1]).toEqual({ type: "text", value: "hello" });
+  });
+
+  it("handles [[br]] at end of paragraph", () => {
+    const tree = runPlugin(makeTree("hello[[br]]"));
+    const children = tree.children[0]!.children;
+    expect(children[0]).toEqual({ type: "text", value: "hello" });
+    expect(children[1]).toEqual({ type: "mdibreak" });
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/__tests__/mdibreak.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/mdibreak.test.ts
@@ -20,9 +20,9 @@ function makeTree(paragraphText: string): Root {
 }
 
 function runPlugin(tree: Root, options?: { enable?: boolean }): Root {
-  const factory = remarkMdiBreakPlugin as unknown as (
-    opts?: { enable?: boolean },
-  ) => (t: Root) => void;
+  const factory = remarkMdiBreakPlugin as unknown as (opts?: {
+    enable?: boolean;
+  }) => (t: Root) => void;
   factory(options)(tree);
   return tree;
 }

--- a/packages/milkdown-plugin-japanese-novel/config.ts
+++ b/packages/milkdown-plugin-japanese-novel/config.ts
@@ -15,6 +15,8 @@ export interface JapaneseNovelOptions {
   enableNoBreak?: boolean;
   /** カーニング指定を有効化する（[[kern:amount:text]] 記法） */
   enableKern?: boolean;
+  /** 明示改行を有効化する（[[br]] 記法） */
+  enableMdiBreak?: boolean;
 }
 
 export const defaultJapaneseNovelOptions: Required<JapaneseNovelOptions> = {
@@ -24,4 +26,5 @@ export const defaultJapaneseNovelOptions: Required<JapaneseNovelOptions> = {
   enableRuby: true,
   enableNoBreak: true,
   enableKern: true,
+  enableMdiBreak: true,
 };

--- a/packages/milkdown-plugin-japanese-novel/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/index.ts
@@ -10,6 +10,7 @@ import { rubySchema } from "./nodes/ruby";
 import { tcySchema } from "./nodes/tcy";
 import { nobreakSchema } from "./nodes/nobreak";
 import { kernSchema } from "./nodes/kern";
+import { mdibreakSchema } from "./nodes/mdibreak";
 import { headingAnchorSchema } from "./nodes/heading-anchor";
 import {
   remarkHeadingAnchorPlugin,
@@ -17,6 +18,7 @@ import {
   remarkTcyPlugin,
   remarkNoBreakPlugin,
   remarkKernPlugin,
+  remarkMdiBreakPlugin,
 } from "./syntax";
 import { createHeadingIdFixerPlugin } from "./plugins/heading-id-fixer";
 import { createHardbreakIndentPlugin } from "./plugins/hardbreak-indent";
@@ -30,7 +32,15 @@ export { calculateManuscriptPages, countCharacters } from "./utils";
  */
 export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugin[] {
   const opts = { ...defaultJapaneseNovelOptions, ...options };
-  const { isVertical, showManuscriptLine, enableRuby, enableTcy, enableNoBreak, enableKern } = opts;
+  const {
+    isVertical,
+    showManuscriptLine,
+    enableRuby,
+    enableTcy,
+    enableNoBreak,
+    enableKern,
+    enableMdiBreak,
+  } = opts;
 
   const classes: string[] = ["milkdown-japanese-base"];
   if (isVertical) {
@@ -59,6 +69,11 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     "japaneseNovelKern",
     () => remarkKernPlugin as (o?: { enable?: boolean }) => (tree: unknown) => void,
     { enable: enableKern },
+  );
+  const remarkMdiBreak = $remark(
+    "japaneseNovelMdiBreak",
+    () => remarkMdiBreakPlugin as (o?: { enable?: boolean }) => (tree: unknown) => void,
+    { enable: enableMdiBreak },
   );
   const remarkHeadingAnchor = $remark(
     "japaneseNovelHeadingAnchor",
@@ -92,6 +107,7 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
   const plugins: MilkdownPlugin[] = [
     ...(enableRuby ? [remarkRuby, rubySchema] : []),
     ...(enableTcy ? [remarkTcy, tcySchema] : []),
+    ...(enableMdiBreak ? [remarkMdiBreak, mdibreakSchema] : []),
     ...(enableNoBreak ? [remarkNoBreak, nobreakSchema] : []),
     ...(enableKern ? [remarkKern, kernSchema] : []),
     remarkHeadingAnchor,

--- a/packages/milkdown-plugin-japanese-novel/nodes/mdibreak.ts
+++ b/packages/milkdown-plugin-japanese-novel/nodes/mdibreak.ts
@@ -1,0 +1,30 @@
+/**
+ * MDI explicit line break (改行) node: `[[br]]` → `<br class="mdi-break">`.
+ *
+ * Unlike CommonMark's `hardbreak` (Shift+Enter or trailing two spaces), this
+ * node represents an MDI-native explicit line break. It round-trips as
+ * `[[br]]` in `.mdi` files, independent of CommonMark's soft/hard break rules.
+ */
+
+import { $nodeSchema } from "@milkdown/utils";
+
+export const mdibreakSchema = $nodeSchema("mdibreak", () => ({
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: false,
+  parseDOM: [{ tag: "br.mdi-break" }],
+  toDOM: () => ["br", { class: "mdi-break" }],
+  parseMarkdown: {
+    match: (node) => (node as { type?: string }).type === "mdibreak",
+    runner: (state, _node, type) => {
+      state.addNode(type);
+    },
+  },
+  toMarkdown: {
+    match: (node) => node.type.name === "mdibreak",
+    runner: (state) => {
+      state.addNode("text", undefined, "[[br]]");
+    },
+  },
+}));

--- a/packages/milkdown-plugin-japanese-novel/plugins/hardbreak-indent.ts
+++ b/packages/milkdown-plugin-japanese-novel/plugins/hardbreak-indent.ts
@@ -21,10 +21,10 @@ export function createHardbreakIndentPlugin(): Plugin {
         state.doc.descendants((node: Node, pos: number) => {
           if (node.type.name !== "paragraph") return;
 
-          // Scan children for hardbreak nodes
+          // Scan children for hardbreak / mdibreak nodes
           node.forEach((child, offset) => {
-            if (child.type.name === "hardbreak") {
-              // Insert spacer widget right after the hardbreak node
+            if (child.type.name === "hardbreak" || child.type.name === "mdibreak") {
+              // Insert spacer widget right after the break node
               const afterPos = pos + 1 + offset + child.nodeSize;
               const widget = Decoration.widget(
                 afterPos,

--- a/packages/milkdown-plugin-japanese-novel/syntax.ts
+++ b/packages/milkdown-plugin-japanese-novel/syntax.ts
@@ -19,12 +19,16 @@ const NO_BREAK_RE = /\[\[no-break:([^\]]+)\]\]/g;
 const KERN_RE = /\[\[kern:([+-]?\d+(?:\.\d+)?em):([^\]]+)\]\]/g;
 const KERN_AMOUNT_VALID_RE = /^[+-]?\d+(\.\d+)?em$/;
 
+/** MDI 明示改行: [[br]] */
+const MDI_BREAK_RE = /\[\[br\]\]/g;
+
 type TextNode = { type: "text"; value: string };
 type RubyNode = { type: "ruby"; base: string; text: string };
 type TcyNode = { type: "tcy"; value: string };
 type NoBreakNode = { type: "nobreak"; text: string };
 type KernNode = { type: "kern"; amount: string; text: string };
-type InlineNode = TextNode | RubyNode | TcyNode | NoBreakNode | KernNode;
+type MdiBreakNode = { type: "mdibreak" };
+type InlineNode = TextNode | RubyNode | TcyNode | NoBreakNode | KernNode | MdiBreakNode;
 
 type HeadingNode = {
   type: "heading";
@@ -183,6 +187,43 @@ export const remarkKernPlugin: Plugin<[RemarkKernOptions | undefined], Root> = (
       const value = (node as TextNode).value;
       if (!/\[\[kern:/.test(value)) return;
       const segments = splitKern(value);
+      if (segments.length === 0 || (segments.length === 1 && segments[0]!.type === "text")) return;
+      const children = (parent as { children: unknown[] }).children;
+      children.splice(index, 1, ...segments);
+    });
+  };
+};
+
+function splitMdiBreak(text: string): InlineNode[] {
+  const segments: InlineNode[] = [];
+  let lastIndex = 0;
+  let m: RegExpExecArray | null;
+  MDI_BREAK_RE.lastIndex = 0;
+  while ((m = MDI_BREAK_RE.exec(text)) !== null) {
+    if (m.index > lastIndex) {
+      segments.push({ type: "text", value: text.slice(lastIndex, m.index) });
+    }
+    segments.push({ type: "mdibreak" });
+    lastIndex = m.index + m[0].length;
+  }
+  if (lastIndex < text.length) {
+    segments.push({ type: "text", value: text.slice(lastIndex) });
+  }
+  return segments;
+}
+
+export interface RemarkMdiBreakOptions {
+  enable?: boolean;
+}
+
+export const remarkMdiBreakPlugin: Plugin<[RemarkMdiBreakOptions | undefined], Root> = (opts) => {
+  const enable = opts?.enable !== false;
+  return (tree) => {
+    visit(tree, "text", (node, index, parent) => {
+      if (!parent || typeof index !== "number" || !enable) return;
+      const value = (node as TextNode).value;
+      if (!value.includes("[[br]]")) return;
+      const segments = splitMdiBreak(value);
       if (segments.length === 0 || (segments.length === 1 && segments[0]!.type === "text")) return;
       const children = (parent as { children: unknown[] }).children;
       children.splice(index, 1, ...segments);


### PR DESCRIPTION
## Summary

- Introduce MDI-native `[[br]]` syntax so paragraph-internal line breaks survive load → edit → save in `.mdi` files.
- Independent from CommonMark hardbreak semantics; `.md` files retain existing behavior.
- Docs-first workflow: spec → implementation → consistency checks.

Closes #1235

## Changes

**Docs** (`docs/MDI/`)
- `spec.md` §6 Explicit Line Break (ruby-literal treatment, code-block exclusion, escape note, `br.mdi-break` CSS)
- `implementation.md` + `roadmap.md` entries; `CLAUDE.md` references

**Editor**
- `syntax.ts` — `MDI_BREAK_RE` + `remarkMdiBreakPlugin`
- `nodes/mdibreak.ts` — ProseMirror atom node (`<br class="mdi-break">` ↔ `[[br]]`)
- `config.ts` + `index.ts` — `enableMdiBreak` wiring
- `MilkdownEditor.tsx` — gated on `mdiExtensionsEnabled`
- `hardbreak-indent.ts` — decorates `mdibreak` too

**Export**
- `mdi-parser.ts` — `MDI_BREAK_RE`, strip + ruby-text paths → `\n`
- `mdi-to-html.ts` — preProcess placeholder + `br.mdi-break` stylesheet rule
- `docx-exporter.ts` — sentinel split so CommonMark softbreaks stay text and `[[br]]` becomes `<w:br/>` via `TextRun({ break: 1 })`

## Test plan

- [x] `npx vitest run` — 29 files / 610 tests passed
- [x] `npm run type-check` — no new errors (baseline pre-existing)
- [x] `npm run lint` — touched files clean
- [ ] Manual: open `.mdi` with `[[br]]` → save → reload (round-trip)
- [ ] Manual: EPUB/DOCX/TXT export renders `[[br]]` correctly in horizontal + vertical
- [ ] Manual: `.md` file treats `[[br]]` as literal text

🤖 Generated with [Claude Code](https://claude.com/claude-code)