### PR TITLE
fix(terminal): re-introduce sequential terminal tab labels (#1473)

### DIFF
--- a/lib/tab-manager/__tests__/terminal-label.test.ts
+++ b/lib/tab-manager/__tests__/terminal-label.test.ts
@@ -1,0 +1,38 @@
+// lib/tab-manager/__tests__/terminal-label.test.ts
+import { describe, it, expect } from "vitest";
+
+import { nextTerminalLabel } from "@/lib/tab-manager/terminal-label";
+
+/**
+ * Regression test for PR #1425 / issue #1473.
+ *
+ * `newTerminalTab` in use-tab-state.ts uses nextTerminalLabel to allocate
+ * sequential tab titles. This test exercises the same production helper
+ * to ensure the numbering contract does not silently regress to a fixed
+ * "ターミナル" label or to indices starting at 0.
+ */
+describe("nextTerminalLabel", () => {
+  it("returns 'ターミナル 1' on the first call when counter starts at 0", () => {
+    const counter = { current: 0 };
+    expect(nextTerminalLabel(counter)).toBe("ターミナル 1");
+  });
+
+  it("increments sequentially across calls with the same counter", () => {
+    const counter = { current: 0 };
+    expect(nextTerminalLabel(counter)).toBe("ターミナル 1");
+    expect(nextTerminalLabel(counter)).toBe("ターミナル 2");
+    expect(nextTerminalLabel(counter)).toBe("ターミナル 3");
+  });
+
+  it("mutates counter.current as a side effect", () => {
+    const counter = { current: 4 };
+    nextTerminalLabel(counter);
+    expect(counter.current).toBe(5);
+  });
+
+  it("uses an ASCII space and Japanese 'ターミナル' prefix (label format contract)", () => {
+    const counter = { current: 0 };
+    const label = nextTerminalLabel(counter);
+    expect(label).toMatch(/^ターミナル \d+$/);
+  });
+});

--- a/lib/tab-manager/terminal-label.ts
+++ b/lib/tab-manager/terminal-label.ts
@@ -1,0 +1,22 @@
+// lib/tab-manager/terminal-label.ts
+/**
+ * Mutable counter abstraction compatible with React's MutableRefObject<number>.
+ * Defined here to keep this module test-friendly without importing React.
+ */
+export interface TerminalLabelCounter {
+  current: number;
+}
+
+/**
+ * Allocate the next sequential terminal tab label (`ターミナル 1`, `ターミナル 2`, …).
+ *
+ * Side effect: increments `counter.current` by 1.
+ * Used by `useTabState.newTerminalTab`. Extracted as a pure helper so that the
+ * numbering contract can be regression-tested without `@testing-library/react`.
+ *
+ * Regression target: PR #1425 / issue #1473
+ */
+export function nextTerminalLabel(counter: TerminalLabelCounter): string {
+  counter.current += 1;
+  return `ターミナル ${counter.current}`;
+}

--- a/lib/tab-manager/use-tab-state.ts
+++ b/lib/tab-manager/use-tab-state.ts
@@ -7,6 +7,7 @@ import type { TabId, TabState, EditorTabState, TerminalTabState, DiffTabState } 
 import { isEditorTab } from "./tab-types";
 import { createNewTab, generateTabId } from "./types";
 import type { TabManagerCore } from "./types";
+import { nextTerminalLabel } from "./terminal-label";
 import { useEditorMode } from "@/contexts/EditorModeContext";
 import { isElectronRenderer } from "../utils/runtime-env";
 
@@ -161,13 +162,16 @@ export function useTabState(): UseTabStateReturn {
     setActiveTabId(tab.id);
   }, []);
 
+  const terminalCounterRef = useRef(0);
+
   const newTerminalTab = useCallback((pendingId?: string) => {
+    const label = nextTerminalLabel(terminalCounterRef);
     const tab: TerminalTabState = {
       tabKind: "terminal",
       id: generateTabId(),
       sessionId: "",
       pendingId: pendingId ?? null,
-      label: "ターミナル",
+      label,
       cwd: "",
       shell: "",
       status: "connecting",


### PR DESCRIPTION
## Summary

- 再実装 (3/5): #1464 配下、元 PR #1425 の **ターミナル関連** を分割再導入
- 連番ラベル: `ターミナル 1`, `ターミナル 2`, … を `nextTerminalLabel` 純粋ヘルパー経由で採番
- PTY kill ロジックは再導入しない（dockview 経路は既存 `handleCloseTabWithPtyCleanup` でカバー済み — #1105）

## Scope

| | 元 PR #1425 | 本 PR |
|---|---|---|
| 連番ラベル | ✅ | ✅ 再導入 |
| dockview 経路の PTY kill | ✅ | ⏭️ 既存実装あり（`use-diff-tabs.ts:44`）|
| Cmd+W 経路の PTY kill | ❌ 未修正 | ⏭️ Out of scope（フォローアップ issue 化予定） |

## Changes

| ファイル | 種別 |
|---|---|
| `lib/tab-manager/terminal-label.ts` | 新規 — 純粋ヘルパー `nextTerminalLabel(counter)` |
| `lib/tab-manager/use-tab-state.ts` | 編集 — `terminalCounterRef` 追加、`newTerminalTab` で `nextTerminalLabel` 使用 |
| `lib/tab-manager/__tests__/terminal-label.test.ts` | 新規 — 4 件の regression test |

## Test plan

- [x] `vitest run lib/tab-manager/__tests__/terminal-label.test.ts` — 4/4 pass
- [x] `tsc --noEmit` — 本 PR 起因のエラーなし
- [x] `eslint` — 本 PR 起因の warning/error なし
- [ ] アプリ起動 → ターミナルを 3 つ開いて「ターミナル 1/2/3」と表示されること
- [ ] dockview のタブ × ボタンで閉じ → shell PID が 1〜2 秒以内に消えること（既存 PTY kill 経路が無傷であることの回帰確認）
- [ ] エディタタブ操作・縦書きトグルに副作用なし（#1457/#1445 P0 regression の再発防止）

## Plan & Review

- 実装プラン: [docs/superpowers/plans/2026-05-23-reimpl-terminal-1473.md](https://github.com/Iktahana/illusions/blob/main/docs/superpowers/plans/2026-05-23-reimpl-terminal-1473.md)
- Codex peer review: 3 イテレーション後 **APPROVED**（R1 重複実装回避、R2 tautology test 解消、R3 検証コマンド修正、R4 永続化前提の修正、R5 スコープ正確化、R6 timing 明示）

## Follow-up

- Cmd+W メニュー経由のターミナルクローズで PTY が孤立する既存問題（元 PR #1425 でも未修正） — 別 issue として起票予定

## Related

- Parent: #1464
- Original PR: #1425（v1.2.7 でロールバック）
- Avoid regressing: #1457, #1445

Closes: #1473

🤖 Generated with [Claude Code](https://claude.com/claude-code)