### PR TITLE
feat(vfs): 再起動後の VFS ルートを自動復元 (#1476)

### DIFF
--- a/electron/ipc/__tests__/vfs-approved-paths-persist.test.ts
+++ b/electron/ipc/__tests__/vfs-approved-paths-persist.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for VFS approved-paths persistence (vfs-approvals.js)
+ *
+ * These tests exercise the pure persistence helpers that back the
+ * `vfs:set-root` rehydration feature (issue #1476).
+ *
+ * Architecture note: vfs-ipc.js is a CommonJS Electron main-process module
+ * that cannot be imported directly into vitest. We test the extracted pure
+ * functions from electron/lib/vfs-approvals.js instead.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import os from "os";
+import fsSync from "fs";
+import path from "path";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+/** @type {{ loadAllApprovals, loadApprovals, saveApprovals, clearApprovalsCache }} */
+const {
+  loadAllApprovals,
+  loadApprovals,
+  saveApprovals,
+  clearApprovalsCache,
+} = require("../../../electron/lib/vfs-approvals.js");
+
+// -----------------------------------------------------------------------
+// Test helpers
+// -----------------------------------------------------------------------
+
+/** Create a fresh temporary file path for each test (not created yet). */
+function tempFilePath() {
+  return path.join(os.tmpdir(), `vfs-approvals-test-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+}
+
+let tmpFile: string;
+
+beforeEach(() => {
+  tmpFile = tempFilePath();
+  clearApprovalsCache();
+});
+
+afterEach(() => {
+  // Clean up temp file if it was created
+  try {
+    fsSync.unlinkSync(tmpFile);
+  } catch {
+    // ignore if not created
+  }
+  clearApprovalsCache();
+});
+
+// -----------------------------------------------------------------------
+// approve writes JSON
+// -----------------------------------------------------------------------
+describe("saveApprovals()", () => {
+  it("creates the JSON file with correct schema on first write", async () => {
+    const paths = new Set(["/Users/alice/novel1"]);
+    await saveApprovals(tmpFile, "proj_001", paths);
+
+    const raw = fsSync.readFileSync(tmpFile, "utf-8");
+    const data = JSON.parse(raw);
+    expect(data.version).toBe(1);
+    expect(Array.isArray(data.approvals)).toBe(true);
+    expect(data.approvals).toHaveLength(1);
+    expect(data.approvals[0].projectId).toBe("proj_001");
+    expect(data.approvals[0].path).toBe("/Users/alice/novel1");
+    expect(typeof data.approvals[0].approvedAt).toBe("string");
+  });
+
+  it("replaces only the given projectId, keeping other projects intact", async () => {
+    // Seed file with two projects
+    const seed = {
+      version: 1,
+      approvals: [
+        { projectId: "proj_A", path: "/Users/alice/projectA", approvedAt: "2026-01-01T00:00:00.000Z" },
+        { projectId: "proj_B", path: "/Users/bob/projectB", approvedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    };
+    fsSync.writeFileSync(tmpFile, JSON.stringify(seed));
+    clearApprovalsCache();
+
+    // Update proj_A only
+    await saveApprovals(tmpFile, "proj_A", new Set(["/Users/alice/novel2"]));
+
+    const raw = fsSync.readFileSync(tmpFile, "utf-8");
+    const data = JSON.parse(raw);
+    const projBEntry = data.approvals.find((a: { projectId: string; path: string }) => a.projectId === "proj_B");
+    const projAEntry = data.approvals.find((a: { projectId: string; path: string }) => a.projectId === "proj_A");
+
+    // proj_B must remain untouched
+    expect(projBEntry).toBeDefined();
+    expect(projBEntry.path).toBe("/Users/bob/projectB");
+
+    // proj_A must be updated
+    expect(projAEntry).toBeDefined();
+    expect(projAEntry.path).toBe("/Users/alice/novel2");
+  });
+});
+
+// -----------------------------------------------------------------------
+// restart-simulated reload restores only projectId-matching paths
+// -----------------------------------------------------------------------
+describe("loadApprovals()", () => {
+  it("returns only paths belonging to the requested projectId", async () => {
+    const data = {
+      version: 1,
+      approvals: [
+        { projectId: "proj_X", path: "/Users/alice/xProject", approvedAt: "2026-01-01T00:00:00.000Z" },
+        { projectId: "proj_Y", path: "/Users/alice/yProject", approvedAt: "2026-01-01T00:00:00.000Z" },
+      ],
+    };
+    fsSync.writeFileSync(tmpFile, JSON.stringify(data));
+    clearApprovalsCache();
+
+    const result = await loadApprovals(tmpFile, "proj_X");
+    expect(result.has("/Users/alice/xProject")).toBe(true);
+    expect(result.has("/Users/alice/yProject")).toBe(false);
+  });
+
+  it("returns empty Set when projectId has no entries", async () => {
+    const data = { version: 1, approvals: [] };
+    fsSync.writeFileSync(tmpFile, JSON.stringify(data));
+    clearApprovalsCache();
+
+    const result = await loadApprovals(tmpFile, "proj_UNKNOWN");
+    expect(result.size).toBe(0);
+  });
+
+  it("simulates restart: cache cleared → reads from disk", async () => {
+    await saveApprovals(tmpFile, "proj_restart", new Set(["/Users/carol/myProject"]));
+    // Simulate restart: clear in-memory cache
+    clearApprovalsCache();
+
+    const restored = await loadApprovals(tmpFile, "proj_restart");
+    expect(restored.has("/Users/carol/myProject")).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------
+// corrupt JSON → empty Set fallback
+// -----------------------------------------------------------------------
+describe("corrupt JSON fallback", () => {
+  it("returns empty Set when file is not valid JSON", async () => {
+    fsSync.writeFileSync(tmpFile, "{ this is not json }", "utf-8");
+    clearApprovalsCache();
+
+    const result = await loadApprovals(tmpFile, "proj_any");
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty Set when version field is wrong", async () => {
+    const data = { version: 999, approvals: [{ projectId: "proj_x", path: "/foo" }] };
+    fsSync.writeFileSync(tmpFile, JSON.stringify(data));
+    clearApprovalsCache();
+
+    const result = await loadApprovals(tmpFile, "proj_x");
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty Set when file does not exist", async () => {
+    const nonExistentFile = path.join(os.tmpdir(), "does-not-exist-vfs-approvals.json");
+    clearApprovalsCache();
+
+    const result = await loadApprovals(nonExistentFile, "proj_x");
+    expect(result.size).toBe(0);
+  });
+
+  it("skips malformed entries (missing path or projectId)", async () => {
+    const data = {
+      version: 1,
+      approvals: [
+        null,
+        { projectId: "proj_ok", path: "/good/path", approvedAt: "2026-01-01T00:00:00.000Z" },
+        { projectId: "proj_ok" }, // missing path
+        { path: "/no/projectId" }, // missing projectId
+      ],
+    };
+    fsSync.writeFileSync(tmpFile, JSON.stringify(data));
+    clearApprovalsCache();
+
+    const result = await loadApprovals(tmpFile, "proj_ok");
+    expect(result.has("/good/path")).toBe(true);
+    expect(result.size).toBe(1);
+  });
+});
+
+// -----------------------------------------------------------------------
+// denied path NOT persisted (security regression)
+// -----------------------------------------------------------------------
+describe("security: denied paths are never auto-persisted", () => {
+  it("only saves paths that are explicitly added to the Set", async () => {
+    // saveApprovals only saves the Set that is passed to it.
+    // A denied path should never appear in the Set — caller responsibility.
+    const approvedSet = new Set(["/Users/alice/allowedProject"]);
+    // Denied path is simply never added to the set
+    await saveApprovals(tmpFile, "proj_sec", approvedSet);
+
+    clearApprovalsCache();
+    const restored = await loadApprovals(tmpFile, "proj_sec");
+    expect(restored.has("/Users/alice/allowedProject")).toBe(true);
+    expect(restored.has("/etc/passwd")).toBe(false);
+    expect(restored.size).toBe(1);
+  });
+
+  it("empty Set means no paths are persisted for the project", async () => {
+    await saveApprovals(tmpFile, "proj_empty", new Set());
+    clearApprovalsCache();
+    const restored = await loadApprovals(tmpFile, "proj_empty");
+    expect(restored.size).toBe(0);
+  });
+});
+
+// -----------------------------------------------------------------------
+// different projectId → independent approval set (R6 scoping)
+// -----------------------------------------------------------------------
+describe("R6 scoping: different projectId gets isolated approval set", () => {
+  it("paths from project A are not visible when querying project B", async () => {
+    await saveApprovals(tmpFile, "proj_alpha", new Set(["/Users/alice/alpha"]));
+    clearApprovalsCache();
+    await saveApprovals(tmpFile, "proj_beta", new Set(["/Users/bob/beta"]));
+
+    clearApprovalsCache();
+    const alphaApprovals = await loadApprovals(tmpFile, "proj_alpha");
+    const betaApprovals = await loadApprovals(tmpFile, "proj_beta");
+
+    expect(alphaApprovals.has("/Users/alice/alpha")).toBe(true);
+    expect(alphaApprovals.has("/Users/bob/beta")).toBe(false);
+
+    expect(betaApprovals.has("/Users/bob/beta")).toBe(true);
+    expect(betaApprovals.has("/Users/alice/alpha")).toBe(false);
+  });
+
+  it("switching projects clears only the target project's approvals, not others", async () => {
+    // Set up two projects
+    await saveApprovals(tmpFile, "proj_alpha", new Set(["/alpha/path"]));
+    clearApprovalsCache();
+    await saveApprovals(tmpFile, "proj_beta", new Set(["/beta/path"]));
+
+    // Reset proj_alpha (simulate switching away)
+    clearApprovalsCache();
+    await saveApprovals(tmpFile, "proj_alpha", new Set());
+
+    clearApprovalsCache();
+    const alphaApprovals = await loadApprovals(tmpFile, "proj_alpha");
+    const betaApprovals = await loadApprovals(tmpFile, "proj_beta");
+
+    expect(alphaApprovals.size).toBe(0);
+    expect(betaApprovals.has("/beta/path")).toBe(true);
+  });
+});
+
+// -----------------------------------------------------------------------
+// in-memory cache: avoids disk reads on repeated calls
+// -----------------------------------------------------------------------
+describe("in-memory cache (NEW-3)", () => {
+  it("returns cached result without re-reading disk after first load", async () => {
+    const data = { version: 1, approvals: [{ projectId: "proj_c", path: "/c/path", approvedAt: "2026-01-01T00:00:00.000Z" }] };
+    fsSync.writeFileSync(tmpFile, JSON.stringify(data));
+    clearApprovalsCache();
+
+    // First load populates cache
+    await loadApprovals(tmpFile, "proj_c");
+
+    // Overwrite file on disk with different content
+    const updated = { version: 1, approvals: [{ projectId: "proj_c", path: "/different/path", approvedAt: "2026-01-02T00:00:00.000Z" }] };
+    fsSync.writeFileSync(tmpFile, JSON.stringify(updated));
+
+    // Should still return cached (original) result
+    const result = await loadApprovals(tmpFile, "proj_c");
+    expect(result.has("/c/path")).toBe(true);
+    expect(result.has("/different/path")).toBe(false);
+  });
+
+  it("saveApprovals() invalidates cache so next loadApprovals reads fresh data", async () => {
+    await saveApprovals(tmpFile, "proj_d", new Set(["/d/original"]));
+    // Cache is populated after save. Now save again with different paths:
+    await saveApprovals(tmpFile, "proj_d", new Set(["/d/updated"]));
+
+    // After second save cache is invalidated and repopulated with fresh data
+    const result = await loadApprovals(tmpFile, "proj_d");
+    expect(result.has("/d/updated")).toBe(true);
+    expect(result.has("/d/original")).toBe(false);
+  });
+});

--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -13,6 +13,9 @@ const {
   assertPathInsideRoot,
   getWindowsDenyPrefixes,
 } = require("../lib/path-utils");
+// #1476: rehydration — begin
+const { loadApprovals, saveApprovals } = require("../lib/vfs-approvals");
+// #1476: rehydration — end
 
 /** Maximum content size accepted by write-file (same limit as file-ipc.js) */
 const MAX_CONTENT_BYTES = 50 * 1024 * 1024; // 50 MB
@@ -27,6 +30,44 @@ function registerVFSHandlers() {
   const MAX_APPROVED_PATHS = 200;
   /** @type {Map<number, Map<string, true>>} webContentsId -> (path -> true) LRU map */
   const dialogApprovedPaths = new Map();
+
+  // #1476: rehydration — begin
+  /**
+   * Path to the persistent approved-vfs-paths.json file stored in userData.
+   * @type {string}
+   */
+  const APPROVED_PATHS_FILE = path.join(app.getPath("userData"), "approved-vfs-paths.json");
+
+  /**
+   * Maps senderId (webContents.id) → projectId.
+   * Populated by the `vfs:set-root` handler so that `approveDialogPath` can
+   * associate approvals with the correct project.
+   * @type {Map<number, string>}
+   */
+  const senderProjectId = new Map();
+
+  /**
+   * Debounce timer for persisting approvals to disk.
+   * Prevents repeated rapid writes during bulk approval.
+   * @type {NodeJS.Timeout | null}
+   */
+  let saveDebounceTimer = null;
+
+  /**
+   * Debounced wrapper for saveApprovals — flushes after 500 ms of inactivity.
+   * @param {string} projectId
+   * @param {Set<string>} paths
+   */
+  function scheduleSaveApprovals(projectId, paths) {
+    if (saveDebounceTimer) clearTimeout(saveDebounceTimer);
+    saveDebounceTimer = setTimeout(() => {
+      saveDebounceTimer = null;
+      saveApprovals(APPROVED_PATHS_FILE, projectId, paths).catch((err) => {
+        console.error("[VFS IPC] Failed to persist approved paths:", err);
+      });
+    }, 500);
+  }
+  // #1476: rehydration — end
 
   /**
    * Get or create the per-window LRU path map for a given webContentsId.
@@ -302,7 +343,8 @@ function registerVFSHandlers() {
   }
 
   // Set root directory programmatically (for restoring a recent project without dialog)
-  ipcMain.handle("vfs:set-root", async (event, rootPath) => {
+  // #1476: rehydration — extended to accept projectId for project-scoped approval persistence
+  ipcMain.handle("vfs:set-root", async (event, rootPath, projectId) => {
     const resolved = path.resolve(rootPath);
     const normalizedResolved = normalizePath(resolved);
 
@@ -312,10 +354,17 @@ function registerVFSHandlers() {
     }
 
     // 2. Verify the path actually exists and is a directory
+    let resolvedReal;
     try {
       const stats = await fs.stat(resolved);
       if (!stats.isDirectory()) {
         throw new Error("指定されたパスはディレクトリではありません");
+      }
+      // #1476: rehydration — resolve symlinks to mitigate path-traversal via symlink
+      try {
+        resolvedReal = normalizePath(await fs.realpath(resolved));
+      } catch {
+        resolvedReal = normalizedResolved;
       }
     } catch (error) {
       if (error.code === "ENOENT") {
@@ -324,13 +373,33 @@ function registerVFSHandlers() {
       throw error;
     }
 
-    // 3. Require dialog approval — renderer cannot promote arbitrary paths
-    //    to VFS root without prior native dialog consent.
-    //    If the path was not previously approved (e.g. after app restart),
-    //    prompt the user with a native directory dialog for confirmation.
-    //    This prevents a compromised renderer from escalating an arbitrary
-    //    path to an allowed root (fixes security issue #1043).
-    if (!dialogApprovedPaths.get(event.sender.id)?.has(resolved)) {
+    // 3. Register projectId association for this sender
+    // #1476: rehydration — store projectId so approvals can be project-scoped
+    if (typeof projectId === "string" && projectId) {
+      senderProjectId.set(event.sender.id, projectId);
+    }
+    const effectiveProjectId = senderProjectId.get(event.sender.id);
+
+    // 4. Check approval: in-session dialog approval OR persisted project approval
+    // #1476: rehydration — load persisted approvals so re-prompting is skipped on restart
+    const alreadyApprovedInSession = dialogApprovedPaths.get(event.sender.id)?.has(resolved);
+    let alreadyApprovedFromDisk = false;
+    if (!alreadyApprovedInSession && effectiveProjectId) {
+      const persistedSet = await loadApprovals(APPROVED_PATHS_FILE, effectiveProjectId);
+      alreadyApprovedFromDisk = persistedSet.has(resolvedReal) || persistedSet.has(resolved);
+      if (alreadyApprovedFromDisk) {
+        // Restore in-session approval so subsequent calls are fast
+        approveDialogPath(event.sender.id, resolved);
+      }
+    }
+
+    if (!alreadyApprovedInSession && !alreadyApprovedFromDisk) {
+      // 5. Require dialog approval — renderer cannot promote arbitrary paths
+      //    to VFS root without prior native dialog consent.
+      //    If the path was not previously approved (e.g. after app restart),
+      //    prompt the user with a native directory dialog for confirmation.
+      //    This prevents a compromised renderer from escalating an arbitrary
+      //    path to an allowed root (fixes security issue #1043).
       const win = BrowserWindow.fromWebContents(event.sender);
       const result = await dialog.showOpenDialog(win ?? undefined, {
         title: "プロジェクトフォルダへのアクセスを許可",
@@ -350,17 +419,26 @@ function registerVFSHandlers() {
       }
 
       approveDialogPath(event.sender.id, confirmedPath);
+
+      // #1476: rehydration — persist the newly approved path so restart skips the dialog
+      if (effectiveProjectId) {
+        const windowPaths = dialogApprovedPaths.get(event.sender.id);
+        const pathsToSave = new Set(windowPaths ? [...windowPaths.keys()] : [confirmedPath]);
+        scheduleSaveApprovals(effectiveProjectId, pathsToSave);
+      }
     }
 
     allowedRoots.set(event.sender.id, resolved);
     return { path: resolved, name: path.basename(resolved) };
   });
 
-  // Clean up allowedRoots and dialogApprovedPaths when a window is destroyed to prevent memory leaks
+  // Clean up allowedRoots, dialogApprovedPaths, and senderProjectId when a window is destroyed
   app.on("web-contents-created", (_, contents) => {
     contents.on("destroyed", () => {
       allowedRoots.delete(contents.id);
       dialogApprovedPaths.delete(contents.id);
+      // #1476: rehydration — clean up projectId association
+      senderProjectId.delete(contents.id);
     });
   });
 

--- a/electron/lib/vfs-approvals.js
+++ b/electron/lib/vfs-approvals.js
@@ -1,0 +1,114 @@
+/**
+ * Persistence helpers for VFS dialog-approved paths.
+ *
+ * Stores the set of paths the user has approved via the native directory picker,
+ * keyed by projectId. On app restart the approved set is reloaded from disk so
+ * the `vfs:set-root` handler can skip the re-approval dialog for previously
+ * accepted project roots.
+ *
+ * Schema (approved-vfs-paths.json):
+ * {
+ *   "version": 1,
+ *   "approvals": [
+ *     { "projectId": "proj_abc123", "path": "/Users/.../novel1", "approvedAt": "2026-..." }
+ *   ]
+ * }
+ *
+ * Security properties:
+ * - Project-scoped: only paths belonging to `projectId` are returned.
+ * - No auto-promotion of denied paths.
+ * - Caller must use fs.realpath() before passing paths to avoid symlink traversal.
+ * - TOCTOU: path existence is NOT checked here; rely on assertPathInsideRoot at access time.
+ */
+
+// #1476: rehydration — begin
+const fs = require("fs/promises");
+const path = require("path");
+
+/**
+ * In-memory cache so we don't re-read the JSON file on every approval check.
+ * Invalidated (set to null) whenever saveApprovals() writes new data.
+ * @type {Array<{projectId: string, path: string, approvedAt: string}> | null}
+ */
+let approvalsCache = null;
+
+/**
+ * Load the entire approvals array from disk (or return the in-memory cache).
+ * Returns an empty array when the file is missing or corrupt.
+ *
+ * @param {string} filePath - Absolute path to approved-vfs-paths.json
+ * @returns {Promise<Array<{projectId: string, path: string, approvedAt: string}>>}
+ */
+async function loadAllApprovals(filePath) {
+  if (approvalsCache !== null) return approvalsCache;
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    if (data?.version !== 1 || !Array.isArray(data.approvals)) {
+      approvalsCache = [];
+    } else {
+      // Defensive: keep only well-formed entries
+      approvalsCache = data.approvals.filter(
+        (a) =>
+          a !== null &&
+          typeof a === "object" &&
+          typeof a.projectId === "string" &&
+          typeof a.path === "string",
+      );
+    }
+  } catch {
+    approvalsCache = [];
+  }
+  return approvalsCache;
+}
+
+/**
+ * Load the set of approved paths for a specific project.
+ * Returns only paths belonging to `projectId`.
+ *
+ * @param {string} filePath - Absolute path to approved-vfs-paths.json
+ * @param {string} projectId - Project identifier
+ * @returns {Promise<Set<string>>}
+ */
+async function loadApprovals(filePath, projectId) {
+  if (typeof projectId !== "string" || !projectId) return new Set();
+  const all = await loadAllApprovals(filePath);
+  return new Set(all.filter((a) => a.projectId === projectId).map((a) => a.path));
+}
+
+/**
+ * Persist the approval set for a specific project, replacing any existing entries
+ * for that project. Entries for other projects are kept intact.
+ * Invalidates the in-memory cache.
+ *
+ * @param {string} filePath - Absolute path to approved-vfs-paths.json
+ * @param {string} projectId - Project identifier
+ * @param {Set<string>} paths - Set of approved absolute paths
+ */
+async function saveApprovals(filePath, projectId, paths) {
+  if (typeof projectId !== "string" || !projectId) return;
+  const all = await loadAllApprovals(filePath);
+  const others = all.filter((a) => a.projectId !== projectId);
+  const fresh = [...paths].map((p) => ({
+    projectId,
+    path: p,
+    approvedAt: new Date().toISOString(),
+  }));
+  approvalsCache = [...others, ...fresh];
+  await fs.writeFile(
+    filePath,
+    JSON.stringify({ version: 1, approvals: approvalsCache }, null, 2),
+    "utf-8",
+  );
+}
+
+/**
+ * Invalidate the in-memory cache. Used in tests to simulate a fresh process start.
+ */
+function clearApprovalsCache() {
+  approvalsCache = null;
+}
+
+// #1476: rehydration — end
+
+module.exports = { loadAllApprovals, loadApprovals, saveApprovals, clearApprovalsCache };

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -197,7 +197,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   vfs: {
     openDirectory: () => ipcRenderer.invoke("vfs:open-directory"),
     openFile: (opts) => ipcRenderer.invoke("vfs:open-file", opts),
-    setRoot: (rootPath) => ipcRenderer.invoke("vfs:set-root", rootPath),
+    // #1476: rehydration — projectId added for project-scoped approval persistence
+    setRoot: (rootPath, projectId) => ipcRenderer.invoke("vfs:set-root", rootPath, projectId),
     readFile: (filePath) => ipcRenderer.invoke("vfs:read-file", filePath),
     writeFile: (filePath, content) => ipcRenderer.invoke("vfs:write-file", filePath, content),
     readDirectory: (dirPath) => ipcRenderer.invoke("vfs:read-directory", dirPath),

--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -133,8 +133,10 @@ export function useFileOpening({
           try {
             const vfs = getVFS();
             if ("setRootPath" in vfs) {
-              await (vfs as { setRootPath: (p: string) => Promise<void> }).setRootPath(
+              // #1476: rehydration — pass projectId so the approval is persisted project-scoped
+              await (vfs as { setRootPath: (p: string, projectId?: string) => Promise<void> }).setRootPath(
                 project.rootPath,
+                projectId,
               );
             }
             // NOTE: signalVfsReady() is deferred to AFTER tab restore so that the

--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -194,8 +194,10 @@ export class ProjectService {
       if (parentPath) {
         projectRootPath = `${parentPath}/${name}`;
         if ("setRootPath" in this.vfs) {
-          await (this.vfs as { setRootPath: (p: string) => Promise<void> }).setRootPath(
+          // #1476: rehydration — pass projectId for project-scoped approval persistence
+          await (this.vfs as { setRootPath: (p: string, projectId?: string) => Promise<void> }).setRootPath(
             projectRootPath,
+            projectId,
           );
         }
       }
@@ -569,8 +571,10 @@ export class ProjectService {
     if (isElectronRenderer() && project.rootPath) {
       // Re-set the VFS root using the stored absolute path
       if ("setRootPath" in this.vfs) {
-        await (this.vfs as { setRootPath: (p: string) => Promise<void> }).setRootPath(
+        // #1476: rehydration — pass projectId so the approval is looked up project-scoped
+        await (this.vfs as { setRootPath: (p: string, projectId?: string) => Promise<void> }).setRootPath(
           project.rootPath,
+          project.projectId,
         );
       }
       return await this.vfs.getDirectoryHandle("");

--- a/lib/vfs/electron-vfs.ts
+++ b/lib/vfs/electron-vfs.ts
@@ -404,14 +404,19 @@ export class ElectronVFS implements VirtualFileSystem {
    * Used for recovering VFS root after page reload (Electron).
    * Also updates the main process allowed root for path validation.
    * @param rootPath - Absolute path to the project root directory
+   * @param projectId - Optional project ID for project-scoped approval persistence (#1476)
    */
-  async setRootPath(rootPath: string): Promise<void> {
+  async setRootPath(rootPath: string, projectId?: string): Promise<void> {
     // Await the main process root update before updating local state,
     // so this.rootPath is never set to a value the main process rejected.
     try {
       const bridge = getVFSBridge();
       if ("setRoot" in bridge) {
-        await (bridge as { setRoot: (p: string) => Promise<unknown> }).setRoot(rootPath);
+        // #1476: rehydration — pass projectId for project-scoped persistence
+        await (bridge as { setRoot: (p: string, projectId?: string) => Promise<unknown> }).setRoot(
+          rootPath,
+          projectId,
+        );
       }
     } catch (error: unknown) {
       // Bridge may not be available during early initialization — that's expected.


### PR DESCRIPTION
## 概要

アプリ再起動後、前回承認したプロジェクトルートを再プロンプトなしで自動復元する。

Closes #1476

## Pre-implementation audit gate 結果

```
grep -rn "setRootPath\|setRootHandle" lib/ app/ --include="*.ts" --include="*.tsx"
```

結果: 既存の `use-file-opening.ts` (L135, L282) と `project-service.ts` (L208, L495, L504) が `setRootPath` / `setRootHandle` を呼び出している。`workspace-persistence.ts` は `setRootPath` を呼ばない。

**判断**: 新規 `app-init-service.ts` は不要。既存の `handleOpenRecentProject` → `setRootPath` → `vfs:set-root` 経路が起動時の復元パスを担う。main process の `vfs:set-root` ハンドラが再起動後に dialog を表示してしまう問題のみ修正する。

## 修正概要

| ファイル | 変更内容 |
|---|---|
| `electron/lib/vfs-approvals.js` | **新規**: 承認済みパス永続化ロジック (pure functions, テスト可能) |
| `electron/ipc/vfs-ipc.js` | `vfs:set-root` を `(rootPath, projectId)` に拡張。起動時に JSON から承認を復元、承認後に非同期 debounced 永続化 |
| `electron/preload.js` | `vfs.setRoot(rootPath, projectId)` に引数追加 |
| `lib/vfs/electron-vfs.ts` | `setRootPath(rootPath, projectId?)` に optional param 追加 |
| `lib/editor-page/use-file-opening.ts` | `handleOpenRecentProject` で `projectId` を `setRootPath` に渡す |
| `lib/project/project-service.ts` | `createProject` / `getVFSDirectoryHandle` で `projectId` を渡す |
| `electron/ipc/__tests__/vfs-approved-paths-persist.test.ts` | **新規**: 15 tests — 永続化・復元・corrupt fallback・security regression・R6 scoping |

## 永続化スキーマ

`~/Library/Application Support/illusions/approved-vfs-paths.json`:
```json
{
  "version": 1,
  "approvals": [
    { "projectId": "proj_abc123", "path": "/Users/.../novel1", "approvedAt": "2026-05-24T..." }
  ]
}
```

## Security notes

- `fs.realpath()` でシンボリックリンクを解決してから比較 (path traversal 緩和)
- denied path は `saveApprovals()` に渡す Set に含まれない (呼び出し側の責務)
- TOCTOU: load 時の path 存在チェックなし → VFS access 時の既存 `assertPathInsideRoot` で守る
- `version !== 1` または corrupt JSON → 空 Set にフォールバック
- project-scoped: project A の承認が project B に漏れない (R6 scoping テストで確認済み)

## Verification 手順

1. Electron でプロジェクトを開く → 終了
2. 再起動 → dialog なしでプロジェクトがロードされること
3. 別プロジェクトに切替 → dialog が出ること
4. `~/Library/Application Support/illusions/approved-vfs-paths.json` の内容を確認

## PR-C (#1475) との調整

PR-C はまだ未 push。`vfs-ipc.js` の変更箇所は異なる (PR-C: `vfs:open-file` ハンドラ追加、PR-D: `vfs:set-root` 拡張)。PR-C merge 後の rebase は機械的 (`// #1476: rehydration` コメントブロックで分離済み)。

## Risks

- `handleOpenAsProject` (Finder ダブルクリック) は `projectId` が最初の `setRootPath` 時に未知のため `undefined` を渡す。このフローはユーザーが直接ダイアログを通して開くため dialog は表示される。次回 "最近のプロジェクト" からの open 時に永続化される。
- Windows: パスセパレータは `normalizePath()` で正規化済み

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>