### PR TITLE
fix(search): 検索結果パネルが prop 更新を反映しない + VSCode 風置換プレビュー (#1502)

### DIFF
--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -32,16 +32,42 @@ export default function SearchResults({
   const [showReplace, setShowReplace] = useState(true);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
+  // #1502: Sync incoming props → state during render (React-recommended
+  // "derived state" pattern). useState only reads the initializer on mount,
+  // so without this an already-mounted SearchResults silently ignores props
+  // pushed by SearchDialog's "すべての検索結果を表示" button. Using render-time
+  // detection (vs useEffect) avoids the extra-render flush delay that breaks
+  // jsdom tests and trips React 18+ act() expectations.
+  const [lastInitialSearchTerm, setLastInitialSearchTerm] =
+    useState(initialSearchTerm);
+  if (initialSearchTerm !== lastInitialSearchTerm) {
+    setLastInitialSearchTerm(initialSearchTerm);
+    if (initialSearchTerm !== undefined) {
+      setSearchTerm(initialSearchTerm);
+    }
+  }
+
+  const [lastInitialMatches, setLastInitialMatches] =
+    useState(initialMatches);
+  if (initialMatches !== lastInitialMatches) {
+    setLastInitialMatches(initialMatches);
+    if (initialMatches !== undefined) {
+      setMatches(initialMatches);
+    }
+  }
+
   // 文書内の一致箇所を検索する
   useEffect(() => {
-    if (!editorView || !searchTerm) {
+    // #1502: when there's no editor, leave matches as-is so prop-sourced
+    // initialMatches survive. Local recompute only runs against a real editor.
+    if (!editorView) {
+      return;
+    }
+    if (!searchTerm) {
       setMatches([]);
-      // Clear highlights
-      if (editorView) {
-        const { state, dispatch } = editorView;
-        const tr = state.tr.setMeta("searchDecorations", []);
-        dispatch(tr);
-      }
+      const { state, dispatch } = editorView;
+      const tr = state.tr.setMeta("searchDecorations", []);
+      dispatch(tr);
       return;
     }
 
@@ -311,9 +337,29 @@ export default function SearchResults({
                       <button onClick={() => goToMatch(match, index)} className="w-full text-left">
                         <p className="text-sm text-foreground break-words">
                           <span className="text-foreground-secondary">{context.before}</span>
-                          <span className="bg-accent-light text-accent font-semibold px-1 rounded">
-                            {context.text}
-                          </span>
+                          {showReplace && replaceTerm ? (
+                            // #1502: VSCode-style replace preview (strikethrough + red old,
+                            // green new). Only when replaceTerm is non-empty; preserves the
+                            // plain highlight rendering otherwise.
+                            <>
+                              <span
+                                className="line-through bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 px-1 rounded"
+                                data-testid="replace-preview-old"
+                              >
+                                {context.text}
+                              </span>
+                              <span
+                                className="bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 font-semibold px-1 rounded ml-0.5"
+                                data-testid="replace-preview-new"
+                              >
+                                {replaceTerm}
+                              </span>
+                            </>
+                          ) : (
+                            <span className="bg-accent-light text-accent font-semibold px-1 rounded">
+                              {context.text}
+                            </span>
+                          )}
                           <span className="text-foreground-secondary">{context.after}</span>
                         </p>
                         <p className="text-xs text-foreground-tertiary mt-1">

--- a/components/__tests__/SearchResults-prop-sync.test.tsx
+++ b/components/__tests__/SearchResults-prop-sync.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Tests for SearchResults – issue #1502.
+ *
+ * Two regressions covered:
+ *   1) Prop → state sync: when SearchDialog pushes results via
+ *      "すべての検索結果を表示", an already-mounted SearchResults must
+ *      reflect the new searchTerm/matches.
+ *   2) Replace preview: when replaceTerm is non-empty, results render
+ *      VSCode-style diff (strikethrough+red for old text, green for new).
+ */
+
+// Tell React this is a controlled test environment so act() flushes effects.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+// Stub centerEditorPosition (uses ProseMirror coordsAtPos which is not
+// available in jsdom mocks).
+vi.mock("@/lib/editor-page/center-editor-position", () => ({
+  centerEditorPosition: vi.fn(),
+}));
+
+import SearchResults from "../SearchResults";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Wrapper that simulates SidebarPanel's behavior: SearchResults is kept
+ * mounted while its props change (the exact scenario from #1502).
+ *
+ * Note: SearchResults's public prop names are `searchTerm` / `matches`
+ * (destructured internally as `initialSearchTerm` / `initialMatches`).
+ */
+function Wrapper({
+  searchTerm,
+  matches,
+}: {
+  searchTerm?: string;
+  matches?: { from: number; to: number }[];
+}) {
+  return (
+    <SearchResults
+      editorView={null}
+      onClose={() => {}}
+      searchTerm={searchTerm}
+      matches={matches}
+    />
+  );
+}
+
+describe("SearchResults – prop sync (#1502)", () => {
+  it("reflects updated initialSearchTerm / initialMatches without remount", async () => {
+    // Mount with no initial term — empty placeholder appears
+    await act(async () => {
+      root.render(<Wrapper />);
+    });
+    expect(container.textContent).toContain("検索語を入力してください");
+
+    // Re-render the SAME root with new props — this is what happens when
+    // SidebarPanel re-renders due to setSearchResults({...}) state change.
+    // The case branch is still "search" so SearchResults is updated, not
+    // remounted.
+    await act(async () => {
+      root.render(
+        <Wrapper
+          searchTerm="四月一日"
+          matches={[
+            { from: 5, to: 9 },
+            { from: 328, to: 332 },
+          ]}
+        />,
+      );
+    });
+
+    // After prop sync, placeholder should be gone and input should reflect
+    // the new searchTerm.
+    expect(container.textContent).not.toContain("検索語を入力してください");
+    const input = container.querySelector(
+      'input[type="text"]',
+    ) as HTMLInputElement | null;
+    expect(input).not.toBeNull();
+    expect(input!.value).toBe("四月一日");
+    expect(container.textContent).toContain("2件見つかりました");
+  });
+});
+
+describe("SearchResults – replace preview (#1502)", () => {
+  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value",
+  )?.set;
+
+  function findInputByPlaceholder(
+    placeholder: string,
+  ): HTMLInputElement | undefined {
+    return Array.from(
+      container.querySelectorAll('input[type="text"]'),
+    ).find(
+      (el) => (el as HTMLInputElement).placeholder === placeholder,
+    ) as HTMLInputElement | undefined;
+  }
+
+  it("shows old (strikethrough+red) and new (green) when replaceTerm is set", async () => {
+    await act(async () => {
+      root.render(
+        <Wrapper
+          searchTerm="四月一日"
+          matches={[{ from: 5, to: 9 }]}
+        />,
+      );
+    });
+
+    // Confirm fresh mount worked
+    expect(container.textContent).toContain("1件見つかりました");
+
+    const replaceInput = findInputByPlaceholder("置換後...");
+    expect(replaceInput).toBeDefined();
+
+    await act(async () => {
+      nativeInputValueSetter?.call(replaceInput!, "ああああ");
+      replaceInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const oldNode = container.querySelector(
+      '[data-testid="replace-preview-old"]',
+    );
+    const newNode = container.querySelector(
+      '[data-testid="replace-preview-new"]',
+    );
+    expect(oldNode).not.toBeNull();
+    expect(newNode).not.toBeNull();
+    expect(oldNode!.className).toMatch(/line-through/);
+    expect(oldNode!.className).toMatch(/red/);
+    expect(newNode!.className).toMatch(/green/);
+    expect(newNode!.textContent).toBe("ああああ");
+  });
+
+  it("falls back to plain highlight when replaceTerm is empty", async () => {
+    await act(async () => {
+      root.render(
+        <Wrapper
+          searchTerm="四月一日"
+          matches={[{ from: 5, to: 9 }]}
+        />,
+      );
+    });
+
+    // No replace preview rendered when replaceTerm is empty
+    expect(
+      container.querySelector('[data-testid="replace-preview-old"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="replace-preview-new"]'),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## 修正概要

### 問題 1: 「すべての検索結果を表示」が左パネルに反映されない

左サイドバーの検索パネルを開いている状態で `Cmd-F` の小窓 SearchDialog から「すべての検索結果を表示」をクリックしても、左パネルが空のまま (「検索語を入力してください」が表示) という不具合を修正。

**Root Cause**: \`useState(initial)\` は初回マウント時のみ評価され、SearchResults が既にマウント済みで prop が後から変わっても state は同期しない。

**Fix**: React 推奨の "derived state in render" パターンで prop → state を render 中に同期。useEffect ベースだと React 18 act() の flush 遅延でテストが書きづらいため、render-time 検出を採用。

### 問題 2 (新機能): VSCode 風置換プレビュー

置換欄に入力があるとき、結果リストの各マッチを diff 風に表示:
- マッチ文字列: 取り消し線 + 赤背景
- 置換後文字列: 緑背景 + bold (ml-0.5 で視覚分離)

dark mode カラーも対応。

### 追加修正: editor 不在時の matches 保持

\`useEffect\` の \`(!editorView || !searchTerm)\` を分離。editor が無い場合は早期 return で matches を保持。production 動作 (editor 常時存在) には影響なし、test 用の安全策。

## Verification 手順

1. \`npm run electron:dev\` でアプリ起動
2. 任意プロジェクトを開く → 左サイドバーの検索アイコンをクリック (空の検索パネル表示)
3. Cmd-F で SearchDialog を呼び出す → "四月一日" 等の単語を検索 → 件数表示確認
4. 「すべての検索結果を表示 (N件)」をクリック → **左パネルに検索語と結果一覧が即反映** されることを確認
5. 結果リストで「置換」を展開 → 置換欄に "ああああ" を入力
6. **マッチ文字列に赤+取り消し線、緑の "ああああ" が並ぶ** ことを確認
7. 置換欄をクリア → 通常のハイライト表示に戻る
8. 縦書きモード切替後も挙動が変わらない

## Tests

- \`components/__tests__/SearchResults-prop-sync.test.tsx\` 新規 (3 cases, 全 pass)
  - prop sync: remount せず props 変更で入力欄値と件数表示が反映
  - replace preview: 置換欄入力で diff span 出現 + line-through/red/green class 検証
  - fallback: 置換欄空のとき diff span は出さない
- 全テスト suite: 1031 pass / 1 pre-existing fail (credits.json 欠落、本 PR と無関係)
- type-check: clean
- lint: 0 errors / 1 warning (既存 \`setState in effect\` パターン、変更未追加)

## Risks

- 既存の検索結果リストレンダリングを if/else 分岐に切り替えた。\`replaceTerm\` が空のときは従来通りのハイライト span のみ → 既存挙動は維持
- "derived state in render" パターンは React 公式推奨だが、再帰 setState の無限ループに注意。\`if (initialX !== lastInitialX)\` ガードで防止済み
- editor null 時の早期 return 変更は production 影響なし (常に editor 存在)

Closes #1502

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>