### PR TITLE
fix(mdi): re-implement [[blank]] paragraph marker (re #1471)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1085,9 +1085,12 @@ export default function EditorPage() {
       // so that a restored snapshot that differs from disk is not treated as clean.
       if (activeTabId !== null) {
         const currentTab = tabsRef.current.find((t) => t.id === activeTabId);
-        const lastSaved =
-          currentTab && isEditorTab(currentTab) ? (currentTab.lastSavedContent ?? "") : "";
-        const isClean = sanitizeMdiContent(restoredContent) === sanitizeMdiContent(lastSaved);
+        const editorTab = currentTab && isEditorTab(currentTab) ? currentTab : null;
+        const lastSaved = editorTab ? (editorTab.lastSavedContent ?? "") : "";
+        const fileTypeOpts = editorTab ? { fileType: editorTab.fileType } : undefined;
+        const isClean =
+          sanitizeMdiContent(restoredContent, fileTypeOpts) ===
+          sanitizeMdiContent(lastSaved, fileTypeOpts);
         updateTab(activeTabId, {
           fileSyncStatus: isClean ? "clean" : "dirty",
           conflictDiskContent: null,

--- a/components/Characters.tsx
+++ b/components/Characters.tsx
@@ -3,9 +3,10 @@
 import { useState, useRef, useCallback, useEffect, memo } from "react";
 import { Plus, X, Sparkles, Loader2 } from "lucide-react";
 
+import { useCharacterExtractionSettings } from "@/contexts/EditorSettingsContext";
+import { stripMdiBlankMarkers } from "@/lib/export/mdi-parser";
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
 import { fetchAppState, persistAppState } from "@/lib/storage/app-state-manager";
-import { useCharacterExtractionSettings } from "@/contexts/EditorSettingsContext";
 import CharacterCard from "./Characters/CharacterCard";
 import NewCharacterForm from "./Characters/NewCharacterForm";
 import type { Character } from "./Characters/types";
@@ -145,7 +146,7 @@ function Characters({ content }: CharactersProps) {
 
     try {
       const nlpClient = getNlpClient();
-      const tokens = await nlpClient.tokenizeParagraph(content);
+      const tokens = await nlpClient.tokenizeParagraph(stripMdiBlankMarkers(content));
 
       const properNouns = new Map<string, boolean>();
 

--- a/components/WordFrequency.tsx
+++ b/components/WordFrequency.tsx
@@ -4,10 +4,11 @@ import { useState, useEffect, useMemo, useCallback, memo, useRef } from "react";
 import { RefreshCw, LoaderCircle } from "lucide-react";
 import clsx from "clsx";
 
+import ContextMenu from "@/components/ContextMenu";
+import { stripMdiBlankMarkers } from "@/lib/export/mdi-parser";
+import { useContextMenu } from "@/lib/hooks/use-context-menu";
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
 import type { WordEntry } from "@/lib/nlp-client/types";
-import { useContextMenu } from "@/lib/hooks/use-context-menu";
-import ContextMenu from "@/components/ContextMenu";
 import { getVFS } from "@/lib/vfs";
 
 /** Cache file schema for word frequency results */
@@ -169,7 +170,7 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
 
       // Run NLP analysis
       const nlpClient = getNlpClient();
-      const wordEntries = await nlpClient.analyzeWordFrequency(content);
+      const wordEntries = await nlpClient.analyzeWordFrequency(stripMdiBlankMarkers(content));
 
       // Discard stale result if a newer analysis was started (#1078)
       if (genRef.current !== myGen) return;

--- a/docs/MDI/spec.md
+++ b/docs/MDI/spec.md
@@ -294,7 +294,7 @@ br.mdi-break {
 - 生成元は **paste / import / 外部書き込み のみ**。ProseMirror エディタでの Enter 連打で作った空段落は CommonMark serializer により blank line へ collapse されるため `[[blank]]` は emit されない
 - エクスポート時: TXT → 空行、HTML → `<p></p>`、DOCX → 空段落
 - ユーザーが `[[blank]]` をリテラル文字列として入力した場合は空白段落として解釈される（bracket macro 全般の既知 escape 制限と同様）
-- **既知の限界**: fenced code block (` ``` `) 内や引用ブロック内の単独 `[[blank]]` も exporter (txt/html/docx) では空段落に変換される。これは既存 `[[br]]` の exporter ハンドリング (§6.1) と同じクラスの制約
+- **既知の限界**: fenced code block (` ``` `) 内の単独 `[[blank]]` は exporter (txt/html/docx) で空段落に変換される。引用ブロック (`> ...`) 内の `[[blank]]` は行頭マッチ条件 (`/^\[\[blank\]\][ \t]*\r?$/m`) を満たさないためリテラル文字列として保持される。これは既存 `[[br]]` の exporter ハンドリング (§6.1) と同じクラスの制約
 
 ### 6.3 Editor UX Rules
 

--- a/docs/MDI/spec.md
+++ b/docs/MDI/spec.md
@@ -277,15 +277,35 @@ br.mdi-break {
 - 段落の途中で `\n` 1 つだけ（空行なし）は CommonMark の soft break。`.mdi` ではデフォルトでは改行にならず、単なる空白として扱われる（段落内の文字の続き）。
 - 明示的に段落内改行したい場合は `[[br]]` または CommonMark hardbreak (`  \n`) を使う（§6.1）。
 
+#### 意図的な空白段落（内部表現: `[[blank]]`）
+
+外部 HTML や Word から貼り付けた / 取り込んだ単独 `<br />` 行は、`.mdi` ファイルへ保存される際に `[[blank]]` マーカーへ変換される。
+
+```
+春は曙。
+
+[[blank]]
+
+夏は夜。
+```
+
+- 内部表現であり、ユーザーが直接入力するマーカーではない
+- **`.mdi` モードのみ有効**（`.md` ファイルでは Step 1a を無効化し `<br />` は単純に改行へ変換される）
+- 生成元は **paste / import / 外部書き込み のみ**。ProseMirror エディタでの Enter 連打で作った空段落は CommonMark serializer により blank line へ collapse されるため `[[blank]]` は emit されない
+- エクスポート時: TXT → 空行、HTML → `<p></p>`、DOCX → 空段落
+- ユーザーが `[[blank]]` をリテラル文字列として入力した場合は空白段落として解釈される（bracket macro 全般の既知 escape 制限と同様）
+- **既知の限界**: fenced code block (` ``` `) 内や引用ブロック内の単独 `[[blank]]` も exporter (txt/html/docx) では空段落に変換される。これは既存 `[[br]]` の exporter ハンドリング (§6.1) と同じクラスの制約
+
 ### 6.3 Editor UX Rules
 
 エディタ上でのキー操作と MDI 構文の対応：
 
-| キー / 操作   | 挙動                           | Markdown 表現 | ProseMirror ノード |
-| ------------- | ------------------------------ | ------------- | ------------------ |
-| `Enter`       | 新しい段落（換段）             | 空行 (`\n\n`) | `paragraph`（別）  |
-| `Shift+Enter` | CommonMark hardbreak（段落内） | `  \n`        | `hardbreak`        |
-| `[[br]]` 入力 | MDI 改行マーカー（段落内）     | `[[br]]`      | `mdibreak`         |
+| キー / 操作      | 挙動                           | Markdown 表現 | ProseMirror ノード |
+| ---------------- | ------------------------------ | ------------- | ------------------ |
+| `Enter`          | 新しい段落（換段）             | 空行 (`\n\n`) | `paragraph`（別）  |
+| `Shift+Enter`    | CommonMark hardbreak（段落内） | `  \n`        | `hardbreak`        |
+| `[[br]]` 入力    | MDI 改行マーカー（段落内）     | `[[br]]`      | `mdibreak`         |
+| `[[blank]]` 保存 | 意図的な空白段落               | `[[blank]]`   | `paragraph`（空）  |
 
 **推奨運用**
 

--- a/lib/editor-page/text-statistics.ts
+++ b/lib/editor-page/text-statistics.ts
@@ -5,6 +5,8 @@
  * and in plain Node.js / test environments.
  */
 
+import { stripMdiBlankMarkers } from "@/lib/export/mdi-parser";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -66,7 +68,7 @@ const LINE_END_PROHIBITED = new Set("（〔［｛〈《「『【".split(""));
  * 12. バックスラッシュエスケープ (`\X`) → バックスラッシュのみ除去
  */
 export function extractVisibleText(rawContent: string): string {
-  let text = rawContent;
+  let text = stripMdiBlankMarkers(rawContent);
 
   // 1. コードブロック（```...```、フェンス含む）
   text = text.replace(/```[\s\S]*?```/g, "");

--- a/lib/export/__tests__/blank-paragraph-export.test.ts
+++ b/lib/export/__tests__/blank-paragraph-export.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { unzipSync, strFromU8 } from "fflate";
+import { mdiToHtml } from "@/lib/export/mdi-to-html";
+import { mdiToPlainText } from "@/lib/export/txt-exporter";
+import { generateDocxBlob } from "@/lib/export/docx-exporter";
+
+describe("html exporter — [[blank]] paragraph handling", () => {
+  it("[[blank]] → <p></p>", () => {
+    const html = mdiToHtml("A\n\n[[blank]]\n\nB", { bodyOnly: true });
+    expect(html).toContain("<p></p>");
+    expect(html).not.toContain("[[blank]]");
+    // U+E000 sentinel must not leak
+    expect(html).not.toContain("");
+  });
+
+  it("連続 [[blank]] → 2 連続の <p></p>", () => {
+    const html = mdiToHtml("A\n\n[[blank]]\n\n[[blank]]\n\nB", { bodyOnly: true });
+    const count = (html.match(/<p><\/p>/g) ?? []).length;
+    expect(count).toBe(2);
+  });
+});
+
+describe("txt exporter — [[blank]] paragraph handling", () => {
+  it("[[blank]] → 強制空行", () => {
+    const txt = mdiToPlainText("A段落\n\n[[blank]]\n\nB段落");
+    expect(txt).not.toContain("[[blank]]");
+    // A段落 and B段落 should have at least one blank line between them
+    const lines = txt.split("\n");
+    const aIdx = lines.findIndex((l) => l.includes("A段落"));
+    const bIdx = lines.findIndex((l) => l.includes("B段落"));
+    expect(aIdx).toBeGreaterThanOrEqual(0);
+    expect(bIdx).toBeGreaterThan(aIdx);
+    // At least one blank line between them
+    const between = lines.slice(aIdx + 1, bIdx);
+    expect(between.some((l) => l.trim() === "")).toBe(true);
+  });
+});
+
+describe("docx exporter — [[blank]] paragraph handling", () => {
+  it("[[blank]] → 空 <w:p> in word/document.xml", async () => {
+    const blob = await generateDocxBlob("A\n\n[[blank]]\n\nB", {
+      metadata: { title: "テスト", language: "ja" },
+    });
+    const arrayBuffer = await blob.arrayBuffer();
+    const unzipped = unzipSync(new Uint8Array(arrayBuffer));
+    const documentXml = strFromU8(unzipped["word/document.xml"]!);
+    // The exporter inserts an empty <w:p> for [[blank]] (no <w:r> text runs inside).
+    // Pattern: <w:p ... /> or <w:p>...</w:p> with no <w:r> tag
+    // Look for at least one <w:p> that contains no <w:r>
+    expect(documentXml).not.toContain("[[blank]]");
+    // A simpler smoke check: ensure A and B paragraphs are both present and total <w:p> count is ≥ 3 (A + blank + B)
+    const pCount = (documentXml.match(/<w:p[\s>]/g) ?? []).length;
+    expect(pCount).toBeGreaterThanOrEqual(3);
+    expect(documentXml).toContain("A");
+    expect(documentXml).toContain("B");
+  });
+});

--- a/lib/export/__tests__/blank-paragraph-export.test.ts
+++ b/lib/export/__tests__/blank-paragraph-export.test.ts
@@ -18,6 +18,15 @@ describe("html exporter — [[blank]] paragraph handling", () => {
     const count = (html.match(/<p><\/p>/g) ?? []).length;
     expect(count).toBe(2);
   });
+
+  it("fenced code block 内の [[blank]] でも U+E000 sentinel はリークしない", () => {
+    // markdown-it は fenced code を <pre><code>…</code></pre> として描画する。
+    // pre-process で行頭 [[blank]] → U+E000 に置換した結果、コードブロック内に sentinel が
+    // 残るため、最終 sweep で除去されることを確認する (Copilot review #1483 round 2)。
+    const html = mdiToHtml("文章\n\n```\n[[blank]]\n```\n\n続き", { bodyOnly: true });
+    expect(html).not.toContain("");
+    expect(html).not.toContain("[[blank]]");
+  });
 });
 
 describe("txt exporter — [[blank]] paragraph handling", () => {

--- a/lib/export/__tests__/mdi-parser-blank.test.ts
+++ b/lib/export/__tests__/mdi-parser-blank.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { stripMdiBlankMarkers, MDI_BLANK_RE } from "@/lib/export/mdi-parser";
+
+describe("stripMdiBlankMarkers", () => {
+  it("単独 [[blank]] 行を空文字に変換", () => {
+    expect(stripMdiBlankMarkers("[[blank]]")).toBe("");
+  });
+  it("段落間の [[blank]] を空文字に変換し、周囲の改行は維持", () => {
+    const input = "A段落\n\n[[blank]]\n\nB段落";
+    expect(stripMdiBlankMarkers(input)).toBe("A段落\n\n\n\nB段落");
+  });
+  it("CRLF: [[blank]]\\r\\n の \\r まで吸収して空文字 + \\n を残す", () => {
+    expect(stripMdiBlankMarkers("[[blank]]\r\n")).toBe("\n");
+  });
+  it("行内の [[blank]] は変換しない", () => {
+    expect(stripMdiBlankMarkers("foo [[blank]] bar")).toBe("foo [[blank]] bar");
+  });
+  it("MDI_BLANK_RE は global + multiline フラグを持つ", () => {
+    expect(MDI_BLANK_RE.flags).toBe("gm");
+  });
+});

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -209,6 +209,13 @@ function parseMarkdownToDocxParagraphs(
       continue;
     }
 
+    // [[blank]] marker → empty DOCX paragraph
+    if (/^\[\[blank\]\]$/.test(trimmed)) {
+      flushParagraph();
+      paragraphs.push(new Paragraph({ spacing: { before: 0, after: 120 } }));
+      continue;
+    }
+
     // Heading detection
     const headingMatch = trimmed.match(/^(#{1,6})\s+(.+)$/);
     if (headingMatch) {

--- a/lib/export/mdi-parser.ts
+++ b/lib/export/mdi-parser.ts
@@ -32,6 +32,18 @@ export const MDI_KERN_RE = /\[\[kern:([^:\]]+):([^\]]+)\]\]/g;
 /** MDI explicit line break: [[br]] */
 export const MDI_BREAK_RE = /\[\[br\]\]/g;
 
+/** MDI blank paragraph marker (internal representation, written by sanitizeMdiContent) */
+export const MDI_BLANK_RE = /^\[\[blank\]\][ \t]*\r?$/gm;
+
+/**
+ * Strip [[blank]] markers for plain-text analysis consumers (NLP, word count, etc.).
+ * Replaces the marker line with empty string; surrounding blank lines remain.
+ * CRLF note: on CRLF files a preceding \r is absorbed; normalize line endings before passing if required.
+ */
+export function stripMdiBlankMarkers(content: string): string {
+  return content.replace(MDI_BLANK_RE, "");
+}
+
 /** Escaped MDI opening brace: \{ */
 export const MDI_ESC_BRACE_RE = /\\(\{)/g;
 

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -253,8 +253,12 @@ export function mdiToHtml(
   const BLANK_SENTINEL = "";
   const preprocessed = markdown.replace(new RegExp(MDI_BLANK_RE.source, "gm"), BLANK_SENTINEL);
   const rawHtml = md.render(preprocessed);
-  // Replace the sentinel paragraph with a true empty paragraph.
-  const bodyHtml = rawHtml.replace(new RegExp(`<p>${BLANK_SENTINEL}\\s*</p>`, "g"), "<p></p>");
+  // Replace the sentinel paragraph with a true empty paragraph. Then final-sweep any
+  // remaining sentinel that escaped the <p>…</p> wrap (e.g. inside fenced code blocks
+  // where markdown-it emits <pre><code>…</code></pre> instead of <p>).
+  const bodyHtml = rawHtml
+    .replace(new RegExp(`<p>${BLANK_SENTINEL}\\s*</p>`, "g"), "<p></p>")
+    .replace(new RegExp(BLANK_SENTINEL, "g"), "");
 
   if (options?.bodyOnly) {
     return bodyHtml;

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -19,6 +19,7 @@ import {
   MDI_KERN_RE,
   MDI_BREAK_RE,
   MDI_KERN_AMOUNT_RE,
+  MDI_BLANK_RE,
 } from "./mdi-parser";
 
 const MDI_RUBY_AT_START_RE = new RegExp(`^${MDI_RUBY_RE.source}`);
@@ -247,7 +248,13 @@ export function mdiToHtml(
   },
 ): string {
   const md = createMarkdownIt();
-  const bodyHtml = md.render(markdown);
+  // Pre-process: replace [[blank]] paragraph markers with a U+E000 PUA sentinel.
+  // markdown-it will wrap the sentinel in <p>…</p>; we swap it for an empty <p></p> after rendering.
+  const BLANK_SENTINEL = "";
+  const preprocessed = markdown.replace(new RegExp(MDI_BLANK_RE.source, "gm"), BLANK_SENTINEL);
+  const rawHtml = md.render(preprocessed);
+  // Replace the sentinel paragraph with a true empty paragraph.
+  const bodyHtml = rawHtml.replace(new RegExp(`<p>${BLANK_SENTINEL}\\s*</p>`, "g"), "<p></p>");
 
   if (options?.bodyOnly) {
     return bodyHtml;

--- a/lib/export/txt-exporter.ts
+++ b/lib/export/txt-exporter.ts
@@ -11,6 +11,9 @@ import { stripMdiInlineSyntax, replaceMdiWithRubyText } from "./mdi-parser";
 /** Sentinel to distinguish scene breaks from paragraph-separation blank lines */
 const SCENE_BREAK_MARKER = "\x00SCENE_BREAK\x00";
 
+/** Inline regex for [[blank]] paragraph marker (whole line) */
+const BLANK_PARA_RE = /^\[\[blank\]\]$/;
+
 /**
  * Convert MDI markdown to plain text without ruby annotations.
  * Strips all MDI syntax and markdown formatting.
@@ -55,6 +58,12 @@ function stripMarkdown(text: string): string {
 
   for (const line of lines) {
     let processed = line;
+
+    // [[blank]] paragraph marker → forced blank line (via SCENE_BREAK_MARKER)
+    if (BLANK_PARA_RE.test(processed.trim())) {
+      result.push(SCENE_BREAK_MARKER);
+      continue;
+    }
 
     // Headings: # Title → Title
     processed = processed.replace(/^#{1,6}\s+/, "");

--- a/lib/services/diff-service.ts
+++ b/lib/services/diff-service.ts
@@ -8,6 +8,7 @@
 import { diffChars } from "diff";
 
 import type { Change } from "diff";
+import { stripMdiBlankMarkers } from "@/lib/export/mdi-parser";
 
 /**
  * Normalize text for diff comparison by stripping HTML tags.
@@ -18,7 +19,9 @@ import type { Change } from "diff";
  * その他のHTMLタグは削除する。
  */
 export function stripHtmlForDiff(text: string): string {
-  return text.replace(/<br\s*\/?>/gi, "\n").replace(/<[^>]+>/g, "");
+  return stripMdiBlankMarkers(text)
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, "");
 }
 
 /** A single diff chunk with type and value */

--- a/lib/tab-manager/__tests__/sanitize-isclean.test.ts
+++ b/lib/tab-manager/__tests__/sanitize-isclean.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeMdiContent } from "@/lib/tab-manager/types";
+
+describe("sanitizeMdiContent — history restore isClean parity", () => {
+  it("(.mdi) restored content with <br /> matches saved [[blank]]", () => {
+    // After save: <br /> → [[blank]] is on disk.
+    const saved = "A\n\n[[blank]]\n\nB";
+    // Restored from snapshot: could be either form depending on snapshot age.
+    const restored = "A\n\n<br />\n\nB";
+    expect(sanitizeMdiContent(restored, { fileType: ".mdi" })).toBe(
+      sanitizeMdiContent(saved, { fileType: ".mdi" }),
+    );
+  });
+  it("(.md) restored content with <br /> matches saved \\n", () => {
+    // When an .md file containing "A\n\n<br />\n\nB" is saved, the <br /> is
+    // converted to \n by Step 1b, producing "A\n\n\n\n\nB" on disk.
+    const saved = "A\n\n\n\n\nB";
+    const restored = "A\n\n<br />\n\nB";
+    expect(sanitizeMdiContent(restored, { fileType: ".md" })).toBe(
+      sanitizeMdiContent(saved, { fileType: ".md" }),
+    );
+  });
+});

--- a/lib/tab-manager/__tests__/types-sanitize-blank.test.ts
+++ b/lib/tab-manager/__tests__/types-sanitize-blank.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeMdiContent } from "@/lib/tab-manager/types";
+
+const MDI = { fileType: ".mdi" as const };
+const MD = { fileType: ".md" as const };
+
+describe("sanitizeMdiContent — blank paragraph conversion (.mdi only)", () => {
+  it("(.mdi) standalone <br /> → [[blank]]", () => {
+    expect(sanitizeMdiContent("<br />", MDI)).toBe("[[blank]]");
+  });
+  it("(.mdi) standalone <br/> → [[blank]]", () => {
+    expect(sanitizeMdiContent("<br/>", MDI)).toBe("[[blank]]");
+  });
+  it("(.mdi) standalone <br> (no slash) → [[blank]]", () => {
+    expect(sanitizeMdiContent("<br>", MDI)).toBe("[[blank]]");
+  });
+  it("(.mdi) standalone <BR /> uppercase → newline (Step 1a is case-sensitive)", () => {
+    expect(sanitizeMdiContent("<BR />", MDI)).toBe("\n");
+  });
+  it("(.mdi) <br /> with CRLF → [[blank]] + LF", () => {
+    expect(sanitizeMdiContent("<br />\r\n", MDI)).toBe("[[blank]]\n");
+  });
+  it("(.mdi) <br> inside text → newline", () => {
+    expect(sanitizeMdiContent("Hello<br>World", MDI)).toBe("Hello\nWorld");
+  });
+  it("(.mdi) blank paragraph in context", () => {
+    const input = "A段落\n\n<br />\n\nB段落";
+    expect(sanitizeMdiContent(input, MDI)).toBe("A段落\n\n[[blank]]\n\nB段落");
+  });
+  it("(.md) standalone <br /> → newline, NOT [[blank]]", () => {
+    expect(sanitizeMdiContent("<br />", MD)).toBe("\n");
+  });
+  it("(.md) blank paragraph in context → no [[blank]] marker", () => {
+    const input = "A段落\n\n<br />\n\nB段落";
+    const out = sanitizeMdiContent(input, MD);
+    expect(out).not.toContain("[[blank]]");
+    expect(out).toBe("A段落\n\n\n\n\nB段落");
+  });
+  it("(no options) defaults to non-.mdi behavior (Step 1a off) — back-compat for unmigrated callers", () => {
+    expect(sanitizeMdiContent("<br />")).toBe("\n");
+  });
+});

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -247,10 +247,24 @@ const VOID_TAG_PATTERN = new RegExp(`<(${VOID_HTML_TAGS.join("|")})(\\s[^>]*)?\\
  * Sanitize MDI content before saving.
  * Strips known HTML tags that should not appear in .mdi files,
  * while preserving arbitrary angle-bracket content (e.g. `A<B>C`).
+ *
+ * @param options.fileType - When ".mdi", Step 1a converts standalone `<br />` lines
+ *   to `[[blank]]` markers before Step 1b handles remaining inline `<br>` tags.
+ *   For all other file types (or when omitted), Step 1a is skipped.
  */
-export function sanitizeMdiContent(content: string): string {
+export function sanitizeMdiContent(
+  content: string,
+  options?: { fileType?: SupportedFileExtension },
+): string {
   let result = content;
-  // Step 1: Convert <br> tags to newlines
+  // Step 1a (MDI only): standalone <br /> on its own line → [[blank]] marker.
+  // CRLF-safe: allows optional \r before end-of-line.
+  // Known limitation: user-authored standalone <br /> in .mdi is treated as a blank paragraph
+  // (same class of escape gap as other bracket macros).
+  if (options?.fileType === ".mdi") {
+    result = result.replace(/^<br\s*\/?>[ \t]*\r?$/gm, "[[blank]]");
+  }
+  // Step 1b: remaining inline <br> tags → newline
   result = result.replace(/<br\s*\/?>/gi, "\n");
   // Step 2: Remove properly paired known HTML tags, keeping inner content.
   // Only matched pairs (e.g. <div>...</div>) are stripped; an orphaned

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -258,13 +258,14 @@ export function sanitizeMdiContent(
 ): string {
   let result = content;
   // Step 1a (MDI only): standalone <br /> on its own line → [[blank]] marker.
+  // Intentionally case-sensitive (lowercase only) — <BR /> falls through to Step 1b.
   // CRLF-safe: allows optional \r before end-of-line.
   // Known limitation: user-authored standalone <br /> in .mdi is treated as a blank paragraph
   // (same class of escape gap as other bracket macros).
   if (options?.fileType === ".mdi") {
     result = result.replace(/^<br\s*\/?>[ \t]*\r?$/gm, "[[blank]]");
   }
-  // Step 1b: remaining inline <br> tags → newline
+  // Step 1b: remaining inline <br> tags → newline (case-insensitive)
   result = result.replace(/<br\s*\/?>/gi, "\n");
   // Step 2: Remove properly paired known HTML tags, keeping inner content.
   // Only matched pairs (e.g. <div>...</div>) are stripped; an orphaned

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -88,7 +88,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
         setTabs((prev) => prev.map((t) => (t.id === tab.id ? { ...t, isSaving: true } : t)));
         void (async () => {
           try {
-            const sanitized = sanitizeMdiContent(tab.content);
+            const sanitized = sanitizeMdiContent(tab.content, { fileType: tab.fileType });
             if (isProjectRef.current && tab.file?.path) {
               const vfs = getVFS();
               suppressFileWatch(tab.file.path);
@@ -97,7 +97,8 @@ export function useAutoSave(params: UseAutoSaveParams): void {
               setTabs((prev) =>
                 prev.map((t) => {
                   if (t.id !== tab.id || !isEditorTab(t)) return t;
-                  const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+                  const newIsDirty =
+                    sanitizeMdiContent(t.content, { fileType: t.fileType }) !== sanitized;
                   return {
                     ...t,
                     lastSavedContent: sanitized,
@@ -121,7 +122,8 @@ export function useAutoSave(params: UseAutoSaveParams): void {
                 setTabs((prev) =>
                   prev.map((t) => {
                     if (t.id !== tab.id || !isEditorTab(t)) return t;
-                    const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+                    const newIsDirty =
+                      sanitizeMdiContent(t.content, { fileType: t.fileType }) !== sanitized;
                     return {
                       ...t,
                       file: result.descriptor,

--- a/lib/tab-manager/use-close-dialog.ts
+++ b/lib/tab-manager/use-close-dialog.ts
@@ -82,7 +82,7 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
     }
 
     try {
-      const sanitized = sanitizeMdiContent(tab.content);
+      const sanitized = sanitizeMdiContent(tab.content, { fileType: tab.fileType });
 
       if (isProjectRef.current && tab.file?.path) {
         const vfs = getVFS();

--- a/lib/tab-manager/use-electron-menu-bindings.ts
+++ b/lib/tab-manager/use-electron-menu-bindings.ts
@@ -126,7 +126,7 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
           continue;
         }
 
-        const sanitized = sanitizeMdiContent(tab.content);
+        const sanitized = sanitizeMdiContent(tab.content, { fileType: tab.fileType });
 
         if (!tab.file) {
           // New unsaved document: show Save As dialog so the user can give it a path.

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -239,7 +239,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
       updateTab(tabId, { isSaving: true });
 
       try {
-        const sanitized = sanitizeMdiContent(tab.content);
+        const sanitized = sanitizeMdiContent(tab.content, { fileType: tab.fileType });
 
         // Project mode: VFS direct write
         if (isProjectRef.current && tab.file?.path) {
@@ -263,7 +263,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           setTabs((prev) =>
             prev.map((t) => {
               if (t.id !== tabId || !isEditorTab(t)) return t;
-              const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+              const newIsDirty =
+                sanitizeMdiContent(t.content, { fileType: t.fileType }) !== sanitized;
               return {
                 ...t,
                 lastSavedContent: sanitized,
@@ -290,7 +291,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           setTabs((prev) =>
             prev.map((t) => {
               if (t.id !== tabId || !isEditorTab(t)) return t;
-              const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+              const newIsDirty =
+                sanitizeMdiContent(t.content, { fileType: t.fileType }) !== sanitized;
               return {
                 ...t,
                 file: result.descriptor,
@@ -352,7 +354,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
     updateTab(tabId, { isSaving: true });
 
     try {
-      const sanitized = sanitizeMdiContent(tab.content);
+      const sanitized = sanitizeMdiContent(tab.content, { fileType: tab.fileType });
       const descriptor: MdiFileDescriptor | null = tab.file
         ? { path: null, handle: null, name: tab.file.name }
         : null;
@@ -367,7 +369,8 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           prev.map((t) =>
             t.id === tabId && isEditorTab(t)
               ? (() => {
-                  const newIsDirty = sanitizeMdiContent(t.content) !== sanitized;
+                  const newIsDirty =
+                    sanitizeMdiContent(t.content, { fileType: t.fileType }) !== sanitized;
                   return {
                     ...t,
                     file: result.descriptor,

--- a/lib/utils/readability.ts
+++ b/lib/utils/readability.ts
@@ -12,6 +12,7 @@
  *   const enhanced = enrichReadabilityWithMorphology(base, tokens);
  */
 
+import { stripMdiBlankMarkers } from "@/lib/export/mdi-parser";
 import type { Token } from "@/lib/nlp-client/types";
 import type {
   EnhancedReadabilityAnalysis,
@@ -24,7 +25,7 @@ import type {
 
 /** 文字数カウント用にMarkdownを整形する */
 export function cleanMarkdown(markdown: string): string {
-  return markdown
+  return stripMdiBlankMarkers(markdown)
     .replace(/```[\s\S]*?```/g, "")
     .replace(/`[^`]+`/g, "")
     .replace(/\[([^\]]+)\]\([^\)]+\)/g, "$1")

--- a/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank-roundtrip.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank-roundtrip.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import { sanitizeMdiContent } from "@/lib/tab-manager/types";
+import { remarkMdiBlankPlugin } from "../syntax";
+
+function saveThenLoad(raw: string) {
+  // Save direction: simulate the editor → sanitize → on-disk markdown
+  const sanitized = sanitizeMdiContent(raw, { fileType: ".mdi" });
+  // Load direction: parse the on-disk markdown back to mdast and run the blank plugin
+  const tree = unified().use(remarkParse).parse(sanitized);
+  const runner = (
+    remarkMdiBlankPlugin as unknown as (opts?: { enable?: boolean }) => (t: unknown) => void
+  )({ enable: true });
+  runner(tree);
+  return { sanitized, tree };
+}
+
+describe("MDI blank paragraph — save → load composition round-trip", () => {
+  it("paste-origin <br /> → 保存形 [[blank]] → load で空 paragraph", () => {
+    const { sanitized, tree } = saveThenLoad("A段落\n\n<br />\n\nB段落");
+    expect(sanitized).toBe("A段落\n\n[[blank]]\n\nB段落");
+    const root = tree as { children: { type: string; children: unknown[] }[] };
+    const middle = root.children[1];
+    expect(middle.type).toBe("paragraph");
+    expect(middle.children).toHaveLength(0);
+  });
+
+  it("連続 <br /> → 連続 [[blank]] → 2 連続の空 paragraph", () => {
+    const { sanitized, tree } = saveThenLoad("A\n\n<br />\n\n<br />\n\nB");
+    expect(sanitized).toBe("A\n\n[[blank]]\n\n[[blank]]\n\nB");
+    const root = tree as { children: { type: string; children: unknown[] }[] };
+    const emptyParagraphs = root.children.filter(
+      (n) => n.type === "paragraph" && n.children.length === 0,
+    );
+    expect(emptyParagraphs.length).toBe(2);
+  });
+
+  it("先頭空段落 → 保持される", () => {
+    const { sanitized, tree } = saveThenLoad("<br />\n\nA");
+    expect(sanitized).toBe("[[blank]]\n\nA");
+    const root = tree as { children: { type: string; children: unknown[] }[] };
+    expect(root.children[0].type).toBe("paragraph");
+    expect(root.children[0].children).toHaveLength(0);
+  });
+
+  it("(known limitation) ProseMirror 空段落 → markdown serializer is intentionally NOT round-tripped via [[blank]]", () => {
+    // ProseMirror の空段落は serializer が blank line に折り畳むため、保存ファイルには
+    // [[blank]] が現れない。[[blank]] の生成元は paste / import / 外部書き込みのみ。
+    // この制約は docs/MDI/spec.md にも明記する (Task 9)。
+    expect(true).toBe(true);
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank-roundtrip.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank-roundtrip.test.ts
@@ -44,10 +44,12 @@ describe("MDI blank paragraph — save → load composition round-trip", () => {
     expect(root.children[0].children).toHaveLength(0);
   });
 
-  it("(known limitation) ProseMirror 空段落 → markdown serializer is intentionally NOT round-tripped via [[blank]]", () => {
-    // ProseMirror の空段落は serializer が blank line に折り畳むため、保存ファイルには
-    // [[blank]] が現れない。[[blank]] の生成元は paste / import / 外部書き込みのみ。
-    // この制約は docs/MDI/spec.md にも明記する (Task 9)。
-    expect(true).toBe(true);
+  it("(known limitation) ProseMirror 由来の連続空行 → sanitize は [[blank]] を生成しない", () => {
+    // ProseMirror の空段落は markdown serializer が連続空行に折り畳むため、保存ファイルには
+    // [[blank]] が現れない（[[blank]] の生成元は paste / import / 外部書き込み (<br />) のみ）。
+    // この制約は docs/MDI/spec.md §6.2 にも明記する。
+    const serializedEmptyParagraphs = "A\n\n\n\nB"; // 3+ newlines = 空段落を含む serializer 出力
+    const sanitized = sanitizeMdiContent(serializedEmptyParagraphs, { fileType: ".mdi" });
+    expect(sanitized).not.toContain("[[blank]]");
   });
 });

--- a/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { remarkMdiBlankPlugin } from "../syntax";
+
+type TextNode = { type: "text"; value: string };
+type Paragraph = { type: "paragraph"; children: TextNode[] };
+type Root = { type: "root"; children: Paragraph[] };
+
+function makeTree(paragraphText: string): Root {
+  return {
+    type: "root",
+    children: [{ type: "paragraph", children: [{ type: "text", value: paragraphText }] }],
+  };
+}
+
+function runPlugin(tree: Root, options?: { enable?: boolean }): Root {
+  const factory = remarkMdiBlankPlugin as unknown as (opts?: {
+    enable?: boolean;
+  }) => (t: Root) => void;
+  factory(options)(tree);
+  return tree;
+}
+
+describe("remarkMdiBlankPlugin", () => {
+  it("[[blank]]-only paragraph → children becomes []", () => {
+    const tree = runPlugin(makeTree("[[blank]]"));
+    expect(tree.children[0]!.children).toHaveLength(0);
+  });
+
+  it("normal text paragraph → unchanged", () => {
+    const tree = runPlugin(makeTree("春は曙。"));
+    expect(tree.children[0]!.children).toHaveLength(1);
+    expect(tree.children[0]!.children[0]).toEqual({ type: "text", value: "春は曙。" });
+  });
+
+  it("[[blank]] with surrounding text → unchanged (mixed content)", () => {
+    const tree = runPlugin(makeTree("before [[blank]] after"));
+    expect(tree.children[0]!.children).toHaveLength(1);
+  });
+
+  it("disabled via { enable: false } → unchanged", () => {
+    const tree = runPlugin(makeTree("[[blank]]"), { enable: false });
+    expect(tree.children[0]!.children).toHaveLength(1);
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/index.ts
@@ -14,6 +14,7 @@ import { mdibreakSchema } from "./nodes/mdibreak";
 import { headingAnchorSchema } from "./nodes/heading-anchor";
 import {
   remarkHeadingAnchorPlugin,
+  remarkMdiBlankPlugin,
   remarkRubyPlugin,
   remarkTcyPlugin,
   remarkNoBreakPlugin,
@@ -75,6 +76,11 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     () => remarkMdiBreakPlugin as (o?: { enable?: boolean }) => (tree: unknown) => void,
     { enable: enableMdiBreak },
   );
+  const remarkMdiBlank = $remark(
+    "japaneseNovelMdiBlank",
+    () => remarkMdiBlankPlugin as (o?: { enable?: boolean }) => (tree: unknown) => void,
+    { enable: enableMdiBreak },
+  );
   const remarkHeadingAnchor = $remark(
     "japaneseNovelHeadingAnchor",
     () => remarkHeadingAnchorPlugin,
@@ -107,7 +113,7 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
   const plugins: MilkdownPlugin[] = [
     ...(enableRuby ? [remarkRuby, rubySchema] : []),
     ...(enableTcy ? [remarkTcy, tcySchema] : []),
-    ...(enableMdiBreak ? [remarkMdiBreak, mdibreakSchema] : []),
+    ...(enableMdiBreak ? [remarkMdiBreak, remarkMdiBlank, mdibreakSchema] : []),
     ...(enableNoBreak ? [remarkNoBreak, nobreakSchema] : []),
     ...(enableKern ? [remarkKern, kernSchema] : []),
     remarkHeadingAnchor,

--- a/packages/milkdown-plugin-japanese-novel/syntax.ts
+++ b/packages/milkdown-plugin-japanese-novel/syntax.ts
@@ -2,7 +2,7 @@
  * 日本語小説向けの記法（ルビ/縦中横など）を扱う Remark プラグイン
  */
 
-import type { Root } from "mdast";
+import type { Paragraph, Root, Text } from "mdast";
 import type { Plugin } from "unified";
 import { visit } from "unist-util-visit";
 
@@ -235,5 +235,25 @@ export const remarkHeadingAnchorPlugin: Plugin<[], Root> = () => {
   return (tree) => {
     // 見出しアンカーはここでは処理しない
     // ID は見出しの内容から直接生成される
+  };
+};
+
+export interface RemarkMdiBlankOptions {
+  enable?: boolean;
+}
+
+export const remarkMdiBlankPlugin: Plugin<[RemarkMdiBlankOptions | undefined], Root> = (opts) => {
+  const enable = opts?.enable !== false;
+  return (tree) => {
+    if (!enable) return;
+    visit(tree, "paragraph", (node: Paragraph) => {
+      if (
+        node.children.length === 1 &&
+        node.children[0].type === "text" &&
+        (node.children[0] as Text).value.trim() === "[[blank]]"
+      ) {
+        node.children.length = 0;
+      }
+    });
   };
 };


### PR DESCRIPTION
## Summary

Re-implements the MDI `[[blank]]` paragraph marker that was lost in the v1.2.7 rollback (original PR #1425). Scope is narrowly limited to the blank-paragraph slice; SearchDialog/terminal/etc. are tracked in sibling sub-issues.

- **Save direction** (`.mdi` only): `sanitizeMdiContent` Step 1a converts standalone `<br />` lines (paste/import origin) → `[[blank]]` marker
- **Load direction**: new `remarkMdiBlankPlugin` walks mdast and clears `[[blank]]`-only paragraphs to empty paragraphs
- **Analysis consumers** (5 files): NLP / word frequency / text statistics / diff / readability all strip `[[blank]]` via new `stripMdiBlankMarkers` helper
- **Exporters** (3 files): txt → `SCENE_BREAK_MARKER` (forced blank line); html → U+E000 sentinel → `<p></p>` via markdown-it pre/post-process; docx → empty `<w:p>` with `spacing: { after: 120 }`
- **Spec doc**: `docs/MDI/spec.md` §6.2 + §6.3 updated with the new marker semantics and known limitations

## Architecture

Plan + 3 rounds of Codex peer review: `docs/superpowers/plans/2026-05-23-mdi-blank-paragraph-reimplementation.md`

### Key design decisions
- **`.mdi`-only gate** (Codex R1): `sanitizeMdiContent(content, { fileType })` — `.md` files are untouched. All 6 production call sites updated, including `app/page.tsx:1090` history-restore `isClean` parity (Codex R9 catch).
- **Save direction is paste/import only**: ProseMirror native empty paragraphs collapse via CommonMark serializer; this is the load-side intention of `[[blank]]` and is explicitly documented as a known limitation.
- **U+E000 PUA sentinel** in html exporter is function-local + has a regression test (`not.toContain("\\uE000")`) to prevent leakage.

## Test plan

### Automated (passes)
- [x] `npx vitest run` → 713 tests pass across 48 suites (1 pre-existing suite failure: `components/settings/__tests__/tab-registry.test.ts` cannot resolve `@/generated/credits.json` — unrelated to this PR, exists on `dev` already)
- [x] `npm run type-check` → clean
- [x] New tests added: 5 (parser) + 10 (sanitize gate) + 2 (isClean parity) + 4 (remarkMdiBlankPlugin) + 4 (round-trip composition) + 4 (exporter html/txt/docx) = 29 new test cases
- [x] No-touch list audit: `git diff origin/dev --name-only` shows 0 of the 9 files explicitly excluded for #1457 / #1445 regression risk are modified

### Manual (must be performed before merge — agent cannot run Electron)
- [ ] Electron dev: open a `.mdi` file, paste HTML with `<br />`, save → confirm `[[blank]]` appears in the saved file
- [ ] Reopen the saved file → empty paragraph displays in editor
- [ ] Export to txt / html / docx → each preserves the empty paragraph as the expected format
- [ ] `.md` regression: edit a `.md` file with `<br />`, save → confirm NO `[[blank]]` appears (Step 1a stays off)
- [ ] #1457 regression check: click editor after window blur → no scroll-to-top, cursor preserved
- [ ] #1445 regression check: vertical/horizontal toggle works

## Closes
- Closes #1471

Parent issue #1464 will be closed separately after sibling sub-issues (#1473 terminal, #1472 search, #1474 txt, #1475 vfs) all land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)