### PR TITLE
chore(deps): split Dependabot groups and document security update routing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,18 @@
 version: 2
 
 # ----------------------------------------------------------------------------
-# Base branch policy (see .github/copilot-instructions.md § Branch Strategy):
-#   All bot-generated PRs MUST target `dev`, never `main`.
-#   `main` receives merges only via the weekly release PR.
+# Base branch policy (see CLAUDE.md § Branch Strategy):
+#   - Regular Dependabot version updates target `dev` (via `target-branch`).
+#   - Dependabot security updates ALWAYS target the default branch (`main`)
+#     and ignore `target-branch` by design. Policy: merge security PRs to
+#     `main` promptly, then back-merge `main` → `dev` so dev tracks the fix.
+#   - `main` otherwise receives merges only via the weekly release PR.
+#
+# Group strategy:
+#   Minor/patch updates are bundled (low risk, batch reviewable). Major
+#   updates are split out so a single breaking change cannot redden CI for
+#   the entire bundle (see PR #1454 retro: archiver 7→8 + electron 41→42 +
+#   lint-staged 16→17 collectively failed every check).
 # ----------------------------------------------------------------------------
 
 updates:
@@ -32,9 +41,20 @@ updates:
       - dependency-name: "tailwindcss"
         versions: ["4.x"]
     groups:
-      npm_and_yarn:
+      npm-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-major-production:
+        dependency-type: "production"
+        update-types:
+          - "major"
+      npm-major-development:
+        dependency-type: "development"
+        update-types:
+          - "major"
 
   - package-ecosystem: "npm"
     directory: "/packages/milkdown-plugin-japanese-novel"
@@ -52,9 +72,17 @@ updates:
       prefix: "chore"
       include: "scope"
     groups:
-      milkdown_plugin_npm:
+      milkdown-plugin-minor-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      milkdown-plugin-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Split the catch-all `npm_and_yarn` / `milkdown_plugin_npm` groups by `update-types` so major version bumps land in **separate PRs** from minor/patch bundles.
- Documents in the file header that Dependabot **security updates always target the default branch (`main`)** by design and ignore `target-branch`; policy is to merge security PRs promptly and back-merge `main` → `dev`.

## Motivation
Retro from PR #1454 (closed in favor of this change): the previous single-group setup bundled 12 deps including three breaking majors (`archiver` 7→8 ESM-only, `electron` 41→42, `lint-staged` 16→17). Every CI check went red and the PR was unrecoverable without splitting by hand.

PR #1451 (axios security update) surfaced the second issue: it was opened against `main` despite `target-branch: dev`, because Dependabot security updates intentionally route to the default branch.

## New grouping
**Root npm:**
- `npm-minor-patch` — all minor + patch (batched)
- `npm-major-production` — production majors (one per major dep)
- `npm-major-development` — devDependency majors (one per major dep)

**`packages/milkdown-plugin-japanese-novel`:**
- `milkdown-plugin-minor-patch`
- `milkdown-plugin-major`

`github-actions` stays single-group (no churn pattern there).

## Test plan
- [ ] Wait for next Monday 09:00 JST Dependabot run; verify majors come through as separate PRs.
- [ ] Confirm minor/patch bundle PR(s) target `dev`.
- [ ] Confirm any new security PR (if any) opens against `main` as expected.