### PR TITLE
fix(dockview): v6 で分割レイアウトの向きが復元されない不具合を修正

### DIFF
--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -24,7 +24,6 @@ import type {
   SimplifiedGroupLayout,
 } from "./types";
 import type { WorkspaceDockviewLayout } from "@/lib/project/project-types";
-import { toAbsolutePath } from "@/lib/project/workspace-persistence";
 import { loadDockviewLayout } from "./use-dockview-persistence";
 
 // ---------------------------------------------------------------------------
@@ -146,50 +145,43 @@ function applySimplifiedLayout(
   // Track a representative panel per created group to apply sizes afterward
   const groupRepresentatives: Array<IDockviewPanel | null> = [null]; // index 0 = original group
 
+  // The original (default) group holds all panels at this point. Capture it as
+  // the stable reference for every split so the new groups are siblings of it.
+  const referenceGroup = api.groups[0];
+
   for (let i = 1; i < layout.groups.length; i++) {
     const savedGroup = layout.groups[i];
-    // In dockview, HORIZONTAL orientation = root axis is horizontal = panels side-by-side
-    // (left-right split); VERTICAL = panels stacked top-bottom. So a saved HORIZONTAL
-    // layout must be reconstructed with direction "right", not "bottom".
-    const direction = layout.orientation === "HORIZONTAL" ? "right" : "bottom";
+    // addGroup() orthogonalizes the root grid for the requested direction, so a
+    // saved HORIZONTAL (side-by-side) layout reliably becomes a left-right split.
+    // A raw moveTo() from the single default group is orientation-ambiguous —
+    // getLocationOrientation([]) returns the *orthogonal* of the root orientation,
+    // which made both "right" and "bottom" collapse to a top-bottom split (#1527).
+    const direction: "right" | "below" = layout.orientation === "HORIZONTAL" ? "right" : "below";
 
-    let firstPanelInGroup: IDockviewPanel | null = null;
-
+    // Resolve this group's panels (already added to the default group by the sync effect).
+    const panels: IDockviewPanel[] = [];
     for (const savedKey of savedGroup.tabPaths) {
       if (!savedKey) continue;
       const panelId = panelIdByKey.get(savedKey);
       if (!panelId) continue;
       const panel = api.getPanel(panelId);
-      if (!panel) continue;
+      if (panel) panels.push(panel);
+    }
+    if (panels.length === 0) {
+      groupRepresentatives.push(null);
+      continue;
+    }
 
-      if (!firstPanelInGroup) {
-        // First panel in this group: split to create a new group
-        try {
-          // Find a reference panel that's still in the default group
-          const refPanel =
-            api.panels.find((p) => p.id !== panelId && p.group !== panel.group) ?? api.panels[0];
-          if (refPanel && refPanel.id !== panelId) {
-            panel.api.moveTo({
-              group: refPanel.group,
-              position: direction,
-            });
-          }
-          firstPanelInGroup = panel;
-        } catch {
-          // Move failed; skip this group
-          break;
-        }
-      } else {
-        // Subsequent panels: move into the same group as the first panel
-        try {
-          panel.api.moveTo({
-            group: firstPanelInGroup.group,
-            position: "center",
-          });
-        } catch {
-          // Move failed; panel stays where it is
-        }
+    let firstPanelInGroup: IDockviewPanel | null = null;
+    try {
+      // Create a new group in the saved direction, then move this group's panels into it.
+      const newGroup = api.addGroup({ direction, referenceGroup });
+      for (const panel of panels) {
+        panel.api.moveTo({ group: newGroup, position: "center" });
       }
+      firstPanelInGroup = panels[0];
+    } catch {
+      // Reconstruction failed; leave panels in the default group.
     }
 
     groupRepresentatives.push(firstPanelInGroup);
@@ -368,18 +360,21 @@ export function useDockviewAdapter({
   useEffect(() => {
     if (layoutAppliedRef.current) return;
 
-    // Project mode: use workspace.json layout (convert relative → absolute paths)
+    // Project mode: use workspace.json layout as-is. Both the saved tabPaths and
+    // a restored tab's file.path are now VFS-relative (#1532), so the layout's
+    // stable keys match the tabs' stable keys WITHOUT converting to absolute.
+    // Converting to absolute here (as before #1532) made the keys mismatch, so no
+    // panels were found and the split layout collapsed to a single group (#1527).
     if (projectLayout && projectLayout.groups.length > 1) {
-      const rootPath = windowKey ?? null;
-      const absoluteLayout: SimplifiedGroupLayout = {
+      const relativeLayout: SimplifiedGroupLayout = {
         groups: projectLayout.groups.map((g) => ({
-          tabPaths: g.tabPaths.map((p) => (p ? toAbsolutePath(p, rootPath) : null)),
-          activeTabPath: g.activeTabPath ? toAbsolutePath(g.activeTabPath, rootPath) : null,
+          tabPaths: g.tabPaths,
+          activeTabPath: g.activeTabPath,
         })),
         orientation: projectLayout.orientation,
         sizes: projectLayout.sizes,
       };
-      savedLayoutRef.current = absoluteLayout;
+      savedLayoutRef.current = relativeLayout;
       setLayoutReadyTick((t) => t + 1);
       return;
     }

--- a/lib/dockview/use-dockview-persistence.ts
+++ b/lib/dockview/use-dockview-persistence.ts
@@ -52,14 +52,20 @@ function extractSimplifiedLayout(
     pathByPanelId.set(tab.id, stableKeyForTab(tab, occurrences));
   }
 
-  // Extract orientation from serialized JSON (the API doesn't expose it directly)
+  // Determine orientation from ACTUAL group geometry rather than the private
+  // toJSON().grid.orientation field, whose value proved ambiguous across
+  // dockview versions (#1527). For a side-by-side (left-right) split each group
+  // is narrower than the container but full-height; for a stacked (top-bottom)
+  // split each group is full-width but shorter. Compare how much width vs height
+  // the first group gives up relative to the container.
   let orientation: "HORIZONTAL" | "VERTICAL" = "HORIZONTAL";
-  try {
-    const json = api.toJSON();
-    const rawOrientation = String(json.grid.orientation);
-    orientation = rawOrientation === "VERTICAL" ? "VERTICAL" : "HORIZONTAL";
-  } catch {
-    // Fall back to default
+  if (groups.length >= 2) {
+    const containerW = api.width;
+    const containerH = api.height;
+    const g0 = groups[0].api;
+    const widthGiveUp = containerW - g0.width;
+    const heightGiveUp = containerH - g0.height;
+    orientation = widthGiveUp >= heightGiveUp ? "HORIZONTAL" : "VERTICAL";
   }
 
   const simplifiedGroups: SimplifiedGroupLayout["groups"] = [];


### PR DESCRIPTION
## Summary

dockview v6 アップグレード（#1492）後、左右/上下に分割したエディタレイアウトが再起動で正しく復元されない問題（#1527）を修正。3つの結合した原因を解消。

## 根本原因と修正

1. **保存 orientation を実ジオメトリから判定** — `api.toJSON().grid.orientation` は v6 で**信頼できない**（top-bottom レイアウトでも "HORIZONTAL" を返す。実機ログで確認）。グループとコンテナの幅/高さ比較で実際の配置を判定するよう変更
2. **`api.addGroup({direction})` で再構築** — 単一の既定グループから `moveTo()` で分割すると、`getLocationOrientation([])` がルートの**直交**を返すため direction が曖昧になり、"right" でも "bottom" でも上下分割に潰れていた。addGroup はルートを orthogonalize するので確実に指定方向の分割になる
3. **pre-load の tabPaths を相対のまま照合** — #1532 で復元タブの `file.path` を VFS 相対に変えたが、レイアウト pre-load は tabPaths を絶対に変換していたため stable-key 照合が失敗し、分割が単一グループに潰れていた。両者を相対で統一

## Changes

- `lib/dockview/use-dockview-persistence.ts`: orientation をジオメトリ判定に変更
- `lib/dockview/use-dockview-adapter.ts`: moveTo 分割 → addGroup 分割、pre-load の絶対変換を撤廃

## Test plan

- [x] `tsc --noEmit` clean / 既存テスト 136 件 pass（tab-manager + dockview 周辺）
- [x] **実機で左右・上下の両レイアウトが再起動後も正しく復元されることを確認済み**（ユーザー検証）

Closes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)