### PR TITLE
fix(auth): Electron で revoke 済 refresh token がタイトループを起こす問題

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -154,12 +154,32 @@ async function fetchMe(): Promise<MeResponse> {
  * Returns whether an error thrown by the Electron auth IPC represents a
  * permanent auth failure (token invalid/revoked) vs a transient error
  * (server unavailable, network issue).
- * The IPC handlers attach `error.status` with the upstream HTTP status code.
+ *
+ * The IPC handlers attach `error.status` (HTTP status) and, for the OAuth
+ * token endpoint, `error.oauthError` (e.g. `invalid_grant`).
+ *
+ * Per RFC 6749 §5.2, the token endpoint returns HTTP 400 for client errors
+ * such as `invalid_grant` (refresh token expired/revoked). Retrying these
+ * cannot succeed, so any 4xx from the auth endpoints must be treated as
+ * permanent — otherwise the renderer falls into a tight refresh loop on
+ * a revoked token.
  */
 function isElectronAuthErrorPermanent(err: unknown): boolean {
-  if (err instanceof Error && "status" in err) {
+  if (!(err instanceof Error)) return false;
+
+  const oauthError = (err as Error & { oauthError?: unknown }).oauthError;
+  if (
+    oauthError === "invalid_grant" ||
+    oauthError === "invalid_client" ||
+    oauthError === "unauthorized_client" ||
+    oauthError === "unsupported_grant_type"
+  ) {
+    return true;
+  }
+
+  if ("status" in err) {
     const status = (err as Error & { status: unknown }).status;
-    return status === 401 || status === 403;
+    if (typeof status === "number" && status >= 400 && status < 500) return true;
   }
   // No status attached (network/IPC error) — treat as transient
   return false;
@@ -187,7 +207,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     (expiresAt: number, refreshToken: string) => {
       clearRefreshTimer();
 
-      const refreshIn = Math.max(expiresAt - Date.now() - 5 * 60 * 1000, 0);
+      // Floor of 60s prevents a tight retry loop when the upstream token has
+      // already expired (refreshIn would otherwise compute to 0 and the
+      // transient-error branch would re-schedule immediately).
+      const TRANSIENT_RETRY_MIN_MS = 60 * 1000;
+      const refreshIn = Math.max(expiresAt - Date.now() - 5 * 60 * 1000, TRANSIENT_RETRY_MIN_MS);
       refreshTimerRef.current = setTimeout(async () => {
         const api = window.electronAPI;
         if (!api?.auth) return;
@@ -213,11 +237,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           scheduleElectronRefresh(newExpiresAt, tokenResponse.refresh_token);
         } catch (err) {
           if (isElectronAuthErrorPermanent(err)) {
-            // Permanent failure (401/403): token is invalid — log out
+            // Permanent failure (4xx / invalid_grant): token is invalid — log out
             setUser(null);
             await clearTokens();
           } else {
-            // Transient failure (5xx / network): keep session, retry at next scheduled interval
+            // Transient failure (5xx / network): keep session, retry after the floor delay
             scheduleElectronRefresh(expiresAt, refreshToken);
           }
         }
@@ -231,7 +255,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     (expiresAt: number) => {
       clearRefreshTimer();
 
-      const refreshIn = Math.max(expiresAt - Date.now() - 5 * 60 * 1000, 0);
+      // 60s floor protects against tight retry loops on transient errors when
+      // the session has already expired (refreshIn would otherwise be 0).
+      const TRANSIENT_RETRY_MIN_MS = 60 * 1000;
+      const refreshIn = Math.max(expiresAt - Date.now() - 5 * 60 * 1000, TRANSIENT_RETRY_MIN_MS);
       refreshTimerRef.current = setTimeout(async () => {
         const me = await fetchMe();
         if (me.authenticated && me.user) {
@@ -241,7 +268,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           // Permanent failure (401/403): token is invalid — log out
           setUser(null);
         } else {
-          // Transient failure (5xx / network): keep session, retry at next scheduled interval
+          // Transient failure (5xx / network): keep session, retry after the floor delay
           scheduleWebRefresh(expiresAt);
         }
       }, refreshIn);

--- a/electron/ipc/auth-ipc.js
+++ b/electron/ipc/auth-ipc.js
@@ -83,8 +83,10 @@ function registerAuthHandlers() {
     if (!response.ok) {
       const err = await response.json().catch(() => ({}));
       const error = new Error(err.error_description || "Token refresh failed");
-      // Attach HTTP status so the renderer can distinguish permanent vs transient errors
+      // Attach HTTP status and OAuth error code so the renderer can distinguish
+      // permanent (e.g. invalid_grant) vs transient (5xx / network) failures.
       error.status = response.status;
+      if (err.error) error.oauthError = err.error;
       throw error;
     }
     return response.json();


### PR DESCRIPTION
## Summary

- Electron 桌面版で revoke 済の refresh token を持って起動すると、`auth:refresh-token` IPC が無限ループで OAuth Server に問い合わせる問題を修正。
- 原因: OAuth Server は失効した refresh token に対し HTTP **400** (`invalid_grant`) を返すが (RFC 6749 §5.2)、`isElectronAuthErrorPermanent` は 401/403 のみを permanent として扱っていたため、400 が transient 扱いとなり `scheduleElectronRefresh` が `expiresAt` 既過去 → `refreshIn = 0` で即時リトライ → 緊密迴圈。

## Changes

- **`electron/ipc/auth-ipc.js`**: refresh-token IPC の例外に OAuth `error` コード (`invalid_grant` 等) を `error.oauthError` として透過。
- **`contexts/AuthContext.tsx`**:
  - `isElectronAuthErrorPermanent` を OAuth `invalid_grant` 系コードと 4xx 全般を permanent として扱うよう拡張。
  - `scheduleElectronRefresh` / `scheduleWebRefresh` に **60 秒の最小遅延フロア**を追加 (今後の同種バグへの defense-in-depth)。

## Repro / Test plan

ユーザーから報告された症状:
\`\`\`
Error occurred in handler for 'auth:refresh-token': Error: Refresh token is invalid or revoked.
    at /Users/.../dist-main/main.js:88170:25
    ...
  status: 400
\`\`\`
(同メッセージが連続で出力)

- [ ] 桌面版を起動 → 既存の失効 refresh token があるユーザーで起動時にエラーが 1 回のみ出力され、自動的にログアウト状態になる
- [ ] 起動後も新規にログイン可能
- [ ] 正常な refresh token を持つユーザーでセッション継続を確認
- [ ] `npm run type-check` ✅ (済)

🤖 Generated with [Claude Code](https://claude.com/claude-code)