### PR TITLE
fix(deps): bump tmp 0.2.5 → 0.2.7 on dev (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17499,9 +17499,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- transitive devDependency `tmp`（electron-builder のビルドチェーン経由）を 0.2.5 → 0.2.7 に更新し、path-traversal 脆弱性 **GHSA-7c78-jf6q-g5cm / GHSA-ph9p-34f9-6g65** を修正
- Dependabot の #1513 は security PR のため base が **main 固定**（GitHub 仕様で retarget しても戻る）。次回リリースで main へ流すため、**dev 側で同等の lockfile 更新**を適用

## Changes

- `package-lock.json`: `node_modules/tmp` を 0.2.7 に更新（#1513 と完全に同一の差分）。`npm update tmp` で生成、package.json 変更なし

## Test plan

- [x] `npm update tmp` で lockfile の tmp のみ 0.2.7 に更新（3行差分）
- [x] tmp は build時のみ使用の dev 依存で製品コード非依存
- [x] CI green を確認してマージ

リリース後、Dependabot #1513（main 向け）は不要になるため close 可能。

## 関連 issue

関連 issue なし。Dependabot #1513 の dev 反映版。