### PR TITLE
fix(file-watch): 保存のたびに「○○が更新されました」通知が出る不具合を修正

### DIFF
--- a/lib/services/__tests__/file-watcher-self-save.test.ts
+++ b/lib/services/__tests__/file-watcher-self-save.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for content-hash self-save suppression in the file watcher.
+ *
+ * Regression context: in Electron the renderer has no native fs.watch, so the
+ * watcher always polls (default 5s). The previous time-only suppression window
+ * (3s) was shorter than the poll interval, so the poll that observed the app's
+ * own save fired AFTER the window expired and surfaced a spurious
+ * "「xxx」が更新されました" toast on every manual save and auto-save.
+ *
+ * The fix:
+ *  - the suppression window now exceeds the poll interval, and
+ *  - suppression matches on the saved content hash, so a genuine external edit
+ *    (different content) within the window is still detected.
+ *
+ * Uses real timers with a short poll interval to exercise the polling path.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock VFS and runtime-env before importing the module under test
+// ---------------------------------------------------------------------------
+
+let mockLastModified = 1000;
+let mockFileContent = "initial content";
+
+const mockGetFileMetadata = vi.fn(async () => ({
+  lastModified: mockLastModified,
+  size: mockFileContent.length,
+}));
+const mockReadFile = vi.fn(async () => mockFileContent);
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => ({
+    getFileMetadata: mockGetFileMetadata,
+    readFile: mockReadFile,
+  }),
+}));
+
+vi.mock("@/lib/utils/runtime-env", () => ({
+  isElectronRenderer: () => false,
+}));
+
+import { createFileWatcher, suppressFileWatch } from "@/lib/services/file-watcher";
+import type { FileChangeCallback, FileWatcher } from "@/lib/services/file-watcher";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const POLL_MS = 30;
+
+describe("WebFileWatcher: content-hash self-save suppression", () => {
+  let watcher: FileWatcher;
+  let onChanged: ReturnType<typeof vi.fn<FileChangeCallback>>;
+
+  beforeEach(() => {
+    mockLastModified = 1000;
+    mockFileContent = "initial content";
+    mockGetFileMetadata.mockClear();
+    mockReadFile.mockClear();
+    onChanged = vi.fn<FileChangeCallback>();
+  });
+
+  afterEach(() => {
+    watcher?.stop();
+    vi.restoreAllMocks();
+  });
+
+  it("suppresses the app's own save when the polled content matches the saved hash", async () => {
+    watcher = createFileWatcher({ path: "/self.mdi", onChanged, pollIntervalMs: POLL_MS });
+    watcher.start();
+    await sleep(POLL_MS); // initialize baseline (mtime 1000)
+
+    // App saves: register suppression with the exact written content, then the
+    // file's mtime advances to reflect the write.
+    const savedContent = "the content the app just wrote";
+    suppressFileWatch("/self.mdi", savedContent);
+    mockLastModified = 2000;
+    mockFileContent = savedContent;
+
+    // Let several poll cycles run — well past the old 3s window would not matter
+    // here because matching is by content hash, not elapsed time.
+    await sleep(POLL_MS * 4);
+
+    expect(onChanged).not.toHaveBeenCalled();
+  });
+
+  it("does NOT suppress a genuine external edit with different content within the window", async () => {
+    watcher = createFileWatcher({ path: "/ext.mdi", onChanged, pollIntervalMs: POLL_MS });
+    watcher.start();
+    await sleep(POLL_MS);
+
+    // App saves content A...
+    suppressFileWatch("/ext.mdi", "app wrote A");
+    // ...but an external process writes different content B and bumps mtime.
+    mockLastModified = 2000;
+    mockFileContent = "external wrote B";
+
+    await sleep(POLL_MS * 4);
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledWith("external wrote B", 2000);
+  });
+
+  it("re-detects a later external change after a suppressed self-save", async () => {
+    watcher = createFileWatcher({ path: "/seq.mdi", onChanged, pollIntervalMs: POLL_MS });
+    watcher.start();
+    await sleep(POLL_MS);
+
+    // Self-save — suppressed.
+    suppressFileWatch("/seq.mdi", "saved by app");
+    mockLastModified = 2000;
+    mockFileContent = "saved by app";
+    await sleep(POLL_MS * 3);
+    expect(onChanged).not.toHaveBeenCalled();
+
+    // Later genuine external change — must be detected.
+    mockLastModified = 3000;
+    mockFileContent = "external change";
+    await sleep(POLL_MS * 3);
+
+    expect(onChanged).toHaveBeenCalledTimes(1);
+    expect(onChanged).toHaveBeenCalledWith("external change", 3000);
+  });
+});

--- a/lib/services/file-watcher.ts
+++ b/lib/services/file-watcher.ts
@@ -45,10 +45,38 @@ const MAX_CONSECUTIVE_FAILURES = 5;
  * ウォッチャーが自身のトリガーによる変更イベントを無視できるようにする。
  * 5分ごとに期限切れエントリを削除し、長時間セッションでのメモリ増大を防止する。
  */
-const saveSuppression = new Map<string, number>();
+interface SuppressionEntry {
+  /** Epoch ms after which this suppression entry is considered expired. */
+  until: number;
+  /**
+   * Hash of the content the application wrote, or null when the caller did not
+   * provide content. A null hash falls back to pure time-window suppression.
+   */
+  hash: string | null;
+}
 
-/** Default suppression duration in milliseconds */
-const SAVE_SUPPRESSION_MS = 3000;
+const saveSuppression = new Map<string, SuppressionEntry>();
+
+/**
+ * Default suppression duration in milliseconds.
+ *
+ * Must comfortably exceed DEFAULT_POLL_INTERVAL_MS: in Electron the renderer
+ * has no native fs.watch (the preload bridge exposes no `watch`), so file
+ * watching always falls back to polling. The poll cycle that observes the
+ * app's own save can land up to one full interval after the write, so a window
+ * shorter than the poll interval would expire before the self-save is seen and
+ * surface a spurious "updated" notification on every save. The companion
+ * content-hash check keeps this longer window from masking genuine external
+ * edits (different content is never suppressed).
+ *
+ * 保存抑制のデフォルト持続時間。DEFAULT_POLL_INTERVAL_MS より十分長くする必要が
+ * ある。Electron renderer にはネイティブ fs.watch が無く（preload bridge が
+ * `watch` を公開していない）、ファイル監視は常にポーリングにフォールバックする。
+ * アプリ自身の保存を検知するポーリングは書き込みから最大1間隔遅れて発火しうるため、
+ * ポーリング間隔より短い窓では自己保存検知前に期限切れとなり、毎回の保存で誤通知が出る。
+ * content-hash 照合により、この長い窓でも真の外部変更（内容が異なる）は抑制しない。
+ */
+const SAVE_SUPPRESSION_MS = DEFAULT_POLL_INTERVAL_MS + 3000;
 
 /** Interval for periodic cleanup of expired suppression entries (5 minutes) */
 const SUPPRESSION_CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
@@ -62,8 +90,8 @@ const SUPPRESSION_CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
  */
 function cleanupExpiredSuppressions(): void {
   const now = Date.now();
-  for (const [filePath, until] of saveSuppression) {
-    if (now >= until) {
+  for (const [filePath, entry] of saveSuppression) {
+    if (now >= entry.until) {
       saveSuppression.delete(filePath);
     }
   }
@@ -83,26 +111,53 @@ if (typeof suppressionCleanupTimer === "object" && "unref" in suppressionCleanup
  * Call this before saving a file to prevent the watcher
  * from treating the save as an external change.
  *
+ * Pass the exact content being written so the watcher can confirm a detected
+ * change is the app's own save by content hash (timing-independent). When
+ * content is omitted, suppression degrades to a pure time window.
+ *
  * 指定パスのファイル監視通知を一時的に抑制する。
  * ファイル保存前に呼び出し、ウォッチャーが自身の保存を
- * 外部変更として扱うのを防ぐ。
+ * 外部変更として扱うのを防ぐ。書き込む内容を渡すと、検知した変更が
+ * 自身の保存かどうかを content hash で（タイミングに依存せず）確認できる。
+ * content を省略した場合は純粋な時間窓による抑制に縮退する。
  *
  * @param filePath - The file path to suppress notifications for
- * @param durationMs - How long to suppress (default 3000ms)
+ * @param content - The content being written (enables content-hash matching)
+ * @param durationMs - How long to suppress (default SAVE_SUPPRESSION_MS)
  */
 export function suppressFileWatch(
   filePath: string,
+  content?: string,
   durationMs: number = SAVE_SUPPRESSION_MS,
 ): void {
-  saveSuppression.set(filePath, Date.now() + durationMs);
+  saveSuppression.set(filePath, {
+    until: Date.now() + durationMs,
+    hash: content === undefined ? null : hashContent(content),
+  });
 }
 
-function isFileSuppressed(filePath: string): boolean {
-  const until = saveSuppression.get(filePath);
-  if (!until) return false;
-  if (Date.now() < until) return true;
-  saveSuppression.delete(filePath);
-  return false;
+/**
+ * Returns true when a detected change should be treated as the application's own
+ * save rather than an external modification.
+ *
+ * A suppression entry matches when it is unexpired AND either it carries no
+ * content hash (legacy time-only suppression) or the observed content hashes to
+ * the same value the app just wrote. A genuine external change (different
+ * content) within the window is NOT suppressed, so concurrent external edits are
+ * still detected even while a self-save window lingers.
+ *
+ * 検知した変更がアプリ自身の保存とみなせる場合に true を返す。期限内であり、
+ * かつ content hash が無い（時間窓のみ）か観測内容のハッシュが保存内容と一致する
+ * 場合にマッチする。窓内でも内容が異なる真の外部変更は抑制しない。
+ */
+function isSelfSave(filePath: string, content: string): boolean {
+  const entry = saveSuppression.get(filePath);
+  if (!entry) return false;
+  if (Date.now() >= entry.until) {
+    saveSuppression.delete(filePath);
+    return false;
+  }
+  return entry.hash === null || entry.hash === hashContent(content);
 }
 
 // -----------------------------------------------------------------------
@@ -234,15 +289,13 @@ class WebFileWatcher implements FileWatcher {
 
         // Catch-up check: detect changes that occurred while the watcher was paused
         if (previousModified > 0 && this.lastModified > previousModified) {
-          if (!isFileSuppressed(this.path)) {
-            try {
-              const content = await this.vfs.readFile(this.path);
-              if (this._isActive) {
-                this.onChanged(content, this.lastModified);
-              }
-            } catch {
-              // File may have been deleted; normal poll cycle will handle it
+          try {
+            const content = await this.vfs.readFile(this.path);
+            if (this._isActive && !isSelfSave(this.path, content)) {
+              this.onChanged(content, this.lastModified);
             }
+          } catch {
+            // File may have been deleted; normal poll cycle will handle it
           }
         }
       })
@@ -288,8 +341,6 @@ class WebFileWatcher implements FileWatcher {
    * MAX_CONSECUTIVE_FAILURES 回連続で失敗した場合、監視を自動停止する。
    */
   private async checkForChanges(): Promise<void> {
-    const suppressed = isFileSuppressed(this.path);
-
     try {
       const metadata = await this.vfs.getFileMetadata(this.path);
 
@@ -299,9 +350,10 @@ class WebFileWatcher implements FileWatcher {
       if (metadata.lastModified > this.lastModified) {
         this.lastModified = metadata.lastModified;
 
-        // Skip callback if suppressed (app's own save), but still update baseline
-        if (!suppressed) {
-          const content = await this.vfs.readFile(this.path);
+        // Read the new content and skip the callback when it is the app's own
+        // save (content-hash match), but still advance the mtime baseline above.
+        const content = await this.vfs.readFile(this.path);
+        if (!isSelfSave(this.path, content)) {
           this.onChanged(content, metadata.lastModified);
         }
       }
@@ -430,20 +482,18 @@ class ElectronFileWatcher implements FileWatcher {
           this.pausedAt > previousModified &&
           metadata.lastModified === previousModified;
 
-        if (
-          this._isActive &&
-          (mtimeAdvanced || possibleSameSecondChange) &&
-          !isFileSuppressed(this.path)
-        ) {
+        if (this._isActive && (mtimeAdvanced || possibleSameSecondChange)) {
           const content = await this.vfs.readFile(this.path);
           if (this._isActive) {
             const contentHash = hashContent(content);
             const contentChanged = contentHash !== this.lastKnownContentHash;
 
             this.lastKnownModified = metadata.lastModified;
+            this.lastKnownContentHash = contentHash;
 
-            if (mtimeAdvanced || contentChanged) {
-              this.lastKnownContentHash = contentHash;
+            // Skip the callback when the change is the app's own save
+            // (content-hash match) but keep the refreshed baseline above.
+            if ((mtimeAdvanced || contentChanged) && !isSelfSave(this.path, content)) {
               this.onChanged(content, metadata.lastModified);
             }
           }
@@ -545,11 +595,6 @@ class ElectronFileWatcher implements FileWatcher {
    * 権限の取り消しやその他のエラーを適切に処理する。
    */
   private async readAndNotify(): Promise<void> {
-    // Skip if this path was recently saved by the application
-    if (isFileSuppressed(this.path)) {
-      return;
-    }
-
     try {
       const [content, metadata] = await Promise.all([
         this.vfs.readFile(this.path),
@@ -557,8 +602,11 @@ class ElectronFileWatcher implements FileWatcher {
       ]);
       const newHash = hashContent(content);
       this.lastKnownModified = metadata.lastModified;
-      // Skip notification if content hasn't changed (e.g. cloud sync metadata update)
-      if (newHash === this.lastKnownContentHash) {
+      // Skip notification when content is unchanged (e.g. cloud sync metadata
+      // touch) or when the change is the application's own save (content-hash
+      // match). Refresh the baseline hash either way.
+      if (newHash === this.lastKnownContentHash || isSelfSave(this.path, content)) {
+        this.lastKnownContentHash = newHash;
         return;
       }
       this.lastKnownContentHash = newHash;

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -95,7 +95,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
             const sanitized = sanitizeMdiContent(tab.content, { fileType: tab.fileType });
             if (isProjectRef.current && tab.file?.path) {
               const vfs = getProjectFileService();
-              suppressFileWatch(tab.file.path);
+              suppressFileWatch(tab.file.path, sanitized);
               await vfs.writeFile(tab.file.path, sanitized);
               if (!mountedRef.current) return;
               setTabs((prev) =>

--- a/lib/tab-manager/use-close-dialog.ts
+++ b/lib/tab-manager/use-close-dialog.ts
@@ -87,7 +87,7 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
 
       if (isProjectRef.current && tab.file?.path) {
         const vfs = getProjectFileService();
-        suppressFileWatch(tab.file.path);
+        suppressFileWatch(tab.file.path, sanitized);
         await vfs.writeFile(tab.file.path, sanitized);
         // B1 fix: tab close → "pre-close" snapshot type
         await tryCreateSnapshot("pre-close", tab.file.path, tab.file.name, sanitized);

--- a/lib/tab-manager/use-electron-menu-bindings.ts
+++ b/lib/tab-manager/use-electron-menu-bindings.ts
@@ -163,7 +163,7 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
         try {
           if (isProjectRef.current && tab.file.path) {
             const vfs = getProjectFileService();
-            suppressFileWatch(tab.file.path);
+            suppressFileWatch(tab.file.path, sanitized);
             await vfs.writeFile(tab.file.path, sanitized);
             // B1 fix: window close "保存" → "pre-close" snapshot type
             await tryCreateSnapshotRef.current?.(

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -281,7 +281,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         // Project mode: VFS direct write
         if (isProjectRef.current && tab.file?.path) {
           const vfs = getProjectFileService();
-          suppressFileWatch(tab.file.path);
+          suppressFileWatch(tab.file.path, sanitized);
           await vfs.writeFile(tab.file.path, sanitized);
 
           // Update project.json lastModified so workspace metadata stays in sync.


### PR DESCRIPTION
## 概要

ファイルを手動保存・自動保存するたびに「「xxx.mdi」が更新されました」というトースト通知が毎回出る不具合を修正します。

## 根本原因

Electron renderer にはネイティブ `fs.watch` がなく（preload の VFS bridge が `watch` チャネルを公開していない）、ファイル監視は常に **5 秒ポーリング**にフォールバックします。一方、保存時の自己保存抑制窓 `SAVE_SUPPRESSION_MS` は **3 秒**で、ポーリング間隔より短いものでした。

その結果:
1. アプリが保存 → 抑制窓は +3s で失効
2. 次のポーリング（最大 +5s）が mtime 変化を検知
3. その時点で抑制は既に失効 → 外部変更とみなして `onChanged` 発火
4. clean タブなので「○○が更新されました」トースト表示

→ 毎回の保存で誤通知。

## 修正

- `SAVE_SUPPRESSION_MS` をポーリング間隔超（`DEFAULT_POLL_INTERVAL_MS + 3000`）に延長し、自己保存を検知するポーリングが窓内に収まるようにする
- 抑制判定を**経過時間だけでなく保存内容のハッシュ照合**に変更（`isSelfSave`）。これにより延長した窓内でも、内容が異なる**真の外部変更は検知し続ける**（外部変更検知・コンフリクト機能を潰さない）
- `suppressFileWatch()` が書き込み内容を受け取るよう変更し、4 つの保存パス（auto-save / menu-bindings / close-dialog / file-io）すべてが内容を渡す

## テスト

`file-watcher-self-save.test.ts` に 3 件の回帰テストを追加:
- 自己保存（内容一致）はポーリングで抑制される
- 窓内でも内容が異なる外部編集は抑制されず検知される
- 自己保存抑制後の後続の外部変更を再検知できる

既存の file-watcher / tab-manager テスト 351 件 + 新規 3 件すべて green、typecheck clean。

## 関連 issue

関連 issue なし（#1448 は file watcher 責務分離の refactor epic で別物）。