### PR TITLE
feat(settings): regroup nav + add fuzzy search

### DIFF
--- a/components/settings/__tests__/nav-config.test.ts
+++ b/components/settings/__tests__/nav-config.test.ts
@@ -11,17 +11,32 @@ vi.mock("@/lib/utils/runtime-env", () => ({
 const { buildSettingsNavConfig } = await import("../nav-config");
 
 describe("buildSettingsNavConfig — structure", () => {
-  it("returns six labelled groups", () => {
+  it("returns seven labelled groups", () => {
     const groups = buildSettingsNavConfig();
-    expect(groups).toHaveLength(6);
+    expect(groups).toHaveLength(7);
     expect(groups.map((g) => g.label)).toEqual([
+      "AI/LLM",
       "アカウント",
-      "AI とオンライン機能",
+      "校正と文体・辞書",
       "エディタと表示",
       "入出力",
       "システム",
       "ヘルプ",
     ]);
+  });
+
+  it("marks top of features section and help with separators", () => {
+    const groups = buildSettingsNavConfig();
+    const separated = groups.filter((g) => g.separator).map((g) => g.label);
+    expect(separated).toEqual(["校正と文体・辞書", "ヘルプ"]);
+  });
+
+  it("places terminal inside エディタと表示 (not 入出力)", () => {
+    const groups = buildSettingsNavConfig();
+    const editor = groups.find((g) => g.label === "エディタと表示");
+    const io = groups.find((g) => g.label === "入出力");
+    expect(editor?.items.map((i) => i.id)).toContain("terminal");
+    expect(io?.items.map((i) => i.id)).not.toContain("terminal");
   });
 
   it("all items have ids and labels", () => {

--- a/components/settings/nav-config.ts
+++ b/components/settings/nav-config.ts
@@ -29,15 +29,19 @@ export function buildSettingsNavConfig(): ReadonlyArray<SettingsNavGroup<Setting
   const isElectron = isElectronRenderer();
   return [
     {
+      label: "AI/LLM",
+      items: [{ id: "ai-connection", label: "AI API 接続", icon: Bot }],
+    },
+    {
       label: "アカウント",
       items: [{ id: "account", label: "アカウント", icon: UserCircle }],
     },
     {
-      label: "AI とオンライン機能",
+      label: "校正と文体・辞書",
+      separator: true,
       items: [
-        { id: "ai-connection", label: "AI API 接続", icon: Bot },
         { id: "linting", label: "校正と文体", icon: SpellCheck },
-        { id: "dictionary", label: "辞典", icon: BookOpen },
+        { id: "dictionary", label: "辞書", icon: BookOpen },
       ],
     },
     {
@@ -47,14 +51,12 @@ export function buildSettingsNavConfig(): ReadonlyArray<SettingsNavGroup<Setting
         { id: "scroll", label: "スクロールと縦書き", icon: Columns2 },
         { id: "pos-highlight", label: "品詞ハイライト", icon: Highlighter },
         { id: "keymap", label: "キーマップ", icon: Keyboard },
+        { id: "terminal", label: "ターミナル", icon: Terminal, hidden: !isElectron },
       ],
     },
     {
       label: "入出力",
-      items: [
-        { id: "speech", label: "音声読み上げ", icon: AudioLines },
-        { id: "terminal", label: "ターミナル", icon: Terminal, hidden: !isElectron },
-      ],
+      items: [{ id: "speech", label: "音声読み上げ", icon: AudioLines }],
     },
     {
       label: "システム",
@@ -62,6 +64,7 @@ export function buildSettingsNavConfig(): ReadonlyArray<SettingsNavGroup<Setting
     },
     {
       label: "ヘルプ",
+      separator: true,
       items: [{ id: "about", label: "illusions について", icon: Info }],
     },
   ];

--- a/components/settings/primitives/SettingsNav.tsx
+++ b/components/settings/primitives/SettingsNav.tsx
@@ -16,6 +16,8 @@ export interface SettingsNavGroup<C extends string> {
   /** Optional section heading rendered above the group's items. */
   label?: string;
   items: Array<SettingsNavItem<C>>;
+  /** When true, render a horizontal divider just above this group. */
+  separator?: boolean;
 }
 
 export interface SettingsNavProps<C extends string> {
@@ -43,44 +45,57 @@ export default function SettingsNav<C extends string>({
       className="min-w-[10rem] max-w-[12rem] flex-shrink-0 overflow-y-auto border-r border-border bg-background-secondary p-2"
     >
       <ul className="space-y-1">
-        {groups.map((group, groupIdx) => {
-          const visibleItems = group.items.filter((item) => !item.hidden);
-          if (visibleItems.length === 0) return null;
-          return (
-            <li key={group.label ?? `group-${groupIdx}`} className="space-y-1">
-              {group.label && (
-                <div className="px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-foreground-tertiary">
-                  {group.label}
-                </div>
-              )}
-              <ul className="space-y-1">
-                {visibleItems.map((item) => {
-                  const Icon = item.icon;
-                  const isActive = item.id === active;
-                  return (
-                    <li key={item.id}>
-                      <button
-                        type="button"
-                        onClick={() => onSelect(item.id)}
-                        aria-current={isActive ? "page" : undefined}
-                        className={clsx(
-                          "flex w-full items-center gap-1.5 rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors",
-                          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
-                          isActive
-                            ? "bg-accent text-accent-foreground"
-                            : "text-foreground-secondary hover:bg-hover hover:text-foreground",
-                        )}
-                      >
-                        {Icon && <Icon className="h-4 w-4" aria-hidden />}
-                        <span>{item.label}</span>
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            </li>
-          );
-        })}
+        {(() => {
+          const rendered: React.ReactNode[] = [];
+          let hasRenderedGroup = false;
+          groups.forEach((group, groupIdx) => {
+            const visibleItems = group.items.filter((item) => !item.hidden);
+            if (visibleItems.length === 0) return;
+            if (group.separator && hasRenderedGroup) {
+              rendered.push(
+                <li key={`sep-${groupIdx}`} aria-hidden>
+                  <hr className="my-2 border-border" />
+                </li>,
+              );
+            }
+            rendered.push(
+              <li key={group.label ?? `group-${groupIdx}`} className="space-y-1">
+                {group.label && (
+                  <div className="px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-foreground-tertiary">
+                    {group.label}
+                  </div>
+                )}
+                <ul className="space-y-1">
+                  {visibleItems.map((item) => {
+                    const Icon = item.icon;
+                    const isActive = item.id === active;
+                    return (
+                      <li key={item.id}>
+                        <button
+                          type="button"
+                          onClick={() => onSelect(item.id)}
+                          aria-current={isActive ? "page" : undefined}
+                          className={clsx(
+                            "flex w-full items-center gap-1.5 rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                            isActive
+                              ? "bg-accent text-accent-foreground"
+                              : "text-foreground-secondary hover:bg-hover hover:text-foreground",
+                          )}
+                        >
+                          {Icon && <Icon className="h-4 w-4" aria-hidden />}
+                          <span>{item.label}</span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </li>,
+            );
+            hasRenderedGroup = true;
+          });
+          return rendered;
+        })()}
       </ul>
     </nav>
   );

--- a/components/settings/primitives/SettingsNav.tsx
+++ b/components/settings/primitives/SettingsNav.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import type React from "react";
+import { useMemo, useState } from "react";
 import type { LucideIcon } from "lucide-react";
+import { Search } from "lucide-react";
 import clsx from "clsx";
+
+import { matchesQuery } from "./fuzzy-match";
 
 export interface SettingsNavItem<C extends string> {
   id: C;
@@ -26,32 +30,62 @@ export interface SettingsNavProps<C extends string> {
   onSelect: (id: C) => void;
   /** Accessible landmark label (e.g., "設定カテゴリ"). */
   "aria-label"?: string;
+  /** Placeholder text for the search input. */
+  searchPlaceholder?: string;
 }
 
 /**
  * Grouped left navigation for the settings modal. Replaces the 150 lines
  * of hand-written <button>s in SettingsModal.tsx with a data-driven
- * grouped list.
+ * grouped list. A fuzzy search box at the top filters items across all
+ * groups; during an active search, group headings and separators are
+ * suppressed so matches read as a flat list.
  */
 export default function SettingsNav<C extends string>({
   groups,
   active,
   onSelect,
   "aria-label": ariaLabel,
+  searchPlaceholder = "検索",
 }: SettingsNavProps<C>): React.ReactElement {
+  const [query, setQuery] = useState("");
+  const isSearching = query.trim().length > 0;
+
+  const filteredGroups = useMemo(() => {
+    return groups.map((group) => ({
+      ...group,
+      items: group.items.filter((item) => !item.hidden && matchesQuery(item.label, query)),
+    }));
+  }, [groups, query]);
+
   return (
     <nav
       aria-label={ariaLabel}
-      className="min-w-[10rem] max-w-[12rem] flex-shrink-0 overflow-y-auto border-r border-border bg-background-secondary p-2"
+      className="flex min-w-[10rem] max-w-[12rem] flex-shrink-0 flex-col overflow-hidden border-r border-border bg-background-secondary"
     >
-      <ul className="space-y-1">
+      <div className="border-b border-border p-2">
+        <div className="relative">
+          <Search
+            className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-foreground-tertiary"
+            aria-hidden
+          />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={searchPlaceholder}
+            aria-label="設定を検索"
+            className="w-full rounded-md border border-border bg-background py-1.5 pl-7 pr-2 text-sm placeholder:text-foreground-tertiary focus:border-accent focus:outline-none"
+          />
+        </div>
+      </div>
+      <ul className="flex-1 space-y-1 overflow-y-auto p-2">
         {(() => {
           const rendered: React.ReactNode[] = [];
           let hasRenderedGroup = false;
-          groups.forEach((group, groupIdx) => {
-            const visibleItems = group.items.filter((item) => !item.hidden);
-            if (visibleItems.length === 0) return;
-            if (group.separator && hasRenderedGroup) {
+          filteredGroups.forEach((group, groupIdx) => {
+            if (group.items.length === 0) return;
+            if (group.separator && hasRenderedGroup && !isSearching) {
               rendered.push(
                 <li key={`sep-${groupIdx}`} aria-hidden>
                   <hr className="my-2 border-border" />
@@ -60,13 +94,13 @@ export default function SettingsNav<C extends string>({
             }
             rendered.push(
               <li key={group.label ?? `group-${groupIdx}`} className="space-y-1">
-                {group.label && (
+                {group.label && !isSearching && (
                   <div className="px-3 pb-1 pt-2 text-[11px] font-semibold uppercase tracking-wide text-foreground-tertiary">
                     {group.label}
                   </div>
                 )}
                 <ul className="space-y-1">
-                  {visibleItems.map((item) => {
+                  {group.items.map((item) => {
                     const Icon = item.icon;
                     const isActive = item.id === active;
                     return (
@@ -94,6 +128,16 @@ export default function SettingsNav<C extends string>({
             );
             hasRenderedGroup = true;
           });
+          if (rendered.length === 0 && isSearching) {
+            rendered.push(
+              <li
+                key="no-results"
+                className="px-3 py-4 text-center text-xs text-foreground-tertiary"
+              >
+                一致する項目がありません
+              </li>,
+            );
+          }
           return rendered;
         })()}
       </ul>

--- a/components/settings/primitives/__tests__/fuzzy-match.test.ts
+++ b/components/settings/primitives/__tests__/fuzzy-match.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Contract tests for the settings-nav fuzzy match helper.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { matchesQuery, normalizeForSearch } from "../fuzzy-match";
+
+describe("matchesQuery — empty query", () => {
+  it("returns true for any label when the query is empty", () => {
+    expect(matchesQuery("AI API 接続", "")).toBe(true);
+    expect(matchesQuery("", "")).toBe(true);
+  });
+
+  it("treats whitespace-only queries as empty", () => {
+    expect(matchesQuery("文字組み", "   ")).toBe(true);
+  });
+});
+
+describe("matchesQuery — substring pass", () => {
+  it("matches direct substrings (Japanese)", () => {
+    expect(matchesQuery("文字組み", "文字")).toBe(true);
+    expect(matchesQuery("音声読み上げ", "読み上げ")).toBe(true);
+  });
+
+  it("matches case-insensitively (ASCII)", () => {
+    expect(matchesQuery("AI API 接続", "ai")).toBe(true);
+    expect(matchesQuery("AI API 接続", "API")).toBe(true);
+  });
+
+  it("folds full-width ASCII via NFKC", () => {
+    // Full-width "ＡＩ" normalizes to "AI"
+    expect(matchesQuery("ＡＩ API 接続", "ai")).toBe(true);
+  });
+});
+
+describe("matchesQuery — subsequence pass", () => {
+  it("matches when query characters appear in order with gaps", () => {
+    // "aピ" — 'a' from "API", 'ピ' from the next token of a compound label
+    expect(matchesQuery("AI APIピン", "aピ")).toBe(true);
+  });
+
+  it("matches skipping intermediate characters in Japanese", () => {
+    // 'ス' from スクロール, 'き' from 縦書き
+    expect(matchesQuery("スクロールと縦書き", "スき")).toBe(true);
+  });
+
+  it("requires in-order chars (wrong order → no match)", () => {
+    expect(matchesQuery("スクロールと縦書き", "きス")).toBe(false);
+  });
+
+  it("rejects when a required char is missing", () => {
+    expect(matchesQuery("スクロールと縦書き", "xyz")).toBe(false);
+  });
+});
+
+describe("normalizeForSearch", () => {
+  it("lowercases ASCII", () => {
+    expect(normalizeForSearch("API")).toBe("api");
+  });
+
+  it("applies NFKC folding to full-width forms", () => {
+    expect(normalizeForSearch("ＡＩ")).toBe("ai");
+  });
+});

--- a/components/settings/primitives/fuzzy-match.ts
+++ b/components/settings/primitives/fuzzy-match.ts
@@ -1,0 +1,31 @@
+/**
+ * Fuzzy match helper for the settings nav search box.
+ *
+ * Matches in two passes so that natural typed queries and casual
+ * abbreviations both work:
+ *   1. Normalized substring (handles copy/paste, partial typing)
+ *   2. Normalized subsequence (handles skipping characters — "ai接" → "AI API 接続")
+ *
+ * Normalization: NFKC + lowercase. NFKC folds full-width ASCII and
+ * compatibility forms so "ＡＩ" matches "ai".
+ */
+export function normalizeForSearch(value: string): string {
+  return value.normalize("NFKC").toLowerCase();
+}
+
+export function matchesQuery(label: string, query: string): boolean {
+  const q = normalizeForSearch(query.trim());
+  if (q.length === 0) return true;
+  const l = normalizeForSearch(label);
+  if (l.includes(q)) return true;
+
+  let cursor = 0;
+  const target = Array.from(q);
+  for (const ch of l) {
+    if (ch === target[cursor]) {
+      cursor += 1;
+      if (cursor === target.length) return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

左ナビを 7 グループに再構成し、上部に模糊検索ボックスを追加する。

### 1. ナビ再構成（commit 5cee9af）

12 フラット → 7 群 + 2 本の区切り線。ユーザ判断で「AI(外部 API) と 校正(ローカル形態素) は別ドメイン」「入出力と System はユーザ視点で区切りたい」。

| 群                | 項目                                                            |
| ----------------- | --------------------------------------------------------------- |
| AI/LLM            | ai-connection                                                   |
| アカウント        | account                                                         |
| ─── 区切り線 ───  |                                                                 |
| 校正と文体・辞書  | linting, dictionary                                             |
| エディタと表示    | typography, scroll, pos-highlight, keymap, terminal (Electron)  |
| 入出力            | speech                                                          |
| システム          | power (Electron)                                                |
| ─── 区切り線 ───  |                                                                 |
| ヘルプ            | about                                                           |

- `terminal` を「入出力」→「エディタと表示」へ移動
- `dictionary` は AI 群 → 校正群（実装はローカル、AI ではない）
- ラベル「辞典」→「辞書」
- `separator: true` は前に可視群がある場合のみ `<hr>` を挿入（Web で Electron 専用群が消えても孤立区切りにならない）

### 2. 模糊検索（commit 5239c6d）

左ナビ上部に検索入力を追加。NFKC 正規化 + 大文字小文字を無視した

1. substring 一致（コピペ・部分入力に対応）
2. subsequence 一致（`スき` → 「スクロールと縦書き」のような飛ばし入力）

の 2 パスでフィルタする。検索中はグループ見出しと区切り線を抑制してフラット表示にし、一致ゼロ時は「一致する項目がありません」を表示。

## Changed files

- `components/settings/nav-config.ts` — 7 groups + separators, terminal を Editor 群へ
- `components/settings/primitives/SettingsNav.tsx` — separator render + 検索 UI/フィルタ
- `components/settings/primitives/fuzzy-match.ts` — 純粋関数で抽出（React 非依存、単体テスト容易）
- `components/settings/__tests__/nav-config.test.ts` — 新構造を検証
- `components/settings/primitives/__tests__/fuzzy-match.test.ts` — 11 cases

## Verification

- `npx vitest run components/settings` → **56/56 passed** (9 test files, 5 new + 11 new)
- `npx tsc --noEmit` → 0 errors
- `npm run format:check` → clean

## Test plan

- [ ] Web: 左ナビが 7 群、区切り線 2 本、terminal/power は非表示
- [ ] Electron: terminal が「エディタと表示」内、power が「システム」内
- [ ] 検索で `ターミナル`/`ta`/`文字` など入力 → 一致項目だけ残る
- [ ] 検索中は見出し・区切り線なし、一致ゼロ時は空状態メッセージ

🤖 Generated with [Claude Code](https://claude.com/claude-code)