### PR TITLE
perf(lint): move L1 rule execution into a Web Worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ illusions は、日本語で小説を書くためのエディタです。
 - [MDI ドキュメント](docs/MDI/README.md)
 - [Deep Wiki](https://deepwiki.com/Iktahana/illusions)
 - [Code Wiki](https://codewiki.google/github.com/Iktahana/illusions)
-  
+
 ## 開発者向け
 
 このリポジトリを開発用途で扱う場合は、まず [`docs/`](docs/README.md) を参照してください。  

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -19,7 +19,8 @@ import { buildSegments, buildSpeechChunks, buildSpeechMap } from "@/lib/hooks/sp
 import { scrollToSpeechTarget, cancelSpeechScroll } from "@/lib/editor-page/speech-auto-scroll";
 import { useSelectionTracking } from "@/lib/editor-page/use-selection-tracking";
 import { localPreferences } from "@/lib/storage/local-preferences";
-import type { RuleRunner, LintIssue } from "@/lib/linting";
+import type { LintIssue } from "@/lib/linting";
+import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import { useTypographySettings, useSpeechSettings } from "@/contexts/EditorSettingsContext";
 import { useCharWidth, MEASURE_TEXT } from "@/lib/editor-page/use-char-width";
 
@@ -34,7 +35,7 @@ interface EditorProps {
   onEditorViewReady?: (view: EditorView) => void;
   onShowAllSearchResults?: (matches: SearchMatch[], searchTerm: string) => void;
   // リンティング設定
-  lintingRuleRunner?: RuleRunner | null;
+  lintingRuleRunner?: RuleRunnerLike | null;
   onLintIssuesUpdated?: (issues: LintIssue[]) => void;
   onNlpError?: (error: Error) => void;
   // 音声設定を開くコールバック

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -46,7 +46,7 @@ import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { DocxExportSettings } from "@/lib/export/docx-export-settings";
 import type { EpubExportOptions } from "@/lib/export/epub-shared";
 import type { ExportMetadata } from "@/lib/export/types";
-import type { RuleRunner } from "@/lib/linting/rule-runner";
+import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import { DockviewReact } from "dockview-react";
 type SidebarPanelSharedProps = Omit<React.ComponentProps<typeof SidebarPanel>, "view">;
 
@@ -163,7 +163,7 @@ interface EditorLayoutProps {
     handleShowAllSearchResults: NonNullable<
       React.ComponentProps<typeof NovelEditor>["onShowAllSearchResults"]
     >;
-    ruleRunner: RuleRunner;
+    ruleRunner: RuleRunnerLike | null;
     handleLintIssuesUpdated: (issues: LintIssue[]) => void;
     handleNlpError: (error: Error) => void;
     handleOpenRubyDialog: () => void;

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -38,7 +38,8 @@ import {
   getScrollProgress,
   setScrollProgress,
 } from "@/packages/milkdown-plugin-japanese-novel/scroll-progress";
-import type { RuleRunner, LintIssue } from "@/lib/linting";
+import type { LintIssue } from "@/lib/linting";
+import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import {
   useTypographySettings,
   useLintingSettings,
@@ -57,7 +58,7 @@ interface MilkdownEditorProps {
   isVertical: boolean;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   onEditorViewReady?: (view: EditorView) => void;
-  lintingRuleRunner?: RuleRunner | null;
+  lintingRuleRunner?: RuleRunnerLike | null;
   onLintIssuesUpdated?: (issues: LintIssue[]) => void;
   onNlpError?: (error: Error) => void;
   onOpenRubyDialog?: () => void;

--- a/docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
+++ b/docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
@@ -232,17 +232,17 @@ RuleRunner | null` — switch to `RuleRunnerLike | null`).
 - [ ] Create `worker/protocol.ts`.
 - [ ] Define `RuleRunnerLike`:
       `ts
-    interface RuleRunnerLike {
-      setConfig(id: string, cfg: LintRuleConfig): void;
-      setActiveGuidelines(g: string[] | null): void;
-      setGuidelineMap(m: Map<string, string | undefined>): void;
-      hasMorphologicalRules(): boolean;
-      hasDocumentRules(): boolean;
-      runBatch(req: RunBatchRequest): Promise<RunBatchResponse>;
-      cancelInFlight(): void;
-      dispose(): void;
-    }
-    `
+interface RuleRunnerLike {
+  setConfig(id: string, cfg: LintRuleConfig): void;
+  setActiveGuidelines(g: string[] | null): void;
+  setGuidelineMap(m: Map<string, string | undefined>): void;
+  hasMorphologicalRules(): boolean;
+  hasDocumentRules(): boolean;
+  runBatch(req: RunBatchRequest): Promise<RunBatchResponse>;
+  cancelInFlight(): void;
+  dispose(): void;
+}
+`
 - [ ] Define the message protocol as **two** discriminated unions: - `WorkerRequest` (main → worker): all variants carry
       `correlationId: number`. Variants: `SET_GUIDELINE_MAP`,
       `SET_ACTIVE_GUIDELINES`, `SET_CONFIG`, `RUN_BATCH` (also carries
@@ -262,7 +262,7 @@ RuleRunner | null` — switch to `RuleRunnerLike | null`).
       register `getAllRules()` + `createJsonDrivenRules()`, call
       `setGuidelineMap(RULE_GUIDELINE_MAP)`.
 - [ ] Wire `self.onmessage = (e) => { ...switch on e.data.type ...
-    self.postMessage({ type: "RESPONSE", correlationId, payload }); }`.
+self.postMessage({ type: "RESPONSE", correlationId, payload }); }`.
       Catch any rule-execution error per request and post
       `{ type: "ERROR", correlationId, error: { name, message } }`
       instead. An uncaught top-level throw becomes
@@ -310,15 +310,15 @@ RuleRunner | null` — switch to `RuleRunnerLike | null`).
 
 - [ ] Replace the synchronous lazy `RuleRunner` construction with:
       `ts
-    const [ruleRunner, setRuleRunner] = useState<RuleRunnerLike | null>(null);
-    useEffect(() => {
-      if (typeof window === "undefined") return;
-      const proxy = new RuleRunnerProxy();
-      proxy.setGuidelineMap(RULE_GUIDELINE_MAP);
-      setRuleRunner(proxy);
-      return () => proxy.dispose();
-    }, []);
-    `
+const [ruleRunner, setRuleRunner] = useState<RuleRunnerLike | null>(null);
+useEffect(() => {
+  if (typeof window === "undefined") return;
+  const proxy = new RuleRunnerProxy();
+  proxy.setGuidelineMap(RULE_GUIDELINE_MAP);
+  setRuleRunner(proxy);
+  return () => proxy.dispose();
+}, []);
+`
 - [ ] Keep the existing `lintingRuleConfigs` sync `useEffect` and the
       `correctionGuidelines` sync `useEffect` — they call sync setters
       that the proxy forwards as fire-and-forget messages.
@@ -330,11 +330,11 @@ RuleRunner | null` — switch to `RuleRunnerLike | null`).
 - [ ] Change `currentRuleRunner` type to `RuleRunnerLike | null`.
 - [ ] Replace L242–273 (per-paragraph loop) with a **single**
       `await runner.runBatch({ paragraphs: uncached, mode: "per-paragraph",
-    version })` call. Result populates `issueCache` for each
+version })` call. Result populates `issueCache` for each
       paragraph text.
 - [ ] Replace L281–322 (document rules block) with a single
       `await runner.runBatch({ paragraphs: allParagraphs, mode: "document",
-    version })` call when `runner.hasDocumentRules()` is true.
+version })` call when `runner.hasDocumentRules()` is true.
       (Preserve token shape: paragraphs carry `tokens?` only when
       `runner.hasMorphologicalRules() && nlp` — current registry has none,
       so this branch is dead in practice but kept for forward-compat.)

--- a/docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
+++ b/docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
@@ -170,8 +170,10 @@ useLinting / decoration-plugin
   — typed request/response message contracts; `RuleRunnerLike` interface.
 - `packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts`
   — Worker entry point. Constructs a private `RuleRunner`, registers
-  `getAllRules()` + `createJsonDrivenRules()`, calls
-  `setGuidelineMap(RULE_GUIDELINE_MAP)`. Posts a `READY` message on init.
+  `createJsonDrivenRules()` only (handwritten morphological rules stay on
+  the main thread because their `genjiVocab` dependency uses Electron
+  IPC), and calls `setGuidelineMap(RULE_GUIDELINE_MAP)`. Posts a `READY`
+  message on init.
 - `packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts`
   — main-thread `RuleRunnerLike` implementation. Owns the `Worker` instance,
   correlation IDs, pending-request map, capability flags, version-aware
@@ -203,8 +205,9 @@ uncached, mode: "per-paragraph", version })` call and merge results into
   `issueCache`. Replace the document-rules block (L281–322) with the same
   call carrying `mode: "both"` (or a separate call with `mode: "document"`)
   to halve the round-trips. Wrap each `await` in a `try/catch` that drops
-  `WorkerDisposedError` silently and surfaces other errors via
-  `notificationManager.warning(...)`.
+  `WorkerDisposedError` / `WorkerStaleError` silently and logs other
+  errors via `console.error` (decorations are simply not updated for
+  this pass; no user-facing notification fires).
 - `components/EditorLayout.tsx` — `mainArea.ruleRunner` type changes from
   `RuleRunner` to `RuleRunnerLike | null`; the `<Editor>` prop forwarding
   is null-safe already (`Editor.tsx` declares `lintingRuleRunner?:
@@ -214,8 +217,6 @@ RuleRunner | null` — switch to `RuleRunnerLike | null`).
 - `components/editor/MilkdownEditor.tsx` — same prop type update; the
   forwarding into `updateLintingSettings({ ruleRunner: lintingRuleRunner })`
   is unchanged in shape.
-- `app/page.tsx` — destructure consumes `ruleRunner: RuleRunnerLike | null`;
-  type widens automatically.
 
 ### Reused (do not modify)
 
@@ -259,8 +260,10 @@ interface RuleRunnerLike {
 ### Task 2 — Worker entry point
 
 - [ ] Create `worker/linting.worker.ts`. Top-level: build a `RuleRunner`,
-      register `getAllRules()` + `createJsonDrivenRules()`, call
-      `setGuidelineMap(RULE_GUIDELINE_MAP)`.
+      register `createJsonDrivenRules()` only — handwritten morphological
+      rules deliberately stay on the main thread (`genjiVocab` uses
+      Electron IPC), so `getAllRules()` is **not** called here. Then
+      call `setGuidelineMap(RULE_GUIDELINE_MAP)`.
 - [ ] Wire `self.onmessage = (e) => { ...switch on e.data.type ...
 self.postMessage({ type: "RESPONSE", correlationId, payload }); }`.
       Catch any rule-execution error per request and post

--- a/docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
+++ b/docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
@@ -232,24 +232,31 @@ RuleRunner | null` — switch to `RuleRunnerLike | null`).
 
 - [ ] Create `worker/protocol.ts`.
 - [ ] Define `RuleRunnerLike`:
-      `ts
-interface RuleRunnerLike {
-  setConfig(id: string, cfg: LintRuleConfig): void;
-  setActiveGuidelines(g: string[] | null): void;
-  setGuidelineMap(m: Map<string, string | undefined>): void;
-  hasMorphologicalRules(): boolean;
-  hasDocumentRules(): boolean;
-  runBatch(req: RunBatchRequest): Promise<RunBatchResponse>;
-  cancelInFlight(): void;
-  dispose(): void;
-}
-`
-- [ ] Define the message protocol as **two** discriminated unions: - `WorkerRequest` (main → worker): all variants carry
-      `correlationId: number`. Variants: `SET_GUIDELINE_MAP`,
-      `SET_ACTIVE_GUIDELINES`, `SET_CONFIG`, `RUN_BATCH` (also carries
-      `version: number`). - `WorkerEvent` (worker → main) is a tagged union of: - `{ type: "READY" }` — out-of-band, no `correlationId`. - `{ type: "RESPONSE", correlationId, payload }` — reply to a
+
+  ```ts
+  interface RuleRunnerLike {
+    setConfig(id: string, cfg: LintRuleConfig): void;
+    setActiveGuidelines(g: string[] | null): void;
+    setGuidelineMap(m: Map<string, string | undefined>): void;
+    hasMorphologicalRules(): boolean;
+    hasDocumentRules(): boolean;
+    runBatch(req: RunBatchRequest): Promise<RunBatchResponse>;
+    cancelInFlight(): void;
+    dispose(): void;
+  }
+  ```
+
+- [ ] Define the message protocol as **two** discriminated unions:
+  - `WorkerRequest` (main → worker): all variants carry
+    `correlationId: number`. Variants: `SET_GUIDELINE_MAP`,
+    `SET_ACTIVE_GUIDELINES`, `SET_CONFIG`, `RUN_BATCH` (also carries
+    `version: number`).
+  - `WorkerEvent` (worker → main) is a tagged union of:
+    - `{ type: "READY" }` — out-of-band, no `correlationId`.
+    - `{ type: "RESPONSE", correlationId, payload }` — reply to a
       specific request. `RUN_BATCH` responses carry `version` so the
-      proxy can apply stale-by-version filtering before resolving. - `{ type: "ERROR", correlationId?, error: { name, message } }`
+      proxy can apply stale-by-version filtering before resolving.
+    - `{ type: "ERROR", correlationId?, error: { name, message } }`
       — `correlationId` is optional because uncaught worker errors
       may not be associated with a specific request.
 - [ ] Define `WorkerDisposedError extends Error` and
@@ -280,13 +287,16 @@ self.postMessage({ type: "RESPONSE", correlationId, payload }); }`.
       Capability flags `hasMorphologicalRules()` / `hasDocumentRules()`
       read from this metadata cache (no async needed).
 - [ ] **Readiness**: hold a private `readyPromise: Promise<void>` that
-      resolves when the worker posts `{ type: "READY" }`. Until READY: - `setConfig` / `setActiveGuidelines` / `setGuidelineMap` calls
-      enqueue messages in a private buffer; the buffer flushes (in
-      FIFO order) immediately after `readyPromise` resolves. - `runBatch` calls `await readyPromise` first, then post. - If `dispose()` is called before READY: terminate the worker,
-      clear the buffer, reject any pending `runBatch` promises with
-      `WorkerDisposedError`. The `readyPromise` itself rejects with
-      `WorkerDisposedError` so any concurrent `runBatch` awaiting it
-      unwinds cleanly.
+      resolves when the worker posts `{ type: "READY" }`. Until READY:
+  - `setConfig` / `setActiveGuidelines` / `setGuidelineMap` calls
+    enqueue messages in a private buffer; the buffer flushes (in
+    FIFO order) immediately after `readyPromise` resolves.
+  - `runBatch` calls `await readyPromise` first, then post.
+  - If `dispose()` is called before READY: terminate the worker,
+    clear the buffer, reject any pending `runBatch` promises with
+    `WorkerDisposedError`. The `readyPromise` itself rejects with
+    `WorkerDisposedError` so any concurrent `runBatch` awaiting it
+    unwinds cleanly.
 - [ ] `runBatch`: increments correlation ID, captures the current
       `version` from the request, posts the message, returns a Promise
       tracked in a `pendingRequests` map.
@@ -312,16 +322,18 @@ self.postMessage({ type: "RESPONSE", correlationId, payload }); }`.
 ### Task 4 — Wire useLinting
 
 - [ ] Replace the synchronous lazy `RuleRunner` construction with:
-      `ts
-const [ruleRunner, setRuleRunner] = useState<RuleRunnerLike | null>(null);
-useEffect(() => {
-  if (typeof window === "undefined") return;
-  const proxy = new RuleRunnerProxy();
-  proxy.setGuidelineMap(RULE_GUIDELINE_MAP);
-  setRuleRunner(proxy);
-  return () => proxy.dispose();
-}, []);
-`
+
+  ```ts
+  const [ruleRunner, setRuleRunner] = useState<RuleRunnerLike | null>(null);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const proxy = new RuleRunnerProxy();
+    proxy.setGuidelineMap(RULE_GUIDELINE_MAP);
+    setRuleRunner(proxy);
+    return () => proxy.dispose();
+  }, []);
+  ```
+
 - [ ] Keep the existing `lintingRuleConfigs` sync `useEffect` and the
       `correctionGuidelines` sync `useEffect` — they call sync setters
       that the proxy forwards as fire-and-forget messages.

--- a/docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
+++ b/docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
@@ -1,0 +1,542 @@
+# Lint Rule Execution → Web Worker Parallelization
+
+**Date**: 2026-05-05 (revised 2026-05-06 after Codex review iteration 1)
+**Branch**: `feature/lint-worker-parallelization`
+**Targets**: `dev`
+
+## Context
+
+Toggling the proofreading panel on long Japanese novels (1000+ paragraphs in
+the "原稿/缶詰" Google Drive project) freezes the editor for several seconds.
+During the freeze the cursor cannot be placed and keystrokes are queued.
+
+Root cause is in
+`packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts`,
+function `scheduleViewportUpdate` (L217–394):
+
+- The function is misnamed — it processes the **entire document**, not just
+  the viewport (L228–232). The original viewport-only design was abandoned
+  to avoid scroll jitter.
+- Per-paragraph `RuleRunner.runAll` / `runAllWithTokens` (L262, L267, L270)
+  and document-level `runDocument*` (L310, L313, L318) execute synchronously
+  on the renderer main thread. The current registry has ~21 JTF L1 regex
+  rules + ~1 manuscript + ~1 NIH-style ruleset (`createJsonDrivenRules` at
+  `lib/linting/rule-registry.ts:17`).
+- `DecorationSet.create(...)` (L386) and `view.dispatch(tr)` (L389) also
+  run synchronously.
+
+For a 100k-character novel the cumulative blocking time exceeds 5 seconds —
+ProseMirror cannot deliver pointer/keyboard events while the main thread is
+busy.
+
+## Goal
+
+Move `RuleRunner` execution off the renderer main thread by hosting it
+inside a **dedicated module-mode Web Worker**. The main thread keeps
+tokenization (already async via Electron IPC / `/api/nlp` HTTP) and
+decoration construction. After the change, toggling proofreading on a long
+document must keep the cursor responsive (typing latency p95 < 100ms during
+the initial scan).
+
+## Architecture
+
+```
+Renderer main thread                            Web Worker
+─────────────────────────                       ─────────────────────
+useLinting / decoration-plugin
+  │
+  ├─ tokenize via electronAPI / fetch
+  │   (Electron IPC or /api/nlp)        ──┐
+  │                                       │ no Worker access to electronAPI
+  │                                       │ (decision: keep both paths on main)
+  │                                       │
+  └─ RuleRunnerProxy.runBatch(req)  ──postMessage──→  RuleRunner
+                                    ←──postMessage──   .runAll* / .runDocument*
+                                                       returns Issue[]
+```
+
+### Key decisions
+
+1. **Single dedicated Worker, not a pool.** Rule runs are short and we need
+   ordered, batched results. A pool adds serialization overhead without
+   throughput gains for this workload.
+2. **Tokenization stays on the main thread.** `electron-nlp-client.ts` uses
+   `window.electronAPI.nlp.*` (preload-bound, unreachable from a Worker).
+   `web-nlp-client.ts` uses `fetch('/api/nlp/...')` and **could** be invoked
+   from a Worker, but moving it provides no benefit for this fix and would
+   diverge the two clients. Kept on main thread for parity / minimal scope.
+3. **Batched RPC, not per-paragraph postMessage.** Sending 1000 messages
+   thrashes the structured-clone path. One `RUN_BATCH` request carries all
+   paragraphs.
+4. **Capability flags computed on the main thread.** `hasMorphologicalRules()`
+   and `hasDocumentRules()` are queried synchronously by both
+   `decoration-plugin.ts` and `use-linting.ts:123`. We cannot make those
+   async without a wider refactor. Solution: the proxy imports the rule
+   registry on the main thread and computes the flags from rule **metadata
+   only** (`rule.engine`, `isDocumentLintRule` type guard). The actual
+   `lint()` work is delegated to the worker; only metadata reads happen on
+   the main thread.
+5. **Module-mode Worker via `new URL(..., import.meta.url)`.** Next.js 16
+   Turbopack and Webpack 5 both bundle this natively — no `worker-loader`,
+   no `next.config.ts` changes. Confirmed:
+   - `tsconfig.json` already lists `"webworker"` in `lib`.
+   - `next.config.ts` has no Worker-specific blockers.
+   - Electron CSP allows `worker-src 'self' blob:` (`electron/main.js`).
+   - `bundle:electron` only bundles main/preload (`scripts/bundle-electron.mjs`),
+     so the renderer is untouched standard Next output (dev:
+     `http://localhost:3020`, prod: `out/index.html` via
+     `electron/window-manager.js`).
+6. **State-driven proxy readiness.** The worker is created lazily in a
+   `useEffect` after `useLinting` mounts (so SSR doesn't choke on
+   `Worker`). The proxy is held in **React state** (not just a ref) so its
+   transition `null → ready` triggers a rerender, propagating into
+   `EditorLayout` → `Editor` → `MilkdownEditor` → linting plugin via
+   `updateLintingSettings({ ruleRunner })`. Holding only a ref would leave
+   the editor stuck with `null`.
+7. **`RuleRunnerLike` is the plugin-path interface.** `useLinting`, the
+   editor components, and the linting plugin switch their type from
+   `RuleRunner` (concrete class) to a new `RuleRunnerLike` interface that
+   adds `runBatch(...)` async + `dispose()` to the existing sync metadata
+   methods. The proxy is the only `RuleRunnerLike` implementation
+   introduced here. The concrete `RuleRunner` class is retained
+   unchanged inside the worker and for any non-plugin call sites (e.g.
+   future unit tests that exercise rules directly without a Worker); it
+   is not expected to satisfy `RuleRunnerLike`.
+8. **Cancellation has three modes:**
+   - **Stale-by-version**: `processingVersion` is sent inside each
+     `RUN_BATCH`. The proxy compares the response's version to the
+     proxy's "latest accepted" version; mismatches reject the awaited
+     promise with `WorkerStaleError`. Callers in `decoration-plugin.ts`
+     catch this and silently drop the result (no cache write, no
+     `view.dispatch(...)`).
+   - **Lint-disabled mid-flight**: when `enabled` flips to `false`, the
+     proxy's `cancelInFlight()` is called from the
+     `decoration-plugin.ts` `apply()` path; pending requests reject
+     with `WorkerStaleError`.
+   - **Disposed**: `proxy.dispose()` (called from the `useLinting`
+     unmount cleanup) terminates the worker and rejects all pending
+     requests with `WorkerDisposedError`.
+
+   Both errors are silent-cancel sentinels — the catch block in
+   `decoration-plugin.ts` swallows them. Any other error is surfaced
+   via `notificationManager.warning(...)` and aborts the current
+   pass.
+
+   In addition to the proxy-side guards, `decoration-plugin.ts` keeps
+   explicit caller-side `version === processingVersion` checks
+   immediately after every `await` and before any cache write or
+   `view.dispatch(...)`. The proxy-side filtering removes the bulk of
+   stale work; the caller-side check is a belt-and-braces guard
+   against ordering races between proxy state and plugin state.
+
+9. **Hybrid L1/L2 split (post-PR-1425 reality).** PR #1425 reintroduced
+   one L2 morphological rule (`GenjiUnknownNounRule`) plus
+   `lib/dict/genji-vocab.ts` and `dict.onInstalled`. `genjiVocab` reads
+   from `window.electronAPI.dict.listNounHeadwords` — unreachable from a
+   Worker. To keep the implementation tonight-shippable:
+   - **Worker registers only non-morphological rules.** That is the
+     three JSON L1 rule sets (`createJtfL1Rules` +
+     `createManuscriptL1Rules` + `createNihongoHyoukiL1Rules`) — ~21
+     regex rules covering ~90%+ of the per-paragraph CPU cost on long
+     documents.
+   - **Main thread keeps a small synchronous `RuleRunner` populated
+     only with morphological rules** (currently just
+     `GenjiUnknownNounRule`). It is invoked **after** tokenization and
+     in a tight loop over paragraphs — but it's a single rule with a
+     hash-set lookup per token, so the per-paragraph cost is
+     micro-second-scale and does not freeze the editor.
+   - **`decoration-plugin.ts` merges** the issues returned by the
+     Worker batch and the main-thread morph runner. Both contribute
+     to the same `issueCache` (per-paragraph) / `documentIssueCache`
+     (document-level) keyed by paragraph text / index.
+   - **Vocab DI / replication is out of scope.** Captured as a future
+     follow-up; if the L2 rule list grows or its CPU cost becomes
+     visible, we revisit moving morph rules into the worker with
+     vocab replication.
+
+## Tech stack
+
+- TypeScript (strict, `lib` already includes `webworker`)
+- Native ES module Web Worker (`type: "module"`)
+- Existing test runner: Vitest
+- No new dependencies (no Comlink — the typed RPC layer is small enough to
+  hand-roll)
+
+## Files
+
+### New
+
+- `packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts`
+  — typed request/response message contracts; `RuleRunnerLike` interface.
+- `packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts`
+  — Worker entry point. Constructs a private `RuleRunner`, registers
+  `getAllRules()` + `createJsonDrivenRules()`, calls
+  `setGuidelineMap(RULE_GUIDELINE_MAP)`. Posts a `READY` message on init.
+- `packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts`
+  — main-thread `RuleRunnerLike` implementation. Owns the `Worker` instance,
+  correlation IDs, pending-request map, capability flags, version-aware
+  cancellation, `WorkerDisposedError`.
+- `packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts`
+  — Vitest test that mocks `globalThis.Worker` and exercises the proxy:
+  `runBatch` round-trip via fake post-message, version filtering,
+  `cancelInFlight`, and dispose-before-READY. (No separate
+  `handle-message.ts` extraction — kept for a future iteration if
+  test friction grows.)
+
+### Modified
+
+- `lib/editor-page/use-linting.ts` — return type changes to `ruleRunner:
+RuleRunnerLike | null`. The runner is built in a `useEffect` and stored
+  in state; on unmount, `proxy.dispose()` is called. Capability checks
+  (`hasMorphologicalRules()`) keep their sync signature — they read the
+  proxy's main-thread metadata cache.
+- `packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts`
+  — `LintingPluginOptions.ruleRunner` and `LintingSettingsUpdate.ruleRunner`
+  switch from `RuleRunner | null` to `RuleRunnerLike | null`.
+- `packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts`
+  — `LintingOptions.ruleRunner` switches from `RuleRunner | null` to
+  `RuleRunnerLike | null` so callers can pass the proxy.
+- `packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts`
+  — change the `currentRuleRunner` type. Replace the per-paragraph
+  `for…of` loop (L242–273) with a single `runner.runBatch({ paragraphs:
+uncached, mode: "per-paragraph", version })` call and merge results into
+  `issueCache`. Replace the document-rules block (L281–322) with the same
+  call carrying `mode: "both"` (or a separate call with `mode: "document"`)
+  to halve the round-trips. Wrap each `await` in a `try/catch` that drops
+  `WorkerDisposedError` silently and surfaces other errors via
+  `notificationManager.warning(...)`.
+- `components/EditorLayout.tsx` — `mainArea.ruleRunner` type changes from
+  `RuleRunner` to `RuleRunnerLike | null`; the `<Editor>` prop forwarding
+  is null-safe already (`Editor.tsx` declares `lintingRuleRunner?:
+RuleRunner | null` — switch to `RuleRunnerLike | null`).
+- `components/Editor.tsx` — `lintingRuleRunner` prop type updated to
+  `RuleRunnerLike | null`.
+- `components/editor/MilkdownEditor.tsx` — same prop type update; the
+  forwarding into `updateLintingSettings({ ruleRunner: lintingRuleRunner })`
+  is unchanged in shape.
+- `app/page.tsx` — destructure consumes `ruleRunner: RuleRunnerLike | null`;
+  type widens automatically.
+
+### Reused (do not modify)
+
+- `lib/linting/rule-runner.ts` — runs unchanged inside the Worker.
+- `lib/linting/rule-registry.ts` — imported by both the worker
+  (registration) and the proxy (metadata).
+- `lib/linting/rules/json-l1/*.ts` — pure logic, no DOM/IPC.
+- `lib/nlp-client/*` — tokenization stays on the main thread.
+
+## Tasks
+
+### Task 1 — Protocol & RuleRunnerLike
+
+- [ ] Create `worker/protocol.ts`.
+- [ ] Define `RuleRunnerLike`:
+      `ts
+    interface RuleRunnerLike {
+      setConfig(id: string, cfg: LintRuleConfig): void;
+      setActiveGuidelines(g: string[] | null): void;
+      setGuidelineMap(m: Map<string, string | undefined>): void;
+      hasMorphologicalRules(): boolean;
+      hasDocumentRules(): boolean;
+      runBatch(req: RunBatchRequest): Promise<RunBatchResponse>;
+      cancelInFlight(): void;
+      dispose(): void;
+    }
+    `
+- [ ] Define the message protocol as **two** discriminated unions: - `WorkerRequest` (main → worker): all variants carry
+      `correlationId: number`. Variants: `SET_GUIDELINE_MAP`,
+      `SET_ACTIVE_GUIDELINES`, `SET_CONFIG`, `RUN_BATCH` (also carries
+      `version: number`). - `WorkerEvent` (worker → main) is a tagged union of: - `{ type: "READY" }` — out-of-band, no `correlationId`. - `{ type: "RESPONSE", correlationId, payload }` — reply to a
+      specific request. `RUN_BATCH` responses carry `version` so the
+      proxy can apply stale-by-version filtering before resolving. - `{ type: "ERROR", correlationId?, error: { name, message } }`
+      — `correlationId` is optional because uncaught worker errors
+      may not be associated with a specific request.
+- [ ] Define `WorkerDisposedError extends Error` and
+      `WorkerStaleError extends Error`. Both are silent-cancel sentinels
+      (callers swallow them; only "real" errors surface via the
+      notification manager).
+
+### Task 2 — Worker entry point
+
+- [ ] Create `worker/linting.worker.ts`. Top-level: build a `RuleRunner`,
+      register `getAllRules()` + `createJsonDrivenRules()`, call
+      `setGuidelineMap(RULE_GUIDELINE_MAP)`.
+- [ ] Wire `self.onmessage = (e) => { ...switch on e.data.type ...
+    self.postMessage({ type: "RESPONSE", correlationId, payload }); }`.
+      Catch any rule-execution error per request and post
+      `{ type: "ERROR", correlationId, error: { name, message } }`
+      instead. An uncaught top-level throw becomes
+      `{ type: "ERROR", error }` (no correlationId).
+- [ ] After the registry is wired, post `{ type: "READY" }` once.
+
+### Task 3 — RuleRunnerProxy
+
+- [ ] Create `worker/rule-runner-proxy.ts`. Implements `RuleRunnerLike`.
+- [ ] Constructor: imports the rule registry **statically**, builds an
+      array of rule metadata `{ id, engine, kind: "doc" | "para" }`.
+      Capability flags `hasMorphologicalRules()` / `hasDocumentRules()`
+      read from this metadata cache (no async needed).
+- [ ] **Readiness**: hold a private `readyPromise: Promise<void>` that
+      resolves when the worker posts `{ type: "READY" }`. Until READY: - `setConfig` / `setActiveGuidelines` / `setGuidelineMap` calls
+      enqueue messages in a private buffer; the buffer flushes (in
+      FIFO order) immediately after `readyPromise` resolves. - `runBatch` calls `await readyPromise` first, then post. - If `dispose()` is called before READY: terminate the worker,
+      clear the buffer, reject any pending `runBatch` promises with
+      `WorkerDisposedError`. The `readyPromise` itself rejects with
+      `WorkerDisposedError` so any concurrent `runBatch` awaiting it
+      unwinds cleanly.
+- [ ] `runBatch`: increments correlation ID, captures the current
+      `version` from the request, posts the message, returns a Promise
+      tracked in a `pendingRequests` map.
+- [ ] **Stale-by-version filtering**: the proxy tracks
+      `latestAcceptedVersion`. On every fresh `runBatch(req)` the
+      proxy updates `latestAcceptedVersion = req.version`. When a
+      `RESPONSE` arrives, if `response.version < latestAcceptedVersion`,
+      the matching entry rejects with `WorkerStaleError` instead of
+      resolving.
+- [ ] `cancelInFlight()`: rejects every entry in `pendingRequests` with
+      `WorkerStaleError` and clears the map. The worker keeps running;
+      next `runBatch` proceeds normally.
+- [ ] `dispose()`: terminates the worker, rejects all pending requests
+      with `WorkerDisposedError`, marks the proxy disposed (subsequent
+      method calls throw or no-op).
+- [ ] On worker `error` / `messageerror` event: reject all pending
+      requests with the underlying error (not a sentinel) — this is a
+      real failure, surface it.
+- [ ] Unknown correlation IDs (e.g. response arriving after
+      `cancelInFlight`) are silently dropped — they may belong to
+      already-rejected entries.
+
+### Task 4 — Wire useLinting
+
+- [ ] Replace the synchronous lazy `RuleRunner` construction with:
+      `ts
+    const [ruleRunner, setRuleRunner] = useState<RuleRunnerLike | null>(null);
+    useEffect(() => {
+      if (typeof window === "undefined") return;
+      const proxy = new RuleRunnerProxy();
+      proxy.setGuidelineMap(RULE_GUIDELINE_MAP);
+      setRuleRunner(proxy);
+      return () => proxy.dispose();
+    }, []);
+    `
+- [ ] Keep the existing `lintingRuleConfigs` sync `useEffect` and the
+      `correctionGuidelines` sync `useEffect` — they call sync setters
+      that the proxy forwards as fire-and-forget messages.
+- [ ] `refreshLinting`: gate on `ruleRunner != null`; when null, no-op.
+- [ ] Return type becomes `ruleRunner: RuleRunnerLike | null`.
+
+### Task 5 — Wire decoration-plugin
+
+- [ ] Change `currentRuleRunner` type to `RuleRunnerLike | null`.
+- [ ] Replace L242–273 (per-paragraph loop) with a **single**
+      `await runner.runBatch({ paragraphs: uncached, mode: "per-paragraph",
+    version })` call. Result populates `issueCache` for each
+      paragraph text.
+- [ ] Replace L281–322 (document rules block) with a single
+      `await runner.runBatch({ paragraphs: allParagraphs, mode: "document",
+    version })` call when `runner.hasDocumentRules()` is true.
+      (Preserve token shape: paragraphs carry `tokens?` only when
+      `runner.hasMorphologicalRules() && nlp` — current registry has none,
+      so this branch is dead in practice but kept for forward-compat.)
+- [ ] Wrap both `await` calls in `try/catch`. Drop `WorkerStaleError`
+      and `WorkerDisposedError` silently (no cache write, no dispatch).
+      Surface other errors through `notificationManager.warning(...)`
+      and bail out of the current pass.
+- [ ] **Keep the explicit caller-side guards.** Immediately after every
+      `await`, before any cache write or `view.dispatch(...)`, re-check
+      `version === processingVersion` and re-read the plugin's
+      `enabled` state via `lintingKey.getState(view.state)?.enabled`.
+      Bail out if either check fails. (The proxy filters most stale
+      responses, but ordering races between proxy state and plugin
+      state are still possible — this is a belt-and-braces guard.)
+- [ ] **Lint-disable cancellation**: in the `apply()` switch, when
+      `meta.enabled === false` is observed, call
+      `currentRuleRunner?.cancelInFlight()` so any in-flight batch
+      stops without dispatching stale decorations.
+- [ ] **Manual-refresh / mode-change cancellation**: the existing
+      `pendingFullScan = true` path already invalidates caches; also
+      call `currentRuleRunner?.cancelInFlight()` in those branches so
+      the queued post-await work doesn't dispatch stale decorations
+      from the previous configuration.
+
+### Task 6 — Type plumbing
+
+- [ ] Update `linting-plugin/types.ts` to use `RuleRunnerLike | null`
+      throughout (`LintingPluginOptions`, `LintingSettingsUpdate`).
+- [ ] Update `linting-plugin/index.ts`: `LintingOptions.ruleRunner`
+      → `RuleRunnerLike | null`. (Without this, callers passing the
+      proxy into `linting(...)` get a TypeScript mismatch.)
+- [ ] Update `components/EditorLayout.tsx` `mainArea.ruleRunner` type to
+      `RuleRunnerLike | null`. The downstream `<Editor>` prop type already
+      tolerates `null`; switch its type alias too.
+- [ ] Update `components/Editor.tsx` and
+      `components/editor/MilkdownEditor.tsx` `lintingRuleRunner` props to
+      `RuleRunnerLike | null`.
+- [ ] `app/page.tsx`: no logic change, but the destructured `ruleRunner`
+      type widens automatically.
+
+### Task 7 — Tests
+
+- [ ] `worker/__tests__/proxy.test.ts` (mocking `globalThis.Worker`): - `runBatch` round-trip: post a `RUN_BATCH`, simulate a
+      `RESPONSE`, assert the awaiter resolves with the parsed payload. - Version filtering: response with `version` lower than the
+      proxy's latest accepted version rejects with `WorkerStaleError`. - `cancelInFlight()` rejects all pending with `WorkerStaleError`,
+      leaves the worker running, next `runBatch` succeeds. - `dispose()` before READY: pending requests reject with
+      `WorkerDisposedError`; the buffered config messages are not
+      flushed (worker terminated).
+- [ ] `lib/editor-page/__tests__/use-linting.worker.test.ts`: - Mock `globalThis.Worker`; assert proxy creation on mount,
+      `dispose()` on unmount, capability flags reflect registry
+      contents (currently `hasMorphologicalRules() === false`,
+      `hasDocumentRules()` true iff any registered JSON L1 rule is a
+      DocumentLintRule — read from registry metadata at construction).
+
+### Task 8 — Manual verification
+
+1. `npm run electron:dev`.
+2. Open the "缶詰" project (long Google-Drive-hosted novel).
+3. Toggle the proofreading panel on.
+4. While decorations are being computed, type into the editor — cursor
+   must remain responsive (no observable freeze longer than ~100ms).
+5. Confirm decorations appear within ~1–2s and match the previous
+   (pre-worker) output for the first 5 paragraphs.
+6. Toggle the panel off and on a second time; confirm caches clear and
+   the second run is faster (warm token cache — n/a today, but no
+   regression).
+7. Activity Monitor: Electron Helper (Renderer) main thread should peak
+   briefly but not pin at 100% CPU; the new worker thread carries the
+   load.
+8. `npm run electron:build` (or equivalent) and smoke-test the packaged
+   build to confirm the Worker bundle is included.
+
+## Out of scope
+
+- Tokenization off the main thread (kuromoji stays on Electron main /
+  Next.js API).
+- Worker pool / sharding.
+- Genji-vocab DI or any L2 rule introduction.
+- The unrelated B1/B2/B3 ENOENT/dialog issues tracked in
+  `2026-05-03-fix-page-unresponsive-on-open.md`.
+
+## Risks & mitigations
+
+- **Risk**: Worker construction races with first lint call.
+  - **Mitigation**: Proxy queues `setConfig` / `setActiveGuidelines`
+    messages until the worker posts `READY`. `runBatch` calls also wait
+    on the same readiness promise.
+- **Risk**: The `processingVersion` cancellation no longer fires per
+  paragraph, only per batch.
+  - **Mitigation**: Versions are sent inside each `RUN_BATCH`; stale
+    responses are dropped before `issueCache` writes or
+    `view.dispatch(...)`. (Codex confirmed this is adequate.)
+- **Risk**: `structuredClone` on a single `RUN_BATCH` could itself block.
+  - **Mitigation**: With the current registry (regex-only L1, no token
+    payload), realistic batch size is ~few-hundred KB of text — safe.
+    If L2 rules return later and tokens make payloads multi-MB, chunk by
+    paragraph count (e.g. 200/batch). Captured as a follow-up.
+- **Risk**: Unhandled promise rejections during editor unmount /
+  re-toggle.
+  - **Mitigation**: `WorkerDisposedError` is treated as silent cancel in
+    `decoration-plugin.ts`; all `await` sites have `try/catch`.
+- **Risk**: SSR explosion from `Worker` reference at import time.
+  - **Mitigation**: Worker is constructed inside `useEffect`, so the
+    module path is reachable but the constructor is not invoked during
+    SSR. The proxy's static metadata import is browser-safe (pure data).
+
+## Review history
+
+### Iteration 1 — Codex review (2026-05-05)
+
+Codex returned **NEEDS_REVISION** with 4 actionable findings (R1
+CRITICAL, R2/R3/R4 IMPORTANT) and 1 wording suggestion (R5).
+
+**Accepted**
+
+- **R1**: Removed all Genji-vocab / `genji-unknown-noun.ts` references.
+  Verified: `lib/dict/genji-vocab.ts` does not exist in dev,
+  `lib/linting/rules/l2/` is empty, `getAllRules()` returns `[]` at
+  `rule-registry.ts:11`, and the preload `dict.*` API has no
+  `onInstalled`. Architecture decision 4 deleted; original Task 4
+  collapsed into the protocol/proxy tasks.
+- **R2**: Replaced "lazy ref" with state-driven readiness (Architecture
+  decision 6). Added `EditorLayout.tsx`, `Editor.tsx`, `MilkdownEditor.tsx`,
+  `linting-plugin/types.ts`, and `app/page.tsx` to the modified-files
+  list. New Task 6 covers the type plumbing.
+- **R3**: Capability flags are computed synchronously on the main
+  thread from rule metadata (`engine` field, `isDocumentLintRule` type
+  guard). The proxy reads its metadata cache; no round-trip needed.
+  Recorded in Architecture decision 4 (renumbered).
+- **R4**: Added `WorkerDisposedError` sentinel. `decoration-plugin.ts`
+  wraps each awaited `runBatch` call in `try/catch` and treats the
+  sentinel as silent cancel; other errors surface via
+  `notificationManager.warning(...)`. Captured in Architecture decision
+  8 and Task 5.
+
+**Adjusted (partial)**
+
+- **R5**: Reworded the NLP scope decision (Architecture decision 2).
+  We don't claim `web-nlp-client.ts` is unreachable from a Worker; we
+  state that keeping both NLP paths on the main thread is a deliberate
+  scope choice for parity / minimal surface change.
+
+**Confirmed (no change needed)**
+
+- A: Worker creation is viable in this Next 16 + Turbopack + Electron
+  setup (CSP + tsconfig + bundle script verified).
+- B: version-in-payload is adequate for cancellation.
+- D: structured-clone size is safe today; chunking captured as a
+  forward-compat risk only.
+- F: `typeof window` check is sufficient given state-driven readiness.
+
+### Iteration 2 — Codex re-review (2026-05-06)
+
+Codex returned **NEEDS_REVISION** with 2 IMPORTANT findings (R6, R7)
+and 1 SUGGESTION (R8). All R1–R4 fixes were verified correct.
+
+**Accepted**
+
+- **R6**: Reshaped the protocol into `WorkerRequest` (always carries
+  `correlationId`) and `WorkerEvent` (tagged union: `READY` without
+  `correlationId`, `RESPONSE`, `ERROR`). Added explicit Task 3
+  bullets for `readyPromise`, message buffer flushing on READY, and
+  dispose-before-READY behavior (worker terminated, buffer cleared,
+  pending requests rejected, `readyPromise` itself rejects with
+  `WorkerDisposedError`).
+- **R7**: Introduced `WorkerStaleError` as a separate sentinel from
+  `WorkerDisposedError`. Stale responses (version mismatch) and
+  in-flight cancellations both reject with `WorkerStaleError`.
+  Caller-side `version === processingVersion` guards are
+  **preserved** post-await (belt-and-braces against proxy/plugin
+  ordering races). Added `proxy.cancelInFlight()` and wired it into
+  `decoration-plugin.ts` `apply()` for `enabled=false`,
+  manual-refresh, and mode-change paths.
+
+**Adjusted (partial)**
+
+- **R8**: Reworded Architecture decision 7. The plan no longer claims
+  `RuleRunner` "satisfies" `RuleRunnerLike`; it states explicitly that
+  the proxy is the only `RuleRunnerLike` impl in the plugin path, and
+  that the concrete `RuleRunner` is retained inside the worker and for
+  non-plugin call sites without the new methods.
+
+### Iteration 3 — Codex final review (2026-05-06)
+
+Codex confirmed R6/R7/R8 are properly addressed and the plan is
+implementable. Returned **NEEDS_REVISION** with one remaining
+IMPORTANT finding:
+
+**Accepted**
+
+- **R9** (IMPORTANT): Added
+  `packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts`
+  to the modified-files list and to Task 6. Without this, callers
+  passing the proxy into `linting(...)` would hit a TypeScript
+  mismatch because `LintingOptions.ruleRunner` was still typed as
+  `RuleRunner | null`.
+
+**Trimmed for YAGNI (per Codex's "safe to drop" hint)**
+
+- Dropped the separate `worker/handle-message.ts` extraction. The
+  worker entry point now wires `self.onmessage` directly. The
+  protocol unit test is replaced by a proxy-side test (`proxy.test.ts`)
+  that mocks `globalThis.Worker` — it covers `runBatch`, version
+  filtering, `cancelInFlight`, and dispose-before-READY without
+  needing the extra extraction.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,10 @@ const config = [
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
       "@typescript-eslint/no-unused-expressions": "warn",
       "react-hooks/rules-of-hooks": "warn",
       "react-hooks/set-state-in-effect": "warn",

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -1,18 +1,21 @@
 import type { EditorView } from "@milkdown/prose/view";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-import { RuleRunner } from "@/lib/linting/rule-runner";
 import type { LintIssue, Severity } from "@/lib/linting/types";
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
 import { RULE_GUIDELINE_MAP } from "@/lib/linting/lint-presets";
-import { getAllRules, createJsonDrivenRules } from "@/lib/linting/rule-registry";
 import type { CorrectionModeId, GuidelineId } from "@/lib/linting/correction-config";
 import { notificationManager } from "@/lib/services/notification-manager";
 import { genjiVocab } from "@/lib/dict/genji-vocab";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
+import {
+  RuleRunnerProxy,
+  type RuleRunnerLike,
+} from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 
 export interface UseLintingResult {
-  ruleRunner: RuleRunner;
+  /** May be `null` until the worker has been spun up after mount. */
+  ruleRunner: RuleRunnerLike | null;
   lintIssues: LintIssue[];
   isLinting: boolean;
   handleLintIssuesUpdated: (issues: LintIssue[]) => void;
@@ -37,25 +40,25 @@ export function useLinting(
   correctionGuidelines?: GuidelineId[],
   correctionMode?: CorrectionModeId,
 ): UseLintingResult {
-  const ruleRunnerRef = useRef<RuleRunner | null>(null);
+  const [ruleRunner, setRuleRunner] = useState<RuleRunnerLike | null>(null);
   const [lintIssues, setLintIssues] = useState<LintIssue[]>([]);
   const [isLinting, setIsLinting] = useState(false);
 
-  // Lazily create and register all rules once
-  if (!ruleRunnerRef.current) {
-    const runner = new RuleRunner();
-    for (const rule of getAllRules()) runner.registerRule(rule);
-    for (const rule of createJsonDrivenRules()) runner.registerRule(rule);
+  // Build the proxy in an effect so the Worker constructor is never invoked
+  // during SSR. The proxy is held in state so its `null → ready` transition
+  // triggers a rerender that propagates the ruleRunner into the editor.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const proxy = new RuleRunnerProxy();
+    proxy.setGuidelineMap(RULE_GUIDELINE_MAP);
+    setRuleRunner(proxy);
+    return () => {
+      proxy.dispose();
+      setRuleRunner(null);
+    };
+  }, []);
 
-    runner.setGuidelineMap(RULE_GUIDELINE_MAP);
-
-    ruleRunnerRef.current = runner;
-  }
-
-  // Guaranteed non-null after the lazy initialization block above
-  const ruleRunner = ruleRunnerRef.current!;
-
-  // Sync rule configs from settings to RuleRunner
+  // Sync rule configs from settings to the runner
   useEffect(() => {
     if (!ruleRunner) return;
 
@@ -96,11 +99,7 @@ export function useLinting(
     if (editorViewInstance && lintingEnabled) {
       import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
         .then(({ updateLintingSettings }) => {
-          updateLintingSettings(
-            editorViewInstance,
-            { ruleRunner: ruleRunnerRef.current },
-            "guideline-change",
-          );
+          updateLintingSettings(editorViewInstance, { ruleRunner }, "guideline-change");
         })
         .catch((err) => {
           console.error("[useLinting] Failed to sync guidelines:", err);
@@ -117,17 +116,17 @@ export function useLinting(
 
   // Force re-run linting on the full document (not just visible paragraphs)
   const refreshLinting = useCallback(() => {
-    if (!editorViewInstance || !lintingEnabled) return;
+    if (!editorViewInstance || !lintingEnabled || !ruleRunner) return;
 
     setIsLinting(true);
     import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
       .then(({ updateLintingSettings }) => {
-        const nlpClient = ruleRunnerRef.current?.hasMorphologicalRules() ? getNlpClient() : null;
+        const nlpClient = ruleRunner.hasMorphologicalRules() ? getNlpClient() : null;
 
         updateLintingSettings(
           editorViewInstance,
           {
-            ruleRunner: ruleRunnerRef.current,
+            ruleRunner,
             nlpClient,
           },
           "manual-refresh",
@@ -137,7 +136,7 @@ export function useLinting(
         console.error("[useLinting] Failed to refresh linting:", err);
         setIsLinting(false);
       });
-  }, [editorViewInstance, lintingEnabled]);
+  }, [editorViewInstance, lintingEnabled, ruleRunner]);
 
   // Bootstrap the Genji noun vocabulary (renderer-side) — Electron only.
   // Fires `refreshLinting` whenever vocab becomes ready or gets reloaded

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -107,10 +107,14 @@ export function useLinting(
     }
   }, [ruleRunner, correctionGuidelines, editorViewInstance, lintingEnabled]);
 
-  // Clear issues when linting is disabled
+  // Clear issues + spinner when linting is disabled. `isLinting` must be
+  // reset here because `handleLintIssuesUpdated` short-circuits while
+  // disabled, so a refresh that was in flight when the user toggled
+  // linting off would otherwise leave the loading state stuck on.
   useEffect(() => {
     if (!lintingEnabled) {
       setLintIssues([]);
+      setIsLinting(false);
     }
   }, [lintingEnabled]);
 

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -36,9 +36,11 @@ export function useLinting(
     { enabled: boolean; severity: Severity; skipDialogue?: boolean }
   >,
   editorViewInstance: EditorView | null,
-  powerSaveMode: boolean = false,
+  // Reserved for future throttling / mode-aware logic; kept in the
+  // signature so callers don't have to be reworked when wired up.
+  _powerSaveMode: boolean = false,
   correctionGuidelines?: GuidelineId[],
-  correctionMode?: CorrectionModeId,
+  _correctionMode?: CorrectionModeId,
 ): UseLintingResult {
   const [ruleRunner, setRuleRunner] = useState<RuleRunnerLike | null>(null);
   const [lintIssues, setLintIssues] = useState<LintIssue[]>([]);

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -55,8 +55,12 @@ export function useLinting(
     proxy.setGuidelineMap(RULE_GUIDELINE_MAP);
     setRuleRunner(proxy);
     return () => {
+      // Don't `setRuleRunner(null)` here — StrictMode's mount → cleanup
+      // → mount cycle would briefly nullify the runner between the two
+      // mounts, causing dependent effects to re-run with `null` for no
+      // reason. On real unmount the component is going away, so the
+      // state write is wasted either way.
       proxy.dispose();
-      setRuleRunner(null);
     };
   }, []);
 

--- a/lib/linting/rule-runner.ts
+++ b/lib/linting/rule-runner.ts
@@ -199,6 +199,18 @@ export class RuleRunner {
     return false;
   }
 
+  /** Check if any enabled rule is a document-level morphological rule. */
+  hasMorphologicalDocumentRules(): boolean {
+    for (const rule of this.rules.values()) {
+      const config = this.configs.get(rule.id);
+      if (!config?.enabled) continue;
+      if (isMorphologicalDocumentLintRule(rule)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Returns all rules for the given engine type.
    * Engine field acts as implementation metadata, not architectural boundary.

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -259,7 +259,10 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           const tokensByText = new Map<string, ReadonlyArray<Token>>();
 
           async function tokenizeIfNeeded(text: string): Promise<ReadonlyArray<Token> | undefined> {
-            if (!useTokens) return undefined;
+            // Re-check `nlpErrorFired` on every call so the first failure
+            // in a batch short-circuits the rest — otherwise a long doc
+            // with a broken NLP backend incurs one failed IPC per paragraph.
+            if (!useTokens || nlpErrorFired) return undefined;
             const cached = tokenCache.get(text);
             if (cached) return cached;
             try {
@@ -280,12 +283,16 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           // Find paragraphs that need fresh per-paragraph rule execution.
           const uncachedParagraphs = targetParagraphs.filter((p) => !issueCache.has(p.text));
 
-          // Pre-tokenize all paragraphs we'll send to the runner. Doing
-          // this in a single pass means tokenCache hits dominate after
-          // the first run.
+          // Per-paragraph morph rules need tokens for uncached paragraphs only
+          // (cached results are reused). Document-level morph rules need tokens
+          // for the full document. Pre-tokenize the union — the second case is
+          // skipped when no document-level morph rule is enabled, avoiding a
+          // full-document NLP sweep on every keystroke.
           const allTokenTexts = new Set<string>();
           for (const p of uncachedParagraphs) allTokenTexts.add(p.text);
-          for (const p of allParagraphs) allTokenTexts.add(p.text);
+          if (currentRuleRunner.hasMorphologicalDocumentRules()) {
+            for (const p of allParagraphs) allTokenTexts.add(p.text);
+          }
           for (const text of allTokenTexts) {
             if (version !== processingVersion) return;
             const tokens = await tokenizeIfNeeded(text);

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -186,6 +186,11 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
             issueCache.clear();
             tokenCache.clear();
             documentIssueCache = null;
+            // Bump the version so any in-flight async tokenization /
+            // runBatch awaits bail at their next `version !==
+            // processingVersion` check, preventing decorations from
+            // being repopulated after the user disabled linting.
+            processingVersion++;
           }
           const updated: LintingPluginState = {
             decorations: pluginState.decorations,

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -304,6 +304,11 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           // Build the per-paragraph batch (uncached only). The runner
           // will route through the worker for L1 + main thread for L2
           // morph; results merge transparently.
+          //
+          // On a real (non-cancellation) error we log and fall through
+          // rather than `return`-ing — otherwise the failure leaves
+          // `isLinting` stuck because `onIssuesUpdated` is never called
+          // and the "全文を再検査" control sticks in its loading state.
           if (uncachedParagraphs.length > 0) {
             const perParaInputs = uncachedParagraphs.map((p) => ({
               text: p.text,
@@ -317,18 +322,14 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
                 version,
               });
               if (version !== processingVersion) return;
-              // Map index → text so we can populate issueCache by text.
-              const indexToText = new Map<number, string>();
-              for (const p of uncachedParagraphs) indexToText.set(p.index, p.text);
               for (const p of uncachedParagraphs) {
-                const text = p.text;
                 const issues = resp.perParagraph.get(p.index) ?? [];
-                issueCache.set(text, issues);
+                issueCache.set(p.text, issues);
               }
             } catch (err) {
               if (isSilentCancelError(err)) return;
               console.error("[Linting] per-paragraph runBatch failed:", err);
-              return;
+              // Fall through with cached results so isLinting clears.
             }
           }
 
@@ -353,7 +354,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
             } catch (err) {
               if (isSilentCancelError(err)) return;
               console.error("[Linting] document runBatch failed:", err);
-              return;
+              // Fall through with documentIssueCache=null so isLinting clears.
             }
           }
 

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -9,14 +9,20 @@
 import { Plugin, PluginKey } from "@milkdown/prose/state";
 import { Decoration, DecorationSet } from "@milkdown/prose/view";
 import type { EditorView } from "@milkdown/prose/view";
-import type { RuleRunner, LintIssue, Severity } from "@/lib/linting";
+import type { LintIssue, Severity } from "@/lib/linting";
 import type { INlpClient } from "@/lib/nlp-client/types";
 import type { Token } from "@/lib/nlp-client/types";
 import type { IgnoredCorrection } from "@/lib/project/project-types";
 import { LRUCache } from "@/lib/utils/lru-cache";
 import { hashString } from "@/lib/utils/hash-string";
 import { getAtomOffset, collectParagraphs } from "../shared/paragraph-helpers";
-import type { LintingPluginState, LintingPluginOptions, LintingSettingsUpdate } from "./types";
+import type {
+  LintingPluginState,
+  LintingPluginOptions,
+  LintingSettingsUpdate,
+  RuleRunnerLike,
+} from "./types";
+import { isSilentCancelError } from "./worker/protocol";
 
 export const lintingKey = new PluginKey<LintingPluginState>("linting");
 
@@ -60,7 +66,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
   let processingVersion = 0;
 
   // Current ruleRunner reference (updated dynamically via setMeta)
-  let currentRuleRunner: RuleRunner | null = ruleRunner;
+  let currentRuleRunner: RuleRunnerLike | null = ruleRunner;
 
   // Current NLP client reference (updated dynamically via setMeta)
   let currentNlpClient: INlpClient | null = nlpClient ?? null;
@@ -147,6 +153,8 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
                 tokenCache.clear();
                 documentIssueCache = null;
                 pendingFullScan = true;
+                // Drop any in-flight worker batch — its results would be stale.
+                currentRuleRunner?.cancelInFlight();
                 break;
               case "rule-config-change":
               case "guideline-change":
@@ -154,6 +162,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
                 issueCache.clear();
                 documentIssueCache = null;
                 pendingFullScan = true;
+                currentRuleRunner?.cancelInFlight();
                 break;
               case "text-edit":
                 // Re-run affected paragraphs only (handled via normal doc-changed path)
@@ -166,6 +175,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
             tokenCache.clear();
             documentIssueCache = null;
             pendingFullScan = true;
+            currentRuleRunner?.cancelInFlight();
           }
           // Update ignoredCorrections list if provided
           if ("ignoredCorrections" in meta) {
@@ -184,6 +194,8 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           // Clear decorations when disabled
           if (meta.enabled === false) {
             updated.decorations = DecorationSet.empty;
+            // Stop any in-flight worker batch — we no longer want its results.
+            currentRuleRunner?.cancelInFlight();
           }
           return updated;
         }
@@ -235,89 +247,106 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           const hasMorphRules = currentRuleRunner.hasMorphologicalRules();
           const nlp = currentNlpClient;
 
-          // Process uncached paragraphs (per-paragraph rules)
+          // Tokenize the paragraphs that morphological rules need.
+          // Tokenization stays on the main thread because the NLP client
+          // depends on `window.electronAPI.nlp.*` (Worker-unreachable).
+          //
+          // We tokenize uncached paragraphs eagerly. For paragraphs that
+          // are cached for per-paragraph rules but still needed for
+          // document-level morph rules, we look up tokenCache and
+          // tokenize the misses.
+          const useTokens = hasMorphRules && nlp && !nlpErrorFired;
+          const tokensByText = new Map<string, ReadonlyArray<Token>>();
+
+          async function tokenizeIfNeeded(text: string): Promise<ReadonlyArray<Token> | undefined> {
+            if (!useTokens) return undefined;
+            const cached = tokenCache.get(text);
+            if (cached) return cached;
+            try {
+              const fresh = await nlp!.tokenizeParagraph(text);
+              tokenCache.set(text, fresh);
+              return fresh;
+            } catch (err) {
+              const error = err instanceof Error ? err : new Error(String(err));
+              console.error("[Linting] NLP tokenization failed — L2 rules disabled:", error);
+              if (!nlpErrorFired) {
+                nlpErrorFired = true;
+                onNlpError?.(error);
+              }
+              return undefined;
+            }
+          }
+
+          // Find paragraphs that need fresh per-paragraph rule execution.
           const uncachedParagraphs = targetParagraphs.filter((p) => !issueCache.has(p.text));
 
-          if (uncachedParagraphs.length > 0) {
-            for (const paragraph of uncachedParagraphs) {
-              if (version !== processingVersion) return;
+          // Pre-tokenize all paragraphs we'll send to the runner. Doing
+          // this in a single pass means tokenCache hits dominate after
+          // the first run.
+          const allTokenTexts = new Set<string>();
+          for (const p of uncachedParagraphs) allTokenTexts.add(p.text);
+          for (const p of allParagraphs) allTokenTexts.add(p.text);
+          for (const text of allTokenTexts) {
+            if (version !== processingVersion) return;
+            const tokens = await tokenizeIfNeeded(text);
+            if (tokens) tokensByText.set(text, tokens);
+          }
 
-              let issues: LintIssue[];
-              if (hasMorphRules && nlp && !nlpErrorFired) {
-                // Get or compute tokens for L2 rules
-                let tokens = tokenCache.get(paragraph.text);
-                if (!tokens) {
-                  try {
-                    tokens = await nlp.tokenizeParagraph(paragraph.text);
-                    tokenCache.set(paragraph.text, tokens);
-                  } catch (err) {
-                    const error = err instanceof Error ? err : new Error(String(err));
-                    console.error("[Linting] NLP tokenization failed — L2 rules disabled:", error);
-                    // Fire the error callback once per failure episode
-                    if (!nlpErrorFired) {
-                      nlpErrorFired = true;
-                      onNlpError?.(error);
-                    }
-                    // Fall back to L1-only rules (no tokens)
-                    issues = currentRuleRunner.runAll(paragraph.text);
-                    issueCache.set(paragraph.text, issues);
-                    continue;
-                  }
-                }
-                issues = currentRuleRunner.runAllWithTokens(paragraph.text, tokens);
-              } else {
-                // No NLP available or NLP has failed — run L1 rules only
-                issues = currentRuleRunner.runAll(paragraph.text);
+          if (version !== processingVersion) return;
+
+          // Build the per-paragraph batch (uncached only). The runner
+          // will route through the worker for L1 + main thread for L2
+          // morph; results merge transparently.
+          if (uncachedParagraphs.length > 0) {
+            const perParaInputs = uncachedParagraphs.map((p) => ({
+              text: p.text,
+              index: p.index,
+              tokens: tokensByText.get(p.text),
+            }));
+            try {
+              const resp = await currentRuleRunner.runBatch({
+                paragraphs: perParaInputs,
+                mode: "per-paragraph",
+                version,
+              });
+              if (version !== processingVersion) return;
+              // Map index → text so we can populate issueCache by text.
+              const indexToText = new Map<number, string>();
+              for (const p of uncachedParagraphs) indexToText.set(p.index, p.text);
+              for (const p of uncachedParagraphs) {
+                const text = p.text;
+                const issues = resp.perParagraph.get(p.index) ?? [];
+                issueCache.set(text, issues);
               }
-              issueCache.set(paragraph.text, issues);
+            } catch (err) {
+              if (isSilentCancelError(err)) return;
+              console.error("[Linting] per-paragraph runBatch failed:", err);
+              return;
             }
           }
 
           if (version !== processingVersion) return;
 
-          // Run document-level rules on all paragraphs (always recompute)
-          // Document-level rules are fast (L1/L2) so recomputing is acceptable
+          // Document-level rules always re-run against all paragraphs.
           documentIssueCache = null;
           if (currentRuleRunner.hasDocumentRules()) {
-            if (hasMorphRules && nlp && !nlpErrorFired) {
-              // Tokenize all paragraphs for morphological document rules (use cache where possible)
-              const paragraphsWithTokens = [];
-              let docNlpFailed = false;
-              for (const p of allParagraphs) {
-                if (version !== processingVersion) return;
-                let tokens = tokenCache.get(p.text);
-                if (!tokens) {
-                  try {
-                    tokens = await nlp.tokenizeParagraph(p.text);
-                    tokenCache.set(p.text, tokens);
-                  } catch (err) {
-                    const error = err instanceof Error ? err : new Error(String(err));
-                    console.error(
-                      "[Linting] NLP tokenization failed during document rules — L2 rules disabled:",
-                      error,
-                    );
-                    if (!nlpErrorFired) {
-                      nlpErrorFired = true;
-                      onNlpError?.(error);
-                    }
-                    docNlpFailed = true;
-                    break;
-                  }
-                }
-                paragraphsWithTokens.push({ text: p.text, index: p.index, tokens });
-              }
-              if (!docNlpFailed) {
-                documentIssueCache = currentRuleRunner.runDocumentWithTokens(paragraphsWithTokens);
-              } else {
-                // Fall back to L1-only document rules
-                documentIssueCache = currentRuleRunner.runDocument(
-                  allParagraphs.map((p) => ({ text: p.text, index: p.index })),
-                );
-              }
-            } else {
-              documentIssueCache = currentRuleRunner.runDocument(
-                allParagraphs.map((p) => ({ text: p.text, index: p.index })),
-              );
+            const docInputs = allParagraphs.map((p) => ({
+              text: p.text,
+              index: p.index,
+              tokens: tokensByText.get(p.text),
+            }));
+            try {
+              const resp = await currentRuleRunner.runBatch({
+                paragraphs: docInputs,
+                mode: "document",
+                version,
+              });
+              if (version !== processingVersion) return;
+              documentIssueCache = resp.document;
+            } catch (err) {
+              if (isSilentCancelError(err)) return;
+              console.error("[Linting] document runBatch failed:", err);
+              return;
             }
           }
 

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
@@ -5,21 +5,24 @@
 
 import type { EditorView } from "@milkdown/prose/view";
 import { $prose } from "@milkdown/utils";
-import type { RuleRunner, LintIssue } from "@/lib/linting";
+import type { LintIssue } from "@/lib/linting";
 import type { INlpClient } from "@/lib/nlp-client/types";
 import type { IgnoredCorrection } from "@/lib/project/project-types";
 import type { ConfigChangeReason } from "@/lib/linting/correction-config";
-import type { LintingSettingsUpdate } from "./types";
+import type { LintingSettingsUpdate, RuleRunnerLike } from "./types";
 import { createLintingPlugin, lintingKey } from "./decoration-plugin";
 
 // Export the plugin key for external use
 export { lintingKey } from "./decoration-plugin";
+export type { RuleRunnerLike } from "./types";
+export { RuleRunnerProxy } from "./worker/rule-runner-proxy";
+export { WorkerStaleError, WorkerDisposedError, isSilentCancelError } from "./worker/protocol";
 
 export interface LintingOptions {
   /** Enable/disable linting - 有効/無効 */
   enabled?: boolean;
-  /** RuleRunner instance for executing lint rules */
-  ruleRunner?: RuleRunner | null;
+  /** RuleRunner-like instance (typically `RuleRunnerProxy`) for executing lint rules. */
+  ruleRunner?: RuleRunnerLike | null;
   /** NLP client for morphological analysis (L2 rules) */
   nlpClient?: INlpClient | null;
   /** Ignored corrections to filter out from decorations */

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
@@ -5,19 +5,20 @@
 
 import type { DecorationSet } from "@milkdown/prose/view";
 import type { LintIssue } from "@/lib/linting";
-import type { RuleRunner } from "@/lib/linting";
 import type { INlpClient } from "@/lib/nlp-client/types";
 import type { IgnoredCorrection } from "@/lib/project/project-types";
 import type { ConfigChangeReason } from "@/lib/linting/correction-config";
+import type { RuleRunnerLike } from "./worker/protocol";
 
 export type { ConfigChangeReason };
+export type { RuleRunnerLike };
 
 /**
  * Options for the linting ProseMirror plugin
  */
 export interface LintingPluginOptions {
   enabled: boolean;
-  ruleRunner: RuleRunner | null;
+  ruleRunner: RuleRunnerLike | null;
   nlpClient?: INlpClient | null;
   ignoredCorrections?: IgnoredCorrection[];
   onIssuesUpdated?: (issues: LintIssue[]) => void;
@@ -41,7 +42,7 @@ export interface LintingPluginState {
  */
 export interface LintingSettingsUpdate {
   enabled?: boolean;
-  ruleRunner?: RuleRunner | null;
+  ruleRunner?: RuleRunnerLike | null;
   nlpClient?: INlpClient | null;
   /** @deprecated Use changeReason instead */
   forceFullScan?: boolean;

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for `RuleRunnerProxy`.
+ *
+ * Mocks the `Worker` constructor and drives the proxy synchronously
+ * through fake post-message events. Exercises the round-trip,
+ * stale-by-version filtering, `cancelInFlight`, and the
+ * dispose-before-READY path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { RuleRunnerProxy } from "../rule-runner-proxy";
+import {
+  type WorkerEvent,
+  type WorkerRequest,
+  WorkerDisposedError,
+  WorkerStaleError,
+} from "../protocol";
+import type { LintIssue } from "@/lib/linting/types";
+
+// ----------------------------------------------------------------
+// Fake Worker
+// ----------------------------------------------------------------
+
+class FakeWorker {
+  onmessage: ((e: MessageEvent<WorkerEvent>) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  onmessageerror: (() => void) | null = null;
+  /** All messages the proxy has posted into the worker, in order. */
+  readonly received: WorkerRequest[] = [];
+  terminated = false;
+
+  postMessage(msg: WorkerRequest): void {
+    this.received.push(msg);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  /** Helper for tests: deliver a fake event to the proxy. */
+  emit(evt: WorkerEvent): void {
+    this.onmessage?.(new MessageEvent("message", { data: evt }));
+  }
+}
+
+let fakeWorker: FakeWorker;
+
+beforeEach(() => {
+  fakeWorker = new FakeWorker();
+});
+
+afterEach(() => {
+  fakeWorker.terminate();
+});
+
+function makeProxy(): RuleRunnerProxy {
+  return new RuleRunnerProxy(() => fakeWorker as unknown as Worker);
+}
+
+function emitReady(): void {
+  fakeWorker.emit({ type: "READY" });
+}
+
+function fakeIssue(ruleId: string, from = 0, to = 1): LintIssue {
+  return {
+    ruleId,
+    severity: "warning",
+    message: "test",
+    messageJa: "テスト",
+    from,
+    to,
+  };
+}
+
+// ----------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------
+
+describe("RuleRunnerProxy", () => {
+  it("buffers config messages until READY, then flushes them", () => {
+    const proxy = makeProxy();
+    proxy.setConfig("rule-x", { enabled: true, severity: "warning" });
+    expect(fakeWorker.received).toHaveLength(0);
+    emitReady();
+    expect(fakeWorker.received).toHaveLength(1);
+    expect(fakeWorker.received[0].type).toBe("SET_CONFIG");
+    proxy.dispose();
+  });
+
+  it("round-trips a runBatch request and resolves with worker issues", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    const promise = proxy.runBatch({
+      paragraphs: [{ text: "hello", index: 0 }],
+      mode: "per-paragraph",
+      version: 1,
+    });
+
+    // Worker message was posted with mode = per-paragraph.
+    const sentRunBatch = fakeWorker.received.find((m) => m.type === "RUN_BATCH");
+    expect(sentRunBatch).toBeDefined();
+    expect(sentRunBatch?.type === "RUN_BATCH" && sentRunBatch.mode).toBe("per-paragraph");
+
+    // Worker replies.
+    const correlationId = sentRunBatch?.type === "RUN_BATCH" ? sentRunBatch.correlationId : -1;
+    fakeWorker.emit({
+      type: "RESPONSE",
+      correlationId,
+      version: 1,
+      perParagraph: [[0, [fakeIssue("rule-a")]]],
+      document: [],
+    });
+
+    const resp = await promise;
+    expect(resp.perParagraph.get(0)).toEqual([fakeIssue("rule-a")]);
+    expect(resp.document.size).toBe(0);
+
+    proxy.dispose();
+  });
+
+  it("rejects stale-by-version responses with WorkerStaleError", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    // Start version 1, then version 2 — version 1's pending entry should
+    // be cancelled eagerly when v2 arrives.
+    const v1Promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+    const v2Promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 2 })
+      .catch((e) => e);
+
+    // v1 should already be rejected (eager cancel).
+    const v1 = await v1Promise;
+    expect(v1).toBeInstanceOf(WorkerStaleError);
+
+    // v2 is still pending; deliver its response.
+    const v2BatchMsg = fakeWorker.received.filter(
+      (m) => m.type === "RUN_BATCH" && m.version === 2,
+    )[0];
+    if (v2BatchMsg?.type !== "RUN_BATCH") throw new Error("unreachable");
+    fakeWorker.emit({
+      type: "RESPONSE",
+      correlationId: v2BatchMsg.correlationId,
+      version: 2,
+      perParagraph: [],
+      document: [],
+    });
+
+    const v2 = await v2Promise;
+    expect(v2 instanceof Error).toBe(false); // resolved, not rejected
+    proxy.dispose();
+  });
+
+  it("cancelInFlight rejects all pending with WorkerStaleError but keeps the worker alive", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    const promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+
+    proxy.cancelInFlight();
+    const result = await promise;
+    expect(result).toBeInstanceOf(WorkerStaleError);
+    expect(fakeWorker.terminated).toBe(false);
+
+    // Subsequent runBatch should still work.
+    const next = proxy.runBatch({ paragraphs: [], mode: "per-paragraph", version: 2 });
+    const batchMsg = fakeWorker.received.find((m) => m.type === "RUN_BATCH" && m.version === 2);
+    if (batchMsg?.type !== "RUN_BATCH") throw new Error("unreachable");
+    fakeWorker.emit({
+      type: "RESPONSE",
+      correlationId: batchMsg.correlationId,
+      version: 2,
+      perParagraph: [],
+      document: [],
+    });
+    await expect(next).resolves.toBeDefined();
+    proxy.dispose();
+  });
+
+  it("dispose-before-READY rejects pending runBatch with WorkerDisposedError", async () => {
+    const proxy = makeProxy();
+    // Don't emit READY.
+    const promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+
+    proxy.dispose();
+    const result = await promise;
+    expect(result).toBeInstanceOf(WorkerDisposedError);
+    expect(fakeWorker.terminated).toBe(true);
+  });
+
+  it("propagates worker ERROR with correlationId to the matching pending request", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    const promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+
+    const batchMsg = fakeWorker.received.find((m) => m.type === "RUN_BATCH");
+    if (batchMsg?.type !== "RUN_BATCH") throw new Error("unreachable");
+    fakeWorker.emit({
+      type: "ERROR",
+      correlationId: batchMsg.correlationId,
+      error: { name: "RuleError", message: "boom" },
+    });
+
+    const err = await promise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("RuleError");
+    expect((err as Error).message).toBe("boom");
+    proxy.dispose();
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
@@ -196,6 +196,37 @@ describe("RuleRunnerProxy", () => {
     expect(fakeWorker.terminated).toBe(true);
   });
 
+  it("cancelInFlight while runBatch is awaiting READY rejects the batch and never posts to the worker", async () => {
+    const proxy = makeProxy();
+    // Do NOT emit READY — runBatch should park its pending entry while
+    // awaiting the readyPromise.
+    const promise = proxy
+      .runBatch({
+        paragraphs: [{ text: "x", index: 0 }],
+        mode: "per-paragraph",
+        version: 1,
+      })
+      .catch((e) => e);
+
+    // Cancel before the worker is ready. The pending entry must already
+    // exist — otherwise cancelInFlight has nothing to reject.
+    proxy.cancelInFlight();
+
+    // Now flush READY. The proxy must NOT post the cancelled batch to
+    // the worker.
+    emitReady();
+    // Yield once so any post-await microtasks settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const result = await promise;
+    expect(result).toBeInstanceOf(WorkerStaleError);
+    const sentBatches = fakeWorker.received.filter((m) => m.type === "RUN_BATCH");
+    expect(sentBatches).toHaveLength(0);
+
+    proxy.dispose();
+  });
+
   it("propagates worker ERROR with correlationId to the matching pending request", async () => {
     const proxy = makeProxy();
     emitReady();

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
@@ -247,6 +247,43 @@ describe("RuleRunnerProxy", () => {
     proxy.dispose();
   });
 
+  it("uncorrelated ERROR after READY poisons the proxy so subsequent runBatch fails fast", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    fakeWorker.emit({
+      type: "ERROR",
+      error: { name: "WorkerError", message: "post-ready boom" },
+    });
+
+    const next = await proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+    expect(next).toBeInstanceOf(Error);
+    expect((next as Error).message).toBe("post-ready boom");
+    // poison() terminates the worker.
+    expect(fakeWorker.terminated).toBe(true);
+
+    proxy.dispose();
+  });
+
+  it("worker.onerror poisons the proxy so subsequent runBatch fails fast", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    // Simulate the underlying Worker emitting an `error` event.
+    fakeWorker.onerror?.(new ErrorEvent("error", { message: "worker crashed" }));
+
+    const next = await proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+    expect(next).toBeInstanceOf(Error);
+    expect((next as Error).message).toBe("worker crashed");
+    expect(fakeWorker.terminated).toBe(true);
+
+    proxy.dispose();
+  });
+
   it("propagates worker ERROR with correlationId to the matching pending request", async () => {
     const proxy = makeProxy();
     emitReady();

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
@@ -227,6 +227,26 @@ describe("RuleRunnerProxy", () => {
     proxy.dispose();
   });
 
+  it("uncorrelated ERROR before READY rejects readyPromise so subsequent runBatch fails fast instead of hanging", async () => {
+    const proxy = makeProxy();
+    // Do NOT emit READY. Send an uncorrelated ERROR (worker startup
+    // failed before posting READY).
+    fakeWorker.emit({
+      type: "ERROR",
+      error: { name: "WorkerError", message: "init failed" },
+    });
+
+    // The proxy is now in a poisoned state. Any new runBatch must
+    // reject promptly via the rejected readyPromise rather than hang.
+    const next = await proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+    expect(next).toBeInstanceOf(Error);
+    expect((next as Error).message).toBe("init failed");
+
+    proxy.dispose();
+  });
+
   it("propagates worker ERROR with correlationId to the matching pending request", async () => {
     const proxy = makeProxy();
     emitReady();

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
@@ -38,9 +38,12 @@ function post(msg: WorkerEvent): void {
 }
 
 function serialize(map: Map<number, LintIssue[]>): SerializedIssueMap {
+  // Drop empty entries — the main thread treats missing keys as "no
+  // issues", and skipping them keeps the structured-clone payload small
+  // for long documents.
   const entries: SerializedIssueMap = [];
   map.forEach((issues, idx) => {
-    entries.push([idx, issues]);
+    if (issues.length > 0) entries.push([idx, issues]);
   });
   return entries;
 }
@@ -66,7 +69,8 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
 
         if (runPer) {
           for (const p of paragraphs) {
-            perParagraph.set(p.index, runner.runAll(p.text));
+            const issues = runner.runAll(p.text);
+            if (issues.length > 0) perParagraph.set(p.index, issues);
           }
         }
         const documentMap: Map<number, LintIssue[]> =

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
@@ -1,0 +1,115 @@
+/// <reference lib="webworker" />
+
+/**
+ * Lint Web Worker entry point.
+ *
+ * Hosts only non-morphological rules (the JSON L1 set). Morphological
+ * rules stay on the main thread because their dependencies
+ * (`window.electronAPI.dict.*` via `genjiVocab`) are unreachable here.
+ *
+ * See plan: docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
+ */
+
+import { RuleRunner } from "@/lib/linting/rule-runner";
+import { createJsonDrivenRules } from "@/lib/linting/rule-registry";
+import { RULE_GUIDELINE_MAP } from "@/lib/linting/lint-presets";
+import type { LintIssue } from "@/lib/linting/types";
+import { isMorphologicalDocumentLintRule, isMorphologicalLintRule } from "@/lib/linting/types";
+
+import type { SerializedIssueMap, WorkerEvent, WorkerRequest } from "./protocol";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+// Module scope acts as the worker singleton — Workers never re-instantiate.
+const runner = new RuleRunner();
+
+for (const rule of createJsonDrivenRules()) {
+  if (isMorphologicalLintRule(rule) || isMorphologicalDocumentLintRule(rule)) {
+    // Defensive: morph rules have IPC-only dependencies, skip if any sneak in.
+    continue;
+  }
+  runner.registerRule(rule);
+}
+
+runner.setGuidelineMap(RULE_GUIDELINE_MAP);
+
+function post(msg: WorkerEvent): void {
+  self.postMessage(msg);
+}
+
+function serialize(map: Map<number, LintIssue[]>): SerializedIssueMap {
+  const entries: SerializedIssueMap = [];
+  map.forEach((issues, idx) => {
+    entries.push([idx, issues]);
+  });
+  return entries;
+}
+
+self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  const msg = event.data;
+  try {
+    switch (msg.type) {
+      case "SET_CONFIG":
+        runner.setConfig(msg.ruleId, msg.config);
+        return;
+      case "SET_ACTIVE_GUIDELINES":
+        runner.setActiveGuidelines(msg.guidelines);
+        return;
+      case "SET_GUIDELINE_MAP":
+        runner.setGuidelineMap(new Map(msg.entries));
+        return;
+      case "RUN_BATCH": {
+        const { correlationId, version, paragraphs, mode } = msg;
+        const perParagraph = new Map<number, LintIssue[]>();
+        const runPer = mode === "per-paragraph" || mode === "both";
+        const runDoc = mode === "document" || mode === "both";
+
+        if (runPer) {
+          for (const p of paragraphs) {
+            perParagraph.set(p.index, runner.runAll(p.text));
+          }
+        }
+        const documentMap: Map<number, LintIssue[]> =
+          runDoc && runner.hasDocumentRules()
+            ? runner.runDocument(paragraphs.map((p) => ({ text: p.text, index: p.index })))
+            : new Map();
+
+        post({
+          type: "RESPONSE",
+          correlationId,
+          version,
+          perParagraph: serialize(perParagraph),
+          document: serialize(documentMap),
+        });
+        return;
+      }
+      default: {
+        const _exhaustive: never = msg;
+        void _exhaustive;
+      }
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    post({
+      type: "ERROR",
+      correlationId: "correlationId" in msg ? msg.correlationId : undefined,
+      error: { name: error.name, message: error.message },
+    });
+  }
+};
+
+self.onerror = (e) => {
+  // Surface any uncaught script-level error. correlationId omitted because
+  // there's no specific request to attribute it to.
+  const error = e instanceof ErrorEvent ? e.error : null;
+  post({
+    type: "ERROR",
+    error: error
+      ? { name: error.name ?? "Error", message: error.message ?? String(e) }
+      : { name: "Error", message: String(e) },
+  });
+};
+
+// Signal readiness — must happen after the runner is fully wired so that
+// any queued main-thread requests find an initialized registry.
+post({ type: "READY" });

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
@@ -74,9 +74,7 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
           }
         }
         const documentMap: Map<number, LintIssue[]> =
-          runDoc && runner.hasDocumentRules()
-            ? runner.runDocument(paragraphs.map((p) => ({ text: p.text, index: p.index })))
-            : new Map();
+          runDoc && runner.hasDocumentRules() ? runner.runDocument(paragraphs) : new Map();
 
         post({
           type: "RESPONSE",

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts
@@ -26,6 +26,12 @@ export interface RuleRunnerLike {
   setGuidelineMap(map: Map<string, string | undefined>): void;
   hasMorphologicalRules(): boolean;
   hasDocumentRules(): boolean;
+  /**
+   * True iff at least one enabled document-level rule needs morphological
+   * tokens. Callers use this to decide whether to tokenize cached
+   * paragraphs in addition to the uncached set.
+   */
+  hasMorphologicalDocumentRules(): boolean;
   /** Execute one batched lint pass. */
   runBatch(req: RunBatchRequest): Promise<RunBatchResponse>;
   /**

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts
@@ -1,0 +1,172 @@
+/**
+ * Worker protocol — types shared between the main thread and the lint
+ * Web Worker.
+ *
+ * The worker hosts only non-morphological rules (the JSON L1 set);
+ * morphological rules stay on the main thread (see plan
+ * docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md,
+ * Architecture decision 9).
+ */
+
+import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
+import type { Token } from "@/lib/nlp-client/types";
+
+// -------------------------------------------------------------------------
+// Plugin-facing surface
+// -------------------------------------------------------------------------
+
+/**
+ * Subset of `RuleRunner` used by the linting ProseMirror plugin.
+ * The proxy implements this with a worker behind it; tests can swap in
+ * a fake. Sync metadata methods stay sync; rule execution becomes async.
+ */
+export interface RuleRunnerLike {
+  setConfig(ruleId: string, config: LintRuleConfig): void;
+  setActiveGuidelines(guidelines: string[] | null): void;
+  setGuidelineMap(map: Map<string, string | undefined>): void;
+  hasMorphologicalRules(): boolean;
+  hasDocumentRules(): boolean;
+  /** Execute one batched lint pass. */
+  runBatch(req: RunBatchRequest): Promise<RunBatchResponse>;
+  /**
+   * Reject every in-flight `runBatch` promise with `WorkerStaleError`.
+   * The worker keeps running; subsequent calls succeed normally.
+   */
+  cancelInFlight(): void;
+  /** Terminate the worker; all pending requests reject with `WorkerDisposedError`. */
+  dispose(): void;
+}
+
+// -------------------------------------------------------------------------
+// Run-batch payload
+// -------------------------------------------------------------------------
+
+export interface BatchParagraph {
+  /** Paragraph text (input to L1 regex rules). */
+  text: string;
+  /** Stable index used to key document-level results. */
+  index: number;
+  /**
+   * Pre-computed kuromoji tokens. Only required when the proxy's main-side
+   * morphological rules need them; ignored by the worker (which has no
+   * morphological rules registered).
+   */
+  tokens?: ReadonlyArray<Token>;
+}
+
+/**
+ * What the runner should compute for this batch.
+ *
+ * - `"per-paragraph"`: run only the per-paragraph rules. Caller typically
+ *   supplies the uncached subset.
+ * - `"document"`: run only the document-level rules. Caller typically
+ *   supplies all paragraphs in the document.
+ * - `"both"`: run both passes against the same input. Useful on initial
+ *   load when no cache exists yet.
+ */
+export type BatchMode = "per-paragraph" | "document" | "both";
+
+export interface RunBatchRequest {
+  paragraphs: ReadonlyArray<BatchParagraph>;
+  mode: BatchMode;
+  /** Monotonic version supplied by the caller; the proxy filters stale responses. */
+  version: number;
+  /**
+   * If `false`, skip the worker round-trip. Useful when the caller
+   * wants only main-thread morph results.
+   * Defaults to `true`.
+   */
+  runWorker?: boolean;
+}
+
+export interface RunBatchResponse {
+  /** Issues per paragraph, keyed by `BatchParagraph.index`. */
+  perParagraph: Map<number, LintIssue[]>;
+  /** Document-level issues per paragraph, keyed by `BatchParagraph.index`. */
+  document: Map<number, LintIssue[]>;
+}
+
+// -------------------------------------------------------------------------
+// Wire format
+// -------------------------------------------------------------------------
+
+/**
+ * Serializable form of `runDocument*` results — `Map` does not
+ * structured-clone reliably across all environments, so we send arrays.
+ */
+export type SerializedIssueMap = Array<[number, LintIssue[]]>;
+
+/** Worker → main events. */
+export type WorkerEvent =
+  | { type: "READY" }
+  | {
+      type: "RESPONSE";
+      correlationId: number;
+      version: number;
+      perParagraph: SerializedIssueMap;
+      document: SerializedIssueMap;
+    }
+  | {
+      type: "ERROR";
+      correlationId?: number;
+      error: { name: string; message: string };
+    };
+
+/** Main → worker requests. */
+export type WorkerRequest =
+  | {
+      type: "SET_CONFIG";
+      correlationId: number;
+      ruleId: string;
+      config: LintRuleConfig;
+    }
+  | {
+      type: "SET_ACTIVE_GUIDELINES";
+      correlationId: number;
+      guidelines: string[] | null;
+    }
+  | {
+      type: "SET_GUIDELINE_MAP";
+      correlationId: number;
+      entries: Array<[string, string | undefined]>;
+    }
+  | {
+      type: "RUN_BATCH";
+      correlationId: number;
+      version: number;
+      paragraphs: ReadonlyArray<{ text: string; index: number }>;
+      mode: BatchMode;
+    };
+
+// -------------------------------------------------------------------------
+// Sentinel errors (silent-cancel)
+// -------------------------------------------------------------------------
+
+/**
+ * Thrown when a `runBatch` promise is rejected because a newer request
+ * has superseded it (or `cancelInFlight()` was called). Callers in the
+ * decoration plugin swallow this — no cache write, no decoration dispatch.
+ */
+export class WorkerStaleError extends Error {
+  constructor(message = "Lint batch superseded by a newer request") {
+    super(message);
+    this.name = "WorkerStaleError";
+  }
+}
+
+/**
+ * Thrown when a `runBatch` promise is rejected because the worker has
+ * been terminated (proxy disposed). Treated identically to
+ * `WorkerStaleError` by callers — silent cancel.
+ */
+export class WorkerDisposedError extends Error {
+  constructor(message = "Lint worker has been disposed") {
+    super(message);
+    this.name = "WorkerDisposedError";
+  }
+}
+
+/** True for any silent-cancel sentinel; callers can drop the result. */
+export function isSilentCancelError(err: unknown): boolean {
+  return err instanceof WorkerStaleError || err instanceof WorkerDisposedError;
+}

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
@@ -140,6 +140,10 @@ export class RuleRunnerProxy implements RuleRunnerLike {
     return this.workerHasDocumentRules || this.mainRunner.hasDocumentRules();
   }
 
+  hasMorphologicalDocumentRules(): boolean {
+    return this.mainRunner.hasMorphologicalDocumentRules();
+  }
+
   // ----------------------------------------------------------------
   // RuleRunnerLike — async batch execution
   // ----------------------------------------------------------------

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
@@ -320,6 +320,13 @@ export class RuleRunnerProxy implements RuleRunnerLike {
             entry.reject(err);
           }
           this.pending.clear();
+          // If the worker errored before posting READY, reject the
+          // readyPromise too. Otherwise any future `runBatch()` call
+          // would hang forever awaiting a worker that is never coming
+          // up.
+          if (!this.ready) {
+            this.rejectReady(err);
+          }
         }
         return;
       }

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
@@ -175,21 +175,11 @@ export class RuleRunnerProxy implements RuleRunnerLike {
       return { perParagraph: mainPerParagraph, document: mainDocument };
     }
 
-    // Wait for worker startup if it hasn't readied yet. If `dispose()`
-    // beats READY, this rejects with `WorkerDisposedError`.
-    if (!this.ready) {
-      try {
-        await this.readyPromise;
-      } catch (err) {
-        if (err instanceof WorkerDisposedError) throw err;
-        throw err;
-      }
-    }
-
-    if (this.disposed) {
-      throw new WorkerDisposedError();
-    }
-
+    // Register the pending entry BEFORE awaiting `readyPromise`, so
+    // `cancelInFlight()` and the stale-by-version sweep can see batches
+    // that are still waiting on worker startup. Without this, a toggle
+    // before READY would leave the batch unreachable and it would fire
+    // anyway once the worker came up.
     const correlationId = this.nextId();
     const workerResponse = new Promise<RunBatchResponse>((resolve, reject) => {
       this.pending.set(correlationId, {
@@ -200,6 +190,34 @@ export class RuleRunnerProxy implements RuleRunnerLike {
         mainDocument,
       });
     });
+
+    // Wait for worker startup if it hasn't readied yet. If `dispose()`
+    // beats READY, this rejects with `WorkerDisposedError`.
+    if (!this.ready) {
+      try {
+        await this.readyPromise;
+      } catch (err) {
+        // If we were already cancelled while waiting, drop silently —
+        // the rejection has already been handed to the caller via the
+        // pending entry.
+        if (!this.pending.has(correlationId)) return workerResponse;
+        this.pending.delete(correlationId);
+        if (err instanceof WorkerDisposedError) throw err;
+        throw err;
+      }
+    }
+
+    // The pending entry may have been cancelled (cancelInFlight or
+    // stale-version sweep) during the await. If so, the promise has
+    // already rejected — just return it.
+    if (!this.pending.has(correlationId)) {
+      return workerResponse;
+    }
+
+    if (this.disposed) {
+      this.pending.delete(correlationId);
+      throw new WorkerDisposedError();
+    }
 
     this.send({
       type: "RUN_BATCH",
@@ -384,7 +402,16 @@ function mergeIssueMaps(
   const out = new Map<number, LintIssue[]>(a);
   for (const [idx, issues] of b) {
     const existing = out.get(idx);
-    out.set(idx, existing ? [...existing, ...issues] : issues);
+    if (existing) {
+      // Preserve the global-by-`from` ordering that callers (corrections
+      // list, navigation) depend on when both worker L1 and main-thread
+      // morph rules contribute issues to the same paragraph.
+      const merged = [...existing, ...issues];
+      merged.sort((x, y) => x.from - y.from);
+      out.set(idx, merged);
+    } else {
+      out.set(idx, issues);
+    }
   }
   return out;
 }

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
@@ -62,6 +62,14 @@ export class RuleRunnerProxy implements RuleRunnerLike {
 
   private ready = false;
   private disposed = false;
+  /**
+   * Non-null once the worker has hit a fatal failure (uncorrelated
+   * ERROR, `onerror`, `messageerror`). Set on either the pre-READY or
+   * post-READY path. Once set, the proxy is poisoned: `runBatch` and
+   * other API calls fail fast with this error instead of attempting
+   * to talk to a dead worker.
+   */
+  private fatalError: Error | null = null;
 
   /** Promise that resolves once the worker has posted READY. */
   readonly readyPromise: Promise<void>;
@@ -95,6 +103,11 @@ export class RuleRunnerProxy implements RuleRunnerLike {
       this.resolveReady = resolve;
       this.rejectReady = reject;
     });
+    // Absorb the rejection so a fatal startup failure doesn't surface
+    // as an unhandled rejection when nothing is awaiting `readyPromise`
+    // yet. Real consumers inside `runBatch` chain their own `await`,
+    // which gets its own rejection.
+    this.readyPromise.catch(() => {});
   }
 
   // ----------------------------------------------------------------
@@ -149,6 +162,9 @@ export class RuleRunnerProxy implements RuleRunnerLike {
   // ----------------------------------------------------------------
 
   async runBatch(req: RunBatchRequest): Promise<RunBatchResponse> {
+    if (this.fatalError) {
+      throw this.fatalError;
+    }
     if (this.disposed) {
       throw new WorkerDisposedError();
     }
@@ -314,19 +330,11 @@ export class RuleRunnerProxy implements RuleRunnerLike {
             entry.reject(err);
           }
         } else {
-          // No correlation — propagate to all pending so callers learn
-          // the worker failed.
-          for (const entry of this.pending.values()) {
-            entry.reject(err);
-          }
-          this.pending.clear();
-          // If the worker errored before posting READY, reject the
-          // readyPromise too. Otherwise any future `runBatch()` call
-          // would hang forever awaiting a worker that is never coming
-          // up.
-          if (!this.ready) {
-            this.rejectReady(err);
-          }
+          // Uncorrelated worker failure — treat as fatal. Reject every
+          // pending request, reject readyPromise if startup hadn't
+          // completed, and poison the proxy so future `runBatch()`
+          // calls fail fast instead of posting into a dead worker.
+          this.poison(err);
         }
         return;
       }
@@ -339,12 +347,29 @@ export class RuleRunnerProxy implements RuleRunnerLike {
 
   private handleWorkerError(e: ErrorEvent | Error): void {
     const err = e instanceof Error ? e : new Error(e.message ?? String(e));
+    this.poison(err);
+  }
+
+  /**
+   * Mark the proxy as fatally broken: reject every pending request and
+   * `readyPromise` (if startup hadn't completed), terminate the worker,
+   * and remember the error so subsequent API calls fail fast instead
+   * of hanging.
+   */
+  private poison(err: Error): void {
+    if (this.fatalError) return;
+    this.fatalError = err;
     for (const entry of this.pending.values()) {
       entry.reject(err);
     }
     this.pending.clear();
+    this.preReadyBuffer.length = 0;
     if (!this.ready) {
       this.rejectReady(err);
+    }
+    if (!this.disposed) {
+      this.disposed = true;
+      this.worker.terminate();
     }
   }
 

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
@@ -1,0 +1,386 @@
+/**
+ * Main-thread proxy for the lint Web Worker.
+ *
+ * Hosts a small synchronous `RuleRunner` for morphological (L2) rules
+ * that cannot run in the worker (their `genjiVocab` dependency uses
+ * Electron IPC). The worker handles regex (L1) rules. `runBatch`
+ * presents a unified async API; callers don't see the split.
+ */
+
+import { RuleRunner } from "@/lib/linting/rule-runner";
+import { createJsonDrivenRules, getAllRules } from "@/lib/linting/rule-registry";
+import { RULE_GUIDELINE_MAP } from "@/lib/linting/lint-presets";
+import {
+  isDocumentLintRule,
+  isMorphologicalDocumentLintRule,
+  isMorphologicalLintRule,
+} from "@/lib/linting/types";
+import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
+
+import {
+  WorkerDisposedError,
+  WorkerStaleError,
+  type RuleRunnerLike,
+  type RunBatchRequest,
+  type RunBatchResponse,
+  type SerializedIssueMap,
+  type WorkerEvent,
+  type WorkerRequest,
+} from "./protocol";
+
+interface PendingRequest {
+  resolve: (response: RunBatchResponse) => void;
+  reject: (err: Error) => void;
+  version: number;
+  /** Per-paragraph issues already computed on the main thread (morph rules). */
+  mainPerParagraph: Map<number, LintIssue[]>;
+  /** Document-level issues already computed on the main thread (morph doc rules). */
+  mainDocument: Map<number, LintIssue[]>;
+}
+
+/**
+ * Worker factory. Exposed for tests that want to inject a fake.
+ * The default uses Vite/Webpack's URL-based worker bundling.
+ */
+export type WorkerFactory = () => Worker;
+
+const defaultWorkerFactory: WorkerFactory = () =>
+  new Worker(new URL("./linting.worker.ts", import.meta.url), {
+    type: "module",
+  });
+
+export class RuleRunnerProxy implements RuleRunnerLike {
+  private readonly worker: Worker;
+  private readonly mainRunner: RuleRunner;
+  /** True iff any worker-side rule is a `DocumentLintRule`. Computed at construction. */
+  private readonly workerHasDocumentRules: boolean;
+
+  private nextCorrelationId = 1;
+  private latestRequestedVersion = 0;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly preReadyBuffer: WorkerRequest[] = [];
+
+  private ready = false;
+  private disposed = false;
+
+  /** Promise that resolves once the worker has posted READY. */
+  readonly readyPromise: Promise<void>;
+  private resolveReady!: () => void;
+  private rejectReady!: (err: Error) => void;
+
+  constructor(factory: WorkerFactory = defaultWorkerFactory) {
+    // 1. Build the main-side runner with morph rules only.
+    this.mainRunner = new RuleRunner();
+    for (const rule of getAllRules()) {
+      if (isMorphologicalLintRule(rule) || isMorphologicalDocumentLintRule(rule)) {
+        this.mainRunner.registerRule(rule);
+      }
+    }
+    this.mainRunner.setGuidelineMap(RULE_GUIDELINE_MAP);
+
+    // 2. Pre-compute worker capability flags from rule metadata so
+    //    `hasDocumentRules()` can answer synchronously.
+    this.workerHasDocumentRules = createJsonDrivenRules().some(
+      (r) =>
+        isDocumentLintRule(r) && !isMorphologicalLintRule(r) && !isMorphologicalDocumentLintRule(r),
+    );
+
+    // 3. Spin up the worker.
+    this.worker = factory();
+    this.worker.onmessage = (e: MessageEvent<WorkerEvent>) => this.handleEvent(e.data);
+    this.worker.onerror = (e) => this.handleWorkerError(e);
+    this.worker.onmessageerror = () => this.handleWorkerError(new Error("Worker messageerror"));
+
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+    });
+  }
+
+  // ----------------------------------------------------------------
+  // RuleRunnerLike — sync metadata methods
+  // ----------------------------------------------------------------
+
+  setConfig(ruleId: string, config: LintRuleConfig): void {
+    if (this.disposed) return;
+    this.mainRunner.setConfig(ruleId, config);
+    this.send({
+      type: "SET_CONFIG",
+      correlationId: this.nextId(),
+      ruleId,
+      config,
+    });
+  }
+
+  setActiveGuidelines(guidelines: string[] | null): void {
+    if (this.disposed) return;
+    this.mainRunner.setActiveGuidelines(guidelines);
+    this.send({
+      type: "SET_ACTIVE_GUIDELINES",
+      correlationId: this.nextId(),
+      guidelines,
+    });
+  }
+
+  setGuidelineMap(map: Map<string, string | undefined>): void {
+    if (this.disposed) return;
+    this.mainRunner.setGuidelineMap(map);
+    this.send({
+      type: "SET_GUIDELINE_MAP",
+      correlationId: this.nextId(),
+      entries: Array.from(map.entries()),
+    });
+  }
+
+  hasMorphologicalRules(): boolean {
+    return this.mainRunner.hasMorphologicalRules();
+  }
+
+  hasDocumentRules(): boolean {
+    return this.workerHasDocumentRules || this.mainRunner.hasDocumentRules();
+  }
+
+  // ----------------------------------------------------------------
+  // RuleRunnerLike — async batch execution
+  // ----------------------------------------------------------------
+
+  async runBatch(req: RunBatchRequest): Promise<RunBatchResponse> {
+    if (this.disposed) {
+      throw new WorkerDisposedError();
+    }
+
+    // Track the latest version requested so older responses can be filtered.
+    if (req.version > this.latestRequestedVersion) {
+      this.latestRequestedVersion = req.version;
+    }
+
+    // Eagerly cancel any pending request with a lower version — the
+    // caller no longer cares about it.
+    for (const [id, entry] of this.pending) {
+      if (entry.version < this.latestRequestedVersion) {
+        this.pending.delete(id);
+        entry.reject(new WorkerStaleError());
+      }
+    }
+
+    // Run main-thread morph rules synchronously while the worker is busy.
+    const { mainPerParagraph, mainDocument } = this.runMainMorph(req);
+
+    const runWorker = req.runWorker !== false;
+    if (!runWorker) {
+      return { perParagraph: mainPerParagraph, document: mainDocument };
+    }
+
+    // Wait for worker startup if it hasn't readied yet. If `dispose()`
+    // beats READY, this rejects with `WorkerDisposedError`.
+    if (!this.ready) {
+      try {
+        await this.readyPromise;
+      } catch (err) {
+        if (err instanceof WorkerDisposedError) throw err;
+        throw err;
+      }
+    }
+
+    if (this.disposed) {
+      throw new WorkerDisposedError();
+    }
+
+    const correlationId = this.nextId();
+    const workerResponse = new Promise<RunBatchResponse>((resolve, reject) => {
+      this.pending.set(correlationId, {
+        resolve,
+        reject,
+        version: req.version,
+        mainPerParagraph,
+        mainDocument,
+      });
+    });
+
+    this.send({
+      type: "RUN_BATCH",
+      correlationId,
+      version: req.version,
+      paragraphs: req.paragraphs.map((p) => ({ text: p.text, index: p.index })),
+      mode: req.mode,
+    });
+
+    return workerResponse;
+  }
+
+  cancelInFlight(): void {
+    const err = new WorkerStaleError();
+    for (const entry of this.pending.values()) {
+      entry.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    const err = new WorkerDisposedError();
+    for (const entry of this.pending.values()) {
+      entry.reject(err);
+    }
+    this.pending.clear();
+    this.preReadyBuffer.length = 0;
+    if (!this.ready) {
+      // Reject the readyPromise so any awaiter unwinds cleanly.
+      this.rejectReady(err);
+    }
+
+    this.worker.terminate();
+  }
+
+  // ----------------------------------------------------------------
+  // Internal helpers
+  // ----------------------------------------------------------------
+
+  private nextId(): number {
+    return this.nextCorrelationId++;
+  }
+
+  private send(msg: WorkerRequest): void {
+    if (this.disposed) return;
+    if (!this.ready) {
+      this.preReadyBuffer.push(msg);
+      return;
+    }
+    this.worker.postMessage(msg);
+  }
+
+  private handleEvent(evt: WorkerEvent): void {
+    switch (evt.type) {
+      case "READY": {
+        this.ready = true;
+        this.resolveReady();
+        // Flush buffered messages in FIFO order.
+        for (const msg of this.preReadyBuffer) {
+          this.worker.postMessage(msg);
+        }
+        this.preReadyBuffer.length = 0;
+        return;
+      }
+      case "RESPONSE": {
+        const entry = this.pending.get(evt.correlationId);
+        if (!entry) return;
+        this.pending.delete(evt.correlationId);
+
+        // Stale-by-version filtering.
+        if (evt.version < this.latestRequestedVersion) {
+          entry.reject(new WorkerStaleError());
+          return;
+        }
+
+        // Merge worker results with the main-thread morph results.
+        const merged: RunBatchResponse = {
+          perParagraph: mergeIssueMaps(entry.mainPerParagraph, deserialize(evt.perParagraph)),
+          document: mergeIssueMaps(entry.mainDocument, deserialize(evt.document)),
+        };
+        entry.resolve(merged);
+        return;
+      }
+      case "ERROR": {
+        const err = new Error(evt.error.message);
+        err.name = evt.error.name;
+        if (evt.correlationId !== undefined) {
+          const entry = this.pending.get(evt.correlationId);
+          if (entry) {
+            this.pending.delete(evt.correlationId);
+            entry.reject(err);
+          }
+        } else {
+          // No correlation — propagate to all pending so callers learn
+          // the worker failed.
+          for (const entry of this.pending.values()) {
+            entry.reject(err);
+          }
+          this.pending.clear();
+        }
+        return;
+      }
+      default: {
+        const _exhaustive: never = evt;
+        void _exhaustive;
+      }
+    }
+  }
+
+  private handleWorkerError(e: ErrorEvent | Error): void {
+    const err = e instanceof Error ? e : new Error(e.message ?? String(e));
+    for (const entry of this.pending.values()) {
+      entry.reject(err);
+    }
+    this.pending.clear();
+    if (!this.ready) {
+      this.rejectReady(err);
+    }
+  }
+
+  private runMainMorph(req: RunBatchRequest): {
+    mainPerParagraph: Map<number, LintIssue[]>;
+    mainDocument: Map<number, LintIssue[]>;
+  } {
+    const mainPerParagraph = new Map<number, LintIssue[]>();
+    const mainDocument = new Map<number, LintIssue[]>();
+
+    if (!this.mainRunner.hasMorphologicalRules() && !this.mainRunner.hasDocumentRules()) {
+      return { mainPerParagraph, mainDocument };
+    }
+
+    const runPer = req.mode === "per-paragraph" || req.mode === "both";
+    const runDoc = req.mode === "document" || req.mode === "both";
+
+    // Per-paragraph morph rules.
+    if (runPer) {
+      for (const p of req.paragraphs) {
+        if (!p.tokens) continue; // morph rules need tokens
+        const issues = this.mainRunner.runAllWithTokens(p.text, p.tokens);
+        if (issues.length > 0) mainPerParagraph.set(p.index, issues);
+      }
+    }
+
+    // Document-level morph rules.
+    if (runDoc && this.mainRunner.hasDocumentRules()) {
+      const docInputs = req.paragraphs
+        .filter((p) => p.tokens != null)
+        .map((p) => ({ text: p.text, index: p.index, tokens: p.tokens! }));
+      if (docInputs.length > 0) {
+        const docResults = this.mainRunner.runDocumentWithTokens(docInputs);
+        docResults.forEach((issues, idx) => {
+          if (issues.length > 0) mainDocument.set(idx, issues);
+        });
+      }
+    }
+
+    return { mainPerParagraph, mainDocument };
+  }
+}
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+function deserialize(entries: SerializedIssueMap): Map<number, LintIssue[]> {
+  const map = new Map<number, LintIssue[]>();
+  for (const [idx, issues] of entries) {
+    if (issues.length > 0) map.set(idx, issues);
+  }
+  return map;
+}
+
+function mergeIssueMaps(
+  a: Map<number, LintIssue[]>,
+  b: Map<number, LintIssue[]>,
+): Map<number, LintIssue[]> {
+  if (a.size === 0) return b;
+  if (b.size === 0) return a;
+  const out = new Map<number, LintIssue[]>(a);
+  for (const [idx, issues] of b) {
+    const existing = out.get(idx);
+    out.set(idx, existing ? [...existing, ...issues] : issues);
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Toggling the proofreading panel on long Japanese novels (1000+ paragraphs) currently freezes the editor for several seconds — cursor cannot be placed, keystrokes queue up. This PR moves the regex (L1) lint rule execution into a dedicated module-mode Web Worker, leaving only the single morphological (L2) rule (`GenjiUnknownNoun`) on the main thread because its `genjiVocab` dependency is bound to `window.electronAPI`.

## Architecture

- **`worker/protocol.ts`** — typed RPC contracts: `WorkerRequest` (always carries `correlationId`), `WorkerEvent` (`READY` / `RESPONSE` / `ERROR` tagged union), `RuleRunnerLike` interface, and two silent-cancel sentinels (`WorkerStaleError` / `WorkerDisposedError`).
- **`worker/linting.worker.ts`** — registers only non-morphological rules (the JSON L1 set), services `RUN_BATCH` for `per-paragraph` / `document` / `both` modes, posts `READY` once.
- **`worker/rule-runner-proxy.ts`** — main-thread `RuleRunnerLike` impl. Hosts both the worker and a small main-thread `RuleRunner` for morph rules; `runBatch` splits work and merges results transparently. Capability flags (`hasMorphologicalRules` / `hasDocumentRules`) stay synchronous via main-thread metadata.
- **`use-linting.ts`** — proxy is now created in a `useEffect` and held in React state so the `null → ready` transition propagates through `EditorLayout` → `Editor` → `MilkdownEditor` → linting plugin.
- **`decoration-plugin.ts`** — replaces the per-paragraph for-loop and document-rules block with two `runBatch` calls. Caller-side `version === processingVersion` guards remain; `cancelInFlight()` is wired into `apply()` for `enabled=false`, manual-refresh, and mode-change branches.

## Plan & review

- Plan: `docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md`
- Codex peer-reviewed across 3 iterations (R1–R9), all blocking findings addressed in the plan and implementation.

## Test plan

- [ ] CI: `npm run type-check`, `npm run lint`, `npm run test`
- [ ] `npm run electron:dev`; open the long Google-Drive `缶詰` project
- [ ] Toggle proofreading on; while decorations compute, type into the editor — cursor must remain responsive (~100ms p95)
- [ ] Decorations match pre-worker output for the first ~5 paragraphs
- [ ] Toggle off then on again; second run should be faster (warm caches)
- [ ] Activity Monitor: renderer main thread should not pin at 100% CPU; the new worker thread carries the load
- [ ] `npm run electron:build` and smoke-test the packaged build to confirm Worker bundling

🤖 Generated with [Claude Code](https://claude.com/claude-code)