### PR TITLE
fix(editor): ルビダイアログを開けない問題を修正 (#1456)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -363,11 +363,16 @@ export default function EditorPage() {
   const [selectedCharCount, setSelectedCharCount] = useState(0);
   const { menu: tabBarMenu, show: showTabBarMenu, close: closeTabBarMenu } = useContextMenu();
   const hasAutoRecoveredRef = useRef(false);
-  const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
+  const [editorViewInstance, setEditorViewInstanceRaw] = useState<EditorView | null>(null);
+  const editorViewRef = useRef<EditorView | null>(null);
+  const setEditorViewInstance = useCallback((view: EditorView | null) => {
+    editorViewRef.current = view; // ref FIRST so sync consumers see fresh value
+    setEditorViewInstanceRaw(view);
+  }, []);
 
   // --- Ruby/TCY hook ---
   const { handleOpenRubyDialog, handleApplyRuby, handleToggleTcy } = useRubyTcy({
-    editorViewInstance,
+    editorViewRef,
     setRubySelectedText: panelHandlers.setRubySelectedText,
     setShowRubyDialog: panelHandlers.setShowRubyDialog,
   });

--- a/components/RubyDialog.tsx
+++ b/components/RubyDialog.tsx
@@ -76,7 +76,16 @@ export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: R
       setError(null);
 
       try {
-        const nlpClient = getNlpClient();
+        let nlpClient;
+        try {
+          nlpClient = getNlpClient();
+        } catch {
+          if (!cancelled) {
+            setError("日本語解析エンジンの初期化に失敗しました");
+            setIsAnalyzing(false);
+          }
+          return;
+        }
         const tokens = await nlpClient.tokenizeParagraph(selectedText);
 
         if (cancelled) return;
@@ -132,6 +141,14 @@ export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: R
       {error && (
         <div className="bg-error/10 border border-error/30 rounded-lg p-3 mb-4">
           <p className="text-xs text-error">{error}</p>
+          <div className="flex justify-end mt-3">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-foreground-secondary hover:text-foreground rounded transition-colors"
+            >
+              閉じる
+            </button>
+          </div>
         </div>
       )}
 

--- a/components/__tests__/RubyDialog.test.tsx
+++ b/components/__tests__/RubyDialog.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for RubyDialog – NLP client failure handling.
+ *
+ * Issue #1456: dialog must gracefully handle getNlpClient() throwing,
+ * show a Japanese error message, and disable the apply button.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+// Mock nlp-client BEFORE importing RubyDialog
+vi.mock("@/lib/nlp-client/nlp-client", () => ({
+  getNlpClient: vi.fn(),
+}));
+
+import RubyDialog from "../RubyDialog";
+import { getNlpClient } from "@/lib/nlp-client/nlp-client";
+
+const mockGetNlpClient = vi.mocked(getNlpClient);
+
+let root: Root;
+
+beforeEach(() => {
+  root = createRoot(document.body);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("RubyDialog – NLP client failure", () => {
+  it("shows Japanese error message when getNlpClient throws", async () => {
+    // Arrange: getNlpClient throws on initialization
+    mockGetNlpClient.mockImplementation(() => {
+      throw new Error("kuromoji init failed");
+    });
+
+    await act(async () => {
+      root.render(
+        <RubyDialog
+          isOpen={true}
+          onClose={() => {}}
+          selectedText="漢字テスト"
+          onApply={() => {}}
+        />,
+      );
+    });
+
+    // Assert: error message must be visible
+    const body = document.body.textContent ?? "";
+    expect(body).toContain("日本語解析エンジンの初期化に失敗しました");
+  });
+
+  it("disables apply button when getNlpClient throws", async () => {
+    mockGetNlpClient.mockImplementation(() => {
+      throw new Error("engine not ready");
+    });
+
+    await act(async () => {
+      root.render(
+        <RubyDialog
+          isOpen={true}
+          onClose={() => {}}
+          selectedText="漢字テスト"
+          onApply={() => {}}
+        />,
+      );
+    });
+
+    // Apply button must not be rendered (or must be disabled) when there is an error
+    const applyButton = document.body.querySelector("button[data-apply]");
+    if (applyButton) {
+      // If button is rendered, it must be disabled
+      expect((applyButton as HTMLButtonElement).disabled).toBe(true);
+    } else {
+      // Button should not be rendered at all in error state
+      // Confirm no "適用" button is accessible
+      const allButtons = Array.from(document.body.querySelectorAll("button"));
+      const applyBtn = allButtons.find((b) => b.textContent?.trim() === "適用");
+      expect(applyBtn).toBeUndefined();
+    }
+  });
+
+  it("still renders dialog structure when getNlpClient throws", async () => {
+    mockGetNlpClient.mockImplementation(() => {
+      throw new Error("fatal error");
+    });
+
+    await act(async () => {
+      root.render(
+        <RubyDialog isOpen={true} onClose={() => {}} selectedText="テスト" onApply={() => {}} />,
+      );
+    });
+
+    // Dialog heading must still be visible
+    const body = document.body.textContent ?? "";
+    expect(body).toContain("ルビ設定");
+  });
+});

--- a/lib/editor-page/__tests__/use-ruby-tcy.test.ts
+++ b/lib/editor-page/__tests__/use-ruby-tcy.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for useRubyTcy hook – ref-based editorView access.
+ *
+ * Issue #1456: dialog failed to open when editorViewInstance was still null
+ * at first context-menu click. Fix migrates to editorViewRef (MutableRefObject)
+ * so the latest view is always read inside callbacks.
+ *
+ * We test via a minimal React render using createRoot + act (no @testing-library/react).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import type { MutableRefObject } from "react";
+import type { EditorView } from "@milkdown/prose/view";
+
+// Minimal EditorView mock factory
+function makeView(from: number, to: number, text: string): EditorView {
+  return {
+    state: {
+      selection: { from, to },
+      doc: {
+        textBetween: (_from: number, _to: number) => text,
+      },
+      schema: { nodes: {} },
+      tr: {
+        replaceWith: vi.fn().mockReturnThis(),
+        insertText: vi.fn().mockReturnThis(),
+      },
+    },
+    dispatch: vi.fn(),
+  } as unknown as EditorView;
+}
+
+// Helper to create typed spy functions
+function makeMocks() {
+  const calls = {
+    selectedText: [] as string[],
+    showDialog: [] as boolean[],
+  };
+  function setRubySelectedText(text: string) {
+    calls.selectedText.push(text);
+  }
+  function setShowRubyDialog(show: boolean) {
+    calls.showDialog.push(show);
+  }
+  function reset() {
+    calls.selectedText.length = 0;
+    calls.showDialog.length = 0;
+  }
+  return { calls, setRubySelectedText, setShowRubyDialog, reset };
+}
+
+// ----- Pure logic extraction for unit testing -----
+
+/**
+ * Test shim that mirrors the REFACTORED useRubyTcy.handleOpenRubyDialog logic.
+ */
+function createHandleOpenRubyDialog(opts: {
+  editorViewRef: MutableRefObject<EditorView | null>;
+  setRubySelectedText: (text: string) => void;
+  setShowRubyDialog: (show: boolean) => void;
+}) {
+  return function handleOpenRubyDialog() {
+    const view = opts.editorViewRef.current;
+    if (!view) return;
+    try {
+      const { from, to } = view.state.selection;
+      if (from === to) return;
+      const text = view.state.doc.textBetween(from, to);
+      if (!text.trim()) return;
+      opts.setRubySelectedText(text);
+      opts.setShowRubyDialog(true);
+    } catch {
+      return;
+    }
+  };
+}
+
+describe("useRubyTcy – ref-based editorView access (TDD logic shim)", () => {
+  let mocks: ReturnType<typeof makeMocks>;
+  let editorViewRef: MutableRefObject<EditorView | null>;
+
+  beforeEach(() => {
+    mocks = makeMocks();
+    editorViewRef = { current: null };
+  });
+
+  it("case 1: ref.current starts null then assigned – second invocation opens dialog", () => {
+    const handleOpenRubyDialog = createHandleOpenRubyDialog({
+      editorViewRef,
+      setRubySelectedText: mocks.setRubySelectedText,
+      setShowRubyDialog: mocks.setShowRubyDialog,
+    });
+
+    // First call: ref is null → dialog must NOT open
+    handleOpenRubyDialog();
+    expect(mocks.calls.showDialog).toHaveLength(0);
+
+    // Assign view (simulates editor mount after first render)
+    editorViewRef.current = makeView(0, 5, "テスト");
+
+    // Second call: ref.current is now valid → dialog must open
+    handleOpenRubyDialog();
+    expect(mocks.calls.selectedText).toContain("テスト");
+    expect(mocks.calls.showDialog).toContain(true);
+  });
+
+  it("case 2: handler reads latest selection from ref.current after selection changes", () => {
+    editorViewRef.current = makeView(0, 3, "初期");
+
+    const handleOpenRubyDialog = createHandleOpenRubyDialog({
+      editorViewRef,
+      setRubySelectedText: mocks.setRubySelectedText,
+      setShowRubyDialog: mocks.setShowRubyDialog,
+    });
+
+    handleOpenRubyDialog();
+    expect(mocks.calls.selectedText).toContain("初期");
+    mocks.reset();
+
+    // Replace with a new view that has a different selection
+    editorViewRef.current = makeView(10, 15, "更新後");
+
+    handleOpenRubyDialog();
+    // Must read fresh selection from updated ref.current, NOT stale captured value
+    expect(mocks.calls.selectedText).toContain("更新後");
+    expect(mocks.calls.showDialog).toContain(true);
+  });
+
+  it("does not open dialog when selection is empty (from === to)", () => {
+    editorViewRef.current = makeView(5, 5, "");
+
+    const handleOpenRubyDialog = createHandleOpenRubyDialog({
+      editorViewRef,
+      setRubySelectedText: mocks.setRubySelectedText,
+      setShowRubyDialog: mocks.setShowRubyDialog,
+    });
+
+    handleOpenRubyDialog();
+    expect(mocks.calls.showDialog).toHaveLength(0);
+  });
+
+  it("does not open dialog when selected text is whitespace only", () => {
+    editorViewRef.current = makeView(0, 3, "   ");
+
+    const handleOpenRubyDialog = createHandleOpenRubyDialog({
+      editorViewRef,
+      setRubySelectedText: mocks.setRubySelectedText,
+      setShowRubyDialog: mocks.setShowRubyDialog,
+    });
+
+    handleOpenRubyDialog();
+    expect(mocks.calls.showDialog).toHaveLength(0);
+  });
+
+  it("swallows thrown errors from destroyed view (defensive)", () => {
+    editorViewRef.current = {
+      state: {
+        get selection(): never {
+          throw new Error("view is destroyed");
+        },
+      },
+    } as unknown as EditorView;
+
+    const handleOpenRubyDialog = createHandleOpenRubyDialog({
+      editorViewRef,
+      setRubySelectedText: mocks.setRubySelectedText,
+      setShowRubyDialog: mocks.setShowRubyDialog,
+    });
+
+    expect(() => handleOpenRubyDialog()).not.toThrow();
+    expect(mocks.calls.showDialog).toHaveLength(0);
+  });
+});
+
+// ----- Integration: test the ACTUAL useRubyTcy hook via React render -----
+// These tests verify the refactored hook accepts editorViewRef interface.
+
+import { useRubyTcy } from "../use-ruby-tcy";
+
+function UseRubyTcyWrapper({
+  editorViewRef,
+  mocks: m,
+  triggerRef,
+}: {
+  editorViewRef: MutableRefObject<EditorView | null>;
+  mocks: ReturnType<typeof makeMocks>;
+  triggerRef: MutableRefObject<(() => void) | null>;
+}) {
+  const { handleOpenRubyDialog } = useRubyTcy({
+    editorViewRef,
+    setRubySelectedText: m.setRubySelectedText,
+    setShowRubyDialog: m.setShowRubyDialog,
+  });
+  triggerRef.current = handleOpenRubyDialog;
+  return null;
+}
+
+describe("useRubyTcy hook – actual implementation (ref-based interface)", () => {
+  let root: Root;
+  let container: HTMLDivElement;
+  let mocks: ReturnType<typeof makeMocks>;
+  let editorViewRef: MutableRefObject<EditorView | null>;
+  let triggerRef: MutableRefObject<(() => void) | null>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks = makeMocks();
+    editorViewRef = { current: null };
+    triggerRef = { current: null };
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  function mountHook() {
+    act(() => {
+      root.render(
+        React.createElement(UseRubyTcyWrapper, {
+          editorViewRef,
+          mocks,
+          triggerRef,
+        }),
+      );
+    });
+  }
+
+  it("hook: ref starts null → then assigned → dialog opens on second call", () => {
+    mountHook();
+
+    // First call with null ref
+    act(() => {
+      triggerRef.current?.();
+    });
+    expect(mocks.calls.showDialog).toHaveLength(0);
+
+    // Set the view on the ref (no re-render needed for ref mutation)
+    editorViewRef.current = makeView(0, 5, "フック統合");
+
+    act(() => {
+      triggerRef.current?.();
+    });
+    expect(mocks.calls.selectedText).toContain("フック統合");
+    expect(mocks.calls.showDialog).toContain(true);
+  });
+
+  it("hook: reads updated selection from ref without requiring re-render", () => {
+    editorViewRef.current = makeView(0, 3, "古い選択");
+    mountHook();
+
+    act(() => {
+      triggerRef.current?.();
+    });
+    expect(mocks.calls.selectedText).toContain("古い選択");
+    mocks.reset();
+
+    // Update ref — no re-render
+    editorViewRef.current = makeView(5, 10, "新しい選択");
+
+    act(() => {
+      triggerRef.current?.();
+    });
+    expect(mocks.calls.selectedText).toContain("新しい選択");
+  });
+});

--- a/lib/editor-page/use-ruby-tcy.ts
+++ b/lib/editor-page/use-ruby-tcy.ts
@@ -1,15 +1,16 @@
 import { useCallback, useRef } from "react";
+import type { MutableRefObject } from "react";
 import { Fragment } from "@milkdown/prose/model";
 import type { EditorView } from "@milkdown/prose/view";
 
 interface UseRubyTcyOptions {
-  editorViewInstance: EditorView | null;
+  editorViewRef: MutableRefObject<EditorView | null>;
   setRubySelectedText: (text: string) => void;
   setShowRubyDialog: (show: boolean) => void;
 }
 
 export function useRubyTcy({
-  editorViewInstance,
+  editorViewRef,
   setRubySelectedText,
   setShowRubyDialog,
 }: UseRubyTcyOptions) {
@@ -17,24 +18,32 @@ export function useRubyTcy({
 
   /** Open the Ruby dialog with current editor selection */
   const handleOpenRubyDialog = useCallback(() => {
-    if (!editorViewInstance) return;
-    const { state } = editorViewInstance;
-    const { from, to } = state.selection;
-    if (from === to) return; // No selection
-    const text = state.doc.textBetween(from, to);
-    if (!text.trim()) return;
-    rubySelectionRef.current = { from, to };
-    setRubySelectedText(text);
-    setShowRubyDialog(true);
-  }, [editorViewInstance, setRubySelectedText, setShowRubyDialog]);
+    const view = editorViewRef.current;
+    if (!view) return;
+    try {
+      const { from, to } = view.state.selection;
+      if (from === to) return; // No selection
+      const text = view.state.doc.textBetween(from, to);
+      if (!text.trim()) return;
+      rubySelectionRef.current = { from, to };
+      setRubySelectedText(text);
+      setShowRubyDialog(true);
+    } catch {
+      // Defensive: view may be torn down during unmount/remount
+      return;
+    }
+    // editorViewRef is a stable ref object; including it here satisfies the React Compiler
+    // without causing extra re-renders (ref identity never changes)
+  }, [editorViewRef, setRubySelectedText, setShowRubyDialog]);
 
   /** Apply Ruby markup by replacing the editor selection with ProseMirror nodes */
   const handleApplyRuby = useCallback(
     (rubyMarkup: string) => {
-      if (!editorViewInstance) return;
+      const view = editorViewRef.current;
+      if (!view) return;
       const sel = rubySelectionRef.current;
       if (!sel) return;
-      const { state, dispatch } = editorViewInstance;
+      const { state, dispatch } = view;
       const rubyNodeType = state.schema.nodes.ruby;
       if (!rubyNodeType) {
         // Fallback: insert as plain text if ruby node type is not available
@@ -63,13 +72,15 @@ export function useRubyTcy({
       dispatch(tr);
       rubySelectionRef.current = null;
     },
-    [editorViewInstance],
+    // editorViewRef is a stable ref object; including it here satisfies the React Compiler
+    [editorViewRef],
   );
 
   /** Wrap selected text with tcy syntax: ^text^ */
   const handleToggleTcy = useCallback(() => {
-    if (!editorViewInstance) return;
-    const { state, dispatch } = editorViewInstance;
+    const view = editorViewRef.current;
+    if (!view) return;
+    const { state, dispatch } = view;
     const { from, to } = state.selection;
     if (from === to) return;
     const text = state.doc.textBetween(from, to);
@@ -83,7 +94,8 @@ export function useRubyTcy({
       const tr = state.tr.insertText(`^${text}^`, from, to);
       dispatch(tr);
     }
-  }, [editorViewInstance]);
+    // editorViewRef is a stable ref object; including it here satisfies the React Compiler
+  }, [editorViewRef]);
 
   return {
     handleOpenRubyDialog,


### PR DESCRIPTION
## 修正概要

コンテキストメニュー「ルビ」を選択してもダイアログが開かない問題を修正しました。

## Root Cause Analysis

`useRubyTcy.handleOpenRubyDialog` が `editorViewInstance` (React state) に依存していたため、
エディター初回ロード直後やページリロード後など、**state の更新が遅延している瞬間にクリックするとダイアログが開かない** という問題が発生していました。

```
// 修正前: state (null の可能性あり)
if (!editorViewInstance) return;  // ← ここで early return していた
```

具体的なシナリオ:
1. エディターがマウントされ `EditorView` インスタンスが生成される
2. `setEditorViewInstance(view)` が呼ばれる → React の state 更新はバッチ処理・非同期
3. 同じ render サイクル内または直後に右クリック → `editorViewInstance` はまだ `null`
4. `handleOpenRubyDialog` が early return → ダイアログが開かない

## 変更内容

### `lib/editor-page/use-ruby-tcy.ts`
- インターフェースを `editorViewInstance: EditorView | null` から `editorViewRef: MutableRefObject<EditorView | null>` に変更
- 各コールバック内で `editorViewRef.current` を読む（クロージャ時点ではなくコール時点の値）
- `try/catch` を追加（unmount/remount 中の view アクセスを防護）

### `app/page.tsx`
- `editorViewRef` を `useRef` で追加
- `setEditorViewInstance` をラッパー関数に変更し、ref と state を同時更新（ref を先に更新してから state を更新）
- `useRubyTcy` に `editorViewRef` を渡すように変更

### `components/RubyDialog.tsx`
- `getNlpClient()` の呼び出しを `try/catch` で囲む
- 初期化失敗時に `"日本語解析エンジンの初期化に失敗しました"` を表示
- エラー状態では適用ボタンを非表示にする

## Verification 手順

1. `npm run dev` でアプリを起動
2. エディターにテキストを入力
3. 漢字を含むテキストを選択
4. 右クリック → ルビ → ダイアログが開くことを確認
5. **ページをリロード (Cmd-R) し、ページ読み込み直後に同じ操作を繰り返す** → ダイアログが開くことを確認
6. 別ファイルを開いた直後でも同様に動作することを確認

## Risks

- **Stale view risk**: `editorViewRef.current` が unmount 直後の破棄済み view を指す瞬間がある。`try/catch` で握りつぶし、ダイアログが開かないだけで UI に影響しない設計。
- **State と ref の sync**: `setEditorViewInstance` ラッパーが ref を先に更新するため、同期的なコンシューマーは常に最新値を参照できる。
- **他の `editorViewInstance` コンシューマー**: `useRubyTcy` のみ ref に移行。他の 9 箇所は state のまま（影響なし）。

Closes #1456

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>