### PR TITLE
chore(deps): split major from minor/patch in dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 8
     labels:
       - "dependencies"
     commit-message:
@@ -32,9 +32,15 @@ updates:
       - dependency-name: "tailwindcss"
         versions: ["4.x"]
     groups:
-      npm_and_yarn:
+      # Minor / patch updates are bundled into a single PR (low risk, batch review).
+      # Major updates are intentionally excluded so each ships as an individual PR
+      # for breaking-change review. See PR #1461 / #1477 for prior mega-PR incidents.
+      npm_minor_patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "npm"
     directory: "/packages/milkdown-plugin-japanese-novel"
@@ -44,7 +50,7 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     labels:
       - "dependencies"
       - "milkdown-plugin"
@@ -52,9 +58,13 @@ updates:
       prefix: "chore"
       include: "scope"
     groups:
-      milkdown_plugin_npm:
+      # Minor / patch only; major bumps ship as individual PRs.
+      milkdown_plugin_minor_patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

Prior `groups: { patterns: [\"*\"] }` rolled **all** npm updates — including major bumps — into a single PR. Recent incidents:

- **#1461**: 30 updates in one PR, all builds FAILURE, closed unmerged
- **#1477**: 28 updates with 4 majors (`archiver` 7→8, `dockview-react` 5→6, `electron` 41→42, `lint-staged` 16→17), all builds FAILURE, closed unmerged

Mega-PRs hide which individual bump broke CI, and a 28-package squash commit is impossible to bisect later.

## Change

Restrict both npm groups to `update-types: [minor, patch]`:

- **Minor / patch** → bundled into 1 PR per ecosystem (low risk, batch review).
- **Major** → individual PRs, one per package (breaking-change review possible).

Also raise `open-pull-requests-limit` to accommodate per-major PRs:
- npm root: 5 → 8
- packages/milkdown-plugin-japanese-novel: 3 → 5

## Test plan

- [ ] CI on this PR is green (lint / format / test / build matrix)
- [ ] Next Dependabot run (Monday 09:00 JST) produces:
  - 1 grouped PR for minor/patch
  - 1 PR per major bump (separate)
- [ ] Existing ignore rules for `eslint@10.x` and `tailwindcss@4.x` remain in effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)