### PR TITLE
fix(vfs): open unsupported file types with the system default app

### DIFF
--- a/electron/ipc/shell-ipc.js
+++ b/electron/ipc/shell-ipc.js
@@ -30,6 +30,16 @@ function registerShellHandlers() {
     return true;
   });
 
+  ipcMain.handle("open-with-default-app", async (_event, filePath) => {
+    if (!filePath || typeof filePath !== "string") return false;
+    if (!path.isAbsolute(filePath) || filePath.includes("..")) {
+      console.warn("[Security] Invalid path in open-with-default-app:", filePath);
+      return false;
+    }
+    const result = await shell.openPath(path.normalize(filePath));
+    return result === ""; // empty string = success on macOS/Windows
+  });
+
   ipcMain.handle("open-external", async (_event, url) => {
     if (typeof url !== "string") return false;
     // Only allow http/https URLs

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -74,6 +74,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   },
   showInFileManager: (dirPath) => ipcRenderer.invoke("show-in-file-manager", dirPath),
   revealInFileManager: (filePath) => ipcRenderer.invoke("reveal-in-file-manager", filePath),
+  openWithDefaultApp: (filePath) => ipcRenderer.invoke("open-with-default-app", filePath),
   openExternal: (url) => ipcRenderer.invoke("open-external", url),
   onMenuOpenProject: (callback) => {
     const handler = () => callback();

--- a/lib/tab-manager/__tests__/open-with-default-app.test.ts
+++ b/lib/tab-manager/__tests__/open-with-default-app.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  EDITABLE_EXTENSIONS,
+  extractExtension,
+  isEditableExtension,
+  resolveNativePath,
+} from "@/lib/tab-manager/open-with-default-app";
+
+describe("extractExtension", () => {
+  it("returns the lowercased dotted extension", () => {
+    expect(extractExtension("dir/report.DOCX")).toBe(".docx");
+    expect(extractExtension("a/b/c.mdi")).toBe(".mdi");
+    expect(extractExtension("notes.tar.gz")).toBe(".gz");
+  });
+
+  it("returns empty string when there is no extension", () => {
+    expect(extractExtension("dir/README")).toBe("");
+    expect(extractExtension("LICENSE")).toBe("");
+  });
+});
+
+describe("isEditableExtension", () => {
+  it("treats the editor extensions as editable", () => {
+    for (const ext of EDITABLE_EXTENSIONS) {
+      expect(isEditableExtension(`file${ext}`)).toBe(true);
+    }
+  });
+
+  it("treats unsupported extensions as non-editable (delegate to OS)", () => {
+    expect(isEditableExtension("paper.docx")).toBe(false);
+    expect(isEditableExtension("scan.pdf")).toBe(false);
+    expect(isEditableExtension("sheet.xlsx")).toBe(false);
+    expect(isEditableExtension("doc.gdoc")).toBe(false);
+  });
+
+  it("treats extensionless files as editable text", () => {
+    expect(isEditableExtension("project/README")).toBe(true);
+  });
+});
+
+describe("resolveNativePath", () => {
+  it("passes through POSIX absolute paths", () => {
+    expect(resolveNativePath("/Users/me/doc.pdf", "/root")).toBe("/Users/me/doc.pdf");
+  });
+
+  it("passes through Windows drive-letter paths", () => {
+    expect(resolveNativePath("C:/Users/me/doc.pdf", "D:/root")).toBe("C:/Users/me/doc.pdf");
+    expect(resolveNativePath("C:\\Users\\me\\doc.pdf", null)).toBe("C:\\Users\\me\\doc.pdf");
+  });
+
+  it("joins relative paths onto the root", () => {
+    expect(resolveNativePath("sub/doc.pdf", "/root")).toBe("/root/sub/doc.pdf");
+  });
+
+  it("returns null for a relative path with no open root", () => {
+    expect(resolveNativePath("sub/doc.pdf", null)).toBeNull();
+  });
+});

--- a/lib/tab-manager/open-with-default-app.ts
+++ b/lib/tab-manager/open-with-default-app.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure helpers for deciding whether a VFS file should be opened with the OS
+ * default app (#1465) rather than the in-app editor, and for resolving the
+ * native absolute path to hand to the `open-with-default-app` IPC.
+ *
+ * Kept side-effect-free so the extension gate and path resolution can be unit
+ * tested without Electron / React. The hook (`useFileIO.openProjectFile`) wires
+ * the result to `notificationManager` and `window.electronAPI.openWithDefaultApp`.
+ */
+
+/** Extensions the editor can open in-app. Everything else delegates to the OS. */
+export const EDITABLE_EXTENSIONS = [".mdi", ".md", ".txt"] as const;
+
+/** Extract a lowercased dotted extension (".docx") from a VFS path, or "" if none. */
+export function extractExtension(vfsPath: string): string {
+  const baseName = vfsPath.split("/").pop() ?? "";
+  if (!baseName.includes(".")) return "";
+  return "." + (baseName.split(".").pop() ?? "").toLowerCase();
+}
+
+/** Whether the editor can open this path in-app (true for .mdi/.md/.txt). */
+export function isEditableExtension(vfsPath: string): boolean {
+  const ext = extractExtension(vfsPath);
+  // No extension (e.g. a README without suffix) is treated as editable text.
+  if (!ext) return true;
+  return (EDITABLE_EXTENSIONS as readonly string[]).includes(ext);
+}
+
+/**
+ * Resolve a VFS path to a native absolute path for `shell.openPath`.
+ *
+ * Already-absolute paths (POSIX `/…` or Windows `C:\…`) pass through; relative
+ * paths are joined onto `rootPath`. Returns null when a relative path cannot be
+ * resolved (no open root), so the caller can fall back to the normal read path.
+ */
+export function resolveNativePath(vfsPath: string, rootPath: string | null): string | null {
+  if (vfsPath.startsWith("/") || /^[a-zA-Z]:[/\\]/.test(vfsPath)) {
+    return vfsPath;
+  }
+  return rootPath ? rootPath + "/" + vfsPath : null;
+}

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -16,6 +16,7 @@ import { suppressFileWatch } from "../services/file-watcher";
 import type { TabId, EditorTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
 import { generateTabId, inferFileType, sanitizeMdiContent, getErrorMessage } from "./types";
+import { isEditableExtension, resolveNativePath } from "./open-with-default-app";
 import type { TabManagerCore } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -540,6 +541,28 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         return;
       }
       openingPathsRef.current.set(vfsPath, preview);
+
+      // Unsupported extensions open with the OS default app instead of the editor.
+      // The editor only handles .mdi / .md / .txt; anything else (e.g. .docx, .pdf,
+      // .gdoc) is delegated to shell.openPath via the open-with-default-app IPC.
+      const baseName = vfsPath.split("/").pop() || vfsPath;
+      if (!isEditableExtension(vfsPath) && window.electronAPI?.openWithDefaultApp) {
+        const rootPath = getProjectFileService().getRootPath?.() ?? null;
+        const nativePath = resolveNativePath(vfsPath, rootPath);
+        if (nativePath) {
+          try {
+            const opened = await window.electronAPI.openWithDefaultApp(nativePath);
+            if (opened) {
+              notificationManager.info(`${baseName} をシステムのデフォルトアプリで開きます`);
+            } else {
+              notificationManager.error(`ファイルを開けませんでした: ${baseName}`);
+            }
+          } finally {
+            openingPathsRef.current.delete(vfsPath);
+          }
+          return;
+        }
+      }
 
       try {
         // Read file from VFS

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -67,6 +67,7 @@ declare global {
     updateKeymapOverrides?: (overrides: KeymapOverrides) => Promise<boolean>;
     showInFileManager?: (dirPath: string) => Promise<boolean>;
     revealInFileManager?: (filePath: string) => Promise<boolean>;
+    openWithDefaultApp?: (filePath: string) => Promise<boolean>;
     openExternal?: (url: string) => Promise<boolean>;
     onMenuShowInFileManager?: (callback: () => void) => (() => void) | void;
     onPasteAsPlaintext?: (callback: () => void) => (() => void) | void;


### PR DESCRIPTION
## Summary
ロールバックされた PR #1426 (元 #1412) を再実装。VFS エクスプローラで非対応拡張子 (.docx / .pdf / .gdoc 等) をクリックすると `vfs.readFile` でエラーになっていたのを、OS 既定アプリで開くよう委譲。

## 変更
- `electron/ipc/shell-ipc.js`: `open-with-default-app` ハンドラ (`shell.openPath`)。相対パス・`..` traversal を拒否。
- `electron/preload.js` + `types/electron.d.ts`: `openWithDefaultApp` を公開。
- `lib/tab-manager/open-with-default-app.ts`: 拡張子ゲート + ネイティブパス解決の純粋関数（editor は .mdi/.md/.txt のみ処理）。
- `use-file-io.ts`: `openProjectFile` が readFile 前に非対応拡張子を捕捉し、ネイティブパス解決後に成功/失敗通知。Web モード (electronAPI なし) は従来の read 経路に素通り。
- 拡張子ゲート + パス解決の unit test。

## Test
- `npx vitest run lib/tab-manager/__tests__/open-with-default-app.test.ts` → 9 passed
- `npx tsc --noEmit` → clean

Closes #1465

🤖 Generated with [Claude Code](https://claude.com/claude-code)