### PR TITLE
fix(project): .illusions メタデータ欠落時に全経路で自動修復

### DIFF
--- a/lib/editor-page/__tests__/project-file-utils.test.ts
+++ b/lib/editor-page/__tests__/project-file-utils.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+
+import { MAX_SNAPSHOTS, RETENTION_DAYS } from "@/lib/services/history-policy";
+
+import { ensureProjectFiles } from "../project-file-utils";
+import type { AnyDirectoryHandle } from "../project-file-utils";
+
+// ---------------------------------------------------------------------------
+// In-memory fake directory/file handles (VFS-style: read()/write()).
+// ---------------------------------------------------------------------------
+
+class FakeFile {
+  content: string;
+  constructor(content = "") {
+    this.content = content;
+  }
+  async read(): Promise<string> {
+    return this.content;
+  }
+  async write(s: string): Promise<void> {
+    this.content = s;
+  }
+}
+
+class FakeDir {
+  name: string;
+  files = new Map<string, FakeFile>();
+  dirs = new Map<string, FakeDir>();
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  async getDirectoryHandle(name: string, opts?: { create?: boolean }): Promise<FakeDir> {
+    let dir = this.dirs.get(name);
+    if (!dir) {
+      if (!opts?.create) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      dir = new FakeDir(name);
+      this.dirs.set(name, dir);
+    }
+    return dir;
+  }
+
+  async getFileHandle(name: string, opts?: { create?: boolean }): Promise<FakeFile> {
+    let file = this.files.get(name);
+    if (!file) {
+      if (!opts?.create) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      file = new FakeFile("");
+      this.files.set(name, file);
+    }
+    return file;
+  }
+
+  async *entries(): AsyncIterable<[string, { kind: "file" | "directory" }]> {
+    for (const name of this.files.keys()) yield [name, { kind: "file" }];
+    for (const name of this.dirs.keys()) yield [name, { kind: "directory" }];
+  }
+}
+
+/** Create a fake project root with the given top-level files. */
+function makeRoot(name: string, topLevelFiles: string[] = []): FakeDir {
+  const root = new FakeDir(name);
+  for (const f of topLevelFiles) root.files.set(f, new FakeFile("manuscript"));
+  return root;
+}
+
+/** Seed a file at a slash-separated relative path, creating intermediate dirs. */
+async function seedFile(root: FakeDir, relPath: string, content: string): Promise<void> {
+  const parts = relPath.split("/");
+  let dir = root;
+  for (let i = 0; i < parts.length - 1; i++) {
+    dir = await dir.getDirectoryHandle(parts[i], { create: true });
+  }
+  const handle = await dir.getFileHandle(parts[parts.length - 1], { create: true });
+  await handle.write(content);
+}
+
+/** Seed a `.illusions/<relPath>` file (relPath may be nested, e.g. history/index.json). */
+function seedIllusionsFile(root: FakeDir, relPath: string, content: string): Promise<void> {
+  return seedFile(root, `.illusions/${relPath}`, content);
+}
+
+async function readIllusionsFile(root: FakeDir, name: string): Promise<string> {
+  const illusions = await root.getDirectoryHandle(".illusions", { create: false });
+  const handle = await illusions.getFileHandle(name, { create: false });
+  return handle.read();
+}
+
+const asHandle = (dir: FakeDir): AnyDirectoryHandle => dir as unknown as AnyDirectoryHandle;
+
+// ---------------------------------------------------------------------------
+// ensureProjectFiles
+// ---------------------------------------------------------------------------
+describe("ensureProjectFiles", () => {
+  it("「花様年華」再現: project.json のみ欠落 → projectId を再利用して復元", async () => {
+    // 本文 + workspace.json + history は在るが project.json だけ無い状態
+    const root = makeRoot("花様年華", ["花様年華.mdi"]);
+    await seedIllusionsFile(root, "workspace.json", JSON.stringify({ openTabs: [] }));
+
+    const result = await ensureProjectFiles(asHandle(root), {
+      projectId: "recent-id-123",
+    });
+
+    expect(result.repaired).toBe(true);
+    expect(result.metadata.projectId).toBe("recent-id-123");
+    expect(result.metadata.name).toBe("花様年華");
+    expect(result.metadata.mainFile).toBe("花様年華.mdi");
+    expect(result.metadata.mainFileExtension).toBe(".mdi");
+
+    // 実ファイルが書き込まれている
+    const written = JSON.parse(await readIllusionsFile(root, "project.json"));
+    expect(written.projectId).toBe("recent-id-123");
+  });
+
+  it("既存の有効な project.json は上書きせず projectId も保持する", async () => {
+    const root = makeRoot("既存", ["既存.mdi"]);
+    const existing = {
+      version: "1.0.0",
+      projectId: "original-id",
+      name: "既存",
+      mainFile: "既存.mdi",
+      mainFileExtension: ".mdi",
+      createdAt: 1,
+      lastModified: 2,
+      editorSettings: {},
+    };
+    await seedIllusionsFile(root, "project.json", JSON.stringify(existing));
+    await seedIllusionsFile(root, "workspace.json", JSON.stringify({ openTabs: [] }));
+    await seedIllusionsFile(
+      root,
+      "history/index.json",
+      JSON.stringify({ snapshots: [], maxSnapshots: 100, retentionDays: 90 }),
+    );
+
+    const result = await ensureProjectFiles(asHandle(root), { projectId: "should-be-ignored" });
+
+    expect(result.repaired).toBe(false);
+    expect(result.metadata.projectId).toBe("original-id");
+  });
+
+  it("mainFile 未指定: ${dirName}.mdi を優先検出する", async () => {
+    const root = makeRoot("MyProject", ["MyProject.mdi", "memo.md"]);
+    const result = await ensureProjectFiles(asHandle(root));
+    expect(result.metadata.mainFile).toBe("MyProject.mdi");
+  });
+
+  it("mainFile 未指定: .mdi が無ければ .md → .txt の優先順で検出する", async () => {
+    const root = makeRoot("Proj", ["note.txt", "draft.md"]);
+    const result = await ensureProjectFiles(asHandle(root));
+    expect(result.metadata.mainFile).toBe("draft.md");
+    expect(result.metadata.mainFileExtension).toBe(".md");
+  });
+
+  it("workspace.json 欠落 → 既定値で補完", async () => {
+    const root = makeRoot("WS", ["WS.mdi"]);
+    await seedIllusionsFile(
+      root,
+      "project.json",
+      JSON.stringify({ projectId: "x", name: "WS", mainFile: "WS.mdi", mainFileExtension: ".mdi" }),
+    );
+    // workspace.json は無し
+
+    const result = await ensureProjectFiles(asHandle(root));
+
+    expect(result.repaired).toBe(true);
+    const ws = JSON.parse(await readIllusionsFile(root, "workspace.json"));
+    expect(ws).toBeTruthy();
+  });
+
+  it("history/index.json 欠落 → 既定の HistoryIndex で補完", async () => {
+    const root = makeRoot("H", ["H.mdi"]);
+    await seedIllusionsFile(
+      root,
+      "project.json",
+      JSON.stringify({ projectId: "x", name: "H", mainFile: "H.mdi", mainFileExtension: ".mdi" }),
+    );
+    await seedIllusionsFile(root, "workspace.json", JSON.stringify({ openTabs: [] }));
+
+    const result = await ensureProjectFiles(asHandle(root));
+
+    expect(result.repaired).toBe(true);
+    const historyDir = await root.getDirectoryHandle(".illusions", { create: false });
+    const hDir = await historyDir.getDirectoryHandle("history", { create: false });
+    const idx = JSON.parse(await (await hDir.getFileHandle("index.json")).read());
+    expect(idx.snapshots).toEqual([]);
+    expect(idx.maxSnapshots).toBe(MAX_SNAPSHOTS);
+    expect(idx.retentionDays).toBe(RETENTION_DAYS);
+  });
+
+  it("全ファイル健在 → 何も書かず repaired:false", async () => {
+    const root = makeRoot("Full", ["Full.mdi"]);
+    await seedIllusionsFile(
+      root,
+      "project.json",
+      JSON.stringify({
+        projectId: "keep",
+        name: "Full",
+        mainFile: "Full.mdi",
+        mainFileExtension: ".mdi",
+      }),
+    );
+    await seedIllusionsFile(root, "workspace.json", JSON.stringify({ openTabs: [] }));
+    await seedIllusionsFile(
+      root,
+      "history/index.json",
+      JSON.stringify({ snapshots: [], maxSnapshots: MAX_SNAPSHOTS, retentionDays: RETENTION_DAYS }),
+    );
+
+    const result = await ensureProjectFiles(asHandle(root));
+    expect(result.repaired).toBe(false);
+    expect(result.metadata.projectId).toBe("keep");
+  });
+
+  it(".illusions 自体が無い空フォルダ + 本文在 → 一式生成、repaired:true", async () => {
+    const root = makeRoot("Scratch", ["Scratch.mdi"]);
+    const result = await ensureProjectFiles(asHandle(root));
+
+    expect(result.repaired).toBe(true);
+    expect(result.metadata.mainFile).toBe("Scratch.mdi");
+    // project.json / workspace.json / history/index.json がすべて作られる
+    expect(await readIllusionsFile(root, "project.json")).toBeTruthy();
+    expect(await readIllusionsFile(root, "workspace.json")).toBeTruthy();
+  });
+
+  it("本文ファイルが 1 つも無い → 検出は空、${dirName}.mdi にフォールバック", async () => {
+    const root = makeRoot("Empty", []);
+    const result = await ensureProjectFiles(asHandle(root));
+    expect(result.repaired).toBe(true);
+    expect(result.metadata.mainFile).toBe("Empty.mdi");
+  });
+});

--- a/lib/editor-page/project-file-utils.ts
+++ b/lib/editor-page/project-file-utils.ts
@@ -1,10 +1,15 @@
 import { getDefaultEditorSettings, getDefaultWorkspaceState } from "@/lib/project/project-types";
+import { MAX_SNAPSHOTS, RETENTION_DAYS } from "@/lib/services/history-policy";
 
 import type { ProjectConfig, SupportedFileExtension } from "@/lib/project/project-types";
+import type { HistoryIndex } from "@/lib/services/history-policy";
 import type { VFSDirectoryHandle } from "@/lib/vfs/types";
 
 /** A directory handle that works for both VFS and Web File System Access API */
 export type AnyDirectoryHandle = VFSDirectoryHandle | FileSystemDirectoryHandle;
+
+/** Supported main-file extensions, in detection-priority order. */
+const SUPPORTED_MAIN_EXTENSIONS: readonly SupportedFileExtension[] = [".mdi", ".md", ".txt"];
 
 /** Read text from a file handle (VFS or Web) */
 export async function readFileHandle(handle: {
@@ -16,6 +21,69 @@ export async function readFileHandle(handle: {
   }
   const file = await handle.getFile!();
   return file.text();
+}
+
+/** Write text to a file handle (VFS `write` or Web `createWritable`). */
+async function writeHandleText(
+  handle: { write?: (s: string) => Promise<void> } | FileSystemFileHandle,
+  text: string,
+): Promise<void> {
+  if ("write" in handle && typeof (handle as { write: unknown }).write === "function") {
+    await (handle as { write: (s: string) => Promise<void> }).write(text);
+  } else {
+    const writable = await (handle as FileSystemFileHandle).createWritable();
+    await writable.write(text);
+    await writable.close();
+  }
+}
+
+/**
+ * Returns true if the file handle already holds non-empty content.
+ * A freshly created (empty) handle counts as "missing" so callers can
+ * populate it with defaults.
+ */
+async function fileHasContent(handle: Parameters<typeof readFileHandle>[0]): Promise<boolean> {
+  try {
+    const raw = await readFileHandle(handle);
+    return raw.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** List top-level file (non-directory) entry names in a directory handle. */
+async function listFileNames(dir: AnyDirectoryHandle): Promise<string[]> {
+  const names: string[] = [];
+  const iterable = (
+    dir as { entries: () => AsyncIterable<[string, { kind: "file" | "directory" }]> }
+  ).entries();
+  for await (const [name, entry] of iterable) {
+    if (entry.kind === "file") names.push(name);
+  }
+  return names;
+}
+
+/**
+ * Detect the most likely main file among existing files.
+ * Priority: `${dirName}.<ext>` exact match, then any file by extension priority
+ * (.mdi → .md → .txt). Returns undefined when no supported file exists.
+ */
+function detectMainFile(fileNames: string[], dirName: string): string | undefined {
+  const candidates = fileNames.filter((n) =>
+    SUPPORTED_MAIN_EXTENSIONS.some((ext) => n.toLowerCase().endsWith(ext)),
+  );
+  if (candidates.length === 0) return undefined;
+  // Prefer a file named after the project directory.
+  for (const ext of SUPPORTED_MAIN_EXTENSIONS) {
+    const preferred = `${dirName}${ext}`;
+    if (candidates.includes(preferred)) return preferred;
+  }
+  // Otherwise pick the first candidate by extension priority.
+  for (const ext of SUPPORTED_MAIN_EXTENSIONS) {
+    const found = candidates.find((n) => n.toLowerCase().endsWith(ext));
+    if (found) return found;
+  }
+  return candidates[0];
 }
 
 /**
@@ -52,74 +120,88 @@ export async function readProjectJson(
 }
 
 /**
- * Read or auto-create .illusions/project.json.
- * If .illusions/ or project.json doesn't exist, creates them with sensible defaults.
- * Use this only when creating a new project, not when restoring an existing one.
+ * Ensure the full set of project management files exists, auto-repairing any
+ * that are missing or empty: `.illusions/project.json`, `.illusions/workspace.json`
+ * and `.illusions/history/index.json`.
+ *
+ * Unlike {@link readProjectJson} (read-only) and {@link ensureProjectJson}
+ * (project.json + workspace.json only), this restores a project whose metadata
+ * was lost — e.g. a Google Drive folder that still holds the manuscript but lost
+ * its `project.json`. User content (the manuscript files) is never created here;
+ * only the `.illusions/` management files are regenerated.
+ *
+ * @param rootDirHandle - The project root directory handle.
+ * @param options.projectId - Reuse this id when (re)creating project.json so the
+ *   recent-projects entry and persisted VFS approval stay consistent. Ignored
+ *   when a valid project.json already exists.
+ * @param options.mainFile - Known main file name. When omitted, the main file is
+ *   detected by scanning existing files in the root directory.
+ * @returns The project metadata, the `.illusions` dir handle, and `repaired`
+ *   (true when any file had to be created).
  */
-export async function ensureProjectJson(
+export async function ensureProjectFiles(
   rootDirHandle: AnyDirectoryHandle,
-  mainFile?: string,
-): Promise<{ metadata: ProjectConfig; illusionsDir: AnyDirectoryHandle }> {
+  options?: { projectId?: string; mainFile?: string },
+): Promise<{ metadata: ProjectConfig; illusionsDir: AnyDirectoryHandle; repaired: boolean }> {
+  let repaired = false;
   const illusionsDir = await rootDirHandle.getDirectoryHandle(".illusions", { create: true });
 
-  // Use { create: true } so getFileHandle never throws ENOENT on the IPC layer.
-  // If the file was just created it will be empty → treat as "does not exist".
+  // --- project.json ---
+  // { create: true } so getFileHandle never throws ENOENT on the IPC layer;
+  // an empty (just-created) file is treated as missing.
   const projectJsonHandle = await illusionsDir.getFileHandle("project.json", { create: true });
-  let metadataText: string | undefined;
-  try {
+  let metadata: ProjectConfig;
+  if (await fileHasContent(projectJsonHandle as Parameters<typeof readFileHandle>[0])) {
     const raw = await readFileHandle(projectJsonHandle as Parameters<typeof readFileHandle>[0]);
-    if (raw.trim()) metadataText = raw;
-  } catch {
-    // read failed — treat as missing
-  }
-
-  if (metadataText) {
-    return { metadata: JSON.parse(metadataText) as ProjectConfig, illusionsDir };
-  }
-
-  // Auto-create project.json with defaults
-  const dirName = rootDirHandle.name || "Untitled";
-  const ext = (mainFile?.match(/\.\w+$/)?.[0] ?? ".mdi") as SupportedFileExtension;
-  const metadata: ProjectConfig = {
-    version: "1.0.0",
-    projectId: crypto.randomUUID(),
-    name: dirName,
-    mainFile: mainFile ?? `${dirName}${ext}`,
-    mainFileExtension: ext,
-    createdAt: Date.now(),
-    lastModified: Date.now(),
-    editorSettings: getDefaultEditorSettings(ext),
-  };
-
-  // projectJsonHandle already exists (created empty above) — write defaults into it
-  if (
-    "write" in projectJsonHandle &&
-    typeof (projectJsonHandle as { write: unknown }).write === "function"
-  ) {
-    await (projectJsonHandle as { write: (s: string) => Promise<void> }).write(
-      JSON.stringify(metadata, null, 2),
-    );
+    metadata = JSON.parse(raw) as ProjectConfig;
   } else {
-    const writable = await (projectJsonHandle as FileSystemFileHandle).createWritable();
-    await writable.write(JSON.stringify(metadata, null, 2));
-    await writable.close();
+    const dirName = rootDirHandle.name || "Untitled";
+    let mainFile = options?.mainFile;
+    if (!mainFile) {
+      const fileNames = await listFileNames(rootDirHandle);
+      mainFile = detectMainFile(fileNames, dirName);
+    }
+    const ext = (mainFile?.match(/\.\w+$/)?.[0] ?? ".mdi") as SupportedFileExtension;
+    metadata = {
+      version: "1.0.0",
+      projectId: options?.projectId ?? crypto.randomUUID(),
+      name: dirName,
+      mainFile: mainFile ?? `${dirName}${ext}`,
+      mainFileExtension: ext,
+      createdAt: Date.now(),
+      lastModified: Date.now(),
+      editorSettings: getDefaultEditorSettings(ext),
+    };
+    await writeHandleText(projectJsonHandle, JSON.stringify(metadata, null, 2));
+    repaired = true;
+    console.info("[Project] Auto-repaired .illusions/project.json for:", dirName);
   }
 
-  // Also create workspace.json
+  // --- workspace.json ---
+  const wsHandle = await illusionsDir.getFileHandle("workspace.json", { create: true });
+  if (!(await fileHasContent(wsHandle as Parameters<typeof readFileHandle>[0]))) {
+    await writeHandleText(wsHandle, JSON.stringify(getDefaultWorkspaceState(), null, 2));
+    repaired = true;
+    console.info("[Project] Auto-repaired .illusions/workspace.json");
+  }
+
+  // --- history/index.json (best-effort) ---
   try {
-    const wsHandle = await illusionsDir.getFileHandle("workspace.json", { create: true });
-    const wsData = JSON.stringify(getDefaultWorkspaceState(), null, 2);
-    if ("write" in wsHandle && typeof (wsHandle as { write: unknown }).write === "function") {
-      await (wsHandle as { write: (s: string) => Promise<void> }).write(wsData);
-    } else {
-      const writable = await (wsHandle as FileSystemFileHandle).createWritable();
-      await writable.write(wsData);
-      await writable.close();
+    const historyDir = await illusionsDir.getDirectoryHandle("history", { create: true });
+    const indexHandle = await historyDir.getFileHandle("index.json", { create: true });
+    if (!(await fileHasContent(indexHandle as Parameters<typeof readFileHandle>[0]))) {
+      const historyIndex: HistoryIndex = {
+        snapshots: [],
+        maxSnapshots: MAX_SNAPSHOTS,
+        retentionDays: RETENTION_DAYS,
+      };
+      await writeHandleText(indexHandle, JSON.stringify(historyIndex, null, 2));
+      repaired = true;
+      console.info("[Project] Auto-repaired .illusions/history/index.json");
     }
   } catch {
-    // workspace.json creation is best-effort
+    // history reconstruction is best-effort — never block opening the project.
   }
 
-  console.info("[Project] Auto-created .illusions/project.json for:", dirName);
-  return { metadata, illusionsDir };
+  return { metadata, illusionsDir, repaired };
 }

--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -153,7 +153,9 @@ export function useFileOpening({
               projectId,
             });
             if (repaired) {
-              notificationManager.info("プロジェクト設定ファイルが見つからなかったため復元しました。");
+              notificationManager.info(
+                "プロジェクト設定ファイルが見つからなかったため復元しました。",
+              );
             }
 
             let workspaceState: ProjectMode["workspaceState"];

--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -7,7 +7,7 @@ import { getProjectFileService as getVFS } from "@/lib/services/project-file-ser
 import { notificationManager } from "@/lib/services/notification-manager";
 
 import type { ProjectMode, StandaloneMode, WorkspaceTab } from "@/lib/project/project-types";
-import { ensureProjectJson, readProjectJson, readFileHandle } from "./project-file-utils";
+import { ensureProjectFiles, readFileHandle } from "./project-file-utils";
 
 interface UseFileOpeningParams {
   isElectron: boolean;
@@ -142,23 +142,19 @@ export function useFileOpening({
             // mount-time standalone restore (use-tab-persistence.ts) does not race
             // with the explicit project tab restore.
             const rootDirHandle = await vfs.getDirectoryHandle("");
-            const projectJsonResult = await readProjectJson(rootDirHandle);
-            if (!projectJsonResult) {
-              signalVfsReady();
-              console.error(
-                "Failed to load recent project: .illusions/project.json not found at",
-                project.rootPath,
-              );
-              if (!isAutoRestoringRef.current) {
-                setConfirmRemoveRecent({
-                  projectId,
-                  message: `プロジェクトのメタデータが見つかりませんでした。\n\nパス: ${project.rootPath}\n\n最近のプロジェクト一覧から削除しますか?`,
-                });
-              }
-              return false;
+            // Auto-repair missing/corrupt .illusions metadata so a recoverable
+            // project (folder present, manuscript intact) opens instead of
+            // silently failing. Reuse the recent-entry projectId so the recent
+            // list and persisted VFS approval stay consistent. If the folder is
+            // gone, setRootPath/getDirectoryHandle above already threw into the
+            // outer catch; if no manuscript exists, getFileHandle(mainFile) below
+            // throws there too — both surface the proper "moved/deleted" dialog.
+            const { metadata, illusionsDir, repaired } = await ensureProjectFiles(rootDirHandle, {
+              projectId,
+            });
+            if (repaired) {
+              notificationManager.info("プロジェクト設定ファイルが見つからなかったため復元しました。");
             }
-
-            const { metadata, illusionsDir } = projectJsonResult;
 
             let workspaceState: ProjectMode["workspaceState"];
             try {
@@ -285,7 +281,12 @@ export function useFileOpening({
         }
 
         const rootDirHandle = await vfs.getDirectoryHandle("");
-        const { metadata, illusionsDir } = await ensureProjectJson(rootDirHandle, initialFile);
+        const { metadata, illusionsDir, repaired } = await ensureProjectFiles(rootDirHandle, {
+          mainFile: initialFile,
+        });
+        if (repaired) {
+          notificationManager.info("プロジェクト設定ファイルが見つからなかったため復元しました。");
+        }
 
         let workspaceState: ProjectMode["workspaceState"];
         try {

--- a/lib/editor-page/use-project-initialization.ts
+++ b/lib/editor-page/use-project-initialization.ts
@@ -5,7 +5,7 @@ import { getDefaultWorkspaceState } from "@/lib/project/project-types";
 import { notificationManager } from "@/lib/services/notification-manager";
 
 import type { ProjectMode, WorkspaceTab } from "@/lib/project/project-types";
-import { readProjectJson, readFileHandle } from "./project-file-utils";
+import { ensureProjectFiles, readFileHandle } from "./project-file-utils";
 
 interface UseProjectInitializationParams {
   isElectron: boolean;
@@ -74,16 +74,12 @@ export function useProjectInitialization({
   const openRestoredProject = useCallback(
     async (handle: FileSystemDirectoryHandle) => {
       try {
-        const result = await readProjectJson(handle);
-        if (!result) {
-          console.error("Failed to load restored project: .illusions/project.json not found");
-          notificationManager.error(
-            "プロジェクトのメタデータが見つかりませんでした。プロジェクトを再度開き直してください。",
-          );
-          return;
+        // Auto-repair missing/corrupt .illusions metadata so a restored project
+        // (handle valid, manuscript intact) opens instead of failing.
+        const { metadata, illusionsDir, repaired } = await ensureProjectFiles(handle);
+        if (repaired) {
+          notificationManager.info("プロジェクト設定ファイルが見つからなかったため復元しました。");
         }
-
-        const { metadata, illusionsDir } = result;
 
         let workspaceState: ProjectMode["workspaceState"];
         try {

--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -10,6 +10,8 @@ import { getProjectManager } from "./project-manager";
 import { isElectronRenderer } from "../utils/runtime-env";
 import { getDefaultEditorSettings, getDefaultWorkspaceState } from "./project-types";
 import { readTextWithEncoding } from "../utils/text-codec";
+import { ensureProjectFiles } from "../editor-page/project-file-utils";
+import { notificationManager } from "../services/notification-manager";
 
 import type { VirtualFileSystem, VFSDirectoryHandle } from "../vfs/types";
 import type { ProjectManager } from "./project-manager";
@@ -224,41 +226,22 @@ export class ProjectService {
   async openProject(): Promise<ProjectMode> {
     const rootDirHandle = await this.vfs.openDirectory();
 
-    // Read .illusions/project.json — do NOT create; fail clearly if not found.
-    let illusionsDir: Awaited<ReturnType<typeof rootDirHandle.getDirectoryHandle>>;
-    try {
-      illusionsDir = await rootDirHandle.getDirectoryHandle(".illusions", { create: false });
-    } catch {
-      throw new Error(
-        "選択したフォルダはプロジェクトフォルダではありません。.illusions フォルダが見つかりません。",
-      );
+    // Auto-repair missing/corrupt .illusions metadata so any selected folder
+    // containing a manuscript opens as a project instead of failing. User
+    // content is never created — only the .illusions management files.
+    const { metadata, repaired } = await ensureProjectFiles(rootDirHandle);
+    if (repaired) {
+      notificationManager.info("プロジェクト設定ファイルが見つからなかったため復元しました。");
     }
 
-    let projectJsonHandle: Awaited<ReturnType<typeof illusionsDir.getFileHandle>>;
-    try {
-      projectJsonHandle = await illusionsDir.getFileHandle("project.json");
-    } catch {
-      throw new Error(
-        "プロジェクトの設定ファイル (.illusions/project.json) が見つかりません。プロジェクトが破損している可能性があります。",
-      );
-    }
-
-    const metadataText = await projectJsonHandle.read();
-    if (!metadataText.trim()) {
-      throw new Error(
-        "プロジェクトの設定ファイル (.illusions/project.json) が空です。プロジェクトが破損している可能性があります。",
-      );
-    }
-    const metadata: ProjectConfig = JSON.parse(metadataText) as ProjectConfig;
-
-    // Read workspace.json (create defaults if missing)
+    // Read workspace.json (ensureProjectFiles guarantees it exists; default-safe)
     let workspaceState: WorkspaceState;
     try {
+      const illusionsDir = await rootDirHandle.getDirectoryHandle(".illusions", { create: false });
       const workspaceJsonHandle = await illusionsDir.getFileHandle("workspace.json");
       const workspaceText = await workspaceJsonHandle.read();
       workspaceState = JSON.parse(workspaceText) as WorkspaceState;
     } catch {
-      // workspace.json may not exist in older projects
       workspaceState = getDefaultWorkspaceState();
     }
 


### PR DESCRIPTION
## Summary

- Google Drive 同期が `.illusions/project.json` を脱落させると、本文 `.mdi` は無事なのにプロジェクトが開けなくなる事故（顧客の「花様年華」）を修正。
- 旧実装は「最近のプロジェクト / 自動復元」経路で read-only の `readProjectJson()` を使い、欠落時は**通知も出さず静かに失敗**して空の WelcomeScreen に落ちていた。
- プロジェクトを開く**全経路**で、欠落・空の `.illusions` 管理ファイル（`project.json` / `workspace.json` / `history/index.json`）を自動修復してから開くようにした。本文などのユーザーコンテンツは生成しない。

## Changes

| ファイル | 変更 |
| --- | --- |
| `lib/editor-page/project-file-utils.ts` | `ensureProjectFiles()` 新設。欠落・空ファイルのみ既定値で生成（既存は `fileHasContent` ガードで上書きしない）、本文検出（`${dirName}.mdi` 優先 → `.mdi`/`.md`/`.txt`）、`projectId` 再利用、`repaired` フラグ返却。`HistoryIndex` 既定値は `history-policy` から再利用。superseded な `ensureProjectJson` を削除 |
| `lib/editor-page/use-file-opening.ts` | `handleOpenRecentProject`（バグ本体）と `handleOpenAsProject` を `ensureProjectFiles` に切替 |
| `lib/editor-page/use-project-initialization.ts` | Web ハンドル復元経路 `openRestoredProject` を修復化 |
| `lib/project/project-service.ts` | 手動「フォルダを開く」`openProject` を修復化（全経路修復） |
| `lib/editor-page/__tests__/project-file-utils.test.ts` | 新規。in-memory fake handle で 9 ケース網羅 |

修復が走った全経路で日本語 info 通知「プロジェクト設定ファイルが見つからなかったため復元しました。」を表示。フォルダ自体が消えている場合は従来どおり「移動/削除」削除確認ダイアログ（回帰なし）。

## Test plan

- [x] `npm run type-check` 0 エラー
- [x] 新規テスト 9 件 + 関連スイート 274 件 全パス（`lib/editor-page` / `lib/project` / `lib/tab-manager`）
- [x] ESLint 0 errors（既存の warning 1 件のみ）
- [x] 実機 E2E: 実際の「花様年華」フォルダ（project.json 欠落状態）を Electron で開き、`project.json` が name・mainFile 正しく自動再生成され、workspace.json と 24 件の history が保持され、ロード失敗 0 件を確認
- [ ] レビュアー確認: 修復通知の文言・タイミング

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)