### PR TITLE
hotfix: render [[blank]] as empty paragraph in editor (blocks v1.2.9)

### DIFF
--- a/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank-roundtrip.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank-roundtrip.test.ts
@@ -17,30 +17,28 @@ function saveThenLoad(raw: string) {
 }
 
 describe("MDI blank paragraph — save → load composition round-trip", () => {
-  it("paste-origin <br /> → 保存形 [[blank]] → load で空 paragraph", () => {
+  it("paste-origin <br /> → 保存形 [[blank]] → load で blankParagraph ノード", () => {
     const { sanitized, tree } = saveThenLoad("A段落\n\n<br />\n\nB段落");
     expect(sanitized).toBe("A段落\n\n[[blank]]\n\nB段落");
     const root = tree as { children: { type: string; children: unknown[] }[] };
     const middle = root.children[1];
-    expect(middle.type).toBe("paragraph");
+    expect(middle.type).toBe("blankParagraph");
     expect(middle.children).toHaveLength(0);
   });
 
-  it("連続 <br /> → 連続 [[blank]] → 2 連続の空 paragraph", () => {
+  it("連続 <br /> → 連続 [[blank]] → 2 連続の blankParagraph", () => {
     const { sanitized, tree } = saveThenLoad("A\n\n<br />\n\n<br />\n\nB");
     expect(sanitized).toBe("A\n\n[[blank]]\n\n[[blank]]\n\nB");
     const root = tree as { children: { type: string; children: unknown[] }[] };
-    const emptyParagraphs = root.children.filter(
-      (n) => n.type === "paragraph" && n.children.length === 0,
-    );
-    expect(emptyParagraphs.length).toBe(2);
+    const blankNodes = root.children.filter((n) => n.type === "blankParagraph");
+    expect(blankNodes.length).toBe(2);
   });
 
   it("先頭空段落 → 保持される", () => {
     const { sanitized, tree } = saveThenLoad("<br />\n\nA");
     expect(sanitized).toBe("[[blank]]\n\nA");
     const root = tree as { children: { type: string; children: unknown[] }[] };
-    expect(root.children[0].type).toBe("paragraph");
+    expect(root.children[0].type).toBe("blankParagraph");
     expect(root.children[0].children).toHaveLength(0);
   });
 

--- a/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-blank.test.ts
@@ -21,24 +21,29 @@ function runPlugin(tree: Root, options?: { enable?: boolean }): Root {
 }
 
 describe("remarkMdiBlankPlugin", () => {
-  it("[[blank]]-only paragraph → children becomes []", () => {
+  it("[[blank]]-only paragraph → rewritten as blankParagraph node with empty children", () => {
     const tree = runPlugin(makeTree("[[blank]]"));
-    expect(tree.children[0]!.children).toHaveLength(0);
+    const node = tree.children[0]! as unknown as { type: string; children: unknown[] };
+    expect(node.type).toBe("blankParagraph");
+    expect(node.children).toHaveLength(0);
   });
 
   it("normal text paragraph → unchanged", () => {
     const tree = runPlugin(makeTree("春は曙。"));
+    expect(tree.children[0]!.type).toBe("paragraph");
     expect(tree.children[0]!.children).toHaveLength(1);
     expect(tree.children[0]!.children[0]).toEqual({ type: "text", value: "春は曙。" });
   });
 
   it("[[blank]] with surrounding text → unchanged (mixed content)", () => {
     const tree = runPlugin(makeTree("before [[blank]] after"));
+    expect(tree.children[0]!.type).toBe("paragraph");
     expect(tree.children[0]!.children).toHaveLength(1);
   });
 
   it("disabled via { enable: false } → unchanged", () => {
     const tree = runPlugin(makeTree("[[blank]]"), { enable: false });
+    expect(tree.children[0]!.type).toBe("paragraph");
     expect(tree.children[0]!.children).toHaveLength(1);
   });
 });

--- a/packages/milkdown-plugin-japanese-novel/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/index.ts
@@ -11,6 +11,7 @@ import { tcySchema } from "./nodes/tcy";
 import { nobreakSchema } from "./nodes/nobreak";
 import { kernSchema } from "./nodes/kern";
 import { mdibreakSchema } from "./nodes/mdibreak";
+import { blankParagraphSchema } from "./nodes/blank-paragraph";
 import { headingAnchorSchema } from "./nodes/heading-anchor";
 import {
   remarkHeadingAnchorPlugin,
@@ -19,6 +20,7 @@ import {
   remarkNoBreakPlugin,
   remarkKernPlugin,
   remarkMdiBreakPlugin,
+  remarkMdiBlankPlugin,
 } from "./syntax";
 import { createHeadingIdFixerPlugin } from "./plugins/heading-id-fixer";
 import { createHardbreakIndentPlugin } from "./plugins/hardbreak-indent";
@@ -75,6 +77,11 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     () => remarkMdiBreakPlugin as (o?: { enable?: boolean }) => (tree: unknown) => void,
     { enable: enableMdiBreak },
   );
+  const remarkMdiBlank = $remark(
+    "japaneseNovelMdiBlank",
+    () => remarkMdiBlankPlugin as (o?: { enable?: boolean }) => (tree: unknown) => void,
+    { enable: true },
+  );
   const remarkHeadingAnchor = $remark(
     "japaneseNovelHeadingAnchor",
     () => remarkHeadingAnchorPlugin,
@@ -110,6 +117,8 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     ...(enableMdiBreak ? [remarkMdiBreak, mdibreakSchema] : []),
     ...(enableNoBreak ? [remarkNoBreak, nobreakSchema] : []),
     ...(enableKern ? [remarkKern, kernSchema] : []),
+    remarkMdiBlank,
+    blankParagraphSchema,
     remarkHeadingAnchor,
     headingAnchorSchema,
     headingIdFixerPlugin,

--- a/packages/milkdown-plugin-japanese-novel/nodes/blank-paragraph.ts
+++ b/packages/milkdown-plugin-japanese-novel/nodes/blank-paragraph.ts
@@ -1,0 +1,35 @@
+/**
+ * MDI blank paragraph (強制空段落) block node: `[[blank]]` (standalone paragraph).
+ *
+ * CommonMark collapses successive blank lines into a single paragraph separator,
+ * so to keep an intentional empty paragraph (often used in Japanese typography
+ * for scene beats), authors write `[[blank]]` as the paragraph contents. This
+ * schema pairs with `remarkMdiBlankPlugin` (which rewrites the mdast paragraph
+ * to `type: "blankParagraph"`) and renders an empty `<p>` in the editor while
+ * round-tripping back to `[[blank]]` on save.
+ */
+
+import { $nodeSchema } from "@milkdown/utils";
+
+export const blankParagraphSchema = $nodeSchema("blankParagraph", () => ({
+  group: "block",
+  atom: true,
+  selectable: true,
+  draggable: false,
+  parseDOM: [{ tag: "p.mdi-blank" }],
+  toDOM: () => ["p", { class: "mdi-blank" }],
+  parseMarkdown: {
+    match: (node) => (node as { type?: string }).type === "blankParagraph",
+    runner: (state, _node, type) => {
+      state.addNode(type);
+    },
+  },
+  toMarkdown: {
+    match: (node) => node.type.name === "blankParagraph",
+    runner: (state) => {
+      state.openNode("paragraph");
+      state.addNode("text", undefined, "[[blank]]");
+      state.closeNode();
+    },
+  },
+}));

--- a/packages/milkdown-plugin-japanese-novel/nodes/blank-paragraph.ts
+++ b/packages/milkdown-plugin-japanese-novel/nodes/blank-paragraph.ts
@@ -2,33 +2,39 @@
  * MDI blank paragraph (強制空段落) block node: `[[blank]]` (standalone paragraph).
  *
  * CommonMark collapses successive blank lines into a single paragraph separator,
- * so to keep an intentional empty paragraph (often used in Japanese typography
- * for scene beats), authors write `[[blank]]` as the paragraph contents. This
- * schema pairs with `remarkMdiBlankPlugin` (which rewrites the mdast paragraph
- * to `type: "blankParagraph"`) and renders an empty `<p>` in the editor while
- * round-tripping back to `[[blank]]` on save.
+ * so authors write `[[blank]]` to keep an intentional empty paragraph (common in
+ * Japanese typography for scene beats). This node behaves exactly like a regular
+ * paragraph in the editor — the user can click in and start typing, which
+ * naturally turns it into prose — but its `toMarkdown` runner emits `[[blank]]`
+ * when the content is still empty, preserving the marker across save/load.
+ *
+ * Pairs with `remarkMdiBlankPlugin` (which rewrites `[[blank]]`-only paragraphs
+ * to mdast type `blankParagraph` on load).
  */
 
 import { $nodeSchema } from "@milkdown/utils";
 
 export const blankParagraphSchema = $nodeSchema("blankParagraph", () => ({
+  content: "inline*",
   group: "block",
-  atom: true,
-  selectable: true,
-  draggable: false,
   parseDOM: [{ tag: "p.mdi-blank" }],
-  toDOM: () => ["p", { class: "mdi-blank" }],
+  toDOM: () => ["p", { class: "mdi-blank" }, 0],
   parseMarkdown: {
     match: (node) => (node as { type?: string }).type === "blankParagraph",
     runner: (state, _node, type) => {
-      state.addNode(type);
+      state.openNode(type);
+      state.closeNode();
     },
   },
   toMarkdown: {
     match: (node) => node.type.name === "blankParagraph",
-    runner: (state) => {
+    runner: (state, node) => {
       state.openNode("paragraph");
-      state.addNode("text", undefined, "[[blank]]");
+      if (node.content.size === 0) {
+        state.addNode("text", undefined, "[[blank]]");
+      } else {
+        state.next(node.content);
+      }
       state.closeNode();
     },
   },

--- a/packages/milkdown-plugin-japanese-novel/styles/index.css
+++ b/packages/milkdown-plugin-japanese-novel/styles/index.css
@@ -44,3 +44,10 @@
 .milkdown-japanese-base .mdi-kern {
   letter-spacing: var(--mdi-kern, 0em);
 }
+
+/* Blank paragraph (強制空段落 `[[blank]]`): when empty, render a line-box of natural height
+   via a zero-width space so paragraph counters don't stack. As soon as the user types,
+   `:empty` no longer matches and the actual content takes over. */
+.milkdown-japanese-base p.mdi-blank:empty::before {
+  content: "\200B";
+}

--- a/packages/milkdown-plugin-japanese-novel/syntax.ts
+++ b/packages/milkdown-plugin-japanese-novel/syntax.ts
@@ -252,7 +252,12 @@ export const remarkMdiBlankPlugin: Plugin<[RemarkMdiBlankOptions | undefined], R
         node.children[0].type === "text" &&
         (node.children[0] as Text).value.trim() === "[[blank]]"
       ) {
-        node.children.length = 0;
+        // Convert to a custom block node so the schema can round-trip `[[blank]]`.
+        // Just clearing children would serialize back as a regular blank line and
+        // lose the marker; the matching `blankParagraphSchema` renders an empty
+        // `<p>` in the editor and re-emits `[[blank]]` on save.
+        (node as unknown as { type: string }).type = "blankParagraph";
+        (node as unknown as { children: unknown[] }).children = [];
       }
     });
   };


### PR DESCRIPTION
## ブロッカー

リリース v1.2.9 のマージ後にユーザー確認した重大バグ。Desktop Build をキャンセル済み。
このホットフィックスが main に入った後、自動再ビルドで v1.2.9 がリリースされる。

## 症状

- エディタで `[[blank]]` が **literal text として表示** される（空段落にならない）
- ファイル保存時に `[[blank]]` が **`\[\[blank\]\]` に escape** されて記録される

## 根本原因

[[blank]] 再実装 (#1483) で `remarkMdiBlankPlugin` を作ったが、`japaneseNovel()` ファクトリーに **登録されていなかった**。
そのため remark パイプラインを通らず、`[[blank]]` は普通のテキストとして ProseMirror に届いてしまっていた。
さらにテキストとして保存されると markdown serializer に `[` が escape される。

## 修正

`mdibreak` と同じパターンで block schema を作成:

1. **`remarkMdiBlankPlugin`** を改修: `[[blank]]` 段落を mdast 型 `blankParagraph` にリライト
   (単に `children` を空にしただけだと serializer で普通の空行になり marker が消える)
2. **`blankParagraphSchema`** を新設: 空 `<p class="mdi-blank">` を描画、`toMarkdown` で `[[blank]]` を復元
3. **`japaneseNovel()`** に両者を登録

## テスト

- `paragraph-blank.test.ts` / `paragraph-blank-roundtrip.test.ts` を新ノード型に合わせて更新
- フル suite 978/978 pass、`tsc --noEmit` clean

## 確認推奨

UI は unit test では完全検証できないため、merge 後ビルドが出たら手元で確認:
- 既存 `.mdi` ファイルの `\[\[blank\]\]` が空段落として表示されるか
- 新規に `[[blank]]` を入力 → 保存 → 再読み込みで round-trip するか

🤖 Generated with [Claude Code](https://claude.com/claude-code)