### PR TITLE
feat(stats): add selected text manuscript page count to inspector

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -361,6 +361,8 @@ export default function EditorPage() {
   const [recoveryExiting, setRecoveryExiting] = useState(false);
   const [newFileTrigger, setNewFileTrigger] = useState(0);
   const [selectedCharCount, setSelectedCharCount] = useState(0);
+  const [selectedManuscriptCells, setSelectedManuscriptCells] = useState(0);
+  const [selectedManuscriptPages, setSelectedManuscriptPages] = useState(0);
   const { menu: tabBarMenu, show: showTabBarMenu, close: closeTabBarMenu } = useContextMenu();
   const hasAutoRecoveredRef = useRef(false);
   const [editorViewInstance, setEditorViewInstanceRaw] = useState<EditorView | null>(null);
@@ -1066,6 +1068,8 @@ export default function EditorPage() {
     compactMode,
     charCount,
     selectedCharCount,
+    selectedManuscriptCells,
+    selectedManuscriptPages,
     paragraphCount,
     manuscriptCellCount,
     manuscriptPages,
@@ -1216,7 +1220,11 @@ export default function EditorPage() {
         editorDomRef,
         handleChange,
         handleInsertText,
-        setSelectedCharCount,
+        onSelectionChange: (count: number, cells: number, pages: number) => {
+          setSelectedCharCount(count);
+          setSelectedManuscriptCells(cells);
+          setSelectedManuscriptPages(pages);
+        },
         searchOpenTrigger,
         searchInitialTerm,
         setEditorViewInstance,

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -28,7 +28,7 @@ interface EditorProps {
   initialContent?: string;
   onChange?: (content: string) => void;
   onInsertText?: (text: string) => void;
-  onSelectionChange?: (charCount: number) => void;
+  onSelectionChange?: (charCount: number, manuscriptCells: number, manuscriptPages: number) => void;
   className?: string;
   searchOpenTrigger?: number;
   searchInitialTerm?: string;

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -154,7 +154,11 @@ interface EditorLayoutProps {
     editorDomRef: RefObject<HTMLDivElement | null>;
     handleChange: NonNullable<React.ComponentProps<typeof NovelEditor>["onChange"]>;
     handleInsertText: NonNullable<React.ComponentProps<typeof NovelEditor>["onInsertText"]>;
-    setSelectedCharCount: Dispatch<SetStateAction<number>>;
+    onSelectionChange: (
+      charCount: number,
+      manuscriptCells: number,
+      manuscriptPages: number,
+    ) => void;
     searchOpenTrigger: number;
     searchInitialTerm?: string;
     setEditorViewInstance: NonNullable<
@@ -460,7 +464,7 @@ export default function EditorLayout({
                                   initialContent={panelContent}
                                   onChange={mainArea.handleChange}
                                   onInsertText={mainArea.handleInsertText}
-                                  onSelectionChange={mainArea.setSelectedCharCount}
+                                  onSelectionChange={mainArea.onSelectionChange}
                                   searchOpenTrigger={panelSearchOpenTrigger}
                                   searchInitialTerm={panelSearchInitialTerm}
                                   onEditorViewReady={mainArea.setEditorViewInstance}

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -34,6 +34,8 @@ export default function Inspector({
   compactMode = false,
   charCount = 0,
   selectedCharCount = 0,
+  selectedManuscriptCells = 0,
+  selectedManuscriptPages = 0,
   paragraphCount = 0,
   manuscriptCellCount,
   manuscriptPages: manuscriptPagesProp,
@@ -378,6 +380,8 @@ export default function Inspector({
           <StatsPanel
             charCount={charCount}
             selectedCharCount={selectedCharCount}
+            selectedManuscriptCells={selectedManuscriptCells}
+            selectedManuscriptPages={selectedManuscriptPages}
             paragraphCount={paragraphCount}
             manuscriptPages={manuscriptPages}
             sentenceCount={sentenceCount}

--- a/components/inspector/StatsPanel.tsx
+++ b/components/inspector/StatsPanel.tsx
@@ -171,11 +171,12 @@ export default function StatsPanel({
           <div className="text-right">
             <span className="text-sm font-bold text-foreground">{manuscriptPages}枚</span>
             {prevDayPageDiff !== null && (
-              <p
-                className={`text-xs font-medium ${prevDayPageDiff > 0 ? "text-success" : prevDayPageDiff < 0 ? "text-error" : "text-foreground-tertiary"}`}
+              <InfoTooltip
+                content="前日（最後に保存した日）の原稿用紙枚数からの増減です。プラスは増加、マイナスは減少を表します。"
+                className={`block text-xs font-medium ${prevDayPageDiff > 0 ? "text-success" : prevDayPageDiff < 0 ? "text-error" : "text-foreground-tertiary"}`}
               >
                 {formatDiff(prevDayPageDiff, "枚")}
-              </p>
+              </InfoTooltip>
             )}
           </div>
         </div>
@@ -369,11 +370,12 @@ export default function StatsPanel({
                 {activeCharCount.toLocaleString()}
               </span>
               {!isSelection && prevDayCharDiff !== null && (
-                <p
-                  className={`text-xs font-medium ${prevDayCharDiff > 0 ? "text-success" : prevDayCharDiff < 0 ? "text-error" : "text-foreground-tertiary"}`}
+                <InfoTooltip
+                  content="前日（最後に保存した日）の総字数からの増減です。プラスは増加、マイナスは減少を表します。"
+                  className={`block text-xs font-medium ${prevDayCharDiff > 0 ? "text-success" : prevDayCharDiff < 0 ? "text-error" : "text-foreground-tertiary"}`}
                 >
                   {formatDiff(prevDayCharDiff, "字")}
-                </p>
+                </InfoTooltip>
               )}
             </div>
           </div>

--- a/components/inspector/StatsPanel.tsx
+++ b/components/inspector/StatsPanel.tsx
@@ -9,6 +9,10 @@ interface StatsPanelProps {
   charCount: number;
   /** 選択中の可視本文文字数 */
   selectedCharCount: number;
+  /** 選択範囲の原稿用紙マス数（20×20、禁則処理あり） */
+  selectedManuscriptCells?: number;
+  /** 選択範囲の原稿用紙換算枚数（切り上げ） */
+  selectedManuscriptPages?: number;
   /** 段落数 */
   paragraphCount: number;
   /** 原稿用紙換算枚数 */
@@ -55,6 +59,8 @@ function formatDiff(diff: number, unit: string): string {
 export default function StatsPanel({
   charCount,
   selectedCharCount,
+  selectedManuscriptCells = 0,
+  selectedManuscriptPages = 0,
   paragraphCount,
   manuscriptPages,
   manuscriptCellCount,
@@ -184,6 +190,26 @@ export default function StatsPanel({
           </span>
         )}
       </div>
+
+      {/* 選択範囲の原稿用紙（選択時のみ表示） */}
+      {isSelection && selectedManuscriptCells > 0 && (
+        <div className="bg-background-secondary rounded-lg p-3 border border-border flex items-center justify-between">
+          <div>
+            <p className="text-xs text-foreground-tertiary font-medium mb-1 flex items-center">
+              <InfoTooltip content="選択範囲を400字詰め原稿用紙（20×20）に換算した枚数。禁則処理あり・端数切り上げ。">
+                原稿用紙
+              </InfoTooltip>
+            </p>
+            <p className="text-xs text-foreground-tertiary">
+              400字詰原稿用紙
+              <span className="ml-1 opacity-70">({selectedManuscriptCells}マス)</span>
+            </p>
+          </div>
+          <div className="text-right">
+            <span className="text-sm font-bold text-foreground">{selectedManuscriptPages}枚</span>
+          </div>
+        </div>
+      )}
 
       {/* 可読性分析 (Readability) */}
       {readabilityAnalysis && !isSelection && (

--- a/components/inspector/types.ts
+++ b/components/inspector/types.ts
@@ -37,6 +37,10 @@ export interface InspectorProps {
   /** 可視本文文字数（空白・改行・記法を除く） */
   charCount?: number;
   selectedCharCount?: number;
+  /** 選択範囲の原稿用紙マス数（20×20、禁則処理あり） */
+  selectedManuscriptCells?: number;
+  /** 選択範囲の原稿用紙換算枚数（切り上げ） */
+  selectedManuscriptPages?: number;
   paragraphCount?: number;
   /** 原稿用紙マス数（20×20、禁則処理あり） */
   manuscriptCellCount?: number;

--- a/lib/editor-page/use-selection-tracking.ts
+++ b/lib/editor-page/use-selection-tracking.ts
@@ -107,6 +107,9 @@ export function useSelectionTracking({
   const onSelectionChangeRef = useRef(onSelectionChange);
   const lastPointerYRef = useRef<number | null>(null);
   const lastReportedCountRef = useRef(0);
+  // 原稿用紙マス数も保持する。可視文字数が同じでも禁則処理でマス数は変わり得るため、
+  // 範囲を選び直したときに古い値が残らないよう、マス数の変化でも callback を発火させる。
+  const lastReportedCellsRef = useRef(0);
   const frameRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -119,8 +122,9 @@ export function useSelectionTracking({
 
   const updateSelectionState = useCallback(() => {
     if (!editorViewInstance) {
-      if (lastReportedCountRef.current !== 0) {
+      if (lastReportedCountRef.current !== 0 || lastReportedCellsRef.current !== 0) {
         lastReportedCountRef.current = 0;
+        lastReportedCellsRef.current = 0;
         onSelectionChangeRef.current?.(0, 0, 0);
       }
       setSelectionState((prev) =>
@@ -166,16 +170,21 @@ export function useSelectionTracking({
         pointerClientY: lastPointerYRef.current,
       };
 
-      if (lastReportedCountRef.current !== selectionCount) {
+      if (
+        lastReportedCountRef.current !== selectionCount ||
+        lastReportedCellsRef.current !== selectionManuscriptCells
+      ) {
         lastReportedCountRef.current = selectionCount;
+        lastReportedCellsRef.current = selectionManuscriptCells;
         onSelectionChangeRef.current?.(
           selectionCount,
           selectionManuscriptCells,
           selectionManuscriptPages,
         );
       }
-    } else if (lastReportedCountRef.current !== 0) {
+    } else if (lastReportedCountRef.current !== 0 || lastReportedCellsRef.current !== 0) {
       lastReportedCountRef.current = 0;
+      lastReportedCellsRef.current = 0;
       onSelectionChangeRef.current?.(0, 0, 0);
     }
 

--- a/lib/editor-page/use-selection-tracking.ts
+++ b/lib/editor-page/use-selection-tracking.ts
@@ -3,7 +3,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { EditorView } from "@milkdown/prose/view";
 
-import { extractVisibleText, countVisibleChars } from "@/lib/editor-page/text-statistics";
+import {
+  extractVisibleText,
+  countVisibleChars,
+  countManuscriptCells,
+  countManuscriptPages,
+} from "@/lib/editor-page/text-statistics";
 
 export interface ViewportRect {
   top: number;
@@ -27,7 +32,7 @@ export interface EditorSelectionState {
 interface UseSelectionTrackingOptions {
   editorViewInstance: EditorView | null;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
-  onSelectionChange?: (charCount: number) => void;
+  onSelectionChange?: (charCount: number, manuscriptCells: number, manuscriptPages: number) => void;
 }
 
 const EMPTY_SELECTION_STATE: EditorSelectionState = {
@@ -116,7 +121,7 @@ export function useSelectionTracking({
     if (!editorViewInstance) {
       if (lastReportedCountRef.current !== 0) {
         lastReportedCountRef.current = 0;
-        onSelectionChangeRef.current?.(0);
+        onSelectionChangeRef.current?.(0, 0, 0);
       }
       setSelectionState((prev) =>
         sameSelectionState(prev, EMPTY_SELECTION_STATE) ? prev : EMPTY_SELECTION_STATE,
@@ -139,7 +144,10 @@ export function useSelectionTracking({
     if (!selection.empty && belongsToEditor) {
       const selectedText = state.doc.textBetween(selection.from, selection.to);
       // MDI 記法を含む可能性があるため extractVisibleText で記法を剥がしてからカウント
-      const selectionCount = countVisibleChars(extractVisibleText(selectedText));
+      const visibleText = extractVisibleText(selectedText);
+      const selectionCount = countVisibleChars(visibleText);
+      const selectionManuscriptCells = countManuscriptCells(visibleText);
+      const selectionManuscriptPages = countManuscriptPages(selectionManuscriptCells);
       const range =
         domSelection && domSelection.rangeCount > 0
           ? domSelection.getRangeAt(0).getBoundingClientRect()
@@ -157,11 +165,18 @@ export function useSelectionTracking({
           range && !(range.width === 0 && range.height === 0) ? toViewportRect(range) : null,
         pointerClientY: lastPointerYRef.current,
       };
-    }
 
-    if (lastReportedCountRef.current !== nextState.selectionCount) {
-      lastReportedCountRef.current = nextState.selectionCount;
-      onSelectionChangeRef.current?.(nextState.selectionCount);
+      if (lastReportedCountRef.current !== selectionCount) {
+        lastReportedCountRef.current = selectionCount;
+        onSelectionChangeRef.current?.(
+          selectionCount,
+          selectionManuscriptCells,
+          selectionManuscriptPages,
+        );
+      }
+    } else if (lastReportedCountRef.current !== 0) {
+      lastReportedCountRef.current = 0;
+      onSelectionChangeRef.current?.(0, 0, 0);
     }
 
     setSelectionState((prev) => (sameSelectionState(prev, nextState) ? prev : nextState));


### PR DESCRIPTION
## Summary

- Users can now see the 400-character manuscript page count when selecting text in the editor
- Selected text range is displayed in the Statistics panel with manuscript cell count (マス) and page number (枚)
- Calculation uses existing kinsoku (禁則処理) processing from the full-text statistics
- Previous-day comparison values (±枚 / ±字) now have hover tooltips explaining what the +/- numbers mean

## Changes

| File | Role |
|------|------|
| `lib/editor-page/use-selection-tracking.ts` | Calculate manuscript cells/pages for selection, pass via callback with 3 parameters |
| `app/page.tsx` | Add state for selected manuscript cells/pages, implement onSelectionChange handler |
| `components/Editor.tsx` | Update onSelectionChange signature to accept 3 parameters (charCount, cells, pages) |
| `components/EditorLayout.tsx` | Update EditorLayoutProps interface and pass new callback to Editor |
| `components/Inspector.tsx` | Accept and relay new props to StatsPanel |
| `components/inspector/types.ts` | Add type definitions for selectedManuscriptCells and selectedManuscriptPages |
| `components/inspector/StatsPanel.tsx` | Render manuscript pages block when text is selected; add InfoTooltip to previous-day diff (枚/字) |

## Test plan

- [ ] Select text in the editor → Statistics panel shows "原稿用紙" block with page count
- [ ] Verify page count matches calculation: `Math.ceil(cells / 400)`
- [ ] Deselect text → block disappears, returns to full-text view
- [ ] Hover over the previous-day diff (e.g. `-1枚`) → tooltip explains it is the change from the last saved day
- [ ] All existing tests pass (1094 tests, 81 test files)
- [ ] Type checking passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)