### PR TITLE
fix(dockview): 保存レイアウトの向き復元の反転を修正（左右→上下になる回帰）

### DIFF
--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -148,8 +148,10 @@ function applySimplifiedLayout(
 
   for (let i = 1; i < layout.groups.length; i++) {
     const savedGroup = layout.groups[i];
-    // In dockview, HORIZONTAL orientation = horizontal split bar = panels stacked top-bottom
-    const direction = layout.orientation === "HORIZONTAL" ? "bottom" : "right";
+    // In dockview, HORIZONTAL orientation = root axis is horizontal = panels side-by-side
+    // (left-right split); VERTICAL = panels stacked top-bottom. So a saved HORIZONTAL
+    // layout must be reconstructed with direction "right", not "bottom".
+    const direction = layout.orientation === "HORIZONTAL" ? "right" : "bottom";
 
     let firstPanelInGroup: IDockviewPanel | null = null;
 
@@ -197,7 +199,8 @@ function applySimplifiedLayout(
   // Use the total container dimension along the split axis to compute absolute pixel sizes.
   if (layout.sizes && layout.sizes.length > 0) {
     const isHorizontal = layout.orientation === "HORIZONTAL";
-    const totalPx = isHorizontal ? api.height : api.width;
+    // HORIZONTAL (side-by-side) groups vary in width along the split axis; VERTICAL in height.
+    const totalPx = isHorizontal ? api.width : api.height;
     if (totalPx > 0) {
       // Find a representative panel for group 0 (the default/first group)
       const firstGroupKey = layout.groups[0]?.tabPaths[0] ?? null;
@@ -216,7 +219,7 @@ function applySimplifiedLayout(
         const rep = groupRepresentatives[i];
         if (!rep) continue;
         try {
-          rep.group.api.setSize(isHorizontal ? { height: targetPx } : { width: targetPx });
+          rep.group.api.setSize(isHorizontal ? { width: targetPx } : { height: targetPx });
         } catch {
           // setSize may fail if the group is already the right size or no longer exists
         }


### PR DESCRIPTION
## Summary

- dockview v6（#1492）後、左右に並べたパネルが再起動で**上下並びに化ける**回帰（#1527）を修正
- `use-dockview-adapter.ts` の復元側で **orientation→direction / size 軸のマッピングが反転**していた

## 根本原因

dockview では `Orientation.HORIZONTAL` = ルート軸が水平 = **パネル左右並び**（dockview-core `getDirectionOrientation`: `'right'`→HORIZONTAL / `'bottom'`→VERTICAL で確認）。だが復元コードは:
- direction を `HORIZONTAL ? "bottom" : "right"` と**逆**に指定（152行）→ 左右保存が上下で復元
- size 軸も `HORIZONTAL ? api.height : api.width`（200行）/ `setSize({height})`（219行）と逆

この反転は v6 以前から存在したが v5 の既定 orientation に隠れていた。v6 で既定が変わり毎回顕在化。保存側（persistence.ts）は正しい軸を記録しているため**移行不要**。

## Changes

- `lib/dockview/use-dockview-adapter.ts`: direction と size 軸の3箇所を反転修正

## Test plan

- [x] `tsc --noEmit` clean
- [ ] 手動: パネルを左右に並べて再起動 → 左右で復元されること（上下に化けない）
- [ ] v5 で保存した既存レイアウトも正しく復元されること

Closes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)