### PR TITLE
fix(search): guard SearchResults dispatch against destroyed editor view (#1507)

### DIFF
--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -12,6 +12,15 @@ interface SearchMatch {
   to: number;
 }
 
+// #1507: After tab switch, the parent's editorViewInstance may still
+// reference a destroyed EditorView for a short window before the new
+// editor's view is ready. ProseMirror sets `docView` to null on destroy.
+// Dispatching on a destroyed view routes through Milkdown plugins whose
+// context has been torn down, throwing "Context editorState not found".
+function isEditorViewAlive(view: EditorView | null): view is EditorView {
+  return view !== null && (view as unknown as { docView: unknown }).docView !== null;
+}
+
 interface SearchResultsProps {
   editorView: EditorView | null;
   matches?: SearchMatch[];
@@ -58,14 +67,19 @@ export default function SearchResults({
   useEffect(() => {
     // #1502: when there's no editor, leave matches as-is so prop-sourced
     // initialMatches survive. Local recompute only runs against a real editor.
-    if (!editorView) {
+    // #1507: also guard against destroyed views during tab switch.
+    if (!isEditorViewAlive(editorView)) {
       return;
     }
     if (!searchTerm) {
       setMatches([]);
-      const { state, dispatch } = editorView;
-      const tr = state.tr.setMeta("searchDecorations", []);
-      dispatch(tr);
+      try {
+        const { state, dispatch } = editorView;
+        const tr = state.tr.setMeta("searchDecorations", []);
+        dispatch(tr);
+      } catch {
+        // Best-effort cleanup — view may have been destroyed mid-dispatch.
+      }
       return;
     }
 
@@ -115,8 +129,12 @@ export default function SearchResults({
         class: "search-result",
       }),
     );
-    const tr = state.tr.setMeta("searchDecorations", decorations);
-    dispatch(tr);
+    try {
+      const tr = state.tr.setMeta("searchDecorations", decorations);
+      dispatch(tr);
+    } catch {
+      // #1507: view torn down mid-search — decorations go with it.
+    }
   }, [searchTerm, caseSensitive, editorView]);
   // Get context text for match
   const getMatchContext = useCallback(
@@ -153,7 +171,7 @@ export default function SearchResults({
   // Jump to specified match and highlight
   const goToMatch = useCallback(
     (match: SearchMatch, index: number) => {
-      if (!editorView) return;
+      if (!isEditorViewAlive(editorView)) return;
 
       const { state, dispatch } = editorView;
 
@@ -183,7 +201,7 @@ export default function SearchResults({
   // Replace single match
   const replaceMatch = useCallback(
     (match: SearchMatch) => {
-      if (!editorView) return;
+      if (!isEditorViewAlive(editorView)) return;
 
       const { state, dispatch } = editorView;
       const tr = state.tr.replaceWith(match.from, match.to, state.schema.text(replaceTerm));
@@ -200,7 +218,7 @@ export default function SearchResults({
 
   // Replace all matches
   const replaceAllMatches = useCallback(() => {
-    if (!editorView || matches.length === 0) return;
+    if (!isEditorViewAlive(editorView) || matches.length === 0) return;
 
     const { state, dispatch } = editorView;
     let tr = state.tr;

--- a/components/__tests__/SearchResults-destroyed-view.test.tsx
+++ b/components/__tests__/SearchResults-destroyed-view.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Regression test for SearchResults — issue #1507.
+ *
+ * When two files are open and the user switches tabs, the parent's
+ * editorViewInstance briefly references the destroyed EditorView before
+ * the new editor mounts. Dispatching on a destroyed view throws
+ * "Context editorState not found" from Milkdown.
+ *
+ * The fix guards every dispatch site with isEditorViewAlive (checks
+ * docView !== null, which ProseMirror sets to null on destroy) and wraps
+ * the cleanup dispatch in try/catch as belt-and-suspenders.
+ */
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import type { EditorView } from "@milkdown/prose/view";
+
+vi.mock("@/lib/editor-page/center-editor-position", () => ({
+  centerEditorPosition: vi.fn(),
+}));
+
+import SearchResults from "../SearchResults";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function makeDestroyedView(): EditorView {
+  // Simulate a ProseMirror EditorView that has been destroyed: docView is
+  // null, and any dispatch attempt throws like Milkdown does when the
+  // editorState context is gone.
+  const throwOnDispatch = () => {
+    throw new Error('Context "editorState" not found, do you forget to inject it?');
+  };
+  return {
+    docView: null,
+    state: {
+      tr: { setMeta: () => ({}) },
+      doc: { textContent: "", textBetween: () => "", content: { size: 0 } },
+    },
+    dispatch: throwOnDispatch,
+    focus: () => {},
+  } as unknown as EditorView;
+}
+
+describe("SearchResults – destroyed editor view (#1507)", () => {
+  it("does not throw when mounted with a destroyed editorView and empty search", () => {
+    const destroyed = makeDestroyedView();
+    expect(() => {
+      act(() => {
+        root.render(
+          <SearchResults editorView={destroyed} onClose={() => {}} searchTerm="" matches={[]} />,
+        );
+      });
+    }).not.toThrow();
+  });
+
+  it("does not throw when searchTerm changes to empty while view is destroyed", () => {
+    const destroyed = makeDestroyedView();
+    act(() => {
+      root.render(
+        <SearchResults
+          editorView={destroyed}
+          onClose={() => {}}
+          searchTerm="foo"
+          matches={[{ from: 1, to: 4 }]}
+        />,
+      );
+    });
+    // Re-render with empty searchTerm — triggers the cleanup dispatch branch
+    // that previously crashed (SearchResults.tsx line 68 in the original bug).
+    expect(() => {
+      act(() => {
+        root.render(
+          <SearchResults editorView={destroyed} onClose={() => {}} searchTerm="" matches={[]} />,
+        );
+      });
+    }).not.toThrow();
+  });
+
+  it("does not throw when editorView prop changes from alive to destroyed", () => {
+    const destroyed = makeDestroyedView();
+    act(() => {
+      root.render(
+        <SearchResults editorView={null} onClose={() => {}} searchTerm="foo" matches={[]} />,
+      );
+    });
+    expect(() => {
+      act(() => {
+        root.render(
+          <SearchResults editorView={destroyed} onClose={() => {}} searchTerm="foo" matches={[]} />,
+        );
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes `MilkdownError: Context "editorState" not found` thrown by `SearchResults.tsx:68` when two files are open and the active editor view is swapped (tab switch).

## Root cause

`MilkdownEditor.tsx` calls `setEditorViewInstance(view)` when a new editor's view is ready but does not clear the parent state on unmount. During the brief window between the old `EditorView.destroy()` and the new view being ready, the parent's `editorViewInstance` still references the destroyed view. Dispatching on it routes through Milkdown plugins whose context has been torn down, throwing the error.

## Fix

- Add `isEditorViewAlive(view)` helper that checks `view.docView !== null` (ProseMirror sets `docView` to null on destroy).
- Guard all 5 `editorView.dispatch(...)` call sites in `SearchResults.tsx`.
- Wrap the cleanup dispatch in try/catch as belt-and-suspenders for any race where the view is alive at the guard but dies before the dispatch completes.

## Test

`components/__tests__/SearchResults-destroyed-view.test.tsx` — 3 cases:
1. Mount with destroyed view + empty search → no throw.
2. searchTerm changes to empty while view is destroyed (the exact crash path) → no throw.
3. editorView prop transitions from `null` to destroyed → no throw.

## Test plan

- [x] Vitest `SearchResults-destroyed-view.test.tsx` passes (3/3)
- [x] Existing `SearchResults-prop-sync.test.tsx` and `search-dialog-drag-cleanup.test.tsx` still pass (10/10)
- [ ] Manual: open two files, search in file A, switch to file B — no error in console

Closes #1507

🤖 Generated with [Claude Code](https://claude.com/claude-code)