### PR TITLE
chore(deps): sync dev with main security patches (axios / follow-redirects / vite)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7098,15 +7098,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
-      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -10422,9 +10422,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -16057,11 +16057,14 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -18969,9 +18972,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- `npm audit fix` を適用して main との security patch 差分を dev に取り込む
- PR #1379 が分岐戦略違反で main に直接マージされ、dev 側に axios 1.15.0 / follow-redirects 1.16.0 / vite 7.3.2 の security fix が欠落していた
- high 2 件 + moderate 1 件（follow-redirects）を解消

## Changes

| パッケージ | before → after | 重大度 | 影響面 |
|-----------|---------------|--------|--------|
| axios | 1.13.4 → 1.15.0 | high | SSRF (no_proxy bypass), CRLF header injection, DoS via __proto__ |
| follow-redirects | < 1.15.11 → 1.16.0 | moderate | cross-domain custom auth header leak |
| vite (transitive) | 7.3.1 → 7.3.2 | high | path traversal, server.fs.deny bypass, arbitrary file read via WS |

※ axios/follow-redirects は `wait-on` 経由の devDependency transitive、本番ビルド非影響。vite 7.3.x は dev サーバー攻撃面。

## 方針メモ

cherry-pick ではなく `npm audit fix` を選択した理由：
- #1379 は www vite 7.3.2 へ戻すが、dev は既に #1378 で www vite 8.0.8 に上がっているため conflict
- audit fix は脆弱 transitive のみを最小差分で patch、package.json 変更なし

残 2 件（moderate）: `nanoid` via `@prosemirror-adapter/react ≤ 0.2.6` は 0.5.3 への breaking change が必要なため本 PR では未対応。別 issue で検討。

## Test plan

- [x] `npm run type-check` — exit 0
- [x] `npm run build` — exit 0（Next.js 本番ビルド成功）
- [x] `npm run test` — 597 passed
- [x] `npm run lint` — exit 0
- [x] `cd www && npm run build` — exit 0（vite 8.0.8 実ビルド）
- [ ] Copilot review on head sha
- [ ] CI green

## 再発防止（別途検討）

`/patrol-prs` フロー内で `baseRefName != "dev"` を検知する pre-merge check。今回 #1379 を `gh pr merge --admin` 時に base 未確認で main へ流れた反省。

🤖 Generated with [Claude Code](https://claude.com/claude-code)