### PR TITLE
perf(lint): move L1 rule execution into a Web Worker

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -19,7 +19,8 @@ import { buildSegments, buildSpeechChunks, buildSpeechMap } from "@/lib/hooks/sp
 import { scrollToSpeechTarget, cancelSpeechScroll } from "@/lib/editor-page/speech-auto-scroll";
 import { useSelectionTracking } from "@/lib/editor-page/use-selection-tracking";
 import { localPreferences } from "@/lib/storage/local-preferences";
-import type { RuleRunner, LintIssue } from "@/lib/linting";
+import type { LintIssue } from "@/lib/linting";
+import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import { useTypographySettings, useSpeechSettings } from "@/contexts/EditorSettingsContext";
 import { useCharWidth, MEASURE_TEXT } from "@/lib/editor-page/use-char-width";
 
@@ -34,7 +35,7 @@ interface EditorProps {
   onEditorViewReady?: (view: EditorView) => void;
   onShowAllSearchResults?: (matches: SearchMatch[], searchTerm: string) => void;
   // リンティング設定
-  lintingRuleRunner?: RuleRunner | null;
+  lintingRuleRunner?: RuleRunnerLike | null;
   onLintIssuesUpdated?: (issues: LintIssue[]) => void;
   onNlpError?: (error: Error) => void;
   // 音声設定を開くコールバック

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -46,7 +46,7 @@ import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { DocxExportSettings } from "@/lib/export/docx-export-settings";
 import type { EpubExportOptions } from "@/lib/export/epub-shared";
 import type { ExportMetadata } from "@/lib/export/types";
-import type { RuleRunner } from "@/lib/linting/rule-runner";
+import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import { DockviewReact } from "dockview-react";
 type SidebarPanelSharedProps = Omit<React.ComponentProps<typeof SidebarPanel>, "view">;
 
@@ -163,7 +163,7 @@ interface EditorLayoutProps {
     handleShowAllSearchResults: NonNullable<
       React.ComponentProps<typeof NovelEditor>["onShowAllSearchResults"]
     >;
-    ruleRunner: RuleRunner;
+    ruleRunner: RuleRunnerLike | null;
     handleLintIssuesUpdated: (issues: LintIssue[]) => void;
     handleNlpError: (error: Error) => void;
     handleOpenRubyDialog: () => void;

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -38,7 +38,8 @@ import {
   getScrollProgress,
   setScrollProgress,
 } from "@/packages/milkdown-plugin-japanese-novel/scroll-progress";
-import type { RuleRunner, LintIssue } from "@/lib/linting";
+import type { LintIssue } from "@/lib/linting";
+import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import {
   useTypographySettings,
   useLintingSettings,
@@ -54,7 +55,7 @@ interface MilkdownEditorProps {
   isVertical: boolean;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   onEditorViewReady?: (view: EditorView) => void;
-  lintingRuleRunner?: RuleRunner | null;
+  lintingRuleRunner?: RuleRunnerLike | null;
   onLintIssuesUpdated?: (issues: LintIssue[]) => void;
   onNlpError?: (error: Error) => void;
   onOpenRubyDialog?: () => void;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,10 @@ const config = [
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "warn",
-      "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
       "@typescript-eslint/no-unused-expressions": "warn",
       "react-hooks/rules-of-hooks": "warn",
       "react-hooks/set-state-in-effect": "warn",

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -1,16 +1,19 @@
 import type { EditorView } from "@milkdown/prose/view";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-import { RuleRunner } from "@/lib/linting/rule-runner";
 import type { LintIssue, Severity } from "@/lib/linting/types";
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
 import { RULE_GUIDELINE_MAP } from "@/lib/linting/lint-presets";
-import { getAllRules, createJsonDrivenRules } from "@/lib/linting/rule-registry";
 import type { CorrectionModeId, GuidelineId } from "@/lib/linting/correction-config";
 import { notificationManager } from "@/lib/services/notification-manager";
+import {
+  RuleRunnerProxy,
+  type RuleRunnerLike,
+} from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 
 export interface UseLintingResult {
-  ruleRunner: RuleRunner;
+  /** May be `null` until the worker has been spun up after mount. */
+  ruleRunner: RuleRunnerLike | null;
   lintIssues: LintIssue[];
   isLinting: boolean;
   handleLintIssuesUpdated: (issues: LintIssue[]) => void;
@@ -31,29 +34,35 @@ export function useLinting(
     { enabled: boolean; severity: Severity; skipDialogue?: boolean }
   >,
   editorViewInstance: EditorView | null,
-  powerSaveMode: boolean = false,
+  // Reserved for future throttling / mode-aware logic; kept in the
+  // signature so callers don't have to be reworked when wired up.
+  _powerSaveMode: boolean = false,
   correctionGuidelines?: GuidelineId[],
-  correctionMode?: CorrectionModeId,
+  _correctionMode?: CorrectionModeId,
 ): UseLintingResult {
-  const ruleRunnerRef = useRef<RuleRunner | null>(null);
+  const [ruleRunner, setRuleRunner] = useState<RuleRunnerLike | null>(null);
   const [lintIssues, setLintIssues] = useState<LintIssue[]>([]);
   const [isLinting, setIsLinting] = useState(false);
 
-  // Lazily create and register all rules once
-  if (!ruleRunnerRef.current) {
-    const runner = new RuleRunner();
-    for (const rule of getAllRules()) runner.registerRule(rule);
-    for (const rule of createJsonDrivenRules()) runner.registerRule(rule);
+  // Build the proxy in an effect so the Worker constructor is never invoked
+  // during SSR. The proxy is held in state so its `null → ready` transition
+  // triggers a rerender that propagates the ruleRunner into the editor.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const proxy = new RuleRunnerProxy();
+    proxy.setGuidelineMap(RULE_GUIDELINE_MAP);
+    setRuleRunner(proxy);
+    return () => {
+      // Don't `setRuleRunner(null)` here — StrictMode's mount → cleanup
+      // → mount cycle would briefly nullify the runner between the two
+      // mounts, causing dependent effects to re-run with `null` for no
+      // reason. On real unmount the component is going away, so the
+      // state write is wasted either way.
+      proxy.dispose();
+    };
+  }, []);
 
-    runner.setGuidelineMap(RULE_GUIDELINE_MAP);
-
-    ruleRunnerRef.current = runner;
-  }
-
-  // Guaranteed non-null after the lazy initialization block above
-  const ruleRunner = ruleRunnerRef.current!;
-
-  // Sync rule configs from settings to RuleRunner
+  // Sync rule configs from settings to the runner
   useEffect(() => {
     if (!ruleRunner) return;
 
@@ -94,11 +103,7 @@ export function useLinting(
     if (editorViewInstance && lintingEnabled) {
       import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
         .then(({ updateLintingSettings }) => {
-          updateLintingSettings(
-            editorViewInstance,
-            { ruleRunner: ruleRunnerRef.current },
-            "guideline-change",
-          );
+          updateLintingSettings(editorViewInstance, { ruleRunner }, "guideline-change");
         })
         .catch((err) => {
           console.error("[useLinting] Failed to sync guidelines:", err);
@@ -106,26 +111,30 @@ export function useLinting(
     }
   }, [ruleRunner, correctionGuidelines, editorViewInstance, lintingEnabled]);
 
-  // Clear issues when linting is disabled
+  // Clear issues + spinner when linting is disabled. `isLinting` must be
+  // reset here because `handleLintIssuesUpdated` short-circuits while
+  // disabled, so a refresh that was in flight when the user toggled
+  // linting off would otherwise leave the loading state stuck on.
   useEffect(() => {
     if (!lintingEnabled) {
       setLintIssues([]);
+      setIsLinting(false);
     }
   }, [lintingEnabled]);
 
   // Force re-run linting on the full document (not just visible paragraphs)
   const refreshLinting = useCallback(() => {
-    if (!editorViewInstance || !lintingEnabled) return;
+    if (!editorViewInstance || !lintingEnabled || !ruleRunner) return;
 
     setIsLinting(true);
     import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
       .then(({ updateLintingSettings }) => {
-        const nlpClient = ruleRunnerRef.current?.hasMorphologicalRules() ? getNlpClient() : null;
+        const nlpClient = ruleRunner.hasMorphologicalRules() ? getNlpClient() : null;
 
         updateLintingSettings(
           editorViewInstance,
           {
-            ruleRunner: ruleRunnerRef.current,
+            ruleRunner,
             nlpClient,
           },
           "manual-refresh",
@@ -135,7 +144,7 @@ export function useLinting(
         console.error("[useLinting] Failed to refresh linting:", err);
         setIsLinting(false);
       });
-  }, [editorViewInstance, lintingEnabled]);
+  }, [editorViewInstance, lintingEnabled, ruleRunner]);
 
   return {
     ruleRunner,

--- a/lib/linting/rule-runner.ts
+++ b/lib/linting/rule-runner.ts
@@ -199,6 +199,18 @@ export class RuleRunner {
     return false;
   }
 
+  /** Check if any enabled rule is a document-level morphological rule. */
+  hasMorphologicalDocumentRules(): boolean {
+    for (const rule of this.rules.values()) {
+      const config = this.configs.get(rule.id);
+      if (!config?.enabled) continue;
+      if (isMorphologicalDocumentLintRule(rule)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   /**
    * Returns all rules for the given engine type.
    * Engine field acts as implementation metadata, not architectural boundary.

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -9,14 +9,20 @@
 import { Plugin, PluginKey } from "@milkdown/prose/state";
 import { Decoration, DecorationSet } from "@milkdown/prose/view";
 import type { EditorView } from "@milkdown/prose/view";
-import type { RuleRunner, LintIssue, Severity } from "@/lib/linting";
+import type { LintIssue, Severity } from "@/lib/linting";
 import type { INlpClient } from "@/lib/nlp-client/types";
 import type { Token } from "@/lib/nlp-client/types";
 import type { IgnoredCorrection } from "@/lib/project/project-types";
 import { LRUCache } from "@/lib/utils/lru-cache";
 import { hashString } from "@/lib/utils/hash-string";
 import { getAtomOffset, collectParagraphs } from "../shared/paragraph-helpers";
-import type { LintingPluginState, LintingPluginOptions, LintingSettingsUpdate } from "./types";
+import type {
+  LintingPluginState,
+  LintingPluginOptions,
+  LintingSettingsUpdate,
+  RuleRunnerLike,
+} from "./types";
+import { isSilentCancelError } from "./worker/protocol";
 
 export const lintingKey = new PluginKey<LintingPluginState>("linting");
 
@@ -60,7 +66,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
   let processingVersion = 0;
 
   // Current ruleRunner reference (updated dynamically via setMeta)
-  let currentRuleRunner: RuleRunner | null = ruleRunner;
+  let currentRuleRunner: RuleRunnerLike | null = ruleRunner;
 
   // Current NLP client reference (updated dynamically via setMeta)
   let currentNlpClient: INlpClient | null = nlpClient ?? null;
@@ -147,6 +153,8 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
                 tokenCache.clear();
                 documentIssueCache = null;
                 pendingFullScan = true;
+                // Drop any in-flight worker batch — its results would be stale.
+                currentRuleRunner?.cancelInFlight();
                 break;
               case "rule-config-change":
               case "guideline-change":
@@ -154,6 +162,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
                 issueCache.clear();
                 documentIssueCache = null;
                 pendingFullScan = true;
+                currentRuleRunner?.cancelInFlight();
                 break;
               case "text-edit":
                 // Re-run affected paragraphs only (handled via normal doc-changed path)
@@ -166,6 +175,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
             tokenCache.clear();
             documentIssueCache = null;
             pendingFullScan = true;
+            currentRuleRunner?.cancelInFlight();
           }
           // Update ignoredCorrections list if provided
           if ("ignoredCorrections" in meta) {
@@ -176,6 +186,11 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
             issueCache.clear();
             tokenCache.clear();
             documentIssueCache = null;
+            // Bump the version so any in-flight async tokenization /
+            // runBatch awaits bail at their next `version !==
+            // processingVersion` check, preventing decorations from
+            // being repopulated after the user disabled linting.
+            processingVersion++;
           }
           const updated: LintingPluginState = {
             decorations: pluginState.decorations,
@@ -184,6 +199,8 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           // Clear decorations when disabled
           if (meta.enabled === false) {
             updated.decorations = DecorationSet.empty;
+            // Stop any in-flight worker batch — we no longer want its results.
+            currentRuleRunner?.cancelInFlight();
           }
           return updated;
         }
@@ -235,89 +252,114 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           const hasMorphRules = currentRuleRunner.hasMorphologicalRules();
           const nlp = currentNlpClient;
 
-          // Process uncached paragraphs (per-paragraph rules)
+          // Tokenize the paragraphs that morphological rules need.
+          // Tokenization stays on the main thread because the NLP client
+          // depends on `window.electronAPI.nlp.*` (Worker-unreachable).
+          //
+          // We tokenize uncached paragraphs eagerly. For paragraphs that
+          // are cached for per-paragraph rules but still needed for
+          // document-level morph rules, we look up tokenCache and
+          // tokenize the misses.
+          const useTokens = hasMorphRules && nlp && !nlpErrorFired;
+          const tokensByText = new Map<string, ReadonlyArray<Token>>();
+
+          async function tokenizeIfNeeded(text: string): Promise<ReadonlyArray<Token> | undefined> {
+            // Re-check `nlpErrorFired` on every call so the first failure
+            // in a batch short-circuits the rest — otherwise a long doc
+            // with a broken NLP backend incurs one failed IPC per paragraph.
+            if (!useTokens || nlpErrorFired) return undefined;
+            const cached = tokenCache.get(text);
+            if (cached) return cached;
+            try {
+              const fresh = await nlp!.tokenizeParagraph(text);
+              tokenCache.set(text, fresh);
+              return fresh;
+            } catch (err) {
+              const error = err instanceof Error ? err : new Error(String(err));
+              console.error("[Linting] NLP tokenization failed — L2 rules disabled:", error);
+              if (!nlpErrorFired) {
+                nlpErrorFired = true;
+                onNlpError?.(error);
+              }
+              return undefined;
+            }
+          }
+
+          // Find paragraphs that need fresh per-paragraph rule execution.
           const uncachedParagraphs = targetParagraphs.filter((p) => !issueCache.has(p.text));
 
-          if (uncachedParagraphs.length > 0) {
-            for (const paragraph of uncachedParagraphs) {
-              if (version !== processingVersion) return;
+          // Per-paragraph morph rules need tokens for uncached paragraphs only
+          // (cached results are reused). Document-level morph rules need tokens
+          // for the full document. Pre-tokenize the union — the second case is
+          // skipped when no document-level morph rule is enabled, avoiding a
+          // full-document NLP sweep on every keystroke.
+          const allTokenTexts = new Set<string>();
+          for (const p of uncachedParagraphs) allTokenTexts.add(p.text);
+          if (currentRuleRunner.hasMorphologicalDocumentRules()) {
+            for (const p of allParagraphs) allTokenTexts.add(p.text);
+          }
+          for (const text of allTokenTexts) {
+            if (version !== processingVersion) return;
+            const tokens = await tokenizeIfNeeded(text);
+            if (tokens) tokensByText.set(text, tokens);
+          }
 
-              let issues: LintIssue[];
-              if (hasMorphRules && nlp && !nlpErrorFired) {
-                // Get or compute tokens for L2 rules
-                let tokens = tokenCache.get(paragraph.text);
-                if (!tokens) {
-                  try {
-                    tokens = await nlp.tokenizeParagraph(paragraph.text);
-                    tokenCache.set(paragraph.text, tokens);
-                  } catch (err) {
-                    const error = err instanceof Error ? err : new Error(String(err));
-                    console.error("[Linting] NLP tokenization failed — L2 rules disabled:", error);
-                    // Fire the error callback once per failure episode
-                    if (!nlpErrorFired) {
-                      nlpErrorFired = true;
-                      onNlpError?.(error);
-                    }
-                    // Fall back to L1-only rules (no tokens)
-                    issues = currentRuleRunner.runAll(paragraph.text);
-                    issueCache.set(paragraph.text, issues);
-                    continue;
-                  }
-                }
-                issues = currentRuleRunner.runAllWithTokens(paragraph.text, tokens);
-              } else {
-                // No NLP available or NLP has failed — run L1 rules only
-                issues = currentRuleRunner.runAll(paragraph.text);
+          if (version !== processingVersion) return;
+
+          // Build the per-paragraph batch (uncached only). The runner
+          // will route through the worker for L1 + main thread for L2
+          // morph; results merge transparently.
+          //
+          // On a real (non-cancellation) error we log and fall through
+          // rather than `return`-ing — otherwise the failure leaves
+          // `isLinting` stuck because `onIssuesUpdated` is never called
+          // and the "全文を再検査" control sticks in its loading state.
+          if (uncachedParagraphs.length > 0) {
+            const perParaInputs = uncachedParagraphs.map((p) => ({
+              text: p.text,
+              index: p.index,
+              tokens: tokensByText.get(p.text),
+            }));
+            try {
+              const resp = await currentRuleRunner.runBatch({
+                paragraphs: perParaInputs,
+                mode: "per-paragraph",
+                version,
+              });
+              if (version !== processingVersion) return;
+              for (const p of uncachedParagraphs) {
+                const issues = resp.perParagraph.get(p.index) ?? [];
+                issueCache.set(p.text, issues);
               }
-              issueCache.set(paragraph.text, issues);
+            } catch (err) {
+              if (isSilentCancelError(err)) return;
+              console.error("[Linting] per-paragraph runBatch failed:", err);
+              // Fall through with cached results so isLinting clears.
             }
           }
 
           if (version !== processingVersion) return;
 
-          // Run document-level rules on all paragraphs (always recompute)
-          // Document-level rules are fast (L1/L2) so recomputing is acceptable
+          // Document-level rules always re-run against all paragraphs.
           documentIssueCache = null;
           if (currentRuleRunner.hasDocumentRules()) {
-            if (hasMorphRules && nlp && !nlpErrorFired) {
-              // Tokenize all paragraphs for morphological document rules (use cache where possible)
-              const paragraphsWithTokens = [];
-              let docNlpFailed = false;
-              for (const p of allParagraphs) {
-                if (version !== processingVersion) return;
-                let tokens = tokenCache.get(p.text);
-                if (!tokens) {
-                  try {
-                    tokens = await nlp.tokenizeParagraph(p.text);
-                    tokenCache.set(p.text, tokens);
-                  } catch (err) {
-                    const error = err instanceof Error ? err : new Error(String(err));
-                    console.error(
-                      "[Linting] NLP tokenization failed during document rules — L2 rules disabled:",
-                      error,
-                    );
-                    if (!nlpErrorFired) {
-                      nlpErrorFired = true;
-                      onNlpError?.(error);
-                    }
-                    docNlpFailed = true;
-                    break;
-                  }
-                }
-                paragraphsWithTokens.push({ text: p.text, index: p.index, tokens });
-              }
-              if (!docNlpFailed) {
-                documentIssueCache = currentRuleRunner.runDocumentWithTokens(paragraphsWithTokens);
-              } else {
-                // Fall back to L1-only document rules
-                documentIssueCache = currentRuleRunner.runDocument(
-                  allParagraphs.map((p) => ({ text: p.text, index: p.index })),
-                );
-              }
-            } else {
-              documentIssueCache = currentRuleRunner.runDocument(
-                allParagraphs.map((p) => ({ text: p.text, index: p.index })),
-              );
+            const docInputs = allParagraphs.map((p) => ({
+              text: p.text,
+              index: p.index,
+              tokens: tokensByText.get(p.text),
+            }));
+            try {
+              const resp = await currentRuleRunner.runBatch({
+                paragraphs: docInputs,
+                mode: "document",
+                version,
+              });
+              if (version !== processingVersion) return;
+              documentIssueCache = resp.document;
+            } catch (err) {
+              if (isSilentCancelError(err)) return;
+              console.error("[Linting] document runBatch failed:", err);
+              // Fall through with documentIssueCache=null so isLinting clears.
             }
           }
 

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
@@ -5,21 +5,24 @@
 
 import type { EditorView } from "@milkdown/prose/view";
 import { $prose } from "@milkdown/utils";
-import type { RuleRunner, LintIssue } from "@/lib/linting";
+import type { LintIssue } from "@/lib/linting";
 import type { INlpClient } from "@/lib/nlp-client/types";
 import type { IgnoredCorrection } from "@/lib/project/project-types";
 import type { ConfigChangeReason } from "@/lib/linting/correction-config";
-import type { LintingSettingsUpdate } from "./types";
+import type { LintingSettingsUpdate, RuleRunnerLike } from "./types";
 import { createLintingPlugin, lintingKey } from "./decoration-plugin";
 
 // Export the plugin key for external use
 export { lintingKey } from "./decoration-plugin";
+export type { RuleRunnerLike } from "./types";
+export { RuleRunnerProxy } from "./worker/rule-runner-proxy";
+export { WorkerStaleError, WorkerDisposedError, isSilentCancelError } from "./worker/protocol";
 
 export interface LintingOptions {
   /** Enable/disable linting - 有効/無効 */
   enabled?: boolean;
-  /** RuleRunner instance for executing lint rules */
-  ruleRunner?: RuleRunner | null;
+  /** RuleRunner-like instance (typically `RuleRunnerProxy`) for executing lint rules. */
+  ruleRunner?: RuleRunnerLike | null;
   /** NLP client for morphological analysis (L2 rules) */
   nlpClient?: INlpClient | null;
   /** Ignored corrections to filter out from decorations */

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
@@ -5,19 +5,20 @@
 
 import type { DecorationSet } from "@milkdown/prose/view";
 import type { LintIssue } from "@/lib/linting";
-import type { RuleRunner } from "@/lib/linting";
 import type { INlpClient } from "@/lib/nlp-client/types";
 import type { IgnoredCorrection } from "@/lib/project/project-types";
 import type { ConfigChangeReason } from "@/lib/linting/correction-config";
+import type { RuleRunnerLike } from "./worker/protocol";
 
 export type { ConfigChangeReason };
+export type { RuleRunnerLike };
 
 /**
  * Options for the linting ProseMirror plugin
  */
 export interface LintingPluginOptions {
   enabled: boolean;
-  ruleRunner: RuleRunner | null;
+  ruleRunner: RuleRunnerLike | null;
   nlpClient?: INlpClient | null;
   ignoredCorrections?: IgnoredCorrection[];
   onIssuesUpdated?: (issues: LintIssue[]) => void;
@@ -41,7 +42,7 @@ export interface LintingPluginState {
  */
 export interface LintingSettingsUpdate {
   enabled?: boolean;
-  ruleRunner?: RuleRunner | null;
+  ruleRunner?: RuleRunnerLike | null;
   nlpClient?: INlpClient | null;
   /** @deprecated Use changeReason instead */
   forceFullScan?: boolean;

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for `RuleRunnerProxy`.
+ *
+ * Mocks the `Worker` constructor and drives the proxy synchronously
+ * through fake post-message events. Exercises the round-trip,
+ * stale-by-version filtering, `cancelInFlight`, and the
+ * dispose-before-READY path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { RuleRunnerProxy } from "../rule-runner-proxy";
+import {
+  type WorkerEvent,
+  type WorkerRequest,
+  WorkerDisposedError,
+  WorkerStaleError,
+} from "../protocol";
+import type { LintIssue } from "@/lib/linting/types";
+
+// ----------------------------------------------------------------
+// Fake Worker
+// ----------------------------------------------------------------
+
+class FakeWorker {
+  onmessage: ((e: MessageEvent<WorkerEvent>) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  onmessageerror: (() => void) | null = null;
+  /** All messages the proxy has posted into the worker, in order. */
+  readonly received: WorkerRequest[] = [];
+  terminated = false;
+
+  postMessage(msg: WorkerRequest): void {
+    this.received.push(msg);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  /** Helper for tests: deliver a fake event to the proxy. */
+  emit(evt: WorkerEvent): void {
+    this.onmessage?.(new MessageEvent("message", { data: evt }));
+  }
+}
+
+let fakeWorker: FakeWorker;
+
+beforeEach(() => {
+  fakeWorker = new FakeWorker();
+});
+
+afterEach(() => {
+  fakeWorker.terminate();
+});
+
+function makeProxy(): RuleRunnerProxy {
+  return new RuleRunnerProxy(() => fakeWorker as unknown as Worker);
+}
+
+function emitReady(): void {
+  fakeWorker.emit({ type: "READY" });
+}
+
+function fakeIssue(ruleId: string, from = 0, to = 1): LintIssue {
+  return {
+    ruleId,
+    severity: "warning",
+    message: "test",
+    messageJa: "テスト",
+    from,
+    to,
+  };
+}
+
+// ----------------------------------------------------------------
+// Tests
+// ----------------------------------------------------------------
+
+describe("RuleRunnerProxy", () => {
+  it("buffers config messages until READY, then flushes them", () => {
+    const proxy = makeProxy();
+    proxy.setConfig("rule-x", { enabled: true, severity: "warning" });
+    expect(fakeWorker.received).toHaveLength(0);
+    emitReady();
+    expect(fakeWorker.received).toHaveLength(1);
+    expect(fakeWorker.received[0].type).toBe("SET_CONFIG");
+    proxy.dispose();
+  });
+
+  it("round-trips a runBatch request and resolves with worker issues", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    const promise = proxy.runBatch({
+      paragraphs: [{ text: "hello", index: 0 }],
+      mode: "per-paragraph",
+      version: 1,
+    });
+
+    // Worker message was posted with mode = per-paragraph.
+    const sentRunBatch = fakeWorker.received.find((m) => m.type === "RUN_BATCH");
+    expect(sentRunBatch).toBeDefined();
+    expect(sentRunBatch?.type === "RUN_BATCH" && sentRunBatch.mode).toBe("per-paragraph");
+
+    // Worker replies.
+    const correlationId = sentRunBatch?.type === "RUN_BATCH" ? sentRunBatch.correlationId : -1;
+    fakeWorker.emit({
+      type: "RESPONSE",
+      correlationId,
+      version: 1,
+      perParagraph: [[0, [fakeIssue("rule-a")]]],
+      document: [],
+    });
+
+    const resp = await promise;
+    expect(resp.perParagraph.get(0)).toEqual([fakeIssue("rule-a")]);
+    expect(resp.document.size).toBe(0);
+
+    proxy.dispose();
+  });
+
+  it("rejects stale-by-version responses with WorkerStaleError", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    // Start version 1, then version 2 — version 1's pending entry should
+    // be cancelled eagerly when v2 arrives.
+    const v1Promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+    const v2Promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 2 })
+      .catch((e) => e);
+
+    // v1 should already be rejected (eager cancel).
+    const v1 = await v1Promise;
+    expect(v1).toBeInstanceOf(WorkerStaleError);
+
+    // v2 is still pending; deliver its response.
+    const v2BatchMsg = fakeWorker.received.filter(
+      (m) => m.type === "RUN_BATCH" && m.version === 2,
+    )[0];
+    if (v2BatchMsg?.type !== "RUN_BATCH") throw new Error("unreachable");
+    fakeWorker.emit({
+      type: "RESPONSE",
+      correlationId: v2BatchMsg.correlationId,
+      version: 2,
+      perParagraph: [],
+      document: [],
+    });
+
+    const v2 = await v2Promise;
+    expect(v2 instanceof Error).toBe(false); // resolved, not rejected
+    proxy.dispose();
+  });
+
+  it("cancelInFlight rejects all pending with WorkerStaleError but keeps the worker alive", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    const promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+
+    proxy.cancelInFlight();
+    const result = await promise;
+    expect(result).toBeInstanceOf(WorkerStaleError);
+    expect(fakeWorker.terminated).toBe(false);
+
+    // Subsequent runBatch should still work.
+    const next = proxy.runBatch({ paragraphs: [], mode: "per-paragraph", version: 2 });
+    const batchMsg = fakeWorker.received.find((m) => m.type === "RUN_BATCH" && m.version === 2);
+    if (batchMsg?.type !== "RUN_BATCH") throw new Error("unreachable");
+    fakeWorker.emit({
+      type: "RESPONSE",
+      correlationId: batchMsg.correlationId,
+      version: 2,
+      perParagraph: [],
+      document: [],
+    });
+    await expect(next).resolves.toBeDefined();
+    proxy.dispose();
+  });
+
+  it("dispose-before-READY rejects pending runBatch with WorkerDisposedError", async () => {
+    const proxy = makeProxy();
+    // Don't emit READY.
+    const promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+
+    proxy.dispose();
+    const result = await promise;
+    expect(result).toBeInstanceOf(WorkerDisposedError);
+    expect(fakeWorker.terminated).toBe(true);
+  });
+
+  it("cancelInFlight while runBatch is awaiting READY rejects the batch and never posts to the worker", async () => {
+    const proxy = makeProxy();
+    // Do NOT emit READY — runBatch should park its pending entry while
+    // awaiting the readyPromise.
+    const promise = proxy
+      .runBatch({
+        paragraphs: [{ text: "x", index: 0 }],
+        mode: "per-paragraph",
+        version: 1,
+      })
+      .catch((e) => e);
+
+    // Cancel before the worker is ready. The pending entry must already
+    // exist — otherwise cancelInFlight has nothing to reject.
+    proxy.cancelInFlight();
+
+    // Now flush READY. The proxy must NOT post the cancelled batch to
+    // the worker.
+    emitReady();
+    // Yield once so any post-await microtasks settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const result = await promise;
+    expect(result).toBeInstanceOf(WorkerStaleError);
+    const sentBatches = fakeWorker.received.filter((m) => m.type === "RUN_BATCH");
+    expect(sentBatches).toHaveLength(0);
+
+    proxy.dispose();
+  });
+
+  it("uncorrelated ERROR before READY rejects readyPromise so subsequent runBatch fails fast instead of hanging", async () => {
+    const proxy = makeProxy();
+    // Do NOT emit READY. Send an uncorrelated ERROR (worker startup
+    // failed before posting READY).
+    fakeWorker.emit({
+      type: "ERROR",
+      error: { name: "WorkerError", message: "init failed" },
+    });
+
+    // The proxy is now in a poisoned state. Any new runBatch must
+    // reject promptly via the rejected readyPromise rather than hang.
+    const next = await proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+    expect(next).toBeInstanceOf(Error);
+    expect((next as Error).message).toBe("init failed");
+
+    proxy.dispose();
+  });
+
+  it("uncorrelated ERROR after READY poisons the proxy so subsequent runBatch fails fast", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    fakeWorker.emit({
+      type: "ERROR",
+      error: { name: "WorkerError", message: "post-ready boom" },
+    });
+
+    const next = await proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+    expect(next).toBeInstanceOf(Error);
+    expect((next as Error).message).toBe("post-ready boom");
+    // poison() terminates the worker.
+    expect(fakeWorker.terminated).toBe(true);
+
+    proxy.dispose();
+  });
+
+  it("worker.onerror poisons the proxy so subsequent runBatch fails fast", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    // Simulate the underlying Worker emitting an `error` event.
+    fakeWorker.onerror?.(new ErrorEvent("error", { message: "worker crashed" }));
+
+    const next = await proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+    expect(next).toBeInstanceOf(Error);
+    expect((next as Error).message).toBe("worker crashed");
+    expect(fakeWorker.terminated).toBe(true);
+
+    proxy.dispose();
+  });
+
+  it("propagates worker ERROR with correlationId to the matching pending request", async () => {
+    const proxy = makeProxy();
+    emitReady();
+
+    const promise = proxy
+      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
+      .catch((e) => e);
+
+    const batchMsg = fakeWorker.received.find((m) => m.type === "RUN_BATCH");
+    if (batchMsg?.type !== "RUN_BATCH") throw new Error("unreachable");
+    fakeWorker.emit({
+      type: "ERROR",
+      correlationId: batchMsg.correlationId,
+      error: { name: "RuleError", message: "boom" },
+    });
+
+    const err = await promise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).name).toBe("RuleError");
+    expect((err as Error).message).toBe("boom");
+    proxy.dispose();
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
@@ -1,0 +1,117 @@
+/// <reference lib="webworker" />
+
+/**
+ * Lint Web Worker entry point.
+ *
+ * Hosts only non-morphological rules (the JSON L1 set). Morphological
+ * rules stay on the main thread because their dependencies
+ * (`window.electronAPI.dict.*` via `genjiVocab`) are unreachable here.
+ *
+ * See plan: docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md
+ */
+
+import { RuleRunner } from "@/lib/linting/rule-runner";
+import { createJsonDrivenRules } from "@/lib/linting/rule-registry";
+import { RULE_GUIDELINE_MAP } from "@/lib/linting/lint-presets";
+import type { LintIssue } from "@/lib/linting/types";
+import { isMorphologicalDocumentLintRule, isMorphologicalLintRule } from "@/lib/linting/types";
+
+import type { SerializedIssueMap, WorkerEvent, WorkerRequest } from "./protocol";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+// Module scope acts as the worker singleton — Workers never re-instantiate.
+const runner = new RuleRunner();
+
+for (const rule of createJsonDrivenRules()) {
+  if (isMorphologicalLintRule(rule) || isMorphologicalDocumentLintRule(rule)) {
+    // Defensive: morph rules have IPC-only dependencies, skip if any sneak in.
+    continue;
+  }
+  runner.registerRule(rule);
+}
+
+runner.setGuidelineMap(RULE_GUIDELINE_MAP);
+
+function post(msg: WorkerEvent): void {
+  self.postMessage(msg);
+}
+
+function serialize(map: Map<number, LintIssue[]>): SerializedIssueMap {
+  // Drop empty entries — the main thread treats missing keys as "no
+  // issues", and skipping them keeps the structured-clone payload small
+  // for long documents.
+  const entries: SerializedIssueMap = [];
+  map.forEach((issues, idx) => {
+    if (issues.length > 0) entries.push([idx, issues]);
+  });
+  return entries;
+}
+
+self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  const msg = event.data;
+  try {
+    switch (msg.type) {
+      case "SET_CONFIG":
+        runner.setConfig(msg.ruleId, msg.config);
+        return;
+      case "SET_ACTIVE_GUIDELINES":
+        runner.setActiveGuidelines(msg.guidelines);
+        return;
+      case "SET_GUIDELINE_MAP":
+        runner.setGuidelineMap(new Map(msg.entries));
+        return;
+      case "RUN_BATCH": {
+        const { correlationId, version, paragraphs, mode } = msg;
+        const perParagraph = new Map<number, LintIssue[]>();
+        const runPer = mode === "per-paragraph" || mode === "both";
+        const runDoc = mode === "document" || mode === "both";
+
+        if (runPer) {
+          for (const p of paragraphs) {
+            const issues = runner.runAll(p.text);
+            if (issues.length > 0) perParagraph.set(p.index, issues);
+          }
+        }
+        const documentMap: Map<number, LintIssue[]> =
+          runDoc && runner.hasDocumentRules() ? runner.runDocument(paragraphs) : new Map();
+
+        post({
+          type: "RESPONSE",
+          correlationId,
+          version,
+          perParagraph: serialize(perParagraph),
+          document: serialize(documentMap),
+        });
+        return;
+      }
+      default: {
+        const _exhaustive: never = msg;
+        void _exhaustive;
+      }
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    post({
+      type: "ERROR",
+      correlationId: "correlationId" in msg ? msg.correlationId : undefined,
+      error: { name: error.name, message: error.message },
+    });
+  }
+};
+
+self.onerror = (e) => {
+  // Surface any uncaught script-level error. correlationId omitted because
+  // there's no specific request to attribute it to.
+  const error = e instanceof ErrorEvent ? e.error : null;
+  post({
+    type: "ERROR",
+    error: error
+      ? { name: error.name ?? "Error", message: error.message ?? String(e) }
+      : { name: "Error", message: String(e) },
+  });
+};
+
+// Signal readiness — must happen after the runner is fully wired so that
+// any queued main-thread requests find an initialized registry.
+post({ type: "READY" });

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts
@@ -1,0 +1,178 @@
+/**
+ * Worker protocol — types shared between the main thread and the lint
+ * Web Worker.
+ *
+ * The worker hosts only non-morphological rules (the JSON L1 set);
+ * morphological rules stay on the main thread (see plan
+ * docs/superpowers/plans/2026-05-05-lint-worker-parallelization.md,
+ * Architecture decision 9).
+ */
+
+import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
+import type { Token } from "@/lib/nlp-client/types";
+
+// -------------------------------------------------------------------------
+// Plugin-facing surface
+// -------------------------------------------------------------------------
+
+/**
+ * Subset of `RuleRunner` used by the linting ProseMirror plugin.
+ * The proxy implements this with a worker behind it; tests can swap in
+ * a fake. Sync metadata methods stay sync; rule execution becomes async.
+ */
+export interface RuleRunnerLike {
+  setConfig(ruleId: string, config: LintRuleConfig): void;
+  setActiveGuidelines(guidelines: string[] | null): void;
+  setGuidelineMap(map: Map<string, string | undefined>): void;
+  hasMorphologicalRules(): boolean;
+  hasDocumentRules(): boolean;
+  /**
+   * True iff at least one enabled document-level rule needs morphological
+   * tokens. Callers use this to decide whether to tokenize cached
+   * paragraphs in addition to the uncached set.
+   */
+  hasMorphologicalDocumentRules(): boolean;
+  /** Execute one batched lint pass. */
+  runBatch(req: RunBatchRequest): Promise<RunBatchResponse>;
+  /**
+   * Reject every in-flight `runBatch` promise with `WorkerStaleError`.
+   * The worker keeps running; subsequent calls succeed normally.
+   */
+  cancelInFlight(): void;
+  /** Terminate the worker; all pending requests reject with `WorkerDisposedError`. */
+  dispose(): void;
+}
+
+// -------------------------------------------------------------------------
+// Run-batch payload
+// -------------------------------------------------------------------------
+
+export interface BatchParagraph {
+  /** Paragraph text (input to L1 regex rules). */
+  text: string;
+  /** Stable index used to key document-level results. */
+  index: number;
+  /**
+   * Pre-computed kuromoji tokens. Only required when the proxy's main-side
+   * morphological rules need them; ignored by the worker (which has no
+   * morphological rules registered).
+   */
+  tokens?: ReadonlyArray<Token>;
+}
+
+/**
+ * What the runner should compute for this batch.
+ *
+ * - `"per-paragraph"`: run only the per-paragraph rules. Caller typically
+ *   supplies the uncached subset.
+ * - `"document"`: run only the document-level rules. Caller typically
+ *   supplies all paragraphs in the document.
+ * - `"both"`: run both passes against the same input. Useful on initial
+ *   load when no cache exists yet.
+ */
+export type BatchMode = "per-paragraph" | "document" | "both";
+
+export interface RunBatchRequest {
+  paragraphs: ReadonlyArray<BatchParagraph>;
+  mode: BatchMode;
+  /** Monotonic version supplied by the caller; the proxy filters stale responses. */
+  version: number;
+  /**
+   * If `false`, skip the worker round-trip. Useful when the caller
+   * wants only main-thread morph results.
+   * Defaults to `true`.
+   */
+  runWorker?: boolean;
+}
+
+export interface RunBatchResponse {
+  /** Issues per paragraph, keyed by `BatchParagraph.index`. */
+  perParagraph: Map<number, LintIssue[]>;
+  /** Document-level issues per paragraph, keyed by `BatchParagraph.index`. */
+  document: Map<number, LintIssue[]>;
+}
+
+// -------------------------------------------------------------------------
+// Wire format
+// -------------------------------------------------------------------------
+
+/**
+ * Serializable form of `runDocument*` results — `Map` does not
+ * structured-clone reliably across all environments, so we send arrays.
+ */
+export type SerializedIssueMap = Array<[number, LintIssue[]]>;
+
+/** Worker → main events. */
+export type WorkerEvent =
+  | { type: "READY" }
+  | {
+      type: "RESPONSE";
+      correlationId: number;
+      version: number;
+      perParagraph: SerializedIssueMap;
+      document: SerializedIssueMap;
+    }
+  | {
+      type: "ERROR";
+      correlationId?: number;
+      error: { name: string; message: string };
+    };
+
+/** Main → worker requests. */
+export type WorkerRequest =
+  | {
+      type: "SET_CONFIG";
+      correlationId: number;
+      ruleId: string;
+      config: LintRuleConfig;
+    }
+  | {
+      type: "SET_ACTIVE_GUIDELINES";
+      correlationId: number;
+      guidelines: string[] | null;
+    }
+  | {
+      type: "SET_GUIDELINE_MAP";
+      correlationId: number;
+      entries: Array<[string, string | undefined]>;
+    }
+  | {
+      type: "RUN_BATCH";
+      correlationId: number;
+      version: number;
+      paragraphs: ReadonlyArray<{ text: string; index: number }>;
+      mode: BatchMode;
+    };
+
+// -------------------------------------------------------------------------
+// Sentinel errors (silent-cancel)
+// -------------------------------------------------------------------------
+
+/**
+ * Thrown when a `runBatch` promise is rejected because a newer request
+ * has superseded it (or `cancelInFlight()` was called). Callers in the
+ * decoration plugin swallow this — no cache write, no decoration dispatch.
+ */
+export class WorkerStaleError extends Error {
+  constructor(message = "Lint batch superseded by a newer request") {
+    super(message);
+    this.name = "WorkerStaleError";
+  }
+}
+
+/**
+ * Thrown when a `runBatch` promise is rejected because the worker has
+ * been terminated (proxy disposed). Treated identically to
+ * `WorkerStaleError` by callers — silent cancel.
+ */
+export class WorkerDisposedError extends Error {
+  constructor(message = "Lint worker has been disposed") {
+    super(message);
+    this.name = "WorkerDisposedError";
+  }
+}
+
+/** True for any silent-cancel sentinel; callers can drop the result. */
+export function isSilentCancelError(err: unknown): boolean {
+  return err instanceof WorkerStaleError || err instanceof WorkerDisposedError;
+}

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
@@ -1,0 +1,449 @@
+/**
+ * Main-thread proxy for the lint Web Worker.
+ *
+ * Hosts a small synchronous `RuleRunner` for morphological (L2) rules
+ * that cannot run in the worker (their `genjiVocab` dependency uses
+ * Electron IPC). The worker handles regex (L1) rules. `runBatch`
+ * presents a unified async API; callers don't see the split.
+ */
+
+import { RuleRunner } from "@/lib/linting/rule-runner";
+import { createJsonDrivenRules, getAllRules } from "@/lib/linting/rule-registry";
+import { RULE_GUIDELINE_MAP } from "@/lib/linting/lint-presets";
+import {
+  isDocumentLintRule,
+  isMorphologicalDocumentLintRule,
+  isMorphologicalLintRule,
+} from "@/lib/linting/types";
+import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
+
+import {
+  WorkerDisposedError,
+  WorkerStaleError,
+  type RuleRunnerLike,
+  type RunBatchRequest,
+  type RunBatchResponse,
+  type SerializedIssueMap,
+  type WorkerEvent,
+  type WorkerRequest,
+} from "./protocol";
+
+interface PendingRequest {
+  resolve: (response: RunBatchResponse) => void;
+  reject: (err: Error) => void;
+  version: number;
+  /** Per-paragraph issues already computed on the main thread (morph rules). */
+  mainPerParagraph: Map<number, LintIssue[]>;
+  /** Document-level issues already computed on the main thread (morph doc rules). */
+  mainDocument: Map<number, LintIssue[]>;
+}
+
+/**
+ * Worker factory. Exposed for tests that want to inject a fake.
+ * The default uses Vite/Webpack's URL-based worker bundling.
+ */
+export type WorkerFactory = () => Worker;
+
+const defaultWorkerFactory: WorkerFactory = () =>
+  new Worker(new URL("./linting.worker.ts", import.meta.url), {
+    type: "module",
+  });
+
+export class RuleRunnerProxy implements RuleRunnerLike {
+  private readonly worker: Worker;
+  private readonly mainRunner: RuleRunner;
+  /** True iff any worker-side rule is a `DocumentLintRule`. Computed at construction. */
+  private readonly workerHasDocumentRules: boolean;
+
+  private nextCorrelationId = 1;
+  private latestRequestedVersion = 0;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly preReadyBuffer: WorkerRequest[] = [];
+
+  private ready = false;
+  private disposed = false;
+  /**
+   * Non-null once the worker has hit a fatal failure (uncorrelated
+   * ERROR, `onerror`, `messageerror`). Set on either the pre-READY or
+   * post-READY path. Once set, the proxy is poisoned: `runBatch` and
+   * other API calls fail fast with this error instead of attempting
+   * to talk to a dead worker.
+   */
+  private fatalError: Error | null = null;
+
+  /** Promise that resolves once the worker has posted READY. */
+  readonly readyPromise: Promise<void>;
+  private resolveReady!: () => void;
+  private rejectReady!: (err: Error) => void;
+
+  constructor(factory: WorkerFactory = defaultWorkerFactory) {
+    // 1. Build the main-side runner with morph rules only.
+    this.mainRunner = new RuleRunner();
+    for (const rule of getAllRules()) {
+      if (isMorphologicalLintRule(rule) || isMorphologicalDocumentLintRule(rule)) {
+        this.mainRunner.registerRule(rule);
+      }
+    }
+    this.mainRunner.setGuidelineMap(RULE_GUIDELINE_MAP);
+
+    // 2. Pre-compute worker capability flags from rule metadata so
+    //    `hasDocumentRules()` can answer synchronously.
+    this.workerHasDocumentRules = createJsonDrivenRules().some(
+      (r) =>
+        isDocumentLintRule(r) && !isMorphologicalLintRule(r) && !isMorphologicalDocumentLintRule(r),
+    );
+
+    // 3. Spin up the worker.
+    this.worker = factory();
+    this.worker.onmessage = (e: MessageEvent<WorkerEvent>) => this.handleEvent(e.data);
+    this.worker.onerror = (e) => this.handleWorkerError(e);
+    this.worker.onmessageerror = () => this.handleWorkerError(new Error("Worker messageerror"));
+
+    this.readyPromise = new Promise<void>((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+    });
+    // Absorb the rejection so a fatal startup failure doesn't surface
+    // as an unhandled rejection when nothing is awaiting `readyPromise`
+    // yet. Real consumers inside `runBatch` chain their own `await`,
+    // which gets its own rejection.
+    this.readyPromise.catch(() => {});
+  }
+
+  // ----------------------------------------------------------------
+  // RuleRunnerLike — sync metadata methods
+  // ----------------------------------------------------------------
+
+  setConfig(ruleId: string, config: LintRuleConfig): void {
+    if (this.disposed) return;
+    this.mainRunner.setConfig(ruleId, config);
+    this.send({
+      type: "SET_CONFIG",
+      correlationId: this.nextId(),
+      ruleId,
+      config,
+    });
+  }
+
+  setActiveGuidelines(guidelines: string[] | null): void {
+    if (this.disposed) return;
+    this.mainRunner.setActiveGuidelines(guidelines);
+    this.send({
+      type: "SET_ACTIVE_GUIDELINES",
+      correlationId: this.nextId(),
+      guidelines,
+    });
+  }
+
+  setGuidelineMap(map: Map<string, string | undefined>): void {
+    if (this.disposed) return;
+    this.mainRunner.setGuidelineMap(map);
+    this.send({
+      type: "SET_GUIDELINE_MAP",
+      correlationId: this.nextId(),
+      entries: Array.from(map.entries()),
+    });
+  }
+
+  hasMorphologicalRules(): boolean {
+    return this.mainRunner.hasMorphologicalRules();
+  }
+
+  hasDocumentRules(): boolean {
+    return this.workerHasDocumentRules || this.mainRunner.hasDocumentRules();
+  }
+
+  hasMorphologicalDocumentRules(): boolean {
+    return this.mainRunner.hasMorphologicalDocumentRules();
+  }
+
+  // ----------------------------------------------------------------
+  // RuleRunnerLike — async batch execution
+  // ----------------------------------------------------------------
+
+  async runBatch(req: RunBatchRequest): Promise<RunBatchResponse> {
+    if (this.fatalError) {
+      throw this.fatalError;
+    }
+    if (this.disposed) {
+      throw new WorkerDisposedError();
+    }
+
+    // Track the latest version requested so older responses can be filtered.
+    if (req.version > this.latestRequestedVersion) {
+      this.latestRequestedVersion = req.version;
+    }
+
+    // Eagerly cancel any pending request with a lower version — the
+    // caller no longer cares about it.
+    for (const [id, entry] of this.pending) {
+      if (entry.version < this.latestRequestedVersion) {
+        this.pending.delete(id);
+        entry.reject(new WorkerStaleError());
+      }
+    }
+
+    // Run main-thread morph rules synchronously while the worker is busy.
+    const { mainPerParagraph, mainDocument } = this.runMainMorph(req);
+
+    const runWorker = req.runWorker !== false;
+    if (!runWorker) {
+      return { perParagraph: mainPerParagraph, document: mainDocument };
+    }
+
+    // Register the pending entry BEFORE awaiting `readyPromise`, so
+    // `cancelInFlight()` and the stale-by-version sweep can see batches
+    // that are still waiting on worker startup. Without this, a toggle
+    // before READY would leave the batch unreachable and it would fire
+    // anyway once the worker came up.
+    const correlationId = this.nextId();
+    const workerResponse = new Promise<RunBatchResponse>((resolve, reject) => {
+      this.pending.set(correlationId, {
+        resolve,
+        reject,
+        version: req.version,
+        mainPerParagraph,
+        mainDocument,
+      });
+    });
+
+    // Wait for worker startup if it hasn't readied yet. If `dispose()`
+    // beats READY, this rejects with `WorkerDisposedError`.
+    if (!this.ready) {
+      try {
+        await this.readyPromise;
+      } catch (err) {
+        // If we were already cancelled while waiting, drop silently —
+        // the rejection has already been handed to the caller via the
+        // pending entry.
+        if (!this.pending.has(correlationId)) return workerResponse;
+        this.pending.delete(correlationId);
+        if (err instanceof WorkerDisposedError) throw err;
+        throw err;
+      }
+    }
+
+    // The pending entry may have been cancelled (cancelInFlight or
+    // stale-version sweep) during the await. If so, the promise has
+    // already rejected — just return it.
+    if (!this.pending.has(correlationId)) {
+      return workerResponse;
+    }
+
+    if (this.disposed) {
+      this.pending.delete(correlationId);
+      throw new WorkerDisposedError();
+    }
+
+    this.send({
+      type: "RUN_BATCH",
+      correlationId,
+      version: req.version,
+      paragraphs: req.paragraphs.map((p) => ({ text: p.text, index: p.index })),
+      mode: req.mode,
+    });
+
+    return workerResponse;
+  }
+
+  cancelInFlight(): void {
+    const err = new WorkerStaleError();
+    for (const entry of this.pending.values()) {
+      entry.reject(err);
+    }
+    this.pending.clear();
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+
+    const err = new WorkerDisposedError();
+    for (const entry of this.pending.values()) {
+      entry.reject(err);
+    }
+    this.pending.clear();
+    this.preReadyBuffer.length = 0;
+    if (!this.ready) {
+      // Reject the readyPromise so any awaiter unwinds cleanly.
+      this.rejectReady(err);
+    }
+
+    this.worker.terminate();
+  }
+
+  // ----------------------------------------------------------------
+  // Internal helpers
+  // ----------------------------------------------------------------
+
+  private nextId(): number {
+    return this.nextCorrelationId++;
+  }
+
+  private send(msg: WorkerRequest): void {
+    if (this.disposed) return;
+    if (!this.ready) {
+      this.preReadyBuffer.push(msg);
+      return;
+    }
+    this.worker.postMessage(msg);
+  }
+
+  private handleEvent(evt: WorkerEvent): void {
+    switch (evt.type) {
+      case "READY": {
+        this.ready = true;
+        this.resolveReady();
+        // Flush buffered messages in FIFO order.
+        for (const msg of this.preReadyBuffer) {
+          this.worker.postMessage(msg);
+        }
+        this.preReadyBuffer.length = 0;
+        return;
+      }
+      case "RESPONSE": {
+        const entry = this.pending.get(evt.correlationId);
+        if (!entry) return;
+        this.pending.delete(evt.correlationId);
+
+        // Stale-by-version filtering.
+        if (evt.version < this.latestRequestedVersion) {
+          entry.reject(new WorkerStaleError());
+          return;
+        }
+
+        // Merge worker results with the main-thread morph results.
+        const merged: RunBatchResponse = {
+          perParagraph: mergeIssueMaps(entry.mainPerParagraph, deserialize(evt.perParagraph)),
+          document: mergeIssueMaps(entry.mainDocument, deserialize(evt.document)),
+        };
+        entry.resolve(merged);
+        return;
+      }
+      case "ERROR": {
+        const err = new Error(evt.error.message);
+        err.name = evt.error.name;
+        if (evt.correlationId !== undefined) {
+          const entry = this.pending.get(evt.correlationId);
+          if (entry) {
+            this.pending.delete(evt.correlationId);
+            entry.reject(err);
+          }
+        } else {
+          // Uncorrelated worker failure — treat as fatal. Reject every
+          // pending request, reject readyPromise if startup hadn't
+          // completed, and poison the proxy so future `runBatch()`
+          // calls fail fast instead of posting into a dead worker.
+          this.poison(err);
+        }
+        return;
+      }
+      default: {
+        const _exhaustive: never = evt;
+        void _exhaustive;
+      }
+    }
+  }
+
+  private handleWorkerError(e: ErrorEvent | Error): void {
+    const err = e instanceof Error ? e : new Error(e.message ?? String(e));
+    this.poison(err);
+  }
+
+  /**
+   * Mark the proxy as fatally broken: reject every pending request and
+   * `readyPromise` (if startup hadn't completed), terminate the worker,
+   * and remember the error so subsequent API calls fail fast instead
+   * of hanging.
+   */
+  private poison(err: Error): void {
+    if (this.fatalError) return;
+    this.fatalError = err;
+    for (const entry of this.pending.values()) {
+      entry.reject(err);
+    }
+    this.pending.clear();
+    this.preReadyBuffer.length = 0;
+    if (!this.ready) {
+      this.rejectReady(err);
+    }
+    if (!this.disposed) {
+      this.disposed = true;
+      this.worker.terminate();
+    }
+  }
+
+  private runMainMorph(req: RunBatchRequest): {
+    mainPerParagraph: Map<number, LintIssue[]>;
+    mainDocument: Map<number, LintIssue[]>;
+  } {
+    const mainPerParagraph = new Map<number, LintIssue[]>();
+    const mainDocument = new Map<number, LintIssue[]>();
+
+    if (!this.mainRunner.hasMorphologicalRules() && !this.mainRunner.hasDocumentRules()) {
+      return { mainPerParagraph, mainDocument };
+    }
+
+    const runPer = req.mode === "per-paragraph" || req.mode === "both";
+    const runDoc = req.mode === "document" || req.mode === "both";
+
+    // Per-paragraph morph rules.
+    if (runPer) {
+      for (const p of req.paragraphs) {
+        if (!p.tokens) continue; // morph rules need tokens
+        const issues = this.mainRunner.runAllWithTokens(p.text, p.tokens);
+        if (issues.length > 0) mainPerParagraph.set(p.index, issues);
+      }
+    }
+
+    // Document-level morph rules.
+    if (runDoc && this.mainRunner.hasDocumentRules()) {
+      const docInputs = req.paragraphs
+        .filter((p) => p.tokens != null)
+        .map((p) => ({ text: p.text, index: p.index, tokens: p.tokens! }));
+      if (docInputs.length > 0) {
+        const docResults = this.mainRunner.runDocumentWithTokens(docInputs);
+        docResults.forEach((issues, idx) => {
+          if (issues.length > 0) mainDocument.set(idx, issues);
+        });
+      }
+    }
+
+    return { mainPerParagraph, mainDocument };
+  }
+}
+
+// ------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------
+
+function deserialize(entries: SerializedIssueMap): Map<number, LintIssue[]> {
+  const map = new Map<number, LintIssue[]>();
+  for (const [idx, issues] of entries) {
+    if (issues.length > 0) map.set(idx, issues);
+  }
+  return map;
+}
+
+function mergeIssueMaps(
+  a: Map<number, LintIssue[]>,
+  b: Map<number, LintIssue[]>,
+): Map<number, LintIssue[]> {
+  if (a.size === 0) return b;
+  if (b.size === 0) return a;
+  const out = new Map<number, LintIssue[]>(a);
+  for (const [idx, issues] of b) {
+    const existing = out.get(idx);
+    if (existing) {
+      // Preserve the global-by-`from` ordering that callers (corrections
+      // list, navigation) depend on when both worker L1 and main-thread
+      // morph rules contribute issues to the same paragraph.
+      const merged = [...existing, ...issues];
+      merged.sort((x, y) => x.from - y.from);
+      out.set(idx, merged);
+    } else {
+      out.set(idx, issues);
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
ロールバックされた PR #1439 を、現行の nlpClient アーキテクチャに適応して再実装。長い原稿 (1000+ 段落) で校正パネルを切り替えると全 lint ルールがメインスレッドで走りエディタが数秒フリーズしていた問題を、L1 (regex/JSON) ルールを専用 Web Worker へ移すことで解消。L2 (形態素) ルールは nlpClient/kuromoji 依存のためメインスレッドに残す。

## 変更
- `worker/protocol.ts`: 型付き RPC 契約 (WorkerRequest/Event, RuleRunnerLike, WorkerStaleError / WorkerDisposedError sentinel)。
- `worker/linting.worker.ts`: JSON L1 セットを登録し RUN_BATCH を処理、READY を1度 post。
- `worker/rule-runner-proxy.ts`: worker + main-thread RuleRunner をホストし runBatch を分割/マージ。stale-by-version filter, cancelInFlight, dispose。
- `use-linting.ts`: proxy を effect で生成し state 保持、null→ready を editor へ伝播。
- `decoration-plugin.ts`: per-paragraph ループと document-rules ブロックを2つの runBatch へ。version guard / cancelInFlight 維持。
- `rule-runner.ts`: `hasMorphologicalDocumentRules()` 追加。

> 旧 PR は genjiVocab 前提だったが、その後 nlpClient へ移行済みのため obsolete な genjiVocab bootstrap は破棄。

## 既知の未対応 (follow-up 候補)
issue #1467 の「再実装方針」にある追加最適化は本 PR に含めていません（実機ベンチが必要なため別途）:
- Worker→main 結果バッチの chunk 化 (≤30 段落/batch)
- decoration build を requestIdleCallback へ defer
- 1000+ 段落での「最初の click 100ms 以内」perf regression test

## Test
- `npx vitest run lib/linting packages/milkdown-plugin-japanese-novel` → 81 passed (proxy 10件含む)
- `npx tsc --noEmit` → clean / `eslint` → 0 errors

Refs #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)