### PR TITLE
fix(editor): guard panelApi.setActive() in onFocus to stop scroll-bounce (#1457)

### DIFF
--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -446,7 +446,14 @@ export default function EditorLayout({
                                 className="h-full"
                                 // NOTE: onFocus は子孫（Milkdown contenteditable）からの bubble を利用。
                                 // tabIndex は不要。パネルへのフォーカスを dockview に伝え activeTabId を最新化する。
-                                onFocus={() => panelApi.setActive()}
+                                // 既に active な panel に対する setActive() は dockview 内部で
+                                // content 要素の DOM detach → re-attach を引き起こし scroll を 0 に
+                                // リセットしてしまう (#1457 回帰)。isActive 時はスキップする。
+                                onFocus={() => {
+                                  if (!panelApi.isActive) {
+                                    panelApi.setActive();
+                                  }
+                                }}
                               >
                                 <NovelEditor
                                   key={`tab-${panelBufferId}-${panelFilePath}-${panelEditorKey}`}

--- a/components/__tests__/active-panel-focus-skip-setActive.test.tsx
+++ b/components/__tests__/active-panel-focus-skip-setActive.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Regression test for #1457: editor click bounces scroll to top.
+ *
+ * Root cause: `panelApi.setActive()` called on an already-active dockview panel
+ * routes through `DockviewGroupPanelModel.openPanel`, which calls
+ * `ContentContainer.renderPanel(panel, { asActive: true })`. That handler
+ * detaches and re-attaches the panel's content element to the DOM — and DOM
+ * re-attachment resets `scrollTop` / `scrollLeft` to 0, with the editor's
+ * contenteditable losing its caret context in the process.
+ *
+ * Fix: the editor wrapper's `onFocus` must skip `setActive()` when the panel
+ * is already active. The redundant call adds nothing and triggers the
+ * detach/reattach side-effect.
+ *
+ * This test exercises a minimal `<div onFocus>` mirror of the JSX shape used
+ * in `EditorLayout.tsx:441-484` (active-panel branch) and asserts that the
+ * guard holds. It does NOT touch the real dockview internals — those are
+ * covered by the bundled `node_modules/dockview-core` source paths cited in
+ * the fix's comment block.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+interface PanelApiLike {
+  isActive: boolean;
+  setActive: () => void;
+}
+
+function EditorWrapper({ panelApi }: { panelApi: PanelApiLike }) {
+  return (
+    <div
+      data-testid="editor-wrapper"
+      tabIndex={-1}
+      onFocus={() => {
+        if (!panelApi.isActive) {
+          panelApi.setActive();
+        }
+      }}
+    >
+      <textarea data-testid="inner-editable" />
+    </div>
+  );
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("#1457 regression — editor wrapper onFocus must guard setActive()", () => {
+  it("does NOT call panelApi.setActive() when the panel is already active", () => {
+    const panelApi: PanelApiLike = {
+      isActive: true,
+      setActive: vi.fn(),
+    };
+
+    act(() => {
+      root.render(<EditorWrapper panelApi={panelApi} />);
+    });
+
+    const wrapper = container.querySelector("[data-testid='editor-wrapper']") as HTMLDivElement;
+
+    act(() => {
+      wrapper.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    });
+
+    expect(panelApi.setActive).not.toHaveBeenCalled();
+  });
+
+  it("DOES call panelApi.setActive() when the panel is not active (multi-panel layout case)", () => {
+    const panelApi: PanelApiLike = {
+      isActive: false,
+      setActive: vi.fn(),
+    };
+
+    act(() => {
+      root.render(<EditorWrapper panelApi={panelApi} />);
+    });
+
+    const wrapper = container.querySelector("[data-testid='editor-wrapper']") as HTMLDivElement;
+
+    act(() => {
+      wrapper.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    });
+
+    expect(panelApi.setActive).toHaveBeenCalledTimes(1);
+  });
+
+  it("focus bubbling from contenteditable descendant also respects the guard", () => {
+    const panelApi: PanelApiLike = {
+      isActive: true,
+      setActive: vi.fn(),
+    };
+
+    act(() => {
+      root.render(<EditorWrapper panelApi={panelApi} />);
+    });
+
+    const inner = container.querySelector("[data-testid='inner-editable']") as HTMLTextAreaElement;
+
+    act(() => {
+      inner.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    });
+
+    expect(panelApi.setActive).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug:** Clicking anywhere inside the editor scrolled the document back to the top. Caret context in the contenteditable was lost.
- **Root cause:** the active-panel wrapper's `onFocus` handler called `panelApi.setActive()` unconditionally. In dockview that routes through `DockviewGroupPanelModel.openPanel`, which calls `ContentContainer.renderPanel(panel, { asActive: true })` even when the panel is already active. `renderPanel` detaches the panel's content element from the DOM and re-attaches it. DOM re-attachment resets `scrollTop` to 0 and disrupts the contenteditable's caret.
- **Fix:** gate `setActive()` on `!panelApi.isActive`. Inactive-panel focus (multi-panel layout case) still fires `setActive()` as before — same external behaviour, no redundant detach/reattach.

## Regression history

PR #1482 (commit `aea71f0`) re-introduced the same `onFocus` handler that the v1.2.7 rollback (#1457 / #1445) had removed, without the guard. This PR restores the guarded form.

## Test plan

- [x] `npx vitest run components/__tests__/active-panel-focus-skip-setActive.test.tsx` — 3/3 pass
  - focus on already-active panel → `setActive()` NOT called
  - focus on inactive panel → `setActive()` called once (multi-panel case still works)
  - focus bubbling from contenteditable descendant → guard still respected
- [x] `npm run type-check` — clean
- [x] `npx vitest run --exclude='.worktrees/**' --exclude='.claude/**'` — 978/978 pass
- [ ] Manual smoke test: open a project, click anywhere mid-document, verify scroll position is preserved
- [ ] Manual smoke test (multi-panel): split editor, click into the non-active panel, verify it becomes active

Closes #1457
Refs #1466 (power-aware re-implementation tracker — separate, still open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)