### PR TITLE
fix(search): SearchDialog を focused editor pane の右上に anchor する (#1504)

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -110,6 +110,9 @@ export default function NovelEditor({
   const speechMapRef = useRef<{ text: string; positions: number[] } | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const isVerticalRef = useRef(false);
+  // #1504: ref to the toolbar 検索 button — SearchDialog uses this to anchor
+  // its floating position to the clicked pane instead of the viewport corner.
+  const searchButtonRef = useRef<HTMLButtonElement | null>(null);
   const [scrollContainerElement, setScrollContainerElement] = useState<HTMLDivElement | null>(null);
   /** Doc position to resume TTS from after the current chunk ends. null = no continuation. */
   const speechContinuationPosRef = useRef<number | null>(null);
@@ -429,6 +432,7 @@ export default function NovelEditor({
         isVertical={isVertical}
         onToggleVertical={handleToggleVertical}
         onSearchClick={handleSearchToggle}
+        searchButtonRef={searchButtonRef}
         speechState={speechState}
         onSpeakToggle={handleSpeakToggle}
         onOpenSpeechSettings={onOpenSpeechSettings}
@@ -518,6 +522,7 @@ export default function NovelEditor({
         onClose={() => setIsSearchOpen(false)}
         onShowAllResults={onShowAllSearchResults}
         initialSearchTerm={contextMenuSearchTerm ?? searchInitialTerm}
+        anchorRef={searchButtonRef}
       />
     </div>
   );

--- a/components/__tests__/search-dialog-anchor-wire.test.tsx
+++ b/components/__tests__/search-dialog-anchor-wire.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Regression test for SearchDialog anchor wiring (#1504).
+ *
+ * Verifies that when an anchorRef is provided, the dialog is positioned
+ * relative to the anchor element's bounding rect (i.e. the focused
+ * editor pane's search button), not the viewport fallback (top: 64, right: 16).
+ */
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import SearchDialog from "../SearchDialog";
+
+let root: Root;
+let anchorEl: HTMLButtonElement;
+
+const ANCHOR_RECT = {
+  top: 50,
+  right: 800, // anchor button's right edge inside a focused dockview pane
+  left: 780,
+  bottom: 80,
+  width: 20,
+  height: 30,
+  x: 780,
+  y: 50,
+  toJSON: () => ({}),
+};
+
+beforeEach(() => {
+  anchorEl = document.createElement("button");
+  anchorEl.setAttribute("data-test-anchor", "");
+  anchorEl.getBoundingClientRect = () => ANCHOR_RECT as DOMRect;
+  document.body.appendChild(anchorEl);
+
+  root = createRoot(document.body);
+  Object.defineProperty(window, "innerWidth", { value: 1440, configurable: true });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.innerHTML = "";
+});
+
+function Wrapper({
+  withAnchor,
+  isOpen,
+}: {
+  withAnchor: boolean;
+  isOpen: boolean;
+}) {
+  const ref = useRef<HTMLButtonElement | null>(anchorEl);
+  return (
+    <SearchDialog
+      editorView={null}
+      isOpen={isOpen}
+      onClose={() => {}}
+      anchorRef={withAnchor ? ref : undefined}
+    />
+  );
+}
+
+describe("SearchDialog – anchor wiring (#1504)", () => {
+  it("positions dialog relative to the anchor element when anchorRef is provided", async () => {
+    await act(async () => {
+      root.render(<Wrapper withAnchor={true} isOpen={true} />);
+    });
+
+    // The portal target is document.body. Find the dialog by its searchInput.
+    // SearchDialog renders an input with placeholder containing "検索".
+    const dialog = Array.from(document.querySelectorAll("div")).find((el) =>
+      el.querySelector('input[placeholder*="検索"]'),
+    ) as HTMLDivElement | undefined;
+    // Walk up to the positioned outer dialog container (has inline `top`/`right`).
+    expect(dialog).toBeDefined();
+
+    // The outermost dialog wrapper has inline style with top + right.
+    // SearchDialog uses Tailwind `fixed` class, not inline position style.
+    // The inline `style` contains top + right values from posStyle.
+    const positioned = Array.from(document.body.querySelectorAll("div"))
+      .find(
+        (el) =>
+          el.className.includes("fixed") &&
+          el.style.top !== "" &&
+          el.style.right !== "",
+      );
+    expect(positioned).toBeDefined();
+
+    // top should match anchor.top; right should be derived from
+    // window.innerWidth - anchor.right + padding (clamped). For our values:
+    //   window.innerWidth=1440, anchor.right=800 → right ≈ 1440 - 800 = 640
+    // The exact value comes from computeAnchorPos's clamp logic; we only
+    // assert it is NOT the viewport fallback {top:64, right:16}.
+    expect(positioned!.style.top).not.toBe("64px");
+    expect(positioned!.style.right).not.toBe("16px");
+    // Numerical sanity: top should be near anchor top (50)
+    expect(parseInt(positioned!.style.top, 10)).toBeGreaterThanOrEqual(0);
+    expect(parseInt(positioned!.style.top, 10)).toBeLessThanOrEqual(60);
+  });
+
+  it("falls back to viewport corner when anchorRef is omitted", async () => {
+    await act(async () => {
+      root.render(<Wrapper withAnchor={false} isOpen={true} />);
+    });
+
+    // SearchDialog uses Tailwind `fixed` class, not inline position style.
+    // The inline `style` contains top + right values from posStyle.
+    const positioned = Array.from(document.body.querySelectorAll("div"))
+      .find(
+        (el) =>
+          el.className.includes("fixed") &&
+          el.style.top !== "" &&
+          el.style.right !== "",
+      );
+    expect(positioned).toBeDefined();
+    // Fallback: SearchDialog.tsx uses { top: 64, right: 16 } when no anchor.
+    expect(positioned!.style.top).toBe("64px");
+    expect(positioned!.style.right).toBe("16px");
+  });
+});

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type React from "react";
 import { Type, AlignLeft, Search, BookAudio, Pause } from "lucide-react";
 import { useTypographySettings } from "@/contexts/EditorSettingsContext";
 import type { SpeechState } from "@/lib/hooks/use-speech";
@@ -9,6 +10,7 @@ export default function EditorToolbar({
   isVertical,
   onToggleVertical,
   onSearchClick,
+  searchButtonRef,
   speechState,
   onSpeakToggle,
   onOpenSpeechSettings,
@@ -16,6 +18,9 @@ export default function EditorToolbar({
   isVertical: boolean;
   onToggleVertical: () => void;
   onSearchClick: () => void;
+  // #1504: anchor for SearchDialog. Forwarded to the 検索 button so the dialog
+  // is positioned relative to the clicked editor pane, not the viewport.
+  searchButtonRef?: React.Ref<HTMLButtonElement>;
   speechState: SpeechState;
   onSpeakToggle: () => void;
   onOpenSpeechSettings?: () => void;
@@ -96,6 +101,7 @@ export default function EditorToolbar({
 
         {/* 検索 */}
         <button
+          ref={searchButtonRef}
           onClick={onSearchClick}
           className="flex items-center gap-2 px-3 py-1.5 rounded text-sm font-medium bg-background-tertiary text-foreground-secondary hover:bg-hover transition-colors"
           title="検索 (⌘F)"


### PR DESCRIPTION
## 修正概要

複数 dockview pane が並んでいる状態で SearchDialog (⌘F) を開くと、クリックした pane の位置とは無関係に**画面右上の固定座標** (top:64, right:16) に表示されてしまうバグを修正。

クリックした pane のツールバー検索アイコンを基準に \`getBoundingClientRect()\` で座標計算するよう配線を追加。

## Root Cause

\`components/Editor.tsx\` で SearchDialog に \`anchorRef\` を渡していなかった。PR #1482 で computeAnchorPos と portal 描画を実装した際に caller 側の配線漏れ。

## 変更内容

- \`EditorToolbar.tsx\`: \`searchButtonRef?: React.Ref<HTMLButtonElement>\` を prop に追加し、検索ボタン要素へ forward
- \`Editor.tsx\`: \`useRef<HTMLButtonElement | null>(null)\` を作成、EditorToolbar と SearchDialog 両方に渡す

## Verification 手順

1. \`npm run electron:dev\` で起動
2. 缶詰.mdi タブとターミナル 1 タブを並べる
3. 缶詰.mdi pane の検索アイコン⌘F を押す → SearchDialog が**缶詰.mdi の右上**に表示
4. 別 pane に切り替えて同様 → 各 pane の右上に表示
5. viewport 端ギリギリでも画面外に切れない (computeAnchorPos の clamp が機能)
6. ドラッグで移動 → close → 再 open → anchor 位置に戻る

## Tests

\`components/__tests__/search-dialog-anchor-wire.test.tsx\` 新規 (2 cases):
- anchorRef あり → 計算位置 (viewport fallback ではない座標) が style に反映
- anchorRef なし → フォールバック \`top: 64px, right: 16px\`

全 suite: 1033 pass / 1 pre-existing fail (credits.json、本 PR と無関係)、type-check clean、lint 0 errors。

## Risks

- 既存テスト \`search-dialog-drag-cleanup\` は \`anchorRef={{current: anchorEl}}\` を渡して anchor 経由の座標計算を verify 済み。本 PR の wire-up はそこと同じ pattern を本番 caller に適用するだけなので、SearchDialog 側のロジックは変更なし
- React.Ref<HTMLButtonElement> 型で受けることで、useRef の RefObject も MutableRefObject も両方受け取れる柔軟な API

Closes #1504

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>