### PR TITLE
fix(tabs): 起動時に復元したファイルがツリーから再度開ける重複タブを修正

### DIFF
--- a/lib/tab-manager/__tests__/restore-path-dedup.test.ts
+++ b/lib/tab-manager/__tests__/restore-path-dedup.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression test for #1528 — duplicate tab for the default/restored file.
+ *
+ * Root cause: a tab restored on startup stored its `file.path` as an ABSOLUTE
+ * path (toAbsolutePath(relativePath, rootPath)), while a tab opened from the
+ * file tree stores the VFS-RELATIVE path (toVFSPath(treePath), i.e. the tree
+ * path with the leading slash stripped). The dedup in openProjectFile compares
+ * `tab.file.path === vfsPath` by string equality, so the same file restored on
+ * launch and then clicked in the tree produced two tabs.
+ *
+ * Fix: restoreProjectTabs now stores `saved.relativePath` (the same VFS-relative
+ * representation the tree passes) as `file.path`. These tests lock that the two
+ * representations match for the dedup, using the real path helpers.
+ */
+
+import { describe, it, expect } from "vitest";
+import { toRelativePath, toAbsolutePath } from "@/lib/project/workspace-persistence";
+
+// Replica of FilesPanel.tsx `toVFSPath` (treePath stripped of a leading slash) —
+// the exact value the file tree hands to openProjectFile as `vfsPath`.
+const toVFSPath = (treePath: string): string => treePath.replace(/^\//, "");
+
+describe("#1528 restored-tab path matches tree-opened path (dedup)", () => {
+  const rootPath = "/Users/iktahana/Library/CloudStorage/GoogleDrive-x/My Drive/原稿/無題";
+
+  it.each([
+    ["/無題.mdi", "無題.mdi"],
+    ["/test.mdi", "test.mdi"],
+    ["/章/01.mdi", "章/01.mdi"],
+  ])("tree path %s and restored path resolve to the same dedup key", (treePath, relativePath) => {
+    // What the file tree passes to openProjectFile (and what a tree-opened tab stores).
+    const treeVfsPath = toVFSPath(treePath);
+
+    // What workspace.json stores for that file, then what the FIXED restore uses
+    // for tab.file.path.
+    const savedRelativePath = relativePath;
+    const restoredTabPath = savedRelativePath; // fixed behavior
+
+    // Dedup (tab.file.path === vfsPath) must now match.
+    expect(restoredTabPath).toBe(treeVfsPath);
+  });
+
+  it("the OLD behavior (absolute restore path) would have broken dedup", () => {
+    const relativePath = "無題.mdi";
+    const treeVfsPath = toVFSPath("/無題.mdi"); // "無題.mdi"
+    const oldRestoredTabPath = toAbsolutePath(relativePath, rootPath); // absolute
+
+    expect(oldRestoredTabPath).not.toBe(treeVfsPath); // this mismatch was the bug
+    expect(oldRestoredTabPath.startsWith(rootPath)).toBe(true);
+  });
+
+  it("round-trips: saved relativePath equals the tree's vfs path for an in-root file", () => {
+    const absoluteOriginal = `${rootPath}/無題.mdi`;
+    const savedRelativePath = toRelativePath(absoluteOriginal, rootPath);
+    expect(savedRelativePath).toBe(toVFSPath("/無題.mdi"));
+    expect(savedRelativePath).toBe("無題.mdi");
+  });
+
+  it("web mode (rootPath null): paths stay relative on both sides", () => {
+    const relativePath = "無題.mdi";
+    // In web mode toAbsolutePath returns the relative path unchanged, so old and
+    // new restore behavior coincide and already matched the tree path.
+    expect(toAbsolutePath(relativePath, null)).toBe(relativePath);
+    expect(relativePath).toBe(toVFSPath("/無題.mdi"));
+  });
+});

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -229,7 +229,13 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
             tabKind: "editor",
             id: generateTabId(),
             file: {
-              path: absolutePath,
+              // Store the VFS-relative path (same representation the file tree
+              // passes to openProjectFile). Using the absolute path here made a
+              // restored tab's path differ from a tree-opened one for the same
+              // file, so the path-equality dedup missed and the file could be
+              // opened a second time (#1528). Content is still read via the
+              // absolute path above.
+              path: saved.relativePath,
               handle: null,
               name: saved.fileName,
             },


### PR DESCRIPTION
## Summary

- 起動時に自動復元された .mdi を、ファイルツリーからクリックすると**もう1つタブが開く**重複（#1528）を修正
- **dockview v6 とは無関係の pre-existing なパス表現不一致**が原因

## 根本原因

- ツリークリック → `vfsPath = toVFSPath(treePath)` = **VFS 相対パス**（例 `無題.mdi`）。`openProjectFile` はこれを `tab.file.path` に保存
- 起動時の復元 → `toAbsolutePath(relativePath, rootPath)` = **絶対パス**（例 `/Users/.../無題.mdi`）を `tab.file.path` に保存
- `openProjectFile` の dedup は `tab.file.path === vfsPath` の**文字列完全一致**。絶対 ≠ 相対で不一致 → 重複タブ

ツリー経由のタブは元々 VFS 相対パスで全機能が正常動作しているため、復元タブも同じ相対表現に揃えるのが一貫した修正。

## Changes

- `lib/tab-manager/use-tab-persistence.ts`: 復元タブの `file.path` を `saved.relativePath`（ツリーと同形式）に変更。コンテンツ読み込みは引き続き絶対パスを使用。Web モード（rootPath null）は従来と同値で影響なし
- `lib/tab-manager/__tests__/restore-path-dedup.test.ts`: 実際の path ヘルパーでパス表現一致を検証する回帰テスト 6 件

## Test plan

- [x] 回帰テスト 6 件 pass
- [x] `tsc --noEmit` clean
- [ ] 手動: 起動 → 自動で開いたファイルをツリーからクリック → **新タブが増えず既存タブがアクティブ化**されること

Closes #1528

🤖 Generated with [Claude Code](https://claude.com/claude-code)