### PR TITLE
fix(editor): #1457 P0 follow-up — file-watcher + lint storm + click trace

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -915,9 +915,19 @@ export default function EditorPage() {
   // --- Ignored corrections hook ---
   const { ignoredCorrections, ignoreCorrection } = useIgnoredCorrections(editorMode);
 
-  // Sync ignoredCorrections to ProseMirror plugin
+  // Sync ignoredCorrections to ProseMirror plugin.
+  //
+  // Skip the call when the list is empty on first sync — the plugin defaults
+  // to no ignored corrections, so an empty-array notification forces a full
+  // document rescan for zero behavioral change. This is the dominant
+  // mount-time blocker for project mode (#1457).
+  const prevIgnoredCorrectionsRef = useRef<typeof ignoredCorrections | null>(null);
   useEffect(() => {
     if (!editorViewInstance) return;
+    const prev = prevIgnoredCorrectionsRef.current;
+    const bothEmpty = (prev == null || prev.length === 0) && ignoredCorrections.length === 0;
+    prevIgnoredCorrectionsRef.current = ignoredCorrections;
+    if (bothEmpty) return;
 
     import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
       .then(({ updateLintingSettings }) => {

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -472,6 +472,7 @@ export default function NovelEditor({
         <MilkdownProvider>
           <ProsemirrorAdapterProvider>
             <MilkdownEditor
+              key={isVertical ? "vertical" : "horizontal"}
               initialContent={initialContent}
               onChange={onChange}
               onInsertText={onInsertText}

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -472,7 +472,6 @@ export default function NovelEditor({
         <MilkdownProvider>
           <ProsemirrorAdapterProvider>
             <MilkdownEditor
-              key={isVertical ? "vertical" : "horizontal"}
               initialContent={initialContent}
               onChange={onChange}
               onInsertText={onInsertText}

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -446,7 +446,14 @@ export default function EditorLayout({
                                 className="h-full"
                                 // NOTE: onFocus は子孫（Milkdown contenteditable）からの bubble を利用。
                                 // tabIndex は不要。パネルへのフォーカスを dockview に伝え activeTabId を最新化する。
-                                onFocus={() => panelApi.setActive()}
+                                onFocus={() => {
+                                  console.warn(
+                                    "[EditorLayout] onFocus → panelApi.setActive",
+                                    `panelId=${panelBufferId}`,
+                                    `activeTabId=${panelActiveTabId}`,
+                                  );
+                                  panelApi.setActive();
+                                }}
                               >
                                 <NovelEditor
                                   key={`tab-${panelBufferId}-${panelFilePath}-${panelEditorKey}`}

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -279,7 +279,7 @@ export default function MilkdownEditor({
 
       return editor;
     },
-    [verticalScrollPlugin, mdiExtensionsEnabled, gfmEnabled],
+    [isVertical, verticalScrollPlugin, mdiExtensionsEnabled, gfmEnabled],
   );
 
   // EditorView インスタンスを取得する

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -323,6 +323,14 @@ export default function MilkdownEditor({
     const editor = get();
     if (!editor) return;
 
+    // Diagnostic: surface unexpected externalContent applications that
+    // could explain the uneditable-from-start regression in #1457.
+    // Remove once the root cause is confirmed not to be here.
+    console.warn(
+      "[MilkdownEditor] applying externalContent (replaceAll)",
+      `length=${externalContent.length}`,
+    );
+
     // Save scroll progress before replacing content
     const container = scrollContainerRef.current;
     let savedProgress: number | null = null;
@@ -371,23 +379,46 @@ export default function MilkdownEditor({
   ]);
 
   // linting 設定を動的に更新（Editor を再作成せずに）
+  //
+  // Defer the first call until idle so the initial paint can finish before
+  // the linting plugin schedules a full-document scan. Without this, opening
+  // a large project document keeps the renderer busy long enough that the
+  // contenteditable feels frozen (#1457).
   useEffect(() => {
     if (!editorViewInstance) return;
 
-    import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
-      .then(({ updateLintingSettings }) => {
-        updateLintingSettings(
-          editorViewInstance,
-          {
-            enabled: lintingEnabled,
-            ruleRunner: lintingRuleRunner,
-          },
-          "rule-config-change",
-        );
-      })
-      .catch((err) => {
-        console.error("[Editor] Failed to update linting settings:", err);
-      });
+    const run = () => {
+      import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
+        .then(({ updateLintingSettings }) => {
+          updateLintingSettings(
+            editorViewInstance,
+            {
+              enabled: lintingEnabled,
+              ruleRunner: lintingRuleRunner,
+            },
+            "rule-config-change",
+          );
+        })
+        .catch((err) => {
+          console.error("[Editor] Failed to update linting settings:", err);
+        });
+    };
+
+    const ric = (
+      window as Window & {
+        requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+      }
+    ).requestIdleCallback;
+    if (typeof ric === "function") {
+      const handle = ric(run, { timeout: 1500 });
+      return () => {
+        const cic = (window as Window & { cancelIdleCallback?: (id: number) => void })
+          .cancelIdleCallback;
+        cic?.(handle);
+      };
+    }
+    const timer = window.setTimeout(run, 100);
+    return () => window.clearTimeout(timer);
   }, [editorViewInstance, lintingEnabled, lintingRuleRunner]);
 
   // 縦書き時: マウスホイールの縦スクロールを横スクロールへ変換する

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -545,6 +545,17 @@ export default function MilkdownEditor({
     isFirstRenderRef.current = false;
 
     const applyStyles = () => {
+      const containerBefore = scrollContainerRef.current;
+      const scrollTopBefore = containerBefore?.scrollTop ?? -1;
+      const scrollLeftBefore = containerBefore?.scrollLeft ?? -1;
+      console.warn(
+        "[MilkdownEditor] applyStyles START",
+        `styleChanged=${styleChanged}`,
+        `shouldAnimate=${shouldAnimate}`,
+        `scrollTop=${scrollTopBefore}`,
+        `scrollLeft=${scrollLeftBefore}`,
+      );
+
       editorDom.classList.remove("milkdown-japanese-vertical", "milkdown-japanese-horizontal");
       editorDom.classList.add(
         isVertical ? "milkdown-japanese-vertical" : "milkdown-japanese-horizontal",
@@ -590,6 +601,13 @@ export default function MilkdownEditor({
           measureBox.style.maxWidth = `${targetWidth}px`;
         }
       }
+
+      const containerAfter = scrollContainerRef.current;
+      console.warn(
+        "[MilkdownEditor] applyStyles END",
+        `scrollTop=${containerAfter?.scrollTop ?? -1}`,
+        `scrollLeft=${containerAfter?.scrollLeft ?? -1}`,
+      );
     };
 
     if (shouldAnimate) {

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -179,6 +179,21 @@ export default function MilkdownEditor({
                 return false;
               },
             },
+            // Diagnostic: log every transaction so we can identify what
+            // dispatches a selection reset to doc start on click (#1457).
+            appendTransaction(transactions, oldState, newState) {
+              const oldSel = oldState.selection;
+              const newSel = newState.selection;
+              if (oldSel.from !== newSel.from || oldSel.to !== newSel.to) {
+                console.warn(
+                  "[ProseMirror] selection change",
+                  `${oldSel.from}-${oldSel.to} → ${newSel.from}-${newSel.to}`,
+                  `docChanged=${transactions.some((t) => t.docChanged)}`,
+                  `metas=${transactions.map((t) => Object.keys((t as unknown as { meta: Record<string, unknown> }).meta || {}).join(",")).join("|")}`,
+                );
+              }
+              return null;
+            },
           }),
       ),
     [],

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -295,6 +295,11 @@ export default function MilkdownEditor({
         if (editor && editor.ctx) {
           const view = editor.ctx.get(editorViewCtx);
           if (view) {
+            console.warn(
+              "[MilkdownEditor] EditorView ready",
+              `attempts=${attempts}`,
+              `instance=${(view as unknown as { dom?: { id?: string } })?.dom?.id ?? "n/a"}`,
+            );
             setEditorViewInstance(view);
             onEditorViewReady?.(view);
             return;

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -331,7 +331,33 @@ export default function MilkdownEditor({
               "[MilkdownEditor] EditorView ready",
               `attempts=${attempts}`,
               `viewId=${tagged.__illusionsViewId}`,
+              `editable=${view.editable}`,
+              `domEditable=${view.dom.contentEditable}`,
+              `domTag=${view.dom.tagName}`,
+              `selFrom=${view.state.selection.from}`,
             );
+            // Click-target trace: confirm clicks actually reach the
+            // contenteditable element (#1457). Attach once per view instance.
+            const taggedForClick = view as unknown as {
+              __illusionsClickHooked?: boolean;
+            };
+            if (!taggedForClick.__illusionsClickHooked) {
+              taggedForClick.__illusionsClickHooked = true;
+              view.dom.addEventListener("mousedown", (e) => {
+                console.warn(
+                  "[ProseMirror] mousedown on .ProseMirror",
+                  `target=${(e.target as Element)?.tagName ?? "n/a"}`,
+                  `defaultPrevented=${e.defaultPrevented}`,
+                );
+              });
+              view.dom.addEventListener("click", (e) => {
+                console.warn(
+                  "[ProseMirror] click on .ProseMirror",
+                  `target=${(e.target as Element)?.tagName ?? "n/a"}`,
+                  `defaultPrevented=${e.defaultPrevented}`,
+                );
+              });
+            }
             setEditorViewInstance(view);
             onEditorViewReady?.(view);
             return;

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -197,6 +197,14 @@ export default function MilkdownEditor({
 
   const { get } = useEditor(
     (root) => {
+      // Diagnostic: trace every Editor.make() invocation to detect whether
+      // useEditor is re-running on click (deps unstable) for #1457 / #1445.
+      console.warn(
+        "[MilkdownEditor] useEditor factory invoked",
+        `isVertical=${isVertical}`,
+        `mdi=${mdiExtensionsEnabled}`,
+        `gfm=${gfmEnabled}`,
+      );
       const value = initialContentRef.current ?? "";
       let editor = Editor.make()
         .config(nord)
@@ -295,10 +303,19 @@ export default function MilkdownEditor({
         if (editor && editor.ctx) {
           const view = editor.ctx.get(editorViewCtx);
           if (view) {
+            // Tag the view with a unique id so we can tell whether subsequent
+            // "ready" log entries refer to the same editor or a newly created
+            // instance (diagnosing #1457 / #1445 click-recreation hypothesis).
+            const tagged = view as unknown as { __illusionsViewId?: string };
+            if (!tagged.__illusionsViewId) {
+              tagged.__illusionsViewId = `v${Date.now().toString(36)}${Math.random()
+                .toString(36)
+                .slice(2, 6)}`;
+            }
             console.warn(
               "[MilkdownEditor] EditorView ready",
               `attempts=${attempts}`,
-              `instance=${(view as unknown as { dom?: { id?: string } })?.dom?.id ?? "n/a"}`,
+              `viewId=${tagged.__illusionsViewId}`,
             );
             setEditorViewInstance(view);
             onEditorViewReady?.(view);

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -279,7 +279,7 @@ export default function MilkdownEditor({
 
       return editor;
     },
-    [isVertical, verticalScrollPlugin, mdiExtensionsEnabled, gfmEnabled],
+    [verticalScrollPlugin, mdiExtensionsEnabled, gfmEnabled],
   );
 
   // EditorView インスタンスを取得する

--- a/docs/superpowers/plans/2026-05-13-fix-1457-editor-uneditable.md
+++ b/docs/superpowers/plans/2026-05-13-fix-1457-editor-uneditable.md
@@ -1,0 +1,467 @@
+# Plan: Fix #1457 — エディタ編集不能 & 縦書き/横書き切替不可 (P0 BUG)
+
+## Goal
+
+v1.2.5 リリース後に発覚した P0 BUG (#1457) を最小限の介入で修復する。具体的には次の 2 つの可観測症状を、それぞれ独立した根本原因に対するピンポイント修正で解消する。
+
+1. エディタ領域をクリックすると先頭にジャンプし、カーソルが消失して編集不能になる
+2. 縦書き ⇔ 横書きモードの切替が反応しない、または切替後にコンテンツが古い状態に戻る
+
+Issue 本文で言及された「Windows 省電力モード時のプロセス無反応」はスコープ外とし、フォロー Issue を起票して別途対応する。これは A/B とは異なる根本原因を持つ可能性が高く、本 PR の爆発半径を大きくしてしまうため。
+
+## Architecture
+
+### 現状の症状ごとの根本原因
+
+**Root cause A — 編集不能 (PR #1427 regression)**
+
+`useFileWatchIntegration` (`lib/tab-manager/use-file-watch-integration.ts`) は `pauseFileWatchers` フラグの変化に応じて `FileWatcher.start()` / `stop()` を呼び分ける。このフラグは `app/page.tsx:235` で `shouldPauseFileWatchers(runtimeActivity)` から計算され、`runtimeActivity.isWindowFocused` が false になっただけで true になる (`lib/editor-page/power-optimization.ts:21-23`)。
+
+`ElectronFileWatcher` (`lib/services/file-watcher.ts:385-486`) の `start()` 経路には catch-up ロジックがあり、`pausedAt > previousModified` の場合に「一時停止中に変更があったかもしれない」と判定して `onChanged()` を発火する (`catchUpAndStartWatcher`)。
+
+問題は、`readAndNotify()` (line 547-551) が suppression 中に early return しており、`lastKnownModified` / `lastKnownContentHash` を更新しない点。auto-save (5 秒ごと) によるディスク書き換えは suppression 内で起きるため：
+
+1. auto-save 走行 → ディスク mtime が進む → `suppressFileWatch()` 発動 → `readAndNotify()` 早期 return → **baseline 更新されない**
+2. ユーザー Cmd+Tab → `pauseFileWatchers=true` → watcher.stop() → `pausedAt = Date.now()`
+3. ユーザー focus 復帰 → `pauseFileWatchers=false` → watcher.start() → catch-up
+4. `previousModified` (auto-save 前の古い mtime) < 現 mtime → `mtimeAdvanced=true` → suppression 切れていれば `onChanged()` 発火
+5. `useFileWatchIntegration` の `buildOnChanged` で `pendingExternalContent: diskContent` をセット
+6. `MilkdownEditor.tsx:321-348` の useEffect が `editor.action(replaceAll(externalContent))` を実行
+7. ProseMirror ドキュメント全置換 → スクロール位置・カーソル位置喪失 → 編集続行不能
+
+メモリ S143 / 645 / 662 / 738 で観測済みのフロー。
+
+**Root cause B — 縦書き切替不可**
+
+`MilkdownEditor.tsx` の `useEditor` フックは deps 配列に `isVertical` を含む (`components/editor/MilkdownEditor.tsx:282`)。React の `isVertical` 切替で Milkdown Editor 全体 (commonmark + gfm + japaneseNovel + history + clipboard + cursor + posHighlight + linting プラグイン) が破棄・再作成される。
+
+問題点：
+
+- 巨大ファイル + 縦書き再構築は十数〜数百 ms かかる → UI が無反応に見える
+- `initialContentRef = useRef<string>(initialContent)` (line 137) はマウント時の値で固定。`useEditor` が deps 変更で再実行されても外側の React コンポーネントは再マウントされないため、`initialContentRef.current` は古いまま → 切替後のエディタが「過去のコンテンツ」で初期化される
+- `useEditor` の暗黙の再生成は ProseMirror state を失うが React state はそのまま → 「半再作成」状態でユーザー入力が捨てられる可能性
+
+### 修正アーキテクチャ
+
+**Patch 1 — focus blur で file watcher を停止しない**
+
+`isBackgroundWindow` の判定から `isWindowFocused` を外す。ファイル監視は visibility 喪失時のみ停止する。他の non-critical 処理 (POS highlight / readability morphology) は別途独自の判定を持たせることで、Patch 1 の影響を file watcher だけに限定する。
+
+**Patch 2 — self-save expected hash で catch-up false positive を根絶 (Root cause A の根本治療)**
+
+R8 を受けて、suppression を「時間ベースの onChanged 抑制」から「期待 hash ベースの self-save 識別」に拡張する。
+
+問題シナリオ (R8): background tab で auto-save → `suppressFileWatch()` 3 秒 → watcher は paused (background) → 3 秒経過 → suppression 期限切れ → tab がアクティブ化されて watcher.start() → catch-up で `mtimeAdvanced=true, isFileSuppressed=false, stale hash` → 誤って `onChanged()` 発火。
+
+解決策:
+
+1. `saveSuppression` Map のエントリを `{ until: number, expectedHash?: string }` に拡張
+2. `suppressFileWatch(path, ttlMs?, expectedHash?)` シグネチャ拡張 (既存呼出しと後方互換)
+3. `expectedHash` 付き登録は TTL を 60 秒に延長 (auto-save 後の長めの blur/focus 復帰をカバー)
+4. `ElectronFileWatcher` の catch-up と `readAndNotify` で、計算した `contentHash` が `expectedHash` と一致したら、suppression 時間切れでも self-save と判定して baseline 更新 + `onChanged()` スキップ
+5. `use-auto-save.ts` / manual save 経路で `suppressFileWatch(path, undefined, computedHash)` を呼び出すよう変更
+6. `_isActive` ガード追加 (R3)
+
+これにより、suppression 期限とは独立に「ディスクの hash が直近 self-save のものと一致するなら self-save」と判定できる。
+
+設計判断: Patch 1 は focus blur 由来の pause/resume サイクルを減らす「リスク削減」レイヤーとして残す。Patch 2 が完成すれば理論上 Patch 1 は不要だが、二重防御として保持する。実機検証後に Patch 1 撤回可否を判定する。
+
+`WebFileWatcher` の `checkForChanges()` は suppression 分岐の前に `this.lastModified = metadata.lastModified` を更新しており (line 299-306)、`initializeLastModified()` も restart 時に毎回再読みするため、catch-up false positive 経路を持たない (R5 確認済み)。Patch 2 の Electron 専用変更とは別に、Web パスでも expectedHash 比較を入れるかは将来検討。本 PR では Electron に限定する。
+
+**Patch 3 — 縦書き切替で MilkdownEditor を明示的に再マウントする**
+
+`components/Editor.tsx` で MilkdownEditor に `key={isVertical ? "vertical" : "horizontal"}` を付与する。これにより：
+
+- `useEditor` の暗黙の再生成ではなく、React コンポーネント自体が再マウントされる
+- `initialContentRef` が最新の `initialContent` prop で再評価される
+- `useEditor` の deps から `isVertical` を外して `useMemo` の deps を明示化 (副作用としての二重再生成を防ぐ)
+
+`useEditor` deps からの `isVertical` 削除は、`japaneseNovel({ isVertical })` プラグイン引数とのバインドが新しい key (再マウント) で行われるため、deps に残す必要がない。
+
+### スコープ外
+
+- **Windows 省電力モードハング**: `electron/main.js:213-225` の powerMonitor リスナーや、PR #1439 の lint-worker と相互作用する可能性。本 PR では触らず、別 Issue (`fix(electron): Windows 省電力モード下でメインプロセス無反応`) を起票する。
+- **editor lifecycle 全面 refactor**: Issue #1445 で言及。長期 refactor として継続。
+
+## Tech Stack
+
+- TypeScript strict mode
+- React 19 (useEffect / useRef / useMemo)
+- Milkdown (`@milkdown/utils`, `@milkdown/core`)
+- ProseMirror
+- Electron IPC for native file watching
+- Test: vitest + @testing-library/react
+
+## Files to Touch
+
+| File                                                   | Change                                                                  |
+| ------------------------------------------------------ | ----------------------------------------------------------------------- |
+| `lib/editor-page/power-optimization.ts`                | `shouldPauseFileWatchers` を visibility のみで判断するよう変更          |
+| `lib/services/file-watcher.ts`                         | `ElectronFileWatcher.readAndNotify()` で suppression 中も baseline 更新 |
+| `components/Editor.tsx`                                | `<MilkdownEditor key={isVertical ? "v" : "h"} ... />` を付与            |
+| `components/editor/MilkdownEditor.tsx`                 | `useEditor` deps から `isVertical` を削除                               |
+| `lib/editor-page/__tests__/power-optimization.test.ts` | `shouldPauseFileWatchers` の新挙動に合わせて更新                        |
+| `lib/services/__tests__/file-watcher-catchup.test.ts`  | suppression 中の baseline 更新を検証する新規ケース追加                  |
+
+## Tasks
+
+### Task 1 — Patch 1: file watcher を visibility のみで停止する
+
+**Goal**: focus blur では file watcher を停止しないようにする。
+
+- [ ] `lib/editor-page/power-optimization.ts` の `shouldPauseFileWatchers` を以下に置き換える:
+  ```ts
+  export function shouldPauseFileWatchers(state: RuntimeActivityState): boolean {
+    // ファイル監視は visibility 喪失時のみ停止する。focus blur (Cmd+Tab など) では継続する。
+    // Reason: focus blur 後の resume で catch-up logic が auto-save 直後の mtime 進行を
+    // 誤って外部変更として扱い、replaceAll() で編集不能になる (#1457 / #1445)
+    return !state.isDocumentVisible;
+  }
+  ```
+- [ ] `isBackgroundWindow` は変更しない (他の非クリティカル処理は従来通り focus blur で停止)
+- [ ] `getAutoSaveIntervalMs` も変更しない (focus blur での auto-save 間隔延長は副作用が小さい)
+- [ ] テスト `lib/editor-page/__tests__/power-optimization.test.ts` に新ケース追加:
+  - `shouldPauseFileWatchers({ powerSaveMode: false, isDocumentVisible: true, isWindowFocused: false })` → `false` を期待
+  - `shouldPauseFileWatchers({ powerSaveMode: false, isDocumentVisible: false, isWindowFocused: true })` → `true` を期待
+- [ ] 検証: `npm run test -- lib/editor-page/__tests__/power-optimization.test.ts`
+
+### Task 2 — Patch 2: self-save expected hash で catch-up false positive 根絶
+
+**Goal**: `saveSuppression` Map に expected hash を持たせ、TTL に依存せず self-save を識別する。`ElectronFileWatcher` の native watch 経路・catch-up 経路の両方で適用。`readAndNotify()` の in-flight 競合は `_isActive` ガードで防ぐ。
+
+#### Step 2.1 — saveSuppression API 拡張 (R8 BLOCKER 修正版)
+
+R8 BLOCKER 対応: hash 不一致 (本物の外部変更) を 60秒間黙って隠蔽してはならない。一方、hash 一致は entry の TTL 内で suppress し続ける。判定を単一の hash-aware 関数に統一する。
+
+- [ ] `lib/services/file-watcher.ts` の `saveSuppression` を以下の型に変更:
+
+  ```ts
+  interface SuppressionEntry {
+    until: number;
+    /** hash 付き = self-save 識別用。未指定 = 旧式 time-only */
+    expectedHash?: string;
+  }
+  const saveSuppression = new Map<string, SuppressionEntry>();
+
+  /** hash 付き suppression の保持期間 (長め、メモリ上限のため終わりはある) */
+  const SAVE_SUPPRESSION_WITH_HASH_MS = 5 * 60_000;
+  /** 旧式 time-only suppression の TTL */
+  const SAVE_SUPPRESSION_MS = 3_000;
+  ```
+
+- [ ] `suppressFileWatch()` のシグネチャは後方互換を保つ:
+  ```ts
+  export function suppressFileWatch(
+    filePath: string,
+    durationMs?: number,
+    expectedHash?: string,
+  ): void {
+    const ttl = durationMs ?? (expectedHash ? SAVE_SUPPRESSION_WITH_HASH_MS : SAVE_SUPPRESSION_MS);
+    saveSuppression.set(filePath, { until: Date.now() + ttl, expectedHash });
+  }
+  ```
+- [ ] 判定関数を **単一の hash-aware** 関数に統一 (R8 完全対応):
+
+  ```ts
+  /**
+   * 内部用：保留中の suppression entry を期限切れガード付きで取得する。
+   */
+  function getActiveSuppression(filePath: string): SuppressionEntry | undefined {
+    const entry = saveSuppression.get(filePath);
+    if (!entry) return undefined;
+    if (Date.now() >= entry.until) {
+      saveSuppression.delete(filePath);
+      return undefined;
+    }
+    return entry;
+  }
+
+  /**
+   * 外部変更通知を抑制すべきか判定する。
+   * - hash 付き entry: contentHash が expectedHash と一致するときのみ suppress
+   *   (一致しないなら本物の外部変更 → 通知すべき、entry は keep して次回 match に備える)
+   * - hash 無し entry (legacy): TTL 内なら常に suppress
+   *
+   * R8: hash 付き entry の TTL 内でも hash 不一致なら通知する。
+   * これにより本物の外部変更が黙って隠蔽されることを防ぐ。
+   */
+  export function shouldSuppressNotification(filePath: string, contentHash: string): boolean {
+    const entry = getActiveSuppression(filePath);
+    if (!entry) return false;
+    if (entry.expectedHash !== undefined) {
+      return entry.expectedHash === contentHash;
+    }
+    return true; // legacy time-only
+  }
+
+  /**
+   * hash 不要な判定 (legacy time-only や、まだ hash 計算前の用途)。
+   * hash 付き entry の場合は **suppress しない** (hash 一致を確認できないため、安全側に倒す)。
+   */
+  function isFileSuppressedTimeOnly(filePath: string): boolean {
+    const entry = getActiveSuppression(filePath);
+    if (!entry) return false;
+    return entry.expectedHash === undefined;
+  }
+  ```
+
+  - **重要**: hash 付き entry に対して `isFileSuppressedTimeOnly` は `false` を返す設計。これは「hash があるのに hash 比較していない判定経路」を排除するため。すべての watcher 経路で hash を計算してから `shouldSuppressNotification(path, hash)` を呼ぶ。
+
+- [ ] `cleanupExpiredSuppressions()` を新 entry 型に追従:
+  ```ts
+  function cleanupExpiredSuppressions(): void {
+    const now = Date.now();
+    for (const [filePath, entry] of saveSuppression) {
+      if (now >= entry.until) {
+        saveSuppression.delete(filePath);
+      }
+    }
+  }
+  ```
+
+#### Step 2.2 — `readAndNotify()` を hash 認識に変更
+
+- [ ] `lib/services/file-watcher.ts:547-` を以下に変更:
+
+  ```ts
+  private async readAndNotify(): Promise<void> {
+    try {
+      const [content, metadata] = await Promise.all([
+        this.vfs.readFile(this.path),
+        this.vfs.getFileMetadata(this.path),
+      ]);
+
+      // R3: async read 完了までに stop() が呼ばれていれば通知しない
+      if (!this._isActive) return;
+
+      const newHash = hashContent(content);
+
+      // baseline は無条件で更新する (R1)
+      this.lastKnownModified = metadata.lastModified;
+
+      // hash-aware 判定 (R8): hash 付き entry でも一致しなければ通知する
+      if (shouldSuppressNotification(this.path, newHash)) {
+        this.lastKnownContentHash = newHash;
+        return;
+      }
+
+      // 内容変化なしの場合は通知スキップ (既存ロジック)
+      if (newHash === this.lastKnownContentHash) {
+        return;
+      }
+
+      this.lastKnownContentHash = newHash;
+      this.onChanged(content, metadata.lastModified);
+    } catch (error) {
+      // 既存のエラーハンドリングを維持
+    }
+  }
+  ```
+
+#### Step 2.3 — `catchUpAndStartWatcher()` を hash 認識に変更
+
+- [ ] `lib/services/file-watcher.ts:418-486` の catch-up 分岐を以下に変更:
+
+  ```ts
+  if (previousModified > 0) {
+    const mtimeAdvanced = metadata.lastModified > previousModified;
+    const possibleSameSecondChange =
+      !mtimeAdvanced &&
+      this.pausedAt > previousModified &&
+      metadata.lastModified === previousModified;
+
+    if (this._isActive && (mtimeAdvanced || possibleSameSecondChange)) {
+      try {
+        const content = await this.vfs.readFile(this.path);
+        if (!this._isActive) return;
+        const contentHash = hashContent(content);
+
+        // baseline は無条件で更新
+        this.lastKnownModified = metadata.lastModified;
+        const previousHash = this.lastKnownContentHash;
+        this.lastKnownContentHash = contentHash;
+
+        // R8: hash 一致なら self-save と判定して通知スキップ。
+        // hash 不一致は本物の外部変更なので通知する (entry は keep)。
+        if (shouldSuppressNotification(this.path, contentHash)) {
+          // self-save、baseline 更新済み、何もしない
+        } else {
+          const contentChanged = contentHash !== previousHash;
+          if (mtimeAdvanced || contentChanged) {
+            this.onChanged(content, metadata.lastModified);
+          }
+        }
+      } catch {
+        this.lastKnownModified = metadata.lastModified;
+      }
+    } else {
+      this.lastKnownModified = metadata.lastModified;
+    }
+  }
+  ```
+
+#### Step 2.4 — 全 save 呼出し元で expectedHash を渡す (R10 対応)
+
+R10: 現在 `suppressFileWatch()` を呼んでいる 4 箇所に加え、`saveMdiFile()` 経由の save も watcher と相互作用するため、抜け漏れなく hash を登録する必要がある。集中管理アプローチを採用:
+
+- [ ] `hashContent` を `lib/services/file-watcher.ts` から named export
+- [ ] **集中管理**: `lib/project/mdi-file.ts:135-` の `saveMdiFile()` 内で、Electron かつ `descriptor.path` がある場合に `suppressFileWatch(path, undefined, hashContent(content))` を呼ぶ。これにより `saveMdiFile()` 経由の全保存が自動的に hash 登録される。
+- [ ] 既存の直接呼出し 4 箇所を hash-aware に更新 (これらは `vfs.writeFile()` を直接叩いているため `saveMdiFile()` 集中管理ではカバーされない):
+  - [ ] `lib/tab-manager/use-auto-save.ts:97`: `suppressFileWatch(tab.file.path, undefined, hashContent(sanitized))` に変更
+  - [ ] `lib/tab-manager/use-close-dialog.ts:89`: 同上
+  - [ ] `lib/tab-manager/use-electron-menu-bindings.ts:165`: 同上
+  - [ ] `lib/tab-manager/use-file-io.ts:247`: 同上
+- [ ] **重要**: `suppressFileWatch()` は `vfs.writeFile()` の **直前** に呼ぶ。逆順 (writeFile → suppress) だと、watcher が write 完了 → change event 検知 → suppress 未登録の状態で `readAndNotify` → false positive となる。現状コードでもこの順序は既に正しい (writeFile 前に suppress) ことを確認済み。
+- [ ] `saveMdiFile()` 内部で suppress を登録する場合、関数の引数として `vfs` を受け取り `vfs.writeFile()` する直前で `suppressFileWatch()` を呼ぶ。Electron 判定は `isElectronRenderer()` を用いる。
+
+#### Step 2.5 — テスト (R9 + R11 対応)
+
+R11: 既存 `file-watcher-catchup.test.ts` は top-level で `vi.mock("../../utils/runtime-env", () => ({ isElectronRenderer: () => false }))` しており、`WebFileWatcher` 経路にロックされている。**新規ファイル必須**。
+
+- [ ] `lib/services/__tests__/file-watcher-electron.test.ts` を **新規作成** (既存ファイルに block 追加では NG):
+
+  ```ts
+  // isElectronRenderer を true にモック
+  vi.mock("../../utils/runtime-env", () => ({ isElectronRenderer: () => true }));
+
+  // watchFile 付き VFS モックを用意
+  const watchFileCallbacks = new Map<string, (event: VFSWatchEvent) => void>();
+  vi.mock("../../vfs", () => ({
+    getVFS: () => ({
+      readFile: vi.fn(...),
+      getFileMetadata: vi.fn(...),
+      writeFile: vi.fn(...),
+      watchFile: (path, cb) => {
+        watchFileCallbacks.set(path, cb);
+        return { stop: () => watchFileCallbacks.delete(path) };
+      },
+    }),
+  }));
+  ```
+
+- [ ] 以下の Case を Electron 環境で実装:
+  - **Case A (Patch 2 核心)**: auto-save 経由で hash 付き suppress 登録 → native watch change event 発火 → onChanged が呼ばれない、baseline 更新済みであることを検証
+  - **Case B (R1+R8)**: watcher start → stop (paused) → 別経路で write & hash 付き suppress 登録 → resume → catch-up が onChanged を呼ばないこと
+  - **Case B2 (R8 核心)**: Case B と同様の手順だが、hash 付き entry の TTL **内** で hash 不一致のファイルを resume → onChanged が呼ばれること (本物の外部変更を隠蔽しないことを検証)
+  - **Case C (R3)**: `readAndNotify` 中に `stop()` を呼出し (`vfs.readFile` を controllable Promise で deferred) → `_isActive` ガードにより onChanged が呼ばれないことを検証
+  - **Case D (回帰)**: hash 不一致 (本物の外部変更) では従来通り onChanged が発火することを検証
+- [ ] 検証: `npm run test -- lib/services/__tests__/file-watcher-electron.test.ts lib/services/__tests__/file-watcher-catchup.test.ts`
+
+### Task 3 — Patch 3: 縦書き切替で MilkdownEditor を明示再マウントする
+
+**Goal**: 縦書き ⇔ 横書き切替で MilkdownEditor を React レベルで再マウントし、最新コンテンツで再初期化する。`useEditor` の deps から `isVertical` を外して二重再生成を防ぐ。
+
+Content flow 確認済み (R4): `EditorLayout.tsx:421-425` で `panelContent = liveEditorTab?.content ?? ""` として渡されるため、key 切替による remount でも `initialContent` には最新の buffer (`tab.content`) が flow する。`use-tab-state.ts:311-320` の `setContent()` で編集中の content が逐次反映されている。
+
+安全性確認済み (R7): `verticalScrollPlugin` は `useMemo([])` で一度だけ生成され `isVerticalRef.current` を読むため、`useEditor` deps から `isVertical` を外しても scroll プラグインの正常性に影響しない。`japaneseNovel({ isVertical })` は新しい key の再マウント時に新しい `isVertical` で再構築される。
+
+- [ ] `components/Editor.tsx` の MilkdownEditor 利用箇所 (line 430 周辺) で `key` prop を付与:
+  ```tsx
+  <MilkdownEditor
+    key={isVertical ? "vertical" : "horizontal"}
+    isVertical={isVertical}
+    initialContent={...}
+    ...
+  />
+  ```
+- [ ] `components/editor/MilkdownEditor.tsx` の `useEditor` deps (line 282) から `isVertical` を削除:
+  ```ts
+  }, [verticalScrollPlugin, mdiExtensionsEnabled, gfmEnabled]);
+  ```
+- [ ] 同ファイルで `isVertical` を直接読んでいる他の useEffect / レイアウト関連は変更不要 (re-mount で再評価される)
+- [ ] 手動 regression test: 大きな MDI ファイルで以下を確認
+  - 未保存編集 → 縦↔横切替 → 編集内容が保持されている (R4 関連回帰防止)
+  - 縦↔横切替を 5 回連続 → エディタが反応・コンテンツ保持・カーソル動作 OK
+
+### Task 4 — フォロー Issue 起票 (Windows 省電力モード)
+
+**Goal**: スコープ外として切り出した Windows 省電力モードハングのフォロー Issue を作成する。
+
+- [ ] `gh issue create` で以下を作成:
+  - Title: `fix(electron): Windows 省電力モード下でメインプロセス無反応 (#1457 から分離)`
+  - Labels: `bug`, `P1`
+  - Body: #1457 のコメント「省電力モードをオンにすると、プロセス無反応になります (Windows)」を引用し、`electron/main.js:213-225` の powerMonitor リスナーと PR #1439 lint-worker の相互作用を candidate として記載
+- [ ] #1457 にコメントで分離 Issue へのリンクを残す
+
+### Task 5 — 統合検証 & commit 分離
+
+- [ ] `npm run type-check`
+- [ ] `npm run test`
+- [ ] `npm run electron:dev` 起動: ハングしないことを確認
+- [ ] 手動 (macOS): エディタ編集中 → Cmd+Tab で別アプリ → 戻る → エディタクリック → カーソル位置維持
+- [ ] 手動 (macOS): 未保存編集 → 縦↔横切替 → 編集内容が保持されていること
+- [ ] 手動 (macOS): 縦↔横切替を 5 回 → 反応・コンテンツ保持
+- [ ] R6 適用: commit を 2 つに分離
+  - Commit 1: `fix(file-watcher): prevent false external-change after auto-save & blur/focus cycle (#1457)` (Patch 1 + 2 + テスト)
+  - Commit 2: `fix(editor): remount MilkdownEditor on vertical/horizontal toggle (#1457)` (Patch 3)
+- [ ] PR description に「Windows 省電力モードは別 Issue で対応」と明記
+- [ ] PR description に Patch 1 の Open Question (撤回可否) を Reviewer note として記載
+
+## Review Iteration 1
+
+### Codex feedback summary
+
+1. **R1 (CRITICAL)** — `catchUpAndStartWatcher()` の suppression skip 分岐でも `lastKnownContentHash` を更新しないと次回 resume で hash 比較が誤判定する
+2. **R2 (IMPORTANT)** — Patch 1 単独では reproduction が visibility 経路か focus 経路か未検証なので「単独 fix」と扱ってはならない
+3. **R3 (IMPORTANT)** — `readAndNotify()` 進行中に `stop()` が呼ばれた場合、async read 完了後に `onChanged()` を呼ぶ競合がある
+4. **R4 (SUGGESTION)** — Patch 3 の `initialContent` は `EditorLayout.tsx:421-425` で `panelContent = liveEditorTab?.content ?? ""` 経由で渡されており、最新の buffer が flow するため remount で unsaved edits は失われない (確認済み)
+5. **R5 (SUGGESTION)** — `WebFileWatcher` は同等のバグを持たない (line 299-306 で suppression 前に baseline 更新済み)
+6. **R6 (SUGGESTION)** — Patch 1+2 と Patch 3 を別 commit に分離すると rollback boundary が明確になる
+7. **R7 (SUGGESTION)** — `verticalScrollPlugin` の `useMemo([])` と `isVerticalRef.current` 利用により、`useEditor` deps からの `isVertical` 削除は安全
+
+### Accepted
+
+- **R1**: Task 2 を「`readAndNotify()` だけでなく `catchUpAndStartWatcher()` も baseline 更新する」に拡張。テストケース B を追加
+- **R3**: Task 2 の `readAndNotify()` 修正に `_isActive` ガード追加。テストケース C を追加
+- **R4**: Architecture section に content flow の確認結果を明記。Task 3 に regression test の手順追加
+- **R5**: Patch 2 の説明セクションに `WebFileWatcher` を意図的にスコープ外とした理由を明記
+- **R7**: Task 3 の説明文に `verticalScrollPlugin` の安全性を明記
+
+### Partially accepted
+
+- **R2**: Patch 1 を「単独 fix」ではなく「defense-in-depth のリスク削減レイヤー」と位置付けることを Architecture section に明記。ただし Patch 1 を撤回はしない (Patch 2 が根本治療として動けば Patch 1 は不要だが、二重防御として残すことで再発リスクを下げる)。Open Questions に「Patch 1 削除可否は実機検証後に判定」と残す
+- **R6**: Issue #1457 は P0 で symptom 1 (編集不能) と symptom 2 (縦書き切替) を両方含むため、1 PR で出すが、commit を `fix(file-watcher): ...` と `fix(editor): vertical toggle ...` の 2 commit に分離する
+
+### Open Questions (post-iteration 1)
+
+- Patch 1 (`shouldPauseFileWatchers` を visibility-only に変更) は Patch 2 が確実に効くなら不要な可能性。実機テスト後に「Patch 1 を撤回して PR #1427 の元の挙動を保つ」選択肢を残す。
+- Patch 1 で focus blur 時の file watcher 継続による CPU 増加は測定する価値があるか？ (PR #1427 の元目的が CPU 削減だったため、回帰を最小化する justification として測定値があると良い)
+
+## Review Iteration 2
+
+### Codex feedback summary
+
+1. **R8 (MAJOR)** — 修正後の `catchUpAndStartWatcher` でも suppression 期限切れ後に self-save が初観測される経路で onChanged が誤発火する
+2. **R9 (MAJOR)** — 既存 `file-watcher-catchup.test.ts` は `isElectronRenderer: () => false` モックで `WebFileWatcher` 経路しか実行されない
+
+### Accepted
+
+- **R8 (一次対応)**: Patch 2 を「saveSuppression を hash 認識に拡張」する根本的な書き直しに変更 → 後に R8 が BLOCKER に格上げされ、Iteration 3 で完全対応
+- **R9**: Task 2 Step 2.5 で Electron-specific test harness を新規作成
+
+## Review Iteration 3
+
+### Codex feedback summary
+
+1. **R8 (BLOCKER 格上げ)** — 二段階の `isOwnSaveByHash() || isFileSuppressed()` 設計には致命的欠陥:
+   - `isOwnSaveByHash()` は entry の `until` 期限を超えると `false` を返すため、laptop sleep など 60 秒超のシナリオで false positive が再発
+   - `isFileSuppressed()` は hash 付き entry でも TTL 内なら `true` を返すので、その間の本物の外部変更を黙って隠蔽する
+2. **R10 (MAJOR)** — `suppressFileWatch` の呼出し元網羅が不完全。`saveMdiFile()` 経由の save がカバーされない
+3. **R11 (MINOR)** — 既存 `file-watcher-catchup.test.ts` は top-level で `isElectronRenderer = false` モック済みなので block 追加では Electron 経路に到達できない。新規ファイル必須
+
+### Accepted
+
+- **R8 (BLOCKER)**: Step 2.1 を完全再設計。`shouldSuppressNotification(path, hash)` 単一関数に統一:
+  - hash 付き entry: hash 一致時のみ suppress、不一致なら通知 (entry は keep)
+  - hash 無し entry (legacy): TTL 内なら常に suppress
+  - hash 付き保持期間は 5 分に延長 (メモリ上限のため終わりは持つが、自然な laptop sleep を超える長さ)
+- **R10**: Step 2.4 を「`saveMdiFile()` 集中管理 + 既存 4 箇所の直接 `vfs.writeFile()` 呼出しを hash 化」の両建てに変更。`suppressFileWatch()` の呼出し順序 (writeFile 直前) を明記
+- **R11**: Step 2.5 を「新規ファイル `file-watcher-electron.test.ts` 必須」に変更、Case B2 (hash 不一致での外部変更通知) を追加
+
+### Rejected
+
+- なし
+
+### Circuit breaker 判定
+
+3 イテレーション目で R8 が BLOCKER に格上げされ、設計の根本見直しを行った。これ以上の Codex レビューは diminishing returns に入る可能性が高いため、本 iteration をもって Codex レビューを終了し、ユーザーに plan を提示する。実機検証 (Task 5) で残った懸念は実装段階で対応する。

--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -329,8 +329,14 @@ export function useDockviewAdapter({
 
       // Listen for dockview panel activation → update tab manager
       api.onDidActivePanelChange((e) => {
-        if (isSyncingRef.current) return;
         const panelId = e?.id;
+        console.warn(
+          "[dockview] onDidActivePanelChange",
+          `panelId=${panelId}`,
+          `currentActive=${tabManager.activeTabId}`,
+          `isSyncing=${isSyncingRef.current}`,
+        );
+        if (isSyncingRef.current) return;
         if (panelId && panelId !== tabManager.activeTabId) {
           isSyncingRef.current = true;
           switchTab(panelId);

--- a/lib/editor-page/__tests__/power-optimization.test.ts
+++ b/lib/editor-page/__tests__/power-optimization.test.ts
@@ -54,6 +54,21 @@ describe("power optimization policy", () => {
     expect(shouldPauseFileWatchers(makeState({ isDocumentVisible: false }))).toBe(true);
   });
 
+  it("does not pause file watchers on focus blur alone (Cmd+Tab)", () => {
+    // Patch 1 (#1457): focus loss must NOT pause file watchers; only visibility loss does.
+    // Previously isBackgroundWindow() gated this, causing catch-up false positives.
+    expect(
+      shouldPauseFileWatchers(makeState({ isWindowFocused: false, isDocumentVisible: true })),
+    ).toBe(false);
+  });
+
+  it("pauses file watchers when document is hidden even if window is focused", () => {
+    // Background tab / minimised window: visibility drives the pause, not focus.
+    expect(
+      shouldPauseFileWatchers(makeState({ isDocumentVisible: false, isWindowFocused: true })),
+    ).toBe(true);
+  });
+
   it("keeps the normal auto-save interval while fully active", () => {
     expect(getAutoSaveIntervalMs(makeState(), 5_000)).toBe(5_000);
   });

--- a/lib/editor-page/power-optimization.ts
+++ b/lib/editor-page/power-optimization.ts
@@ -38,7 +38,10 @@ export function shouldEnablePosHighlight(
 }
 
 export function shouldPauseFileWatchers(state: RuntimeActivityState): boolean {
-  return isBackgroundWindow(state);
+  // ファイル監視は visibility 喪失時のみ停止する。focus blur (Cmd+Tab など) では継続する。
+  // Reason: focus blur 後の resume で catch-up logic が auto-save 直後の mtime 進行を
+  // 誤って外部変更として扱い、replaceAll() で編集不能になる (#1457 / #1445)
+  return !state.isDocumentVisible;
 }
 
 export function getAutoSaveIntervalMs(

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -151,8 +151,13 @@ export function useLinting(
   // Bootstrap the Genji noun vocabulary (renderer-side) — Electron only.
   // Fires `refreshLinting` whenever vocab becomes ready or gets reloaded
   // after a dictionary install so the genji-unknown-noun rule picks it up.
+  //
+  // Gated on the genji-unknown-noun rule being enabled. Otherwise startup
+  // would always initialize the vocabulary AND fire a full-document re-lint
+  // via subscribe(), causing the open-time freeze observed in #1457.
   useEffect(() => {
     if (!isElectronRenderer()) return;
+    if (!lintingRuleConfigs["genji-unknown-noun"]?.enabled) return;
 
     genjiVocab.initialize().catch((err) => {
       console.error("[useLinting] genjiVocab.initialize failed:", err);
@@ -172,7 +177,7 @@ export function useLinting(
       unsubscribe();
       offInstalled?.();
     };
-  }, [refreshLinting]);
+  }, [refreshLinting, lintingRuleConfigs]);
 
   return {
     ruleRunner,

--- a/lib/editor-page/use-text-statistics.ts
+++ b/lib/editor-page/use-text-statistics.ts
@@ -76,21 +76,29 @@ export function useTextStatistics(
     if (!enableMorphologicalAnalysis || cleanedContent.length < 50) return;
 
     let cancelled = false;
-    getNlpClient()
-      .tokenizeParagraph(cleanedContent)
-      .then((tokens) => {
-        if (cancelled) return;
-        setEnrichedAnalysis({
-          content: cleanedContent,
-          analysis: enrichReadabilityWithMorphology(surfaceAnalysis, tokens),
+    // Debounce the full-document tokenization so it doesn't fire on the
+    // mount-time content commit alongside the linting plugin's initial
+    // scan. 600 ms is short enough that statistics stay responsive while
+    // typing but long enough to let the first paint settle (#1457).
+    const timer = window.setTimeout(() => {
+      if (cancelled) return;
+      getNlpClient()
+        .tokenizeParagraph(cleanedContent)
+        .then((tokens) => {
+          if (cancelled) return;
+          setEnrichedAnalysis({
+            content: cleanedContent,
+            analysis: enrichReadabilityWithMorphology(surfaceAnalysis, tokens),
+          });
+        })
+        .catch(() => {
+          // NLP失敗時は表層結果のまま維持（silent fallback）
         });
-      })
-      .catch(() => {
-        // NLP失敗時は表層結果のまま維持（silent fallback）
-      });
+    }, 600);
 
     return () => {
       cancelled = true;
+      window.clearTimeout(timer);
     };
   }, [cleanedContent, surfaceAnalysis, enableMorphologicalAnalysis]);
 

--- a/lib/project/mdi-file.ts
+++ b/lib/project/mdi-file.ts
@@ -1,6 +1,7 @@
 // クロスプラットフォームな .mdi ファイルの開閉/保存
 
 import { getRuntimeEnvironment, isBrowser } from "../utils/runtime-env";
+import { suppressFileWatch, hashContent } from "../services/file-watcher";
 import type { SupportedFileExtension } from "./project-types";
 
 export interface MdiFileDescriptor {
@@ -139,6 +140,11 @@ export async function saveMdiFile(params: SaveMdiParams): Promise<OpenMdiResult 
   if (env === "electron-renderer" && window.electronAPI) {
     const existingPath = descriptor?.path ?? null;
     try {
+      // suppress before write so that the native watcher does not treat the
+      // coming change event as an external modification (#1457 Patch 2)
+      if (existingPath) {
+        suppressFileWatch(existingPath, undefined, hashContent(content));
+      }
       const result = await window.electronAPI.saveFile(existingPath, content, fileType);
       if (!result) {
         // User cancelled the save dialog
@@ -150,6 +156,12 @@ export async function saveMdiFile(params: SaveMdiParams): Promise<OpenMdiResult 
       }
       const savedPath = result as string;
       const name = basename(savedPath);
+      // For newly-created files (existingPath was null), register suppression
+      // now that we have the path. The watcher will be set up later so there
+      // is no race here, but registering keeps behaviour consistent.
+      if (!existingPath) {
+        suppressFileWatch(savedPath, undefined, hashContent(content));
+      }
       return {
         descriptor: {
           path: savedPath,

--- a/lib/services/__tests__/file-watcher-electron.test.ts
+++ b/lib/services/__tests__/file-watcher-electron.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for ElectronFileWatcher — hash-aware suppression and _isActive guard.
+ *
+ * A separate test file is required because the existing file-watcher-catchup.test.ts
+ * mocks isElectronRenderer to false at module scope (WebFileWatcher path), which
+ * cannot be overridden within the same module (R11).
+ *
+ * Covers:
+ *   Case A — auto-save hash suppression: native change event does NOT fire onChanged
+ *   Case B — catch-up suppression: paused watcher resumes and skips self-save via hash
+ *   Case B2 — hash mismatch within TTL: genuine external change still fires onChanged
+ *   Case C — _isActive race: stop() during in-flight readAndNotify cancels notification
+ *   Case D — regression: real external change always fires onChanged
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { VFSWatchEvent } from "@/lib/vfs/types";
+
+// ---------------------------------------------------------------------------
+// Mock isElectronRenderer → true so createFileWatcher returns ElectronFileWatcher
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/utils/runtime-env", () => ({
+  isElectronRenderer: () => true,
+}));
+
+// ---------------------------------------------------------------------------
+// VFS mock with watchFile support
+// ---------------------------------------------------------------------------
+
+type WatchCallback = (event: VFSWatchEvent) => void;
+
+const watchFileCallbacks = new Map<string, WatchCallback>();
+
+const mockReadFile = vi.fn<(path: string) => Promise<string>>();
+const mockGetFileMetadata =
+  vi.fn<(path: string) => Promise<{ lastModified: number; size: number }>>();
+const mockWriteFile = vi.fn<(path: string, content: string) => Promise<void>>();
+
+vi.mock("@/lib/vfs", () => ({
+  getVFS: () => ({
+    readFile: mockReadFile,
+    getFileMetadata: mockGetFileMetadata,
+    writeFile: mockWriteFile,
+    watchFile: (path: string, cb: WatchCallback) => {
+      watchFileCallbacks.set(path, cb);
+      return {
+        stop: () => {
+          watchFileCallbacks.delete(path);
+        },
+      };
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks are set up)
+// ---------------------------------------------------------------------------
+
+import {
+  createFileWatcher,
+  suppressFileWatch,
+  hashContent,
+  shouldSuppressNotification,
+} from "@/lib/services/file-watcher";
+import type { FileWatcher, FileChangeCallback } from "@/lib/services/file-watcher";
+
+// ---------------------------------------------------------------------------
+// Helper: fire a native watch 'change' event for a path
+// ---------------------------------------------------------------------------
+function fireChangeEvent(path: string): void {
+  const cb = watchFileCallbacks.get(path);
+  if (!cb) throw new Error(`No watcher registered for ${path}`);
+  cb({ type: "change", path });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: sleep
+// ---------------------------------------------------------------------------
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ElectronFileWatcher: hash-aware suppression (#1457 Patch 2)", () => {
+  const TEST_PATH = "/test/doc.mdi";
+  let watcher: FileWatcher;
+  let onChanged: ReturnType<typeof vi.fn<FileChangeCallback>>;
+
+  beforeEach(() => {
+    watchFileCallbacks.clear();
+    mockReadFile.mockReset();
+    mockGetFileMetadata.mockReset();
+    mockWriteFile.mockReset();
+    onChanged = vi.fn<FileChangeCallback>();
+  });
+
+  afterEach(() => {
+    watcher?.stop();
+    vi.restoreAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case A: auto-save → hash suppression → native event does NOT call onChanged
+  // -------------------------------------------------------------------------
+  it("Case A: native change event after hash-suppressed save does not fire onChanged", async () => {
+    const content = "hello world";
+    const contentHash = hashContent(content);
+
+    // Set up VFS: metadata returns mtime 1000, readFile returns content
+    mockGetFileMetadata.mockResolvedValue({ lastModified: 1000, size: content.length });
+    mockReadFile.mockResolvedValue(content);
+
+    watcher = createFileWatcher({ path: TEST_PATH, onChanged });
+    watcher.start();
+    await sleep(30); // let catchUpAndStartWatcher complete
+
+    // Simulate auto-save: suppress with expected hash BEFORE the write
+    suppressFileWatch(TEST_PATH, undefined, contentHash);
+
+    // Simulate native filesystem event (what the OS would emit after the write)
+    fireChangeEvent(TEST_PATH);
+    await sleep(30); // let readAndNotify complete
+
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case B: watcher paused → self-save with hash → resume → catch-up skips
+  // -------------------------------------------------------------------------
+  it("Case B: catch-up after resume skips self-save identified by hash", async () => {
+    const initialContent = "initial";
+    const savedContent = "saved by app";
+    const savedHash = hashContent(savedContent);
+
+    // First start: mtime 1000, initial content
+    mockGetFileMetadata.mockResolvedValueOnce({ lastModified: 1000, size: initialContent.length });
+    mockReadFile.mockResolvedValueOnce(initialContent);
+
+    watcher = createFileWatcher({ path: TEST_PATH, onChanged });
+    watcher.start();
+    await sleep(30); // complete initial catchUpAndStartWatcher
+
+    // Stop (simulating blur/background)
+    watcher.stop();
+
+    // Simulate app self-save while paused: register hash suppression
+    suppressFileWatch(TEST_PATH, undefined, savedHash);
+
+    // File has now been written: mtime advanced to 2000, content is savedContent
+    mockGetFileMetadata.mockResolvedValueOnce({ lastModified: 2000, size: savedContent.length });
+    mockReadFile.mockResolvedValueOnce(savedContent);
+
+    // Resume
+    watcher.start();
+    await sleep(30); // let catchUpAndStartWatcher run
+
+    // catch-up should recognise the self-save and NOT call onChanged
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case B2: hash MISMATCH within TTL — genuine external change must still fire
+  // -------------------------------------------------------------------------
+  it("Case B2: hash mismatch within TTL fires onChanged (real external change not hidden)", async () => {
+    const initialContent = "initial";
+    const appSavedContent = "saved by app";
+    const externalContent = "edited externally";
+    const appSavedHash = hashContent(appSavedContent);
+
+    // First start: mtime 1000
+    mockGetFileMetadata.mockResolvedValueOnce({ lastModified: 1000, size: initialContent.length });
+    mockReadFile.mockResolvedValueOnce(initialContent);
+
+    watcher = createFileWatcher({ path: TEST_PATH, onChanged });
+    watcher.start();
+    await sleep(30);
+
+    // Stop
+    watcher.stop();
+
+    // App saved content (registered with hash for appSavedContent)
+    suppressFileWatch(TEST_PATH, undefined, appSavedHash);
+
+    // But the disk actually has EXTERNAL content (different hash)
+    mockGetFileMetadata.mockResolvedValueOnce({ lastModified: 2000, size: externalContent.length });
+    mockReadFile.mockResolvedValueOnce(externalContent);
+
+    // Resume
+    watcher.start();
+    await sleep(30);
+
+    // hash mismatch → must fire onChanged even though entry is within TTL
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledWith(externalContent, 2000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Case C: _isActive guard — stop() during in-flight readAndNotify cancels notification
+  // -------------------------------------------------------------------------
+  it("Case C: stop() during in-flight readAndNotify prevents onChanged", async () => {
+    // Use a controllable promise for readFile so we can call stop() while it is in-flight
+    let resolveRead!: (value: string) => void;
+    const readPromise = new Promise<string>((resolve) => {
+      resolveRead = resolve;
+    });
+
+    const content = "some content";
+    mockGetFileMetadata.mockResolvedValue({ lastModified: 1000, size: content.length });
+    // First call (initial start): resolve immediately so catchUpAndStartWatcher finishes
+    mockReadFile.mockResolvedValueOnce(content);
+    // Second call (readAndNotify from native event): use controllable promise
+    mockReadFile.mockReturnValueOnce(readPromise);
+
+    watcher = createFileWatcher({ path: TEST_PATH, onChanged });
+    watcher.start();
+    await sleep(30); // let initial catch-up complete
+
+    // Fire native event → triggers readAndNotify → hits the deferred readFile
+    fireChangeEvent(TEST_PATH);
+    // readAndNotify is now waiting on readPromise
+
+    // Stop the watcher while read is in-flight
+    watcher.stop();
+
+    // Now resolve the read — _isActive is false so onChanged must NOT be called
+    resolveRead("new content");
+    await sleep(30);
+
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Case D: real external change (hash mismatch, no suppression) fires onChanged
+  // -------------------------------------------------------------------------
+  it("Case D: genuine external change (no suppression) fires onChanged", async () => {
+    const initialContent = "original";
+    const externalContent = "changed externally";
+
+    // Initial start
+    mockGetFileMetadata.mockResolvedValueOnce({ lastModified: 1000, size: initialContent.length });
+    mockReadFile.mockResolvedValueOnce(initialContent);
+
+    watcher = createFileWatcher({ path: TEST_PATH, onChanged });
+    watcher.start();
+    await sleep(30);
+
+    // Native event: file changed externally, no suppression registered
+    mockGetFileMetadata.mockResolvedValueOnce({ lastModified: 2000, size: externalContent.length });
+    mockReadFile.mockResolvedValueOnce(externalContent);
+
+    fireChangeEvent(TEST_PATH);
+    await sleep(30);
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledWith(externalContent, expect.any(Number));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests for shouldSuppressNotification
+// ---------------------------------------------------------------------------
+describe("shouldSuppressNotification", () => {
+  it("returns false when no entry exists", () => {
+    expect(shouldSuppressNotification("/no/entry.mdi", "abc")).toBe(false);
+  });
+
+  it("returns true for hash-matching entry within TTL", () => {
+    const content = "test content";
+    const hash = hashContent(content);
+    suppressFileWatch("/hash-match.mdi", undefined, hash);
+    expect(shouldSuppressNotification("/hash-match.mdi", hash)).toBe(true);
+  });
+
+  it("returns false for hash-mismatching entry (external change not hidden)", () => {
+    const content = "app saved";
+    const hash = hashContent(content);
+    suppressFileWatch("/hash-mismatch.mdi", undefined, hash);
+    expect(shouldSuppressNotification("/hash-mismatch.mdi", hashContent("different"))).toBe(false);
+  });
+
+  it("returns true for legacy time-only entry within TTL", () => {
+    suppressFileWatch("/legacy.mdi", 5000); // no hash → legacy
+    expect(shouldSuppressNotification("/legacy.mdi", "anything")).toBe(true);
+  });
+});

--- a/lib/services/file-watcher.ts
+++ b/lib/services/file-watcher.ts
@@ -38,17 +38,30 @@ const MAX_CONSECUTIVE_FAILURES = 5;
  * Tracks paths that were recently saved by the application,
  * so watchers can ignore self-triggered change events.
  *
+ * Each entry carries an optional expected content hash. When present, the
+ * suppression only applies when the observed file hash matches — so genuine
+ * external changes within the TTL window still fire onChanged.
+ *
  * A periodic cleanup timer evicts expired entries every 5 minutes
  * to prevent unbounded memory growth in long-running sessions.
  *
  * アプリケーション自身による保存を追跡し、
  * ウォッチャーが自身のトリガーによる変更イベントを無視できるようにする。
+ * expectedHash が付いている場合は hash 一致時のみ抑制し、本物の外部変更は通知する。
  * 5分ごとに期限切れエントリを削除し、長時間セッションでのメモリ増大を防止する。
  */
-const saveSuppression = new Map<string, number>();
+interface SuppressionEntry {
+  until: number;
+  /** hash 付き = self-save 識別用。未指定 = 旧式 time-only */
+  expectedHash?: string;
+}
+const saveSuppression = new Map<string, SuppressionEntry>();
 
-/** Default suppression duration in milliseconds */
+/** Default suppression duration in milliseconds (legacy time-only) */
 const SAVE_SUPPRESSION_MS = 3000;
+
+/** hash 付き suppression の保持期間 (長め、メモリ上限のため終わりはある) */
+const SAVE_SUPPRESSION_WITH_HASH_MS = 5 * 60_000;
 
 /** Interval for periodic cleanup of expired suppression entries (5 minutes) */
 const SUPPRESSION_CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
@@ -62,8 +75,8 @@ const SUPPRESSION_CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
  */
 function cleanupExpiredSuppressions(): void {
   const now = Date.now();
-  for (const [filePath, until] of saveSuppression) {
-    if (now >= until) {
+  for (const [filePath, entry] of saveSuppression) {
+    if (now >= entry.until) {
       saveSuppression.delete(filePath);
     }
   }
@@ -83,26 +96,80 @@ if (typeof suppressionCleanupTimer === "object" && "unref" in suppressionCleanup
  * Call this before saving a file to prevent the watcher
  * from treating the save as an external change.
  *
+ * When expectedHash is provided, the suppression entry is kept for
+ * SAVE_SUPPRESSION_WITH_HASH_MS and only suppresses notifications when
+ * the observed file hash matches. This allows genuine external changes
+ * within the window to still fire onChanged.
+ *
  * 指定パスのファイル監視通知を一時的に抑制する。
- * ファイル保存前に呼び出し、ウォッチャーが自身の保存を
- * 外部変更として扱うのを防ぐ。
+ * ファイル保存前に呼び出し、ウォッチャーが自身の保存を外部変更として扱うのを防ぐ。
+ * expectedHash を渡した場合は hash 一致時のみ抑制し、TTL 内でも本物の外部変更は通知する。
  *
  * @param filePath - The file path to suppress notifications for
- * @param durationMs - How long to suppress (default 3000ms)
+ * @param durationMs - How long to suppress (default: 3000ms without hash, 5min with hash)
+ * @param expectedHash - Expected content hash of the self-save (enables hash-aware suppression)
  */
 export function suppressFileWatch(
   filePath: string,
-  durationMs: number = SAVE_SUPPRESSION_MS,
+  durationMs?: number,
+  expectedHash?: string,
 ): void {
-  saveSuppression.set(filePath, Date.now() + durationMs);
+  const ttl = durationMs ?? (expectedHash ? SAVE_SUPPRESSION_WITH_HASH_MS : SAVE_SUPPRESSION_MS);
+  saveSuppression.set(filePath, { until: Date.now() + ttl, expectedHash });
 }
 
-function isFileSuppressed(filePath: string): boolean {
-  const until = saveSuppression.get(filePath);
-  if (!until) return false;
-  if (Date.now() < until) return true;
-  saveSuppression.delete(filePath);
-  return false;
+/**
+ * Internal: retrieve the active suppression entry with expiry guard.
+ * Returns undefined if no entry exists or the entry has expired.
+ *
+ * 内部用：保留中の suppression entry を期限切れガード付きで取得する。
+ */
+function getActiveSuppression(filePath: string): SuppressionEntry | undefined {
+  const entry = saveSuppression.get(filePath);
+  if (!entry) return undefined;
+  if (Date.now() >= entry.until) {
+    saveSuppression.delete(filePath);
+    return undefined;
+  }
+  return entry;
+}
+
+/**
+ * Determine whether an external-change notification should be suppressed.
+ *
+ * - Hash-bearing entry: suppress only when contentHash === expectedHash.
+ *   A hash mismatch means a genuine external change — notify even within TTL
+ *   (R8: do not silently hide real external changes).
+ * - Hash-less entry (legacy time-only): suppress whenever within TTL.
+ *
+ * Note: hash-bearing entries are NOT consumed on match (filesystem can fire
+ * duplicate events for one save). Cleanup is handled by the periodic timer
+ * and the expiry guard in getActiveSuppression().
+ *
+ * 外部変更通知を抑制すべきか判定する。
+ * hash 付き entry: hash 一致時のみ suppress（不一致は本物の外部変更）
+ * hash 無し entry (legacy): TTL 内なら常に suppress
+ */
+export function shouldSuppressNotification(filePath: string, contentHash: string): boolean {
+  const entry = getActiveSuppression(filePath);
+  if (!entry) return false;
+  if (entry.expectedHash !== undefined) {
+    return entry.expectedHash === contentHash;
+  }
+  return true; // legacy time-only
+}
+
+/**
+ * Legacy time-only suppression check (for code paths that have not yet
+ * computed a content hash). Returns false for hash-bearing entries so that
+ * we never silently suppress without actually comparing hashes.
+ *
+ * hash 付き entry に対しては false を返す設計（hash 比較なしに抑制しない安全側）。
+ */
+function isFileSuppressedTimeOnly(filePath: string): boolean {
+  const entry = getActiveSuppression(filePath);
+  if (!entry) return false;
+  return entry.expectedHash === undefined;
 }
 
 // -----------------------------------------------------------------------
@@ -128,7 +195,7 @@ function isFileSuppressed(filePath: string): boolean {
  * @param content - File content string to hash
  * @returns A string representation of the hash
  */
-function hashContent(content: string): string {
+export function hashContent(content: string): string {
   let hash = 5381;
   for (let i = 0; i < content.length; i++) {
     // djb2: hash = hash * 33 ^ charCode
@@ -234,7 +301,7 @@ class WebFileWatcher implements FileWatcher {
 
         // Catch-up check: detect changes that occurred while the watcher was paused
         if (previousModified > 0 && this.lastModified > previousModified) {
-          if (!isFileSuppressed(this.path)) {
+          if (!isFileSuppressedTimeOnly(this.path)) {
             try {
               const content = await this.vfs.readFile(this.path);
               if (this._isActive) {
@@ -288,7 +355,7 @@ class WebFileWatcher implements FileWatcher {
    * MAX_CONSECUTIVE_FAILURES 回連続で失敗した場合、監視を自動停止する。
    */
   private async checkForChanges(): Promise<void> {
-    const suppressed = isFileSuppressed(this.path);
+    const suppressed = isFileSuppressedTimeOnly(this.path);
 
     try {
       const metadata = await this.vfs.getFileMetadata(this.path);
@@ -430,22 +497,29 @@ class ElectronFileWatcher implements FileWatcher {
           this.pausedAt > previousModified &&
           metadata.lastModified === previousModified;
 
-        if (
-          this._isActive &&
-          (mtimeAdvanced || possibleSameSecondChange) &&
-          !isFileSuppressed(this.path)
-        ) {
-          const content = await this.vfs.readFile(this.path);
-          if (this._isActive) {
+        if (this._isActive && (mtimeAdvanced || possibleSameSecondChange)) {
+          try {
+            const content = await this.vfs.readFile(this.path);
+            if (!this._isActive) return;
             const contentHash = hashContent(content);
-            const contentChanged = contentHash !== this.lastKnownContentHash;
 
+            // baseline は無条件で更新する (R1)
             this.lastKnownModified = metadata.lastModified;
+            const previousHash = this.lastKnownContentHash;
+            this.lastKnownContentHash = contentHash;
 
-            if (mtimeAdvanced || contentChanged) {
-              this.lastKnownContentHash = contentHash;
-              this.onChanged(content, metadata.lastModified);
+            // R8: hash 一致なら self-save と判定して通知スキップ。
+            // hash 不一致は本物の外部変更なので通知する (entry は keep)。
+            if (shouldSuppressNotification(this.path, contentHash)) {
+              // self-save confirmed — baseline 更新済み、何もしない
+            } else {
+              const contentChanged = contentHash !== previousHash;
+              if (mtimeAdvanced || contentChanged) {
+                this.onChanged(content, metadata.lastModified);
+              }
             }
+          } catch {
+            this.lastKnownModified = metadata.lastModified;
           }
         } else {
           // Update baseline even when no change detected
@@ -545,22 +619,31 @@ class ElectronFileWatcher implements FileWatcher {
    * 権限の取り消しやその他のエラーを適切に処理する。
    */
   private async readAndNotify(): Promise<void> {
-    // Skip if this path was recently saved by the application
-    if (isFileSuppressed(this.path)) {
-      return;
-    }
-
     try {
       const [content, metadata] = await Promise.all([
         this.vfs.readFile(this.path),
         this.vfs.getFileMetadata(this.path),
       ]);
+
+      // R3: async read 完了までに stop() が呼ばれていれば通知しない
+      if (!this._isActive) return;
+
       const newHash = hashContent(content);
+
+      // baseline は無条件で更新する (R1)
       this.lastKnownModified = metadata.lastModified;
-      // Skip notification if content hasn't changed (e.g. cloud sync metadata update)
+
+      // hash-aware 判定 (R8): hash 付き entry でも一致しなければ通知する
+      if (shouldSuppressNotification(this.path, newHash)) {
+        this.lastKnownContentHash = newHash;
+        return;
+      }
+
+      // 内容変化なしの場合は通知スキップ (既存ロジック)
       if (newHash === this.lastKnownContentHash) {
         return;
       }
+
       this.lastKnownContentHash = newHash;
       this.onChanged(content, metadata.lastModified);
     } catch (error) {

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from "react";
 import { saveMdiFile } from "../project/mdi-file";
 import { getVFS } from "../vfs";
-import { suppressFileWatch } from "../services/file-watcher";
+import { suppressFileWatch, hashContent } from "../services/file-watcher";
 import { notificationManager } from "../services/notification-manager";
 import { isEditorTab } from "./tab-types";
 import type { TabManagerCore } from "./types";
@@ -94,7 +94,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
             const sanitized = sanitizeMdiContent(tab.content);
             if (isProjectRef.current && tab.file?.path) {
               const vfs = getVFS();
-              suppressFileWatch(tab.file.path);
+              suppressFileWatch(tab.file.path, undefined, hashContent(sanitized));
               await vfs.writeFile(tab.file.path, sanitized);
               if (!mountedRef.current) return;
               setTabs((prev) =>

--- a/lib/tab-manager/use-close-dialog.ts
+++ b/lib/tab-manager/use-close-dialog.ts
@@ -3,7 +3,7 @@
 import { useCallback } from "react";
 import { saveMdiFile } from "../project/mdi-file";
 import { getVFS } from "../vfs";
-import { suppressFileWatch } from "../services/file-watcher";
+import { suppressFileWatch, hashContent } from "../services/file-watcher";
 import { notificationManager } from "../services/notification-manager";
 import type { TabId, TabState, EditorTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
@@ -86,7 +86,7 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
 
       if (isProjectRef.current && tab.file?.path) {
         const vfs = getVFS();
-        suppressFileWatch(tab.file.path);
+        suppressFileWatch(tab.file.path, undefined, hashContent(sanitized));
         await vfs.writeFile(tab.file.path, sanitized);
         await tryAutoSnapshot(tab.file.path, tab.file.name, sanitized, true);
       } else {

--- a/lib/tab-manager/use-electron-menu-bindings.ts
+++ b/lib/tab-manager/use-electron-menu-bindings.ts
@@ -3,7 +3,11 @@
 import { useEffect, useRef } from "react";
 import { saveMdiFile } from "../project/mdi-file";
 import { getVFS } from "../vfs";
-import { suppressFileWatch, hashContent } from "../services/file-watcher";
+import {
+  suppressFileWatch,
+  hashContent,
+  shouldSuppressNotification,
+} from "../services/file-watcher";
 import { notificationManager } from "../services/notification-manager";
 import type { SupportedFileExtension } from "../project/project-types";
 import type { TabId, EditorTabState } from "./tab-types";
@@ -219,6 +223,9 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
   }, [isElectron, loadSystemFile, systemFileOpenHandlerRef]);
 
   // Reload non-dirty tabs when window regains visibility (#98)
+  // Skip the app's own recent saves (hash-aware suppression) to avoid #1457:
+  // auto-save → visibility regain → self-save reloaded as "external change"
+  // → replaceAll() → editor loses focus and becomes uneditable.
   useEffect(() => {
     const handleVisibilityChange = async () => {
       if (document.hidden) return;
@@ -233,18 +240,22 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
         if (tab.isDirty) continue;
         try {
           const diskContent = await vfs.readFile(tab.file.path);
-          if (diskContent !== tab.lastSavedContent) {
-            updateTab(tab.id, {
-              content: diskContent,
-              lastSavedContent: diskContent,
-              isDirty: false,
-              lastSavedTime: Date.now(),
-              // Signal the active Milkdown editor to reload with the new content.
-              // Background tabs will naturally use the updated content on remount;
-              // the active editor needs this field in its React key to force remount.
-              pendingExternalContent: diskContent,
-            });
+          if (diskContent === tab.lastSavedContent) continue;
+          // Hash-aware self-save suppression: if the disk content matches a
+          // recently recorded self-save hash, this is not an external change.
+          if (shouldSuppressNotification(tab.file.path, hashContent(diskContent))) {
+            continue;
           }
+          updateTab(tab.id, {
+            content: diskContent,
+            lastSavedContent: diskContent,
+            isDirty: false,
+            lastSavedTime: Date.now(),
+            // Signal the active Milkdown editor to reload with the new content.
+            // Background tabs will naturally use the updated content on remount;
+            // the active editor needs this field in its React key to force remount.
+            pendingExternalContent: diskContent,
+          });
         } catch {
           // File may have been deleted; skip
         }

--- a/lib/tab-manager/use-electron-menu-bindings.ts
+++ b/lib/tab-manager/use-electron-menu-bindings.ts
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from "react";
 import { saveMdiFile } from "../project/mdi-file";
 import { getVFS } from "../vfs";
-import { suppressFileWatch } from "../services/file-watcher";
+import { suppressFileWatch, hashContent } from "../services/file-watcher";
 import { notificationManager } from "../services/notification-manager";
 import type { SupportedFileExtension } from "../project/project-types";
 import type { TabId, EditorTabState } from "./tab-types";
@@ -162,7 +162,7 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
         try {
           if (isProjectRef.current && tab.file.path) {
             const vfs = getVFS();
-            suppressFileWatch(tab.file.path);
+            suppressFileWatch(tab.file.path, undefined, hashContent(sanitized));
             await vfs.writeFile(tab.file.path, sanitized);
             await tryAutoSnapshotRef.current?.(tab.file.path, tab.file.name, sanitized, true);
           } else {

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -11,7 +11,7 @@ import { getStorageService } from "../storage/storage-service";
 import { persistAppState } from "../storage/app-state-manager";
 import { getHistoryService } from "../services/history-service";
 import { getVFS } from "../vfs";
-import { suppressFileWatch } from "../services/file-watcher";
+import { suppressFileWatch, hashContent } from "../services/file-watcher";
 import type { TabId, EditorTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
 import { generateTabId, inferFileType, sanitizeMdiContent, getErrorMessage } from "./types";
@@ -244,7 +244,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         // Project mode: VFS direct write
         if (isProjectRef.current && tab.file?.path) {
           const vfs = getVFS();
-          suppressFileWatch(tab.file.path);
+          suppressFileWatch(tab.file.path, undefined, hashContent(sanitized));
           await vfs.writeFile(tab.file.path, sanitized);
 
           // Update project.json lastModified so workspace metadata stays in sync.


### PR DESCRIPTION
## 概要

#1457 P0 (エディタ編集不能、起動フリーズ) の follow-up 修正セット。

これまでに以下を確認:
- ✅ `replaceAll()` 経由の編集不能は file-watcher hash-aware suppression + visibilitychange ガードで解決
- ✅ `genjiVocab` initialization 起因の起動フリーズは rule-gating で解決
- 🔍 残る「click → 先頭ジャンプ + カーソル消失」は **Issue #1445 と同じ症状** で、replaceAll 経由ではない別の経路 → 診断 log を追加して real-world で原因特定中

## 含まれる commits

| Commit | 内容 |
|---|---|
| 20abb95 | file-watcher hash-aware self-save suppression (Patch 1+2) |
| 30cbc22 | (revert 対象) MilkdownEditor remount on vertical toggle |
| c8aa3cf | revert: 上記を撤回 (Patch 3 撤回) |
| 88350e0 | visibilitychange handler の hash-aware suppression (Patch 4) |
| 51149eb | genjiVocab initialization の rule-gating (Patch 5) |
| 0dc7495 | mount-time lint/NLP storm を idle まで defer (Patch 6) |
| 310c443 | click → focus → active-panel chain の診断 log (Patch 7、検証後削除) |

## 検証

- [x] `npx tsc --noEmit` → pre-existing 2 件のみ、新規エラーなし
- [x] file-watcher hash-aware suppression のテスト追加・通過
- [ ] **未完了**: 「click → 先頭ジャンプ」の真因特定。診断 log の出力を確認中

## 関連

- Closes #1457 (部分的、click ジャンプ症状は別 follow-up が必要)
- Related #1445 (open、PR #1427 regression)

## Test plan

- [ ] `npm run electron:dev` で project mode を開く
- [ ] エディタ領域をクリックして console の log を確認
- [ ] log から特定された真因に対する追加 patch を別 PR で提出

🤖 Generated with [Claude Code](https://claude.com/claude-code)