### PR TITLE
fix(export): EPUB 縦書きのページ送り方向を rtl に修正

### DIFF
--- a/lib/export/__tests__/epub-shared.test.ts
+++ b/lib/export/__tests__/epub-shared.test.ts
@@ -1,0 +1,41 @@
+/**
+ * EPUB shared template generator unit tests
+ *
+ * Focuses on the content.opf spine, which controls page-progression
+ * direction for Japanese vertical writing (must be rtl).
+ */
+
+import { describe, it, expect } from "vitest";
+import { buildEpubFiles } from "../epub-shared";
+
+function getOpf(content: string, verticalWriting: boolean): string {
+  const files = buildEpubFiles(content, {
+    metadata: { title: "テスト小説", language: "ja" },
+    verticalWriting,
+  });
+  const opf = files.get("OEBPS/content.opf");
+  expect(typeof opf).toBe("string");
+  return opf as string;
+}
+
+describe("buildEpubFiles content.opf spine", () => {
+  it("adds page-progression-direction=rtl for vertical writing", () => {
+    const opf = getOpf("# 第一章\n\n縦書き本文です。", true);
+    expect(opf).toContain('<spine page-progression-direction="rtl">');
+  });
+
+  it("omits page-progression-direction for horizontal writing", () => {
+    const opf = getOpf("# 第一章\n\n横書き本文です。", false);
+    expect(opf).toContain("<spine>");
+    expect(opf).not.toContain("page-progression-direction");
+  });
+
+  it("still emits vertical-rl writing-mode in the stylesheet when vertical", () => {
+    const files = buildEpubFiles("本文", {
+      metadata: { title: "テスト", language: "ja" },
+      verticalWriting: true,
+    });
+    const css = files.get("OEBPS/style.css") as string;
+    expect(css).toContain("writing-mode: vertical-rl");
+  });
+});

--- a/lib/export/epub-shared.ts
+++ b/lib/export/epub-shared.ts
@@ -122,6 +122,7 @@ export function buildEpubFiles(
       chapterCount: chapters.length,
       coverFileName,
       coverMediaType,
+      verticalWriting,
     }),
   );
 
@@ -173,6 +174,7 @@ function generateContentOpf(params: {
   chapterCount: number;
   coverFileName?: string;
   coverMediaType?: string;
+  verticalWriting?: boolean;
 }): string {
   const {
     title,
@@ -184,6 +186,7 @@ function generateContentOpf(params: {
     chapterCount,
     coverFileName,
     coverMediaType,
+    verticalWriting,
   } = params;
 
   const manifestItems: string[] = [
@@ -212,6 +215,12 @@ function generateContentOpf(params: {
     spineItems.push(`    <itemref idref="chapter-${i}"/>`);
   }
 
+  // Japanese vertical writing reads right-to-left, so the page-progression
+  // direction must be rtl. Without this, readers default to ltr and pages
+  // turn in the wrong direction. (Per EPUB 3 spec, the spine attribute — not
+  // the body's writing-mode — controls page turn direction.)
+  const spineDirection = verticalWriting ? ' page-progression-direction="rtl"' : "";
+
   const modifiedTimestamp = new Date().toISOString().replace(/\.\d{3}Z/, "Z");
 
   const metadataLines = [
@@ -232,7 +241,7 @@ ${metadataLines.join("\n")}
   <manifest>
 ${manifestItems.join("\n")}
   </manifest>
-  <spine>
+  <spine${spineDirection}>
 ${spineItems.join("\n")}
   </spine>
 </package>`;


### PR DESCRIPTION
## 概要
縦書き (vertical-rl) の `.mdi` を EPUB エクスポートすると、ページ送り方向が左→右になっていた問題を修正する。日本語縦書きは本来 右→左 (rtl)。

## 根本原因
`lib/export/epub-shared.ts` の OPF 生成で `<spine>` に `page-progression-direction` 属性が無く、リーダーが既定の ltr で表示していた。本文の `writing-mode: vertical-rl` はページ内の文字方向を制御するが、**ページ送り方向は OPF の `<spine>` 属性で決まる** (EPUB 3 spec)。

## 修正内容
- `generateContentOpf` に `verticalWriting` を渡す
- `verticalWriting === true` のとき `<spine page-progression-direction="rtl">` を出力
- `buildEpubFiles` の OPF spine に対するユニットテストを追加 (縦書き=rtl付与 / 横書き=無し / CSS は従来通り vertical-rl)

## テスト
- `lib/export/__tests__/epub-shared.test.ts` 新規 3 件 + 既存 epub テスト → 全 10 件 pass
- type-check clean

## 補足
リリース回帰ではなく既存バグ。archiver v8→7 revert (#1525) とは無関係で、EPUB 生成ロジックは不変だった。手動 UI チェックで発見。

Closes #1526

🤖 Generated with [Claude Code](https://claude.com/claude-code)