### PR TITLE
fix(dict): repair dictionary search and improve result display

### DIFF
--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -20,7 +20,8 @@ import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
 import { getUserDictionaryService } from "@/lib/services/user-dictionary-service";
 import DictionaryEntryDialog from "./Dictionary/DictionaryEntryDialog";
 import { getDictService } from "@/lib/dict/dict-service";
-import type { DictEntry } from "@/lib/dict/dict-types";
+import type { DictEntry, DictExample } from "@/lib/dict/dict-types";
+import { isElectronRenderer } from "@/lib/utils/runtime-env";
 
 // Web dictionary sources
 interface WebDictionarySource {
@@ -41,14 +42,6 @@ const WEB_DICTIONARIES: WebDictionarySource[] = [
     urlTemplate: "https://kotobank.jp/word/{query}",
   },
 ];
-
-const isElectron = (): boolean => {
-  return (
-    typeof window !== "undefined" &&
-    typeof window.process !== "undefined" &&
-    window.process?.type === "renderer"
-  );
-};
 
 const EMPTY_FORM: Partial<UserDictionaryEntry> = {
   word: "",
@@ -86,6 +79,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   const [localInstallStatus, setLocalInstallStatus] = useState<
     "not-installed" | "downloading" | "installing" | "installed" | "error"
   >("not-installed");
+  const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
   const [expandedMasterId, setExpandedMasterId] = useState<string | null>(null);
 
   // Persistence
@@ -127,7 +121,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
 
   // Check local install status on mount (Electron only)
   useEffect(() => {
-    if (!isElectron()) return;
+    if (!isElectronRenderer()) return;
     getDictService()
       .getDownloadState("genji")
       .then((state) => setLocalInstallStatus(state.status))
@@ -255,12 +249,23 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   const handleDownloadDict = useCallback(() => {
     const api = (
       window as Window & {
-        electronAPI?: { dict?: { download: () => Promise<{ success?: boolean; error?: string }> } };
+        electronAPI?: {
+          dict?: {
+            download: () => Promise<{ success?: boolean; error?: string }>;
+            onDownloadProgress?: (cb: (data: { progress: number }) => void) => () => void;
+          };
+        };
       }
     ).electronAPI?.dict;
     if (!api) return;
 
     setLocalInstallStatus("downloading");
+    setDownloadProgress(0);
+
+    const cleanup = api.onDownloadProgress?.(({ progress }) => {
+      setDownloadProgress(progress);
+    });
+
     void api
       .download()
       .then((result) => {
@@ -268,6 +273,10 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
       })
       .catch(() => {
         setLocalInstallStatus("error");
+      })
+      .finally(() => {
+        cleanup?.();
+        setDownloadProgress(null);
       });
   }, []);
 
@@ -497,32 +506,20 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                   )}
 
                   {/* Not installed banner (Electron only) */}
-                  {!masterLoading && localInstallStatus === "not-installed" && isElectron() && (
-                    <div className="bg-background-elevated border border-border rounded-lg p-3 flex items-center justify-between gap-3">
-                      <span className="text-sm text-foreground-secondary">
-                        辞典データ未インストール
-                      </span>
-                      <button
-                        onClick={handleDownloadDict}
-                        className="flex items-center gap-1.5 px-2.5 py-1 text-xs bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors flex-shrink-0"
-                      >
-                        <Download className="w-3 h-3" />
-                        ダウンロード
-                      </button>
-                    </div>
-                  )}
+                  {!masterLoading &&
+                    localInstallStatus === "not-installed" &&
+                    isElectronRenderer() && (
+                      <NotInstalledCard compact onDownload={handleDownloadDict} />
+                    )}
 
                   {/* Downloading indicator */}
                   {localInstallStatus === "downloading" && (
-                    <div className="flex items-center gap-2 text-sm text-foreground-secondary">
-                      <Loader2 className="w-4 h-4 animate-spin" />
-                      ダウンロード中...
-                    </div>
+                    <DownloadingCard progress={downloadProgress} />
                   )}
 
                   {/* Master dict results */}
                   {!masterLoading && masterResults.length > 0 && (
-                    <div className="space-y-2">
+                    <div className="space-y-1.5">
                       <div className="text-xs font-semibold text-foreground-tertiary">
                         幻辞 ({masterResults.length} 件)
                       </div>
@@ -530,6 +527,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                         <MasterDictCard
                           key={`${entry.source}:${entry.id}`}
                           entry={entry}
+                          searchTerm={activeSearchQuery}
                           isExpanded={expandedMasterId === entry.id}
                           onToggle={() => toggleExpandMaster(entry.id)}
                         />
@@ -559,7 +557,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                         encodeURIComponent(activeSearchQuery),
                       );
                       const handleOpenDictionary = () => {
-                        if (isElectron() && window.electronAPI?.openDictionaryPopup) {
+                        if (isElectronRenderer() && window.electronAPI?.openDictionaryPopup) {
                           window.electronAPI.openDictionaryPopup(
                             searchUrl,
                             `${dict.name} - ${activeSearchQuery}`,
@@ -589,12 +587,20 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                 </div>
               ) : (
                 /* Empty state */
-                <div className="p-4 text-center py-8 text-foreground-secondary text-sm">
-                  <Globe className="w-8 h-8 mx-auto mb-2 opacity-50" />
-                  <p>検索語を入力してWeb辞書を検索</p>
-                  <p className="mt-1 text-xs">
-                    {WEB_DICTIONARIES.map((d) => d.name).join("、")}で検索します
-                  </p>
+                <div className="p-4 space-y-4">
+                  {isElectronRenderer() && localInstallStatus === "not-installed" && (
+                    <NotInstalledCard onDownload={handleDownloadDict} />
+                  )}
+                  {localInstallStatus === "downloading" && (
+                    <DownloadingCard progress={downloadProgress} />
+                  )}
+                  <div className="text-center py-8 text-foreground-secondary text-sm">
+                    <Globe className="w-8 h-8 mx-auto mb-2 opacity-50" />
+                    <p>検索語を入力してWeb辞書を検索</p>
+                    <p className="mt-1 text-xs">
+                      {WEB_DICTIONARIES.map((d) => d.name).join("、")}で検索します
+                    </p>
+                  </div>
                 </div>
               )}
             </div>
@@ -621,12 +627,86 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
 
 interface MasterDictCardProps {
   entry: DictEntry;
+  searchTerm: string;
   isExpanded: boolean;
   onToggle: () => void;
 }
 
+const EXAMPLES_COLLAPSED_COUNT = 3;
+
+function formatCitation(ex: DictExample): string | null {
+  const parts: string[] = [];
+  const source = ex.citation?.source ?? ex.source;
+  if (source) parts.push(source);
+  if (ex.citation?.author) parts.push(ex.citation.author);
+  if (ex.citation?.note) parts.push(ex.citation.note);
+  return parts.length > 0 ? parts.join("・") : null;
+}
+
+interface ExampleListProps {
+  examples: DictExample[];
+  searchTerm: string;
+}
+
+const ExampleList = memo(function ExampleList({ examples, searchTerm }: ExampleListProps) {
+  const [showAll, setShowAll] = useState(false);
+  const hasMore = examples.length > EXAMPLES_COLLAPSED_COUNT;
+  const visible = showAll ? examples : examples.slice(0, EXAMPLES_COLLAPSED_COUNT);
+  const hiddenCount = examples.length - EXAMPLES_COLLAPSED_COUNT;
+
+  return (
+    <div className="mt-0.5 pl-3 space-y-px">
+      <ul className="space-y-px text-foreground-secondary">
+        {visible.map((ex, j) => {
+          const citation = formatCitation(ex);
+          return (
+            <li
+              key={j}
+              className="before:content-['・'] before:text-foreground-tertiary leading-snug"
+            >
+              {highlightTerm(ex.text, searchTerm)}
+              {citation && <span className="ml-1 text-foreground-tertiary">（{citation}）</span>}
+            </li>
+          );
+        })}
+      </ul>
+      {hasMore && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowAll((v) => !v);
+          }}
+          className="text-foreground-tertiary hover:text-foreground underline-offset-2 hover:underline"
+        >
+          {showAll ? "折りたたむ" : `さらに ${hiddenCount} 件表示`}
+        </button>
+      )}
+    </div>
+  );
+});
+
+function highlightTerm(text: string, term: string): React.ReactNode {
+  if (!term.trim()) return text;
+  const parts = text.split(term);
+  if (parts.length === 1) return text;
+  const out: React.ReactNode[] = [];
+  parts.forEach((part, i) => {
+    if (i > 0) {
+      out.push(
+        <strong key={`h${i}`} className="font-bold text-foreground">
+          {term}
+        </strong>,
+      );
+    }
+    if (part) out.push(part);
+  });
+  return <>{out}</>;
+}
+
 const MasterDictCard = memo(function MasterDictCard({
   entry,
+  searchTerm,
   isExpanded,
   onToggle,
 }: MasterDictCardProps) {
@@ -634,11 +714,14 @@ const MasterDictCard = memo(function MasterDictCard({
   const hasSynonyms = entry.relationships.synonyms.length > 0;
   const hasHomophones = entry.relationships.homophones.length > 0;
   const hasAntonyms = entry.relationships.antonyms.length > 0;
+  const hasRelated = entry.relationships.related.length > 0;
+  const hasInflections = entry.inflections && entry.inflections.length > 0;
+  const hasAlternatives = entry.reading.alternatives.length > 0;
 
   return (
-    <div className="bg-background-elevated border border-border rounded-lg overflow-hidden">
+    <div className="bg-background-elevated border border-border rounded-md overflow-hidden">
       <div
-        className="p-3 cursor-pointer hover:bg-hover transition-colors"
+        className="px-2 py-1.5 cursor-pointer hover:bg-hover transition-colors"
         role="button"
         tabIndex={0}
         onClick={onToggle}
@@ -649,27 +732,27 @@ const MasterDictCard = memo(function MasterDictCard({
           }
         }}
       >
-        <div className="flex items-start gap-2">
+        <div className="flex items-start gap-1.5">
           {isExpanded ? (
-            <ChevronDown className="w-4 h-4 text-foreground-secondary flex-shrink-0 mt-0.5" />
+            <ChevronDown className="w-3.5 h-3.5 text-foreground-secondary flex-shrink-0 mt-1" />
           ) : (
-            <ChevronRight className="w-4 h-4 text-foreground-secondary flex-shrink-0 mt-0.5" />
+            <ChevronRight className="w-3.5 h-3.5 text-foreground-secondary flex-shrink-0 mt-1" />
           )}
           <div className="flex-1 min-w-0">
-            <div className="flex items-baseline gap-2 flex-wrap">
-              <span className="font-semibold text-foreground">{entry.entry}</span>
+            <div className="flex items-baseline gap-1.5 flex-wrap">
+              <span className="font-semibold text-foreground text-sm">{entry.entry}</span>
               {entry.reading.primary && (
-                <span className="text-sm text-foreground-tertiary">{entry.reading.primary}</span>
+                <span className="text-xs text-foreground-tertiary">{entry.reading.primary}</span>
               )}
               {entry.partOfSpeech && (
-                <span className="text-xs px-1.5 py-0.5 bg-background rounded text-foreground-tertiary">
+                <span className="text-[10px] px-1 py-px bg-background rounded text-foreground-tertiary leading-tight">
                   {entry.partOfSpeech}
                 </span>
               )}
             </div>
-            {firstDef && (
-              <p className="text-sm text-foreground-secondary mt-1 line-clamp-1">
-                {firstDef.gloss}
+            {firstDef && !isExpanded && (
+              <p className="text-xs text-foreground-secondary mt-0.5 line-clamp-1">
+                {highlightTerm(firstDef.gloss, searchTerm)}
               </p>
             )}
           </div>
@@ -677,21 +760,36 @@ const MasterDictCard = memo(function MasterDictCard({
       </div>
 
       {isExpanded && (
-        <div className="border-t border-border p-3 bg-background space-y-2">
+        <div className="border-t border-border px-2 py-1.5 bg-background space-y-1.5 text-xs">
           {entry.definitions.length > 0 && (
             <div>
-              <h4 className="text-xs font-semibold text-foreground-secondary mb-1">意味</h4>
+              <h4 className="font-semibold text-foreground-secondary mb-0.5">意味</h4>
               <ol className="space-y-1">
                 {entry.definitions.map((def, i) => (
-                  <li key={i} className="text-sm text-foreground">
-                    {entry.definitions.length > 1 && (
-                      <span className="text-foreground-tertiary mr-1">{i + 1}.</span>
+                  <li key={i} className="text-foreground leading-snug">
+                    <div>
+                      {entry.definitions.length > 1 && (
+                        <span className="text-foreground-tertiary mr-1">{i + 1}.</span>
+                      )}
+                      {highlightTerm(def.gloss, searchTerm)}
+                      {def.register && (
+                        <span className="ml-1 text-foreground-tertiary">({def.register})</span>
+                      )}
+                    </div>
+                    {def.nuance && (
+                      <div className="text-foreground-secondary mt-0.5 pl-3">
+                        <span className="text-foreground-tertiary">ニュアンス: </span>
+                        {def.nuance}
+                      </div>
                     )}
-                    {def.gloss}
-                    {def.register && (
-                      <span className="ml-1 text-xs text-foreground-tertiary">
-                        ({def.register})
-                      </span>
+                    {def.examples && def.examples.length > 0 && (
+                      <ExampleList examples={def.examples} searchTerm={searchTerm} />
+                    )}
+                    {def.collocations && def.collocations.length > 0 && (
+                      <div className="mt-0.5 pl-3 text-foreground-secondary">
+                        <span className="text-foreground-tertiary">連語: </span>
+                        {def.collocations.join("・")}
+                      </div>
                     )}
                   </li>
                 ))}
@@ -699,45 +797,127 @@ const MasterDictCard = memo(function MasterDictCard({
             </div>
           )}
 
-          {(hasSynonyms || hasHomophones || hasAntonyms) && (
-            <div className="space-y-1">
+          {(hasSynonyms || hasHomophones || hasAntonyms || hasRelated) && (
+            <div className="space-y-0.5">
               {hasSynonyms && (
-                <div>
-                  <span className="text-xs font-semibold text-foreground-secondary">類義語: </span>
-                  <span className="text-xs text-foreground">
-                    {entry.relationships.synonyms.slice(0, 8).join("・")}
-                  </span>
+                <div className="leading-snug">
+                  <span className="font-semibold text-foreground-secondary">類義語: </span>
+                  <span className="text-foreground">{entry.relationships.synonyms.join("・")}</span>
                 </div>
               )}
               {hasHomophones && (
-                <div>
-                  <span className="text-xs font-semibold text-foreground-secondary">
-                    同音異義語:{" "}
-                  </span>
-                  <span className="text-xs text-foreground">
-                    {entry.relationships.homophones.slice(0, 8).join("・")}
+                <div className="leading-snug">
+                  <span className="font-semibold text-foreground-secondary">同音異義語: </span>
+                  <span className="text-foreground">
+                    {entry.relationships.homophones.join("・")}
                   </span>
                 </div>
               )}
               {hasAntonyms && (
-                <div>
-                  <span className="text-xs font-semibold text-foreground-secondary">対義語: </span>
-                  <span className="text-xs text-foreground">
-                    {entry.relationships.antonyms.slice(0, 8).join("・")}
-                  </span>
+                <div className="leading-snug">
+                  <span className="font-semibold text-foreground-secondary">対義語: </span>
+                  <span className="text-foreground">{entry.relationships.antonyms.join("・")}</span>
+                </div>
+              )}
+              {hasRelated && (
+                <div className="leading-snug">
+                  <span className="font-semibold text-foreground-secondary">関連語: </span>
+                  <span className="text-foreground">{entry.relationships.related.join("・")}</span>
                 </div>
               )}
             </div>
           )}
 
-          {entry.reading.alternatives.length > 0 && (
-            <div>
-              <span className="text-xs font-semibold text-foreground-secondary">別読み: </span>
-              <span className="text-xs text-foreground">
-                {entry.reading.alternatives.join("、")}
-              </span>
+          {hasInflections && (
+            <div className="leading-snug">
+              <span className="font-semibold text-foreground-secondary">活用: </span>
+              <span className="text-foreground">{entry.inflections!.join("・")}</span>
             </div>
           )}
+
+          {hasAlternatives && (
+            <div className="leading-snug">
+              <span className="font-semibold text-foreground-secondary">別読み: </span>
+              <span className="text-foreground">{entry.reading.alternatives.join("、")}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Not-installed / Downloading cards
+// ---------------------------------------------------------------------------
+
+interface NotInstalledCardProps {
+  onDownload: () => void;
+  compact?: boolean;
+}
+
+const NotInstalledCard = memo(function NotInstalledCard({
+  onDownload,
+  compact = false,
+}: NotInstalledCardProps) {
+  if (compact) {
+    return (
+      <div className="bg-background-elevated border border-border rounded-lg p-3 flex items-center justify-between gap-3">
+        <span className="text-sm text-foreground-secondary">辞典データ未インストール</span>
+        <button
+          onClick={onDownload}
+          className="flex items-center gap-1.5 px-2.5 py-1 text-xs bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors flex-shrink-0"
+        >
+          <Download className="w-3 h-3" />
+          ダウンロード
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-background-elevated border border-border rounded-lg p-4 space-y-3">
+      <div className="flex items-start gap-3">
+        <BookOpen className="w-5 h-5 text-accent flex-shrink-0 mt-0.5" />
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-foreground">辞典データをダウンロード</h3>
+          <p className="text-xs text-foreground-secondary mt-1 leading-relaxed">
+            幻辞データベースが未インストールです。日本語語彙・読み・類義語の検索に必要です（約 526
+            MB）。
+          </p>
+        </div>
+      </div>
+      <button
+        onClick={onDownload}
+        className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors font-medium"
+      >
+        <Download className="w-4 h-4" />
+        辞典をダウンロード
+      </button>
+    </div>
+  );
+});
+
+interface DownloadingCardProps {
+  progress: number | null;
+}
+
+const DownloadingCard = memo(function DownloadingCard({ progress }: DownloadingCardProps) {
+  return (
+    <div className="bg-background-elevated border border-border rounded-lg p-3 space-y-2">
+      <div className="flex items-center justify-between gap-2 text-sm text-foreground-secondary">
+        <span className="flex items-center gap-2">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          {progress !== null && progress >= 95 ? "展開中..." : "ダウンロード中..."}
+        </span>
+        {progress !== null && <span className="text-xs">{progress}%</span>}
+      </div>
+      {progress !== null && (
+        <div className="w-full bg-background rounded-full h-1.5">
+          <div
+            className="bg-accent h-1.5 rounded-full transition-all duration-300"
+            style={{ width: `${progress}%` }}
+          />
         </div>
       )}
     </div>

--- a/components/settings/DictSettingsTab.tsx
+++ b/components/settings/DictSettingsTab.tsx
@@ -139,7 +139,7 @@ export default function DictSettingsTab() {
   return (
     <SettingsSection
       title="辞典データ"
-      description="illusions 辞典データベース（日本語語彙・読み・品詞・類義語）"
+      description="『幻辞.com』データベース（日本語語彙・読み・品詞・類義語）"
     >
       {/* Status card */}
       <div className="bg-background-elevated border border-border rounded-lg p-4 space-y-3">

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -159,10 +159,7 @@ class DictManager {
         .get();
       if (!indexCheck) {
         console.log("[DictManager] Creating indexes...");
-        rwDb.exec(
-          "CREATE INDEX IF NOT EXISTS idx_dict_entry_text ON entries(entry);" +
-            "CREATE INDEX IF NOT EXISTS idx_dict_definitions_entry_id ON definitions(entry_id);",
-        );
+        rwDb.exec("CREATE INDEX IF NOT EXISTS idx_dict_entry_text ON entries(entry);");
         console.log("[DictManager] Indexes created");
       }
     } catch (err) {
@@ -198,15 +195,14 @@ class DictManager {
       const escaped = this._escapeLike(term);
       const rows = db
         .prepare(
-          `SELECT e.id, e.entry, e.reading, e.part_of_speech, e.inflections, e.relations
-           FROM entries e
-           WHERE e.entry = ? OR e.entry LIKE ? ESCAPE '\\'
-           ORDER BY (e.entry = ?) DESC, e.entry
+          `SELECT raw_json FROM entries
+           WHERE entry = ? OR entry LIKE ? ESCAPE '\\'
+           ORDER BY (entry = ?) DESC, length(entry)
            LIMIT ?`,
         )
         .all(term, `${escaped}%`, term, limit);
 
-      return rows.map((row) => this._rowToEntry(row, db));
+      return rows.map((row) => this._rawJsonToEntry(row.raw_json)).filter(Boolean);
     } catch (err) {
       console.error("[DictManager] query error:", err);
       return [];
@@ -226,19 +222,16 @@ class DictManager {
     if (!db) return [];
 
     try {
-      const escaped = this._escapeLike(reading);
       const rows = db
         .prepare(
-          `SELECT e.id, e.entry, e.reading, e.part_of_speech, e.inflections, e.relations
-           FROM entries e
-           WHERE json_extract(e.reading, '$.primary') = ?
-              OR json_extract(e.reading, '$.primary') LIKE ? ESCAPE '\\'
-           ORDER BY (json_extract(e.reading, '$.primary') = ?) DESC, e.entry
+          `SELECT raw_json FROM entries
+           WHERE reading_primary = ?
+           ORDER BY length(entry)
            LIMIT ?`,
         )
-        .all(reading, `${escaped}%`, reading, limit);
+        .all(reading, limit);
 
-      return rows.map((row) => this._rowToEntry(row, db));
+      return rows.map((row) => this._rawJsonToEntry(row.raw_json)).filter(Boolean);
     } catch (err) {
       console.error("[DictManager] queryByReading error:", err);
       return [];
@@ -246,72 +239,62 @@ class DictManager {
   }
 
   /**
-   * Map a DB row to a DictEntry. Fetches definitions via a separate query.
+   * Parse a raw_json string from the entries table and map it to a DictEntry.
+   * Mirrors mapRawJsonToDictEntry() in lib/dict/providers/genji-api-backend.ts.
    * @private
    */
-  _rowToEntry(row, db) {
-    let reading = { primary: "", alternatives: [] };
-    let relationships = { homophones: [], synonyms: [], antonyms: [], related: [] };
-    let inflections = [];
+  _rawJsonToEntry(rawJson) {
+    if (!rawJson) return null;
+    let raw;
+    try {
+      raw = typeof rawJson === "string" ? JSON.parse(rawJson) : rawJson;
+    } catch {
+      return null;
+    }
 
-    try {
-      reading = JSON.parse(row.reading ?? "{}");
-    } catch {}
-    try {
-      const rel = JSON.parse(row.relations ?? "{}");
-      relationships = {
-        homophones: rel.homophones ?? [],
-        synonyms: rel.synonyms ?? [],
-        antonyms: rel.antonyms ?? [],
-        related: rel.related ?? [],
-      };
-    } catch {}
-    try {
-      inflections = JSON.parse(row.inflections ?? "[]");
-    } catch {}
+    const reading = {
+      primary: raw.reading?.primary ?? "",
+      alternatives: raw.reading?.alternatives ?? [],
+    };
 
-    // Fetch definitions (limited to 5 per entry to keep response size small)
-    let definitions = [];
-    try {
-      const defRows = db
-        .prepare(
-          `SELECT gloss, register, nuance, examples, collocations
-           FROM definitions
-           WHERE entry_id = ?
-           LIMIT 5`,
-        )
-        .all(row.id);
-
-      definitions = defRows.map((d) => ({
+    const definitions = (raw.definitions ?? []).map((d) => {
+      const examples = [];
+      if (d.examples?.standard) {
+        for (const ex of d.examples.standard) {
+          if (ex.text) examples.push({ text: ex.text, source: ex.source, citation: ex.citation });
+        }
+      }
+      if (d.examples?.literary) {
+        for (const ex of d.examples.literary) {
+          if (ex.text) examples.push({ text: ex.text, source: ex.source, citation: ex.citation });
+        }
+      }
+      return {
         gloss: d.gloss ?? "",
         register: d.register || undefined,
         nuance: d.nuance || undefined,
-        examples: this._parseJsonArray(d.examples),
-        collocations: this._parseJsonArray(d.collocations),
-      }));
-    } catch {}
+        collocations: d.collocations?.length ? d.collocations : undefined,
+        examples: examples.length > 0 ? examples : undefined,
+      };
+    });
+
+    const relationships = {
+      homophones: raw.relations?.homophones ?? [],
+      synonyms: raw.relations?.synonyms ?? [],
+      antonyms: raw.relations?.antonyms ?? [],
+      related: raw.relations?.related ?? [],
+    };
 
     return {
-      id: row.id,
-      entry: row.entry,
+      id: raw.uuid ?? raw.entry,
+      entry: raw.entry,
       reading,
-      partOfSpeech: row.part_of_speech || undefined,
-      inflections: inflections.length > 0 ? inflections : undefined,
+      partOfSpeech: raw.grammar?.pos?.join("・") || undefined,
+      inflections: raw.grammar?.inflections ?? undefined,
       definitions,
       relationships,
       source: PROVIDER_ID,
     };
-  }
-
-  /** @private */
-  _parseJsonArray(value) {
-    if (!value) return undefined;
-    try {
-      const arr = JSON.parse(value);
-      return Array.isArray(arr) && arr.length > 0 ? arr : undefined;
-    } catch {
-      return undefined;
-    }
   }
 
   // ---------------------------------------------------------------------------

--- a/electron/main.js
+++ b/electron/main.js
@@ -169,7 +169,7 @@ app.whenReady().then(async () => {
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
             "img-src 'self' data: blob: https:",
             "font-src 'self' data: https://fonts.gstatic.com",
-            `connect-src 'self' https://my.illusions.app https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com${extraAiConnectSrc} ws://localhost:*`,
+            `connect-src 'self' https://my.illusions.app https://api.dict.illusions.app https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com${extraAiConnectSrc} ws://localhost:*`,
             "worker-src 'self' blob:",
             "object-src blob:",
             "frame-src blob:",

--- a/lib/dict/dict-types.ts
+++ b/lib/dict/dict-types.ts
@@ -12,11 +12,21 @@ export interface DictReading {
   alternatives: string[];
 }
 
+export interface DictExample {
+  text: string;
+  source?: string;
+  citation?: {
+    source?: string;
+    author?: string;
+    note?: string;
+  };
+}
+
 export interface DictDefinition {
   gloss: string;
   register?: string;
   nuance?: string;
-  examples?: string[];
+  examples?: DictExample[];
   collocations?: string[];
 }
 

--- a/lib/dict/providers/__tests__/genji-api-backend.test.ts
+++ b/lib/dict/providers/__tests__/genji-api-backend.test.ts
@@ -81,11 +81,18 @@ describe("mapRawJsonToDictEntry", () => {
   it("flattens examples from standard + literary", () => {
     const entry = mapRawJsonToDictEntry(SAMPLE_RAW);
 
-    expect(entry.definitions[0].examples).toEqual([
+    const examples = entry.definitions[0].examples ?? [];
+    expect(examples.map((e) => e.text)).toEqual([
       "雪が降る。",
       "雪の日。",
       "記憶は雪のふるやうなもの",
     ]);
+    expect(examples[0]?.source).toBe("幻辞");
+    expect(examples[2]?.citation).toEqual({
+      source: "記憶",
+      author: "萩原朔太郎",
+      note: "青空文庫",
+    });
   });
 
   it("maps multiple definitions", () => {

--- a/lib/dict/providers/genji-api-backend.ts
+++ b/lib/dict/providers/genji-api-backend.ts
@@ -5,7 +5,13 @@
  * `entries` table.  Used as a fallback backend inside GenjiProvider when
  * the local Electron IPC backend is unavailable.
  */
-import type { DictEntry, DictDefinition, DictRelationships, DictReading } from "../dict-types";
+import type {
+  DictEntry,
+  DictDefinition,
+  DictExample,
+  DictRelationships,
+  DictReading,
+} from "../dict-types";
 
 const GENJI_API_BASE = "https://api.dict.illusions.app";
 const FETCH_TIMEOUT_MS = 5000;
@@ -64,16 +70,16 @@ interface RawJson {
 // Mapping
 // ---------------------------------------------------------------------------
 
-function flattenExamples(def: RawDefinition): string[] {
-  const out: string[] = [];
+function flattenExamples(def: RawDefinition): DictExample[] {
+  const out: DictExample[] = [];
   if (def.examples?.standard) {
     for (const ex of def.examples.standard) {
-      if (ex.text) out.push(ex.text);
+      if (ex.text) out.push({ text: ex.text, source: ex.source, citation: ex.citation });
     }
   }
   if (def.examples?.literary) {
     for (const ex of def.examples.literary) {
-      if (ex.text) out.push(ex.text);
+      if (ex.text) out.push({ text: ex.text, source: ex.source, citation: ex.citation });
     }
   }
   return out;

--- a/lib/editor-page/use-panel-state.ts
+++ b/lib/editor-page/use-panel-state.ts
@@ -2,6 +2,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useState } from "react";
 
 import type { ActivityBarView } from "@/components/ActivityBar";
+import { isBottomView } from "@/components/ActivityBar";
 import type { SettingsCategory } from "@/components/SettingsModal";
 
 export interface PanelState {
@@ -73,7 +74,18 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
     if (searchTerm) {
       setDictionarySearchTrigger((prev) => ({ term: searchTerm, id: prev.id + 1 }));
     }
-    setTopView("dictionary");
+    // Dictionary belongs to the bottom activity group. If it's already open in
+    // either slot, just (re)trigger the search — don't spawn a second panel.
+    setTopView((top) => {
+      if (top === "dictionary") return top;
+      if (isBottomView("dictionary")) return top;
+      return "dictionary";
+    });
+    setBottomView((bottom) => {
+      if (bottom === "dictionary") return bottom;
+      if (isBottomView("dictionary")) return "dictionary";
+      return bottom;
+    });
   }, []);
 
   const handleShowAllSearchResults = useCallback(


### PR DESCRIPTION
## Summary

- 辞書パネルで検索しても結果が出なかった複数の根本原因を修正（Electron 判定、CSP、SQL スキーマ）
- 辞典データ未インストール時の誘導カードを検索前から常時表示、ダウンロード進捗バーを追加
- 検索結果カードで全フィールド（ニュアンス・用例・連語・活用・関連語）を表示、レイアウトをタイトに
- 用例に出典（citation）を併記し、3 件超は折り畳み表示、検索語を太字でハイライト
- 右クリック「辞書で調べる」で辞書パネルが重複表示されるバグを修正

## Changes

| 領域 | ファイル | 内容 |
|------|---------|------|
| Electron 判定 | `components/Dictionary.tsx` | 自前 `isElectron()`（`window.process` 依存で contextIsolation 下では常に false）を `isElectronRenderer()` に置換 |
| CSP | `electron/main.js` | `connect-src` に `https://api.dict.illusions.app` を追加 |
| ローカル DB | `electron/dict-manager.js` | 旧スキーマ想定（`e.id` / 別 `definitions` テーブル）を捨て、現行 `entries.raw_json` パース方式に統一 |
| 型 | `lib/dict/dict-types.ts` | `DictDefinition.examples: string[]` → `DictExample[]`（`text, source, citation`） |
| Backend 整合 | `lib/dict/providers/genji-api-backend.ts` | 用例の出典情報を保持するよう mapping を更新 |
| UI | `components/Dictionary.tsx` | `MasterDictCard` に全フィールド表示、`ExampleList`（3 件表示＋展開）、`highlightTerm()` による検索語太字、`NotInstalledCard` / `DownloadingCard` 追加 |
| パネル状態 | `lib/editor-page/use-panel-state.ts` | 辞書（bottom-group view）が top にも開かれる二重表示を修正 |
| ラベル | `components/settings/DictSettingsTab.tsx` | `illusions辞典` → `『幻辞.com』` |
| テスト | `lib/dict/providers/__tests__/genji-api-backend.test.ts` | 新しい `DictExample` 構造に合わせて用例テストを更新 |

## Test plan

- [ ] Electron 再起動（`Cmd+Q` → `npm run electron:dev`）後、辞書パネルを開く
- [ ] 幻辞 DB インストール済みの状態で「雪」などを検索し、結果カードが表示されること
- [ ] 用例が 3 件表示、「さらに N 件表示」ボタンで展開／折り畳みできること
- [ ] 用例末尾に `（出典・著者・注記）` が表示されること
- [ ] gloss / 用例中の検索語が `<strong>` で太字表示されること
- [ ] 幻辞 DB 未インストール状態で、検索前からダウンロード誘導カードが表示されること
- [ ] ダウンロード中に進捗バーが動くこと
- [ ] 右クリック「辞書で調べる」で辞書パネルが二重表示されないこと（既に開いている場合は既存スロットで検索が走る）
- [ ] Web 版で幻辞 API がリモートから取得できること（CSP エラーが出ない）
- [ ] `npx vitest run lib/dict` が全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)