### PR TITLE
fix(auth): prevent repeat refreshToken calls after permanent failure

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -185,6 +185,12 @@ function isElectronAuthErrorPermanent(err: unknown): boolean {
   return false;
 }
 
+// Guards against repeat refresh attempts within the same renderer session
+// after a permanent failure. Module-scoped so it survives React StrictMode
+// remounts and any duplicate AuthProvider lifecycles in dev.
+// Reset on successful login (OAuth callback) and on logout.
+let refreshPermanentlyFailedSession = false;
+
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
@@ -215,6 +221,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       refreshTimerRef.current = setTimeout(async () => {
         const api = window.electronAPI;
         if (!api?.auth) return;
+        if (refreshPermanentlyFailedSession) return;
 
         try {
           const tokenResponse = await api.auth.refreshToken(refreshToken);
@@ -238,6 +245,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         } catch (err) {
           if (isElectronAuthErrorPermanent(err)) {
             // Permanent failure (4xx / invalid_grant): token is invalid — log out
+            refreshPermanentlyFailedSession = true;
             setUser(null);
             await clearTokens();
           } else {
@@ -299,6 +307,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               setIsLoading(false);
               return;
             }
+            if (refreshPermanentlyFailedSession) {
+              await clearTokens();
+              setIsLoading(false);
+              return;
+            }
 
             try {
               const tokenResponse = await api.auth.refreshToken(refreshToken);
@@ -321,6 +334,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             } catch (err) {
               // Only clear tokens on permanent failures (401/403); ignore transient errors on startup
               if (isElectronAuthErrorPermanent(err)) {
+                refreshPermanentlyFailedSession = true;
                 await clearTokens();
               }
             }
@@ -341,6 +355,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               });
               scheduleElectronRefresh(expiresAt, refreshToken);
             } catch {
+              if (refreshPermanentlyFailedSession) {
+                await clearTokens();
+                setIsLoading(false);
+                return;
+              }
               try {
                 const tokenResponse = await api.auth.refreshToken(refreshToken);
                 const newExpiresAt = Date.now() + tokenResponse.expires_in * 1000;
@@ -362,6 +381,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               } catch (err) {
                 // Only clear tokens on permanent failures (401/403); ignore transient errors on startup
                 if (isElectronAuthErrorPermanent(err)) {
+                  refreshPermanentlyFailedSession = true;
                   await clearTokens();
                 }
               }
@@ -437,6 +457,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           plan: userInfo.plan,
         });
 
+        // Fresh tokens — clear the permanent-failure guard so future
+        // refreshes can run.
+        refreshPermanentlyFailedSession = false;
         scheduleElectronRefresh(expiresAt, tokenResponse.refresh_token);
       } catch (err) {
         console.error("[auth] Token exchange failed:", err);
@@ -462,6 +485,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // --- Logout ---
   const logout = useCallback(async () => {
     clearRefreshTimer();
+    refreshPermanentlyFailedSession = false;
 
     if (isElectron.current) {
       const api = window.electronAPI;


### PR DESCRIPTION
## Summary

- 起動時に `invalid_grant` の `auth:refresh-token` エラーが**3回連続**でログに出ていた問題を修正。
- React StrictMode 二重 mount や Next.js dev mode の重複レンダで `useRef` ベースのガードが効かないため、**モジュールスコープのフラグ** で防御する。
- 一度 permanent failure（4xx / `invalid_grant` 等）を検出したら、同一 renderer セッション内では `refreshToken()` を再呼び出ししない。

## Why

- `invalid_grant` は RFC 6749 §5.2 上 permanent failure（refresh token revoked / expired）。再試行しても 100% 失敗する。
- StrictMode と dev fast-refresh で `AuthProvider` が remount され、各 mount で同じ revoked refresh token を使った IPC が走り、ログに同じエラーが3回流れていた。
- 機能上の害は小さい（即座に失敗 → `clearTokens()` で setUser(null)）が、ログノイズと多重 IPC が発生していた。

## Scope

#1437（`AuthContext` 分離）の射程内。フル分解は別途 #1437 で行う想定で、ここは1ファイル24行の最小限ガードのみ。

## What changed

`contexts/AuthContext.tsx`:
- module-level `let refreshPermanentlyFailedSession = false;` を追加
- 全3つの `refreshToken()` 呼び出しサイト（scheduleElectronRefresh の timer / restoreElectronSession 経路A: 期限切れ / 経路B: getUserInfo 失敗時）に short-circuit ガードを追加
- 全3つの permanent failure catch 経路でフラグを立てる
- OAuth callback 成功時とログアウト時にフラグを `false` にリセット

## Test plan

- [ ] type-check が通る（既存の `Editor.tsx` / `MilkdownEditor.tsx` の RefObject エラーは無関係 / 既存）
- [ ] `npm run electron:dev` で revoked token 状態起動し、ログで `auth:refresh-token` エラーが **1回のみ** に収束することを確認
- [ ] 通常の login → logout → login フローが回ること（フラグがリセットされる）
- [ ] transient failure（5xx / network）では従来通り `scheduleElectronRefresh()` で 60秒後リトライが走ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)