### PR TITLE
fix(auth): single-flight refreshToken to stop repeat IPC after permanent failure

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -10,6 +10,11 @@ import React, {
   useMemo,
 } from "react";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
+import {
+  isElectronAuthErrorPermanent,
+  refreshTokenSingleFlight,
+  resetRefreshState,
+} from "@/lib/auth/refresh-single-flight";
 
 export interface AuthUser {
   id: string;
@@ -147,45 +152,6 @@ async function fetchMe(): Promise<MeResponse> {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Returns whether an error thrown by the Electron auth IPC represents a
- * permanent auth failure (token invalid/revoked) vs a transient error
- * (server unavailable, network issue).
- *
- * The IPC handlers attach `error.status` (HTTP status) and, for the OAuth
- * token endpoint, `error.oauthError` (e.g. `invalid_grant`).
- *
- * Per RFC 6749 §5.2, the token endpoint returns HTTP 400 for client errors
- * such as `invalid_grant` (refresh token expired/revoked). Retrying these
- * cannot succeed, so any 4xx from the auth endpoints must be treated as
- * permanent — otherwise the renderer falls into a tight refresh loop on
- * a revoked token.
- */
-function isElectronAuthErrorPermanent(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-
-  const oauthError = (err as Error & { oauthError?: unknown }).oauthError;
-  if (
-    oauthError === "invalid_grant" ||
-    oauthError === "invalid_client" ||
-    oauthError === "unauthorized_client" ||
-    oauthError === "unsupported_grant_type"
-  ) {
-    return true;
-  }
-
-  if ("status" in err) {
-    const status = (err as Error & { status: unknown }).status;
-    if (typeof status === "number" && status >= 400 && status < 500) return true;
-  }
-  // No status attached (network/IPC error) — treat as transient
-  return false;
-}
-
-// ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
 
@@ -217,7 +183,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         if (!api?.auth) return;
 
         try {
-          const tokenResponse = await api.auth.refreshToken(refreshToken);
+          const tokenResponse = await refreshTokenSingleFlight(api.auth.refreshToken, refreshToken);
           const newExpiresAt = Date.now() + tokenResponse.expires_in * 1000;
           await saveTokens({
             accessToken: tokenResponse.access_token,
@@ -301,7 +267,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
             }
 
             try {
-              const tokenResponse = await api.auth.refreshToken(refreshToken);
+              const tokenResponse = await refreshTokenSingleFlight(
+                api.auth.refreshToken,
+                refreshToken,
+              );
               const newExpiresAt = Date.now() + tokenResponse.expires_in * 1000;
               await saveTokens({
                 accessToken: tokenResponse.access_token,
@@ -342,7 +311,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               scheduleElectronRefresh(expiresAt, refreshToken);
             } catch {
               try {
-                const tokenResponse = await api.auth.refreshToken(refreshToken);
+                const tokenResponse = await refreshTokenSingleFlight(
+                  api.auth.refreshToken,
+                  refreshToken,
+                );
                 const newExpiresAt = Date.now() + tokenResponse.expires_in * 1000;
                 await saveTokens({
                   accessToken: tokenResponse.access_token,
@@ -421,6 +393,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           state: data.state,
         });
 
+        // Fresh tokens from a successful login clear any prior permanent-failure
+        // latch so the new session can refresh normally.
+        resetRefreshState();
+
         const expiresAt = Date.now() + tokenResponse.expires_in * 1000;
         await saveTokens({
           accessToken: tokenResponse.access_token,
@@ -462,6 +438,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // --- Logout ---
   const logout = useCallback(async () => {
     clearRefreshTimer();
+    // Reset single-flight/permanent-failure state so a subsequent login starts clean.
+    resetRefreshState();
 
     if (isElectron.current) {
       const api = window.electronAPI;

--- a/lib/auth/__tests__/refresh-single-flight.test.ts
+++ b/lib/auth/__tests__/refresh-single-flight.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isElectronAuthErrorPermanent,
+  PermanentAuthFailureError,
+  refreshTokenSingleFlight,
+  resetRefreshState,
+  isRefreshPermanentlyFailed,
+  type TokenResponse,
+} from "@/lib/auth/refresh-single-flight";
+
+function makeTokenResponse(overrides: Partial<TokenResponse> = {}): TokenResponse {
+  return {
+    access_token: "access",
+    refresh_token: "refresh-next",
+    expires_in: 3600,
+    token_type: "Bearer",
+    scope: "openid",
+    ...overrides,
+  };
+}
+
+/** Build an Error carrying the fields the IPC layer attaches. */
+function authError(opts: { status?: number; oauthError?: string; message?: string }): Error {
+  const err = new Error(opts.message ?? "auth error") as Error & {
+    status?: number;
+    oauthError?: string;
+  };
+  if (opts.status !== undefined) err.status = opts.status;
+  if (opts.oauthError !== undefined) err.oauthError = opts.oauthError;
+  return err;
+}
+
+afterEach(() => {
+  resetRefreshState();
+});
+
+describe("refreshTokenSingleFlight", () => {
+  it("dedupes concurrent callers into a single IPC (the #1468 regression)", async () => {
+    let resolveFn: (value: TokenResponse) => void = () => {};
+    const fn = vi.fn().mockImplementation(
+      () =>
+        new Promise<TokenResponse>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    // Three callers race before the first IPC resolves (StrictMode double-mount
+    // + parallel restore). They must share one in-flight Promise.
+    const p1 = refreshTokenSingleFlight(fn, "refresh-token");
+    const p2 = refreshTokenSingleFlight(fn, "refresh-token");
+    const p3 = refreshTokenSingleFlight(fn, "refresh-token");
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    const response = makeTokenResponse();
+    resolveFn(response);
+    await expect(Promise.all([p1, p2, p3])).resolves.toEqual([response, response, response]);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues a fresh IPC after the previous refresh settled", async () => {
+    const fn = vi.fn().mockResolvedValue(makeTokenResponse());
+
+    await refreshTokenSingleFlight(fn, "rt-1");
+    await refreshTokenSingleFlight(fn, "rt-2");
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("latches permanent failure and short-circuits without calling the IPC again", async () => {
+    const fn = vi.fn().mockRejectedValue(authError({ status: 400, oauthError: "invalid_grant" }));
+
+    await expect(refreshTokenSingleFlight(fn, "revoked")).rejects.toThrow();
+    expect(isRefreshPermanentlyFailed()).toBe(true);
+
+    // Subsequent calls reject with PermanentAuthFailureError and never hit the IPC.
+    await expect(refreshTokenSingleFlight(fn, "revoked")).rejects.toBeInstanceOf(
+      PermanentAuthFailureError,
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT latch on transient failure — retries reach the IPC", async () => {
+    const fn = vi.fn().mockRejectedValue(authError({ status: 503 }));
+
+    await expect(refreshTokenSingleFlight(fn, "rt")).rejects.toThrow();
+    expect(isRefreshPermanentlyFailed()).toBe(false);
+
+    await expect(refreshTokenSingleFlight(fn, "rt")).rejects.toThrow();
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("resetRefreshState clears the permanent-failure latch (login/logout)", async () => {
+    const failing = vi.fn().mockRejectedValue(authError({ oauthError: "invalid_grant" }));
+    await expect(refreshTokenSingleFlight(failing, "revoked")).rejects.toThrow();
+    expect(isRefreshPermanentlyFailed()).toBe(true);
+
+    resetRefreshState();
+    expect(isRefreshPermanentlyFailed()).toBe(false);
+
+    const ok = vi.fn().mockResolvedValue(makeTokenResponse());
+    await expect(refreshTokenSingleFlight(ok, "fresh")).resolves.toEqual(makeTokenResponse());
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("isElectronAuthErrorPermanent", () => {
+  it("treats 4xx as permanent and 5xx / network as transient", () => {
+    expect(isElectronAuthErrorPermanent(authError({ status: 400 }))).toBe(true);
+    expect(isElectronAuthErrorPermanent(authError({ status: 403 }))).toBe(true);
+    expect(isElectronAuthErrorPermanent(authError({ status: 500 }))).toBe(false);
+    expect(isElectronAuthErrorPermanent(authError({}))).toBe(false);
+    expect(isElectronAuthErrorPermanent("not-an-error")).toBe(false);
+  });
+
+  it("treats OAuth client errors as permanent", () => {
+    expect(isElectronAuthErrorPermanent(authError({ oauthError: "invalid_grant" }))).toBe(true);
+    expect(isElectronAuthErrorPermanent(authError({ oauthError: "invalid_client" }))).toBe(true);
+  });
+
+  it("recognises PermanentAuthFailureError", () => {
+    expect(isElectronAuthErrorPermanent(new PermanentAuthFailureError())).toBe(true);
+  });
+});

--- a/lib/auth/refresh-single-flight.ts
+++ b/lib/auth/refresh-single-flight.ts
@@ -1,0 +1,144 @@
+/**
+ * Single-flight dedupe + permanent-failure guard for the Electron auth refresh
+ * IPC (`auth:refresh-token`).
+ *
+ * ## Why this exists
+ *
+ * `AuthProvider` invokes `api.auth.refreshToken()` from three independent call
+ * sites (the scheduled-refresh timer, and the two startup restore paths). Under
+ * React StrictMode double-mount and Next.js fast-refresh, the provider remounts
+ * and several of these paths can fire concurrently, each issuing its own IPC for
+ * the *same* refresh token.
+ *
+ * A module-scope boolean guard (the v1.2.5 approach in the rolled-back PR #1444)
+ * was insufficient: the guard only flips *after* the first IPC resolves, so the
+ * parallel callers that started before resolution all slipped past it — the
+ * `invalid_grant` error still appeared three times in the startup log.
+ *
+ * The robust fix is caller-side **single-flight**: concurrent refresh requests
+ * share one in-flight Promise, so the IPC is issued at most once per refresh
+ * cycle regardless of how many callers race. A separate **permanent-failure**
+ * latch short-circuits all subsequent calls once the refresh token is known to
+ * be revoked/expired (per RFC 6749 §5.2 a 4xx / `invalid_grant` cannot recover
+ * within the session), avoiding repeated doomed IPCs.
+ *
+ * State is module-scope (not React state/ref) so it survives StrictMode remounts
+ * and is shared across every call site within the renderer session. Reset it on
+ * login success, OAuth callback success, and logout via {@link resetRefreshState}.
+ */
+
+/** Token endpoint response shape (mirrors `window.electronAPI.auth.refreshToken`). */
+export interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+  scope: string;
+}
+
+/** A refresh function — typically `window.electronAPI.auth.refreshToken`. */
+export type RefreshTokenFn = (refreshToken: string) => Promise<TokenResponse>;
+
+/**
+ * Thrown by {@link refreshTokenSingleFlight} when a refresh is attempted after
+ * the session has already hit a permanent failure. Recognised as permanent by
+ * {@link isElectronAuthErrorPermanent}, so existing callers log out as expected.
+ */
+export class PermanentAuthFailureError extends Error {
+  constructor(message = "refresh token は永続的に失敗済みのため再試行しません") {
+    super(message);
+    this.name = "PermanentAuthFailureError";
+  }
+}
+
+/**
+ * Returns whether an error thrown by the Electron auth IPC represents a
+ * permanent auth failure (token invalid/revoked) vs a transient error
+ * (server unavailable, network issue).
+ *
+ * The IPC handlers attach `error.status` (HTTP status) and, for the OAuth
+ * token endpoint, `error.oauthError` (e.g. `invalid_grant`).
+ *
+ * Per RFC 6749 §5.2, the token endpoint returns HTTP 400 for client errors
+ * such as `invalid_grant` (refresh token expired/revoked). Retrying these
+ * cannot succeed, so any 4xx from the auth endpoints must be treated as
+ * permanent — otherwise the renderer falls into a tight refresh loop on
+ * a revoked token.
+ */
+export function isElectronAuthErrorPermanent(err: unknown): boolean {
+  if (err instanceof PermanentAuthFailureError) return true;
+  if (!(err instanceof Error)) return false;
+
+  const oauthError = (err as Error & { oauthError?: unknown }).oauthError;
+  if (
+    oauthError === "invalid_grant" ||
+    oauthError === "invalid_client" ||
+    oauthError === "unauthorized_client" ||
+    oauthError === "unsupported_grant_type"
+  ) {
+    return true;
+  }
+
+  if ("status" in err) {
+    const status = (err as Error & { status: unknown }).status;
+    if (typeof status === "number" && status >= 400 && status < 500) return true;
+  }
+  // No status attached (network/IPC error) — treat as transient
+  return false;
+}
+
+// --- Module-scope single-flight state (per renderer session) ---
+let inFlightRefresh: Promise<TokenResponse> | null = null;
+let refreshPermanentlyFailedSession = false;
+
+/**
+ * Refresh the access token, deduping concurrent callers into a single IPC and
+ * short-circuiting once the session has permanently failed.
+ *
+ * - If a prior refresh permanently failed, rejects immediately with
+ *   {@link PermanentAuthFailureError} without touching the IPC.
+ * - If a refresh is already in flight, returns that same Promise.
+ * - Otherwise issues `fn(refreshToken)`, latching the permanent-failure flag on
+ *   a permanent error, and clears the in-flight slot once settled.
+ */
+export function refreshTokenSingleFlight(
+  fn: RefreshTokenFn,
+  refreshToken: string,
+): Promise<TokenResponse> {
+  if (refreshPermanentlyFailedSession) {
+    return Promise.reject(new PermanentAuthFailureError());
+  }
+  if (inFlightRefresh) {
+    return inFlightRefresh;
+  }
+
+  const promise = (async () => {
+    try {
+      return await fn(refreshToken);
+    } catch (err) {
+      if (isElectronAuthErrorPermanent(err)) {
+        refreshPermanentlyFailedSession = true;
+      }
+      throw err;
+    } finally {
+      inFlightRefresh = null;
+    }
+  })();
+
+  inFlightRefresh = promise;
+  return promise;
+}
+
+/**
+ * Clear the single-flight and permanent-failure state. Call on login success,
+ * OAuth callback success, and logout so a fresh token can refresh normally.
+ */
+export function resetRefreshState(): void {
+  inFlightRefresh = null;
+  refreshPermanentlyFailedSession = false;
+}
+
+/** Test-only inspector for the permanent-failure latch. */
+export function isRefreshPermanentlyFailed(): boolean {
+  return refreshPermanentlyFailedSession;
+}


### PR DESCRIPTION
## Summary
ロールバックされた PR #1444 を、より堅牢な caller-side single-flight 方式で再実装。

旧実装の module-scope boolean guard は最初の IPC が resolve した後にしか立たず、StrictMode 二重 mount + 並列 restore で先頭の複数 caller が guard を素通りし、起動ログに `invalid_grant` が3回出ていた。

## 変更
- `lib/auth/refresh-single-flight.ts` を新設。並列 refresh は1つの in-flight Promise を共有（IPC は1サイクル1回）。`invalid_grant` / 4xx (RFC 6749 §5.2) で permanent-failure latch を立て、以降の呼び出しを短絡。
- `isElectronAuthErrorPermanent` を共有モジュールへ移動。
- `AuthContext` の3つの `refreshToken` 呼び出しサイトを single-flight 経由に。OAuth callback 成功時とログアウト時に state をリセット。
- regression test: 同時3回の `refreshTokenSingleFlight()` → IPC は1回のみ。

## Test
- `npx vitest run lib/auth` → 8 passed
- `npx tsc --noEmit` → clean

Closes #1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)