### PR TITLE
style: dev の prettier フォーマット違反 7 ファイル一括修正

### DIFF
--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -38,8 +38,7 @@ export default function SearchResults({
   // pushed by SearchDialog's "すべての検索結果を表示" button. Using render-time
   // detection (vs useEffect) avoids the extra-render flush delay that breaks
   // jsdom tests and trips React 18+ act() expectations.
-  const [lastInitialSearchTerm, setLastInitialSearchTerm] =
-    useState(initialSearchTerm);
+  const [lastInitialSearchTerm, setLastInitialSearchTerm] = useState(initialSearchTerm);
   if (initialSearchTerm !== lastInitialSearchTerm) {
     setLastInitialSearchTerm(initialSearchTerm);
     if (initialSearchTerm !== undefined) {
@@ -47,8 +46,7 @@ export default function SearchResults({
     }
   }
 
-  const [lastInitialMatches, setLastInitialMatches] =
-    useState(initialMatches);
+  const [lastInitialMatches, setLastInitialMatches] = useState(initialMatches);
   if (initialMatches !== lastInitialMatches) {
     setLastInitialMatches(initialMatches);
     if (initialMatches !== undefined) {

--- a/components/__tests__/SearchResults-prop-sync.test.tsx
+++ b/components/__tests__/SearchResults-prop-sync.test.tsx
@@ -10,8 +10,7 @@
  */
 
 // Tell React this is a controlled test environment so act() flushes effects.
-(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
-  true;
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import React from "react";
@@ -56,12 +55,7 @@ function Wrapper({
   matches?: { from: number; to: number }[];
 }) {
   return (
-    <SearchResults
-      editorView={null}
-      onClose={() => {}}
-      searchTerm={searchTerm}
-      matches={matches}
-    />
+    <SearchResults editorView={null} onClose={() => {}} searchTerm={searchTerm} matches={matches} />
   );
 }
 
@@ -92,9 +86,7 @@ describe("SearchResults – prop sync (#1502)", () => {
     // After prop sync, placeholder should be gone and input should reflect
     // the new searchTerm.
     expect(container.textContent).not.toContain("検索語を入力してください");
-    const input = container.querySelector(
-      'input[type="text"]',
-    ) as HTMLInputElement | null;
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement | null;
     expect(input).not.toBeNull();
     expect(input!.value).toBe("四月一日");
     expect(container.textContent).toContain("2件見つかりました");
@@ -107,24 +99,15 @@ describe("SearchResults – replace preview (#1502)", () => {
     "value",
   )?.set;
 
-  function findInputByPlaceholder(
-    placeholder: string,
-  ): HTMLInputElement | undefined {
-    return Array.from(
-      container.querySelectorAll('input[type="text"]'),
-    ).find(
+  function findInputByPlaceholder(placeholder: string): HTMLInputElement | undefined {
+    return Array.from(container.querySelectorAll('input[type="text"]')).find(
       (el) => (el as HTMLInputElement).placeholder === placeholder,
     ) as HTMLInputElement | undefined;
   }
 
   it("shows old (strikethrough+red) and new (green) when replaceTerm is set", async () => {
     await act(async () => {
-      root.render(
-        <Wrapper
-          searchTerm="四月一日"
-          matches={[{ from: 5, to: 9 }]}
-        />,
-      );
+      root.render(<Wrapper searchTerm="四月一日" matches={[{ from: 5, to: 9 }]} />);
     });
 
     // Confirm fresh mount worked
@@ -138,12 +121,8 @@ describe("SearchResults – replace preview (#1502)", () => {
       replaceInput!.dispatchEvent(new Event("input", { bubbles: true }));
     });
 
-    const oldNode = container.querySelector(
-      '[data-testid="replace-preview-old"]',
-    );
-    const newNode = container.querySelector(
-      '[data-testid="replace-preview-new"]',
-    );
+    const oldNode = container.querySelector('[data-testid="replace-preview-old"]');
+    const newNode = container.querySelector('[data-testid="replace-preview-new"]');
     expect(oldNode).not.toBeNull();
     expect(newNode).not.toBeNull();
     expect(oldNode!.className).toMatch(/line-through/);
@@ -154,20 +133,11 @@ describe("SearchResults – replace preview (#1502)", () => {
 
   it("falls back to plain highlight when replaceTerm is empty", async () => {
     await act(async () => {
-      root.render(
-        <Wrapper
-          searchTerm="四月一日"
-          matches={[{ from: 5, to: 9 }]}
-        />,
-      );
+      root.render(<Wrapper searchTerm="四月一日" matches={[{ from: 5, to: 9 }]} />);
     });
 
     // No replace preview rendered when replaceTerm is empty
-    expect(
-      container.querySelector('[data-testid="replace-preview-old"]'),
-    ).toBeNull();
-    expect(
-      container.querySelector('[data-testid="replace-preview-new"]'),
-    ).toBeNull();
+    expect(container.querySelector('[data-testid="replace-preview-old"]')).toBeNull();
+    expect(container.querySelector('[data-testid="replace-preview-new"]')).toBeNull();
   });
 });

--- a/components/__tests__/search-dialog-anchor-wire.test.tsx
+++ b/components/__tests__/search-dialog-anchor-wire.test.tsx
@@ -6,8 +6,7 @@
  * editor pane's search button), not the viewport fallback (top: 64, right: 16).
  */
 
-(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
-  true;
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import React, { useRef } from "react";
@@ -45,13 +44,7 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-function Wrapper({
-  withAnchor,
-  isOpen,
-}: {
-  withAnchor: boolean;
-  isOpen: boolean;
-}) {
+function Wrapper({ withAnchor, isOpen }: { withAnchor: boolean; isOpen: boolean }) {
   const ref = useRef<HTMLButtonElement | null>(anchorEl);
   return (
     <SearchDialog
@@ -80,13 +73,9 @@ describe("SearchDialog – anchor wiring (#1504)", () => {
     // The outermost dialog wrapper has inline style with top + right.
     // SearchDialog uses Tailwind `fixed` class, not inline position style.
     // The inline `style` contains top + right values from posStyle.
-    const positioned = Array.from(document.body.querySelectorAll("div"))
-      .find(
-        (el) =>
-          el.className.includes("fixed") &&
-          el.style.top !== "" &&
-          el.style.right !== "",
-      );
+    const positioned = Array.from(document.body.querySelectorAll("div")).find(
+      (el) => el.className.includes("fixed") && el.style.top !== "" && el.style.right !== "",
+    );
     expect(positioned).toBeDefined();
 
     // top should match anchor.top; right should be derived from
@@ -108,13 +97,9 @@ describe("SearchDialog – anchor wiring (#1504)", () => {
 
     // SearchDialog uses Tailwind `fixed` class, not inline position style.
     // The inline `style` contains top + right values from posStyle.
-    const positioned = Array.from(document.body.querySelectorAll("div"))
-      .find(
-        (el) =>
-          el.className.includes("fixed") &&
-          el.style.top !== "" &&
-          el.style.right !== "",
-      );
+    const positioned = Array.from(document.body.querySelectorAll("div")).find(
+      (el) => el.className.includes("fixed") && el.style.top !== "" && el.style.right !== "",
+    );
     expect(positioned).toBeDefined();
     // Fallback: SearchDialog.tsx uses { top: 64, right: 16 } when no anchor.
     expect(positioned!.style.top).toBe("64px");

--- a/electron/ipc/__tests__/vfs-approved-paths-persist.test.ts
+++ b/electron/ipc/__tests__/vfs-approved-paths-persist.test.ts
@@ -31,7 +31,10 @@ const {
 
 /** Create a fresh temporary file path for each test (not created yet). */
 function tempFilePath() {
-  return path.join(os.tmpdir(), `vfs-approvals-test-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  return path.join(
+    os.tmpdir(),
+    `vfs-approvals-test-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
 }
 
 let tmpFile: string;
@@ -74,8 +77,16 @@ describe("saveApprovals()", () => {
     const seed = {
       version: 1,
       approvals: [
-        { projectId: "proj_A", path: "/Users/alice/projectA", approvedAt: "2026-01-01T00:00:00.000Z" },
-        { projectId: "proj_B", path: "/Users/bob/projectB", approvedAt: "2026-01-01T00:00:00.000Z" },
+        {
+          projectId: "proj_A",
+          path: "/Users/alice/projectA",
+          approvedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          projectId: "proj_B",
+          path: "/Users/bob/projectB",
+          approvedAt: "2026-01-01T00:00:00.000Z",
+        },
       ],
     };
     fsSync.writeFileSync(tmpFile, JSON.stringify(seed));
@@ -86,8 +97,12 @@ describe("saveApprovals()", () => {
 
     const raw = fsSync.readFileSync(tmpFile, "utf-8");
     const data = JSON.parse(raw);
-    const projBEntry = data.approvals.find((a: { projectId: string; path: string }) => a.projectId === "proj_B");
-    const projAEntry = data.approvals.find((a: { projectId: string; path: string }) => a.projectId === "proj_A");
+    const projBEntry = data.approvals.find(
+      (a: { projectId: string; path: string }) => a.projectId === "proj_B",
+    );
+    const projAEntry = data.approvals.find(
+      (a: { projectId: string; path: string }) => a.projectId === "proj_A",
+    );
 
     // proj_B must remain untouched
     expect(projBEntry).toBeDefined();
@@ -107,8 +122,16 @@ describe("loadApprovals()", () => {
     const data = {
       version: 1,
       approvals: [
-        { projectId: "proj_X", path: "/Users/alice/xProject", approvedAt: "2026-01-01T00:00:00.000Z" },
-        { projectId: "proj_Y", path: "/Users/alice/yProject", approvedAt: "2026-01-01T00:00:00.000Z" },
+        {
+          projectId: "proj_X",
+          path: "/Users/alice/xProject",
+          approvedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          projectId: "proj_Y",
+          path: "/Users/alice/yProject",
+          approvedAt: "2026-01-01T00:00:00.000Z",
+        },
       ],
     };
     fsSync.writeFileSync(tmpFile, JSON.stringify(data));
@@ -256,7 +279,10 @@ describe("R6 scoping: different projectId gets isolated approval set", () => {
 // -----------------------------------------------------------------------
 describe("in-memory cache (NEW-3)", () => {
   it("returns cached result without re-reading disk after first load", async () => {
-    const data = { version: 1, approvals: [{ projectId: "proj_c", path: "/c/path", approvedAt: "2026-01-01T00:00:00.000Z" }] };
+    const data = {
+      version: 1,
+      approvals: [{ projectId: "proj_c", path: "/c/path", approvedAt: "2026-01-01T00:00:00.000Z" }],
+    };
     fsSync.writeFileSync(tmpFile, JSON.stringify(data));
     clearApprovalsCache();
 
@@ -264,7 +290,12 @@ describe("in-memory cache (NEW-3)", () => {
     await loadApprovals(tmpFile, "proj_c");
 
     // Overwrite file on disk with different content
-    const updated = { version: 1, approvals: [{ projectId: "proj_c", path: "/different/path", approvedAt: "2026-01-02T00:00:00.000Z" }] };
+    const updated = {
+      version: 1,
+      approvals: [
+        { projectId: "proj_c", path: "/different/path", approvedAt: "2026-01-02T00:00:00.000Z" },
+      ],
+    };
     fsSync.writeFileSync(tmpFile, JSON.stringify(updated));
 
     // Should still return cached (original) result

--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -134,10 +134,9 @@ export function useFileOpening({
             const vfs = getVFS();
             if ("setRootPath" in vfs) {
               // #1476: rehydration — pass projectId so the approval is persisted project-scoped
-              await (vfs as { setRootPath: (p: string, projectId?: string) => Promise<void> }).setRootPath(
-                project.rootPath,
-                projectId,
-              );
+              await (
+                vfs as { setRootPath: (p: string, projectId?: string) => Promise<void> }
+              ).setRootPath(project.rootPath, projectId);
             }
             // NOTE: signalVfsReady() is deferred to AFTER tab restore so that the
             // mount-time standalone restore (use-tab-persistence.ts) does not race

--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -195,10 +195,9 @@ export class ProjectService {
         projectRootPath = `${parentPath}/${name}`;
         if ("setRootPath" in this.vfs) {
           // #1476: rehydration — pass projectId for project-scoped approval persistence
-          await (this.vfs as { setRootPath: (p: string, projectId?: string) => Promise<void> }).setRootPath(
-            projectRootPath,
-            projectId,
-          );
+          await (
+            this.vfs as { setRootPath: (p: string, projectId?: string) => Promise<void> }
+          ).setRootPath(projectRootPath, projectId);
         }
       }
     }
@@ -481,9 +480,11 @@ export class ProjectService {
     if (standalone.fileExtension === ".txt") {
       if (isElectronRenderer() && standalone.filePath) {
         // Read raw bytes via Electron IPC read-file endpoint
-        const bridge = (window.electronAPI as unknown as {
-          vfs?: { readFileRaw?: (p: string) => Promise<Uint8Array> };
-        })?.vfs;
+        const bridge = (
+          window.electronAPI as unknown as {
+            vfs?: { readFileRaw?: (p: string) => Promise<Uint8Array> };
+          }
+        )?.vfs;
         if (bridge?.readFileRaw) {
           const buf = await bridge.readFileRaw(standalone.filePath);
           const { text, eol } = readTextWithEncoding(new Uint8Array(buf));
@@ -572,10 +573,9 @@ export class ProjectService {
       // Re-set the VFS root using the stored absolute path
       if ("setRootPath" in this.vfs) {
         // #1476: rehydration — pass projectId so the approval is looked up project-scoped
-        await (this.vfs as { setRootPath: (p: string, projectId?: string) => Promise<void> }).setRootPath(
-          project.rootPath,
-          project.projectId,
-        );
+        await (
+          this.vfs as { setRootPath: (p: string, projectId?: string) => Promise<void> }
+        ).setRootPath(project.rootPath, project.projectId);
       }
       return await this.vfs.getDirectoryHandle("");
     }

--- a/lib/vfs/electron-vfs.ts
+++ b/lib/vfs/electron-vfs.ts
@@ -232,7 +232,10 @@ export class ElectronVFS implements VirtualFileSystem {
     return {
       path: result.path,
       name: result.name,
-      buf: result.buf instanceof Uint8Array ? result.buf : new Uint8Array(Object.values(result.buf as Record<string, number>)),
+      buf:
+        result.buf instanceof Uint8Array
+          ? result.buf
+          : new Uint8Array(Object.values(result.buf as Record<string, number>)),
     };
   }
 


### PR DESCRIPTION
## 修正概要

dev ブランチで Format Check が失敗していたため一括修正。直近マージされた PR (#1499 / #1500 / #1503 / #1505) で lint-staged だけが走り、prettier --check が CI で初めて違反を捕捉した結果、新規 PR (#1496 / #1497 / dependabot 系) が全て Format Check で失敗していた。

## 変更内容

\`npx prettier --write\` でフォーマット適用のみ:

- \`components/SearchResults.tsx\`
- \`components/__tests__/SearchResults-prop-sync.test.tsx\`
- \`components/__tests__/search-dialog-anchor-wire.test.tsx\`
- \`electron/ipc/__tests__/vfs-approved-paths-persist.test.ts\`
- \`lib/editor-page/use-file-opening.ts\`
- \`lib/project/project-service.ts\`
- \`lib/vfs/electron-vfs.ts\`

**コード変更なし** (whitespace, quote 種類, 改行位置のみ)。\`git diff -w\` でも差分はほぼ同じ。

## Verification

\`\`\`bash
npx prettier --check "**/*.{ts,tsx,js,mjs,json,css,md}"
# → All matched files use Prettier code style!
\`\`\`

## 影響範囲

このマージ後、他の open PR (#1496 / #1497 / #1505 / #1489-1492 等) を rebase すれば Format Check が pass する想定。

関連 issue なし (infra fix)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>