### PR TITLE
docs: update docs/ to reflect recent code changes

### DIFF
--- a/docs/MDI/spec.md
+++ b/docs/MDI/spec.md
@@ -291,7 +291,8 @@ br.mdi-break {
 
 - 内部表現であり、ユーザーが直接入力するマーカーではない
 - **`.mdi` モードのみ有効**（`.md` ファイルでは Step 1a を無効化し `<br />` は単純に改行へ変換される）
-- 生成元は **paste / import / 外部書き込み のみ**。ProseMirror エディタでの Enter 連打で作った空段落は CommonMark serializer により blank line へ collapse されるため `[[blank]]` は emit されない
+- 生成元は **paste / import / 外部書き込み**、および `.mdi` ファイルから読み込んだ既存の `[[blank]]`。ProseMirror エディタでの Enter 連打で作った空段落は CommonMark serializer により blank line へ collapse されるため `[[blank]]` は emit されない
+- エディタ上では専用の `blankParagraph` ノード（`<p class="mdi-blank">`）として描画され、通常の段落と同様に編集できる（クリックして入力するとそのまま本文段落になる）。内容が空のまま保存すると `[[blank]]` マーカーへ round-trip し、文字を入力した場合は通常段落として保存される
 - エクスポート時: TXT → 空行、HTML → `<p></p>`、DOCX → 空段落
 - ユーザーが `[[blank]]` をリテラル文字列として入力した場合は空白段落として解釈される（bracket macro 全般の既知 escape 制限と同様）
 - **既知の限界**: fenced code block (` ``` `) 内の単独 `[[blank]]` は exporter (txt/html/docx) で空段落に変換される。引用ブロック (`> ...`) 内の `[[blank]]` は行頭マッチ条件 (`/^\[\[blank\]\][ \t]*\r?$/m`) を満たさないためリテラル文字列として保持される。これは既存 `[[br]]` の exporter ハンドリング (§6.1) と同じクラスの制約
@@ -305,7 +306,7 @@ br.mdi-break {
 | `Enter`          | 新しい段落（換段）             | 空行 (`\n\n`) | `paragraph`（別）  |
 | `Shift+Enter`    | CommonMark hardbreak（段落内） | `  \n`        | `hardbreak`        |
 | `[[br]]` 入力    | MDI 改行マーカー（段落内）     | `[[br]]`      | `mdibreak`         |
-| `[[blank]]` 保存 | 意図的な空白段落               | `[[blank]]`   | `paragraph`（空）  |
+| `[[blank]]` 保存 | 意図的な空白段落               | `[[blank]]`   | `blankParagraph`   |
 
 **推奨運用**
 

--- a/docs/architecture/vfs.md
+++ b/docs/architecture/vfs.md
@@ -3,7 +3,7 @@ title: Virtual File System
 slug: vfs
 type: architecture
 status: active
-updated: 2026-04-17
+updated: 2026-05-31
 tags:
   - architecture
   - file-system
@@ -258,6 +258,22 @@ Certain sensitive system paths are always blocked, regardless of root:
 
 Paths selected through Electron's native file dialog are tracked in an LRU Map (max 200 entries) to allow subsequent operations on those paths without re-prompting the user.
 
+#### Persistence across restart
+
+Approved roots are also persisted to `approved-vfs-paths.json` (in the app's user-data directory), keyed by `projectId`, via `electron/lib/vfs-approvals.js`. On the next launch the `vfs:set-root` handler reloads the approved set for the current project and skips the re-approval dialog for previously accepted roots.
+
+- **Project-scoped**: only paths belonging to the active `projectId` are restored.
+- **No auto-promotion of denied paths**: persisted entries are still validated against the denylist and per-window root checks at access time (TOCTOU-safe; existence is not assumed).
+- **Schema**: `{ "version": 1, "approvals": [{ "projectId", "path", "approvedAt" }] }`.
+
+### Text Encoding (`.txt` / `.md` / `.mdi`)
+
+Text files are read and written through `lib/utils/text-codec.ts`:
+
+- Decoded as UTF-8. Non-UTF-8 BOMs (UTF-16 LE/BE, UTF-32) are rejected with a Japanese error.
+- A UTF-8 BOM (`EF BB BF`) is stripped on read and not restored on write.
+- The original EOL style (CRLF vs LF) is detected and preserved on write; content is normalized to LF in memory.
+
 ---
 
 ## Platform Comparison
@@ -282,5 +298,5 @@ Paths selected through Electron's native file dialog are tracked in an LRU Map (
 
 ---
 
-**Last Updated**: 2026-02-25
+**Last Updated**: 2026-05-31
 **Version**: 1.0.0

--- a/docs/guides/milkdown-plugin.md
+++ b/docs/guides/milkdown-plugin.md
@@ -3,7 +3,7 @@ title: Milkdown プラグイン開発
 slug: milkdown-plugin
 type: guide
 status: active
-updated: 2026-04-03
+updated: 2026-05-31
 tags:
   - guide
   - milkdown
@@ -60,13 +60,14 @@ Editor.make()
 
 現行のカスタム schema / node は次のとおりです。
 
-| ノード           | ファイル                  | 役割                   |
-| ---------------- | ------------------------- | ---------------------- |
-| `ruby`           | `nodes/ruby.ts`           | `{親文字\|ルビ}`       |
-| `tcy`            | `nodes/tcy.ts`            | `^12^` のような縦中横  |
-| `nobreak`        | `nodes/nobreak.ts`        | `[[no-break:...]]`     |
-| `kern`           | `nodes/kern.ts`           | `[[kern:0.2em:...]]`   |
-| `heading-anchor` | `nodes/heading-anchor.ts` | 見出しアンカー用ノード |
+| ノード           | ファイル                   | 役割                                       |
+| ---------------- | -------------------------- | ------------------------------------------ |
+| `ruby`           | `nodes/ruby.ts`            | `{親文字\|ルビ}`                           |
+| `tcy`            | `nodes/tcy.ts`             | `^12^` のような縦中横                      |
+| `nobreak`        | `nodes/nobreak.ts`         | `[[no-break:...]]`                         |
+| `kern`           | `nodes/kern.ts`            | `[[kern:0.2em:...]]`                       |
+| `heading-anchor` | `nodes/heading-anchor.ts`  | 見出しアンカー用ノード                     |
+| `blankParagraph` | `nodes/blank-paragraph.ts` | `[[blank]]`（強制空段落、round-trip 対応） |
 
 ### 構文パーサ
 
@@ -77,6 +78,7 @@ remark 側の構文プラグインは [`syntax.ts`](../../packages/milkdown-plug
 - `remarkNoBreakPlugin`
 - `remarkKernPlugin`
 - `remarkHeadingAnchorPlugin`
+- `remarkMdiBlankPlugin`（`[[blank]]` のみの段落を `blankParagraph` ノードへ変換）
 
 以前の文書で触れていた `paragraph-id-fixer` は、現在の package 構成には存在しません。
 


### PR DESCRIPTION
## 概要

最近 dev にマージされたコード変更を `docs/` に反映する。daily docs-maintenance workflow の issue #1511 に対応。`.github/agents/docs-updater.agent.md` のトリガー表に従い、影響のある docs のみを surgical edit。

## 変更内容

### `docs/architecture/vfs.md`
- **Dialog-Approved Paths の永続化**を追記（#1476 / #1500）。`approved-vfs-paths.json` に projectId 単位で承認済み root を保存し、再起動後に `vfs:set-root` が再 prompt なしで復元する旨。denylist / per-window root チェックは access 時に維持される点も明記。
- **Text Encoding** subsection を追加（`lib/utils/text-codec.ts`、#1475 / #1499）。UTF-8 のみ対応・非 UTF-8 BOM 拒否・UTF-8 BOM strip・EOL (CRLF/LF) 保持。

### `docs/MDI/spec.md`
- `[[blank]]` の挙動更新（#1476 関連の `blank-paragraph` コミット群）。従来は「paste/import 由来のみ、エディタでは emit されない」と記載していたが、現在は専用 `blankParagraph` ノードとして編集可能な空段落に描画され、空のまま保存すると `[[blank]]` へ round-trip する。§6.3 の ProseMirror ノード列も `paragraph`（空）→ `blankParagraph` に修正。

### `docs/guides/milkdown-plugin.md`
- カスタムノード表に `blankParagraph`（`nodes/blank-paragraph.ts`）を追加。
- 構文パーサ一覧に `remarkMdiBlankPlugin` を追加。

## 言語ルール
英語・日本語のみ。中国語・韓国語なし。

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)