### PR TITLE
fix(mdi): [[blank]] 等のブラケットマクロが保存時にエスケープされる不具合を修正

### DIFF
--- a/lib/tab-manager/__tests__/types-sanitize-blank.test.ts
+++ b/lib/tab-manager/__tests__/types-sanitize-blank.test.ts
@@ -40,3 +40,31 @@ describe("sanitizeMdiContent — blank paragraph conversion (.mdi only)", () => 
     expect(sanitizeMdiContent("<br />")).toBe("\n");
   });
 });
+
+describe("sanitizeMdiContent — bracket macro escape recovery (.mdi only)", () => {
+  it("(.mdi) serializer-escaped \\[\\[blank]] → [[blank]]", () => {
+    expect(sanitizeMdiContent("\\[\\[blank]]", MDI)).toBe("[[blank]]");
+  });
+  it("(.mdi) already-clean [[blank]] is unchanged (idempotent)", () => {
+    expect(sanitizeMdiContent("[[blank]]", MDI)).toBe("[[blank]]");
+  });
+  it("(.mdi) escaped [[blank]] in context", () => {
+    const input = "A段落\n\n\\[\\[blank]]\n\nB段落";
+    expect(sanitizeMdiContent(input, MDI)).toBe("A段落\n\n[[blank]]\n\nB段落");
+  });
+  it("(.mdi) escaped \\[\\[br]] → [[br]]", () => {
+    expect(sanitizeMdiContent("行1\\[\\[br]]行2", MDI)).toBe("行1[[br]]行2");
+  });
+  it("(.mdi) escaped no-break macro → unescaped", () => {
+    expect(sanitizeMdiContent("\\[\\[no-break:東京]]", MDI)).toBe("[[no-break:東京]]");
+  });
+  it("(.mdi) escaped kern macro → unescaped", () => {
+    expect(sanitizeMdiContent("\\[\\[kern:0.5em:漢字]]", MDI)).toBe("[[kern:0.5em:漢字]]");
+  });
+  it("(.mdi) fully-escaped brackets \\[\\[blank\\]\\] → [[blank]]", () => {
+    expect(sanitizeMdiContent("\\[\\[blank\\]\\]", MDI)).toBe("[[blank]]");
+  });
+  it("(.md) escape recovery is skipped (Step 0 is .mdi only)", () => {
+    expect(sanitizeMdiContent("\\[\\[blank]]", MD)).toBe("\\[\\[blank]]");
+  });
+});

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -257,6 +257,19 @@ export function sanitizeMdiContent(
   options?: { fileType?: SupportedFileExtension },
 ): string {
   let result = content;
+  // Step 0 (MDI only): the Milkdown markdown serializer escapes the leading `[`
+  // of MDI bracket macros (`[[blank]]`, `[[br]]`, `[[no-break:…]]`, `[[kern:…]]`)
+  // to `\[`, because CommonMark treats `[` as a link/reference opener. The result
+  // is `\[\[blank]]` on disk instead of `[[blank]]`. Strip those backslashes so
+  // the macros round-trip as authored. Backslashes before `]` are optional too,
+  // in case a serializer config also escapes the closing brackets. Idempotent:
+  // already-clean markers pass through unchanged.
+  if (options?.fileType === ".mdi") {
+    result = result.replace(
+      /\\?\[\\?\[(blank|br|no-break:[^\]\n]*|kern:[^\]\n]*)\\?\]\\?\]/g,
+      "[[$1]]",
+    );
+  }
   // Step 1a (MDI only): standalone <br /> on its own line → [[blank]] marker.
   // Intentionally case-sensitive (lowercase only) — <BR /> falls through to Step 1b.
   // CRLF-safe: allows optional \r before end-of-line.


### PR DESCRIPTION
## Summary

- 換行（空段落）を保存すると `.mdi` に `[[blank]]` ではなく `\[\[blank]]` と書き込まれる不具合を修正
- 同じ root cause を持つ `[[br]]` / `[[no-break:…]]` / `[[kern:…]]` もまとめて修正

## 原因

`blankParagraph` 等のノードは `toMarkdown` で `[[blank]]` を **text ノード**として出力するが、Milkdown が内部で使う CommonMark シリアライザ（mdast-util-to-markdown）が `[` をリンク開始記号とみなして `\[` にエスケープする。結果として `tab.content` に `\[\[blank]]` が入り、全保存パスの正規化ゲート `sanitizeMdiContent` を素通りしてディスクに書き込まれていた。

## Changes

| ファイル | 内容 |
| --- | --- |
| `lib/tab-manager/types.ts` | `sanitizeMdiContent` に **Step 0**（.mdi 限定）を追加し、MDI ブラケットマクロ前後のエスケープ用バックスラッシュを除去 |
| `lib/tab-manager/__tests__/types-sanitize-blank.test.ts` | エスケープ解除の回帰テスト 8 件を追加 |

- 全保存パス（auto-save / file-io / dirty 判定）が同じゲートを通るため一貫して効く
- 既にクリーンな `[[blank]]` は変化しない（冪等）
- `.md` には適用しない（既存挙動を維持）

## Test plan

- [x] `types-sanitize-blank.test.ts`（新規 8 件含む計 18 件）通過
- [x] `paragraph-blank-roundtrip.test.ts`（4 件）通過
- [x] `tsc --noEmit` exit 0
- [x] エディタで空段落を作成 → 保存 → `.mdi` に `[[blank]]` が書かれることを確認

関連 issue なし（#1449 / #1432 は serializer 統一・保存フロー共通化のリファクタ epic で、本修正では close 条件を満たさないため close 対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)