### PR TITLE
fix(vfs): add non-throwing exists() to silence ENOENT handler-error noise

### DIFF
--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -239,6 +239,24 @@ function registerVFSHandlers() {
     }
   });
 
+  // Check whether a path exists without throwing on ENOENT.
+  // Returns false for missing paths; re-throws genuine errors (e.g. EACCES)
+  // so real problems stay visible. Use this for existence checks instead of
+  // relying on stat/readFile rejections, which Electron logs as handler errors.
+  ipcMain.handle("vfs:exists", async (event, filePath) => {
+    try {
+      const resolved = validateVFSPath(event, filePath);
+      await fs.stat(resolved);
+      return true;
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        return false;
+      }
+      console.error("[VFS IPC] exists failed:", error);
+      throw error;
+    }
+  });
+
   // Create directory (with parents)
   ipcMain.handle("vfs:mkdir", async (event, dirPath) => {
     try {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -203,6 +203,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
     writeFile: (filePath, content) => ipcRenderer.invoke("vfs:write-file", filePath, content),
     readDirectory: (dirPath) => ipcRenderer.invoke("vfs:read-directory", dirPath),
     stat: (filePath) => ipcRenderer.invoke("vfs:stat", filePath),
+    exists: (filePath) => ipcRenderer.invoke("vfs:exists", filePath),
     mkdir: (dirPath) => ipcRenderer.invoke("vfs:mkdir", dirPath),
     delete: (targetPath, options) => ipcRenderer.invoke("vfs:delete", targetPath, options),
     rename: (oldPath, newPath) => ipcRenderer.invoke("vfs:rename", oldPath, newPath),

--- a/lib/services/__tests__/ignored-corrections-service.test.ts
+++ b/lib/services/__tests__/ignored-corrections-service.test.ts
@@ -79,9 +79,22 @@ function setupVFSWithContent(content: string): void {
 }
 
 function setupVFSWithENOENT(): void {
-  // Missing file is now signalled by exists() === false, not a thrown ENOENT.
+  // Electron path: getFileHandle resolves a path wrapper and a missing file is
+  // signalled by exists() === false, not a thrown ENOENT.
   mockFileExists.mockResolvedValue(false);
   mockGetFileHandle.mockResolvedValue(mockFileHandle as unknown as typeof mockFileHandle);
+  mockGetIllusionsDirHandle.mockResolvedValue({ getFileHandle: mockGetFileHandle });
+  mockVFS.getDirectoryHandle.mockResolvedValue(mockRootHandle as unknown as typeof mockRootHandle);
+}
+
+/**
+ * Web (File System Access API) path: getFileHandle itself rejects when the file
+ * is absent, before exists() can be consulted. `error` defaults to a DOMException
+ * named "NotFoundError" — the real shape thrown by the native FSAA API.
+ */
+function setupVFSWithGetFileHandleReject(error?: unknown): void {
+  const rejection = error ?? Object.assign(new Error("file not found"), { name: "NotFoundError" });
+  mockGetFileHandle.mockRejectedValue(rejection);
   mockGetIllusionsDirHandle.mockResolvedValue({ getFileHandle: mockGetFileHandle });
   mockVFS.getDirectoryHandle.mockResolvedValue(mockRootHandle as unknown as typeof mockRootHandle);
 }
@@ -108,6 +121,27 @@ describe("IgnoredCorrectionsService — project mode (VFS)", () => {
     setupVFSWithENOENT();
     const result = await svc.loadIgnoredCorrections();
     expect(result).toEqual([]);
+  });
+
+  it("loadIgnoredCorrections returns empty array when getFileHandle throws NotFoundError (web)", async () => {
+    // Regression: on the web (FSAA) backend, getFileHandle rejects with a
+    // NotFoundError for a missing file before exists() can run. Must not throw.
+    setupVFSWithGetFileHandleReject();
+    const result = await svc.loadIgnoredCorrections();
+    expect(result).toEqual([]);
+  });
+
+  it("loadIgnoredCorrections returns empty array when getFileHandle throws ENOENT", async () => {
+    setupVFSWithGetFileHandleReject(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    const result = await svc.loadIgnoredCorrections();
+    expect(result).toEqual([]);
+  });
+
+  it("loadIgnoredCorrections re-throws non-not-found errors from getFileHandle (e.g. permission)", async () => {
+    setupVFSWithGetFileHandleReject(
+      Object.assign(new Error("permission denied"), { name: "NotAllowedError" }),
+    );
+    await expect(svc.loadIgnoredCorrections()).rejects.toThrow("permission denied");
   });
 
   it("loadIgnoredCorrections parses and returns corrections from VFS", async () => {

--- a/lib/services/__tests__/ignored-corrections-service.test.ts
+++ b/lib/services/__tests__/ignored-corrections-service.test.ts
@@ -15,8 +15,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 let mockFileRead = vi.fn<() => Promise<string>>();
 let mockFileWrite = vi.fn<(content: string) => Promise<void>>();
+let mockFileExists = vi.fn<() => Promise<boolean>>();
 
 const mockFileHandle = {
+  exists: () => mockFileExists(),
   read: () => mockFileRead(),
   write: (content: string) => mockFileWrite(content),
 };
@@ -69,6 +71,7 @@ import { getIgnoredCorrectionsService } from "@/lib/services/ignored-corrections
 // ---------------------------------------------------------------------------
 
 function setupVFSWithContent(content: string): void {
+  mockFileExists.mockResolvedValue(true);
   mockFileRead.mockResolvedValue(content);
   mockGetFileHandle.mockResolvedValue(mockFileHandle as unknown as typeof mockFileHandle);
   mockGetIllusionsDirHandle.mockResolvedValue({ getFileHandle: mockGetFileHandle });
@@ -76,8 +79,9 @@ function setupVFSWithContent(content: string): void {
 }
 
 function setupVFSWithENOENT(): void {
-  const err = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-  mockGetFileHandle.mockRejectedValue(err);
+  // Missing file is now signalled by exists() === false, not a thrown ENOENT.
+  mockFileExists.mockResolvedValue(false);
+  mockGetFileHandle.mockResolvedValue(mockFileHandle as unknown as typeof mockFileHandle);
   mockGetIllusionsDirHandle.mockResolvedValue({ getFileHandle: mockGetFileHandle });
   mockVFS.getDirectoryHandle.mockResolvedValue(mockRootHandle as unknown as typeof mockRootHandle);
 }
@@ -94,6 +98,7 @@ describe("IgnoredCorrectionsService — project mode (VFS)", () => {
     mockStorageItems = {};
     mockFileRead = vi.fn();
     mockFileWrite = vi.fn<(content: string) => Promise<void>>().mockResolvedValue(undefined);
+    mockFileExists = vi.fn<() => Promise<boolean>>().mockResolvedValue(true);
     mockGetFileHandle = vi.fn();
     mockGetIllusionsDirHandle = vi.fn();
     svc = getIgnoredCorrectionsService();

--- a/lib/services/ignored-corrections-service.ts
+++ b/lib/services/ignored-corrections-service.ts
@@ -47,19 +47,17 @@ class IgnoredCorrectionsService {
    * Re-throws on JSON corruption or permission errors to prevent data loss.
    */
   async loadIgnoredCorrections(): Promise<IgnoredCorrection[]> {
-    try {
-      const rootDir = await this.vfs.getDirectoryHandle("");
-      const illusionsDir = await rootDir.getDirectoryHandle(".illusions", { create: true });
-      const fileHandle = await illusionsDir.getFileHandle(IGNORED_CORRECTIONS_FILENAME);
-      const raw = await fileHandle.read();
-      const data: IgnoredCorrectionsFile = JSON.parse(raw);
-      return data.ignoredCorrections ?? [];
-    } catch (err) {
-      // File doesn't exist yet — that's fine
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
-      // JSON corruption or permission error — re-throw to prevent overwriting existing data
-      throw err;
-    }
+    const rootDir = await this.vfs.getDirectoryHandle("");
+    const illusionsDir = await rootDir.getDirectoryHandle(".illusions", { create: true });
+    const fileHandle = await illusionsDir.getFileHandle(IGNORED_CORRECTIONS_FILENAME);
+    // Check existence first so a missing file does not surface as a thrown
+    // ENOENT. The error's `code` is dropped across the Electron IPC boundary,
+    // so a post-read code check is unreliable — guard before reading instead.
+    if (!(await fileHandle.exists())) return [];
+    // JSON corruption or permission errors still propagate to prevent data loss.
+    const raw = await fileHandle.read();
+    const data: IgnoredCorrectionsFile = JSON.parse(raw);
+    return data.ignoredCorrections ?? [];
   }
 
   /**

--- a/lib/services/ignored-corrections-service.ts
+++ b/lib/services/ignored-corrections-service.ts
@@ -11,7 +11,7 @@
 import { getProjectFileService } from "../services/project-file-service";
 import { getStorageService } from "../storage/storage-service";
 import { AsyncMutex } from "../utils/async-mutex";
-import type { VirtualFileSystem } from "../vfs/types";
+import type { VirtualFileSystem, VFSFileHandle } from "../vfs/types";
 import type { IStorageService } from "../storage/storage-types";
 import type { IgnoredCorrection, IgnoredCorrectionsFile } from "../project/project-types";
 
@@ -21,6 +21,19 @@ import type { IgnoredCorrection, IgnoredCorrectionsFile } from "../project/proje
 
 const IGNORED_CORRECTIONS_FILENAME = "ignored-corrections.json";
 const STANDALONE_STORAGE_PREFIX = "illusions-ignored-corrections:";
+
+/**
+ * Returns true when an error signals a missing file across either VFS backend:
+ * a Web File System Access API `DOMException` named "NotFoundError", or an
+ * Electron/Node `ENOENT` error code. Used to treat an absent file as "empty"
+ * rather than a hard failure.
+ */
+function isFileNotFoundError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const name = (err as { name?: unknown }).name;
+  const code = (err as { code?: unknown }).code;
+  return name === "NotFoundError" || code === "ENOENT";
+}
 
 // -----------------------------------------------------------------------
 // Service
@@ -49,10 +62,23 @@ class IgnoredCorrectionsService {
   async loadIgnoredCorrections(): Promise<IgnoredCorrection[]> {
     const rootDir = await this.vfs.getDirectoryHandle("");
     const illusionsDir = await rootDir.getDirectoryHandle(".illusions", { create: true });
-    const fileHandle = await illusionsDir.getFileHandle(IGNORED_CORRECTIONS_FILENAME);
-    // Check existence first so a missing file does not surface as a thrown
-    // ENOENT. The error's `code` is dropped across the Electron IPC boundary,
-    // so a post-read code check is unreliable — guard before reading instead.
+
+    let fileHandle: VFSFileHandle;
+    try {
+      fileHandle = await illusionsDir.getFileHandle(IGNORED_CORRECTIONS_FILENAME);
+    } catch (err) {
+      // Web (File System Access API) throws NotFoundError synchronously from
+      // getFileHandle when the file is absent — before exists() can be consulted.
+      // Electron's VFS only builds a path wrapper here and never throws for a
+      // missing file, so this branch is web-only. Any other error (permission,
+      // etc.) must propagate to avoid masking real failures.
+      if (isFileNotFoundError(err)) return [];
+      throw err;
+    }
+
+    // Electron path: a missing file only surfaces on access, and the error's
+    // `code` is dropped across the IPC boundary, so a post-read ENOENT check is
+    // unreliable — guard with exists() before reading instead.
     if (!(await fileHandle.exists())) return [];
     // JSON corruption or permission errors still propagate to prevent data loss.
     const raw = await fileHandle.read();

--- a/lib/vfs/electron-vfs.ts
+++ b/lib/vfs/electron-vfs.ts
@@ -40,6 +40,8 @@ interface ElectronVFSBridge {
   readDirectory: (dirPath: string) => Promise<Array<{ name: string; kind: "file" | "directory" }>>;
   /** Get file stats */
   stat: (filePath: string) => Promise<{ size: number; lastModified: number; type: string }>;
+  /** Check whether a path exists without throwing on ENOENT */
+  exists: (filePath: string) => Promise<boolean>;
   /** Create a directory (with parents) */
   mkdir: (dirPath: string) => Promise<void>;
   /** Delete a file or directory */
@@ -106,6 +108,11 @@ class ElectronVFSFileHandle implements VFSFileHandle {
     });
   }
 
+  async exists(): Promise<boolean> {
+    const bridge = getVFSBridge();
+    return bridge.exists(this.absolutePath);
+  }
+
   async read(): Promise<string> {
     const bridge = getVFSBridge();
     return bridge.readFile(this.absolutePath);
@@ -141,12 +148,11 @@ class ElectronVFSDirectoryHandle implements VFSDirectoryHandle {
     const relPath = this.path ? joinPath(this.path, name) : name;
 
     if (options?.create) {
-      // Ensure the parent directory exists, then write an empty file if needed
+      // Ensure the parent directory exists, then write an empty file if needed.
+      // Use a non-throwing existence check so Electron does not log the expected
+      // ENOENT as a handler error on first creation.
       const bridge = getVFSBridge();
-      try {
-        await bridge.stat(filePath);
-      } catch {
-        // File does not exist, create it
+      if (!(await bridge.exists(filePath))) {
         await bridge.writeFile(filePath, "");
       }
     }

--- a/lib/vfs/types.ts
+++ b/lib/vfs/types.ts
@@ -64,6 +64,8 @@ export interface VFSFileHandle {
   readonly nativeFileHandle?: FileSystemFileHandle;
   /** Get the underlying File object */
   getFile(): Promise<File>;
+  /** Check whether the file exists on disk without throwing */
+  exists(): Promise<boolean>;
   /** Read file content as UTF-8 text */
   read(): Promise<string>;
   /** Write UTF-8 text content to the file */

--- a/lib/vfs/web-vfs.ts
+++ b/lib/vfs/web-vfs.ts
@@ -105,6 +105,16 @@ class WebVFSFileHandle implements VFSFileHandle {
     return this.handle.getFile();
   }
 
+  async exists(): Promise<boolean> {
+    try {
+      await this.handle.getFile();
+      return true;
+    } catch {
+      // NotFoundError — the underlying file was removed after the handle was obtained
+      return false;
+    }
+  }
+
   async read(): Promise<string> {
     const file = await this.handle.getFile();
     return file.text();

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -128,6 +128,8 @@ declare global {
       ) => Promise<Array<{ name: string; kind: "file" | "directory" }>>;
       /** Get file stats */
       stat: (filePath: string) => Promise<{ size: number; lastModified: number; type: string }>;
+      /** Check whether a path exists without throwing on ENOENT */
+      exists: (filePath: string) => Promise<boolean>;
       /** Create a directory (recursive) */
       mkdir: (dirPath: string) => Promise<void>;
       /** Delete a file or directory */


### PR DESCRIPTION
## Summary

- Electron が IPC handler の throw を必ず `Error occurred in handler for ...` としてログ出力するため、起動時に `vfs:stat` / `vfs:read-file` の ENOENT が大量のノイズとして表示されていた（履歴ファイルの存在チェック、`ignored-corrections.json` の読み込み）
- 機能上は正常（catch 済み）だが、コンソールが「エラーだらけ」に見えて誤解を招くため、**投げない存在チェック `vfs:exists`** を VFS 抽象に通して解消
- おまけで、IPC を跨ぐと error の `code` プロパティが剥がれて `loadIgnoredCorrections` の `err.code === "ENOENT"` 判定が実際にはマッチしていなかった潜在バグも修正

## Changes

| ファイル | 変更 |
| --- | --- |
| `electron/ipc/vfs-ipc.js` | `vfs:exists` ハンドラ追加（ENOENT→`false`、本物のエラーは re-throw） |
| `electron/preload.js` / `types/electron.d.ts` | `exists` を bridge に公開・型定義 |
| `lib/vfs/types.ts` | `VFSFileHandle.exists()` を抽象 interface に追加 |
| `lib/vfs/electron-vfs.ts` | `exists()` 実装 + `getFileHandle({create})` を stat-throw → `exists` 判定に変更（履歴 stat ノイズ消滅） |
| `lib/vfs/web-vfs.ts` | web 側 `exists()` 実装（対称性維持） |
| `lib/services/ignored-corrections-service.ts` | `read()` 前に `exists()` ガード（read-file ノイズ消滅 + `code` 判定バグ修正） |
| `lib/services/__tests__/ignored-corrections-service.test.ts` | モックを新フローに更新（ENOENT は exists()===false で表現） |

※ `auth:refresh-token` の invalid_grant ログはコードのバグではなく refresh token 失効（再ログインで解消）のため、本 PR の対象外。

## Test plan

- [x] `tsc --noEmit` クリーン
- [x] `ignored-corrections-service` テスト 14 件パス
- [x] `vfs` / `history-service`（root）テストパス
- [x] Prettier クリーン
- [ ] Electron 実機で起動し、プロジェクトを開いてもコンソールに `Error occurred in handler for 'vfs:stat'` / `'vfs:read-file'` ENOENT が出ないことを確認

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)