### PR TITLE
fix(watcher): prevent false external-change detection on cloud-synced files

### DIFF
--- a/lib/services/__tests__/file-watch-integration.test.ts
+++ b/lib/services/__tests__/file-watch-integration.test.ts
@@ -57,6 +57,7 @@ function buildOnChangedForTest(
     const fileName = tab.file?.name ?? "ファイル";
 
     if (tab.fileSyncStatus === "clean") {
+      // Clean tab: auto-reload via pendingExternalContent (preserves scroll position)
       setTabs((prev) =>
         prev.map((t) => {
           if (t.id !== tabId || !isEditorTab(t)) return t;
@@ -71,7 +72,6 @@ function buildOnChangedForTest(
           } as EditorTabState;
         }),
       );
-      onEditorRemountNeeded?.();
       notifications.push({
         message: `「${fileName}」が更新されました`,
         type: "info",
@@ -217,13 +217,13 @@ describe("file-watch: clean tab receives external change", () => {
     expect(getTab().pendingExternalContent).toBe("new disk content");
   });
 
-  it("calls onEditorRemountNeeded after auto-reload", () => {
+  it("does NOT call onEditorRemountNeeded (uses pendingExternalContent for scroll preservation)", () => {
     const tab = makeEditorTab({ fileSyncStatus: "clean", content: "old", lastSavedContent: "old" });
     const { onChanged, onEditorRemountNeeded } = buildContext(tab);
 
     onChanged("new disk content", Date.now());
 
-    expect(onEditorRemountNeeded).toHaveBeenCalledTimes(1);
+    expect(onEditorRemountNeeded).not.toHaveBeenCalled();
   });
 
   it("emits an info notification", () => {

--- a/lib/services/file-watcher.ts
+++ b/lib/services/file-watcher.ts
@@ -555,8 +555,13 @@ class ElectronFileWatcher implements FileWatcher {
         this.vfs.readFile(this.path),
         this.vfs.getFileMetadata(this.path),
       ]);
+      const newHash = hashContent(content);
       this.lastKnownModified = metadata.lastModified;
-      this.lastKnownContentHash = hashContent(content);
+      // Skip notification if content hasn't changed (e.g. cloud sync metadata update)
+      if (newHash === this.lastKnownContentHash) {
+        return;
+      }
+      this.lastKnownContentHash = newHash;
       this.onChanged(content, metadata.lastModified);
     } catch (error) {
       // Check for permission-related errors (DOMException with NotAllowedError)

--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -66,7 +66,8 @@ function buildOnChanged(
     const fileName = tab.file?.name ?? "ファイル";
 
     if (tab.fileSyncStatus === "clean") {
-      // Clean tab: auto-reload with disk content
+      // Clean tab: auto-reload with disk content via pendingExternalContent
+      // (preserves scroll position instead of remounting the editor)
       setTabs((prev) =>
         prev.map((t) => {
           if (t.id !== tabId || !isEditorTab(t)) return t;
@@ -77,10 +78,10 @@ function buildOnChanged(
             isDirty: false,
             fileSyncStatus: "clean",
             conflictDiskContent: null,
+            pendingExternalContent: diskContent,
           } satisfies EditorTabState;
         }),
       );
-      onEditorRemountNeeded?.();
       notificationManager.info(`「${fileName}」が更新されました`, 3000);
     } else if (tab.fileSyncStatus === "dirty") {
       // Dirty tab: do NOT touch buffer; enter conflicted state


### PR DESCRIPTION
## Summary

- Google Drive 等のクラウド同期エージェントが保存後にファイルメタデータを更新することで、ファイルウォッチャーが誤って外部変更と判定し、エディタ内容がリフレッシュされてスクロール位置が最上部に戻る問題を修正
- AI によるファイル直接修正など、正当な外部変更時のスクロール位置保持も改善

## Changes

| File | Change |
|------|--------|
| `lib/services/file-watcher.ts` | `readAndNotify()` にコンテンツハッシュ比較を追加。メタデータのみの変更時は `onChanged` 発火をスキップ |
| `lib/tab-manager/use-file-watch-integration.ts` | Clean タブの自動リロードで `onEditorRemountNeeded`（エディタ再マウント）の代わりに `pendingExternalContent`（スクロール位置保持パス）を使用 |
| `lib/services/__tests__/file-watch-integration.test.ts` | テストのローカル `buildOnChanged` と期待値を新しい動作に合わせて更新 |

## Test plan

- [x] `vitest run lib/services/__tests__/file-watch-integration.test.ts` — 全21テスト合格
- [x] `tsc --noEmit` — 型チェック合格
- [ ] 手動テスト: Google Drive 上のファイルを保存 → クラウド同期後に誤った「更新されました」通知が表示されないことを確認
- [ ] 手動テスト: 外部エディタでファイルを変更 → エディタがスクロール位置を保持したまま内容を更新することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)