### PR TITLE
fix(search): 位置対応マッチャで検索ハイライトのずれを修正

### DIFF
--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -7,6 +7,7 @@ import { EditorView, Decoration } from "@milkdown/prose/view";
 import { TextSelection } from "@milkdown/prose/state";
 import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
 import { computeAnchorPos } from "@/lib/search-dialog/compute-anchor-pos";
+import { findSearchMatches, type SearchMatch } from "@/lib/editor-page/find-search-matches";
 
 const DIALOG_WIDTH = 320; // w-80 と一致させる
 const DIALOG_PADDING = 16; // 8px top offset / 16px right offset の元値と整合
@@ -23,10 +24,7 @@ interface SearchDialogProps {
   anchorRef?: React.RefObject<HTMLElement | null>;
 }
 
-export interface SearchMatch {
-  from: number;
-  to: number;
-}
+export type { SearchMatch };
 
 export default function SearchDialog({
   editorView,
@@ -150,38 +148,7 @@ export default function SearchDialog({
 
     const { state } = editorView;
     const { doc } = state;
-    const foundMatches: SearchMatch[] = [];
-    const searchStr = caseSensitive ? searchTerm : searchTerm.toLowerCase();
-
-    // Search within each text node and ruby atom using correct ProseMirror positions.
-    // ruby nodes have atom:true so doc.descendants does not recurse into them;
-    // we inspect node.attrs.base directly and emit a decoration for the whole atom.
-    doc.descendants((node, pos) => {
-      if (node.isText && node.text) {
-        const nodeText = caseSensitive ? node.text : node.text.toLowerCase();
-        let searchIndex = 0;
-        while (searchIndex < nodeText.length) {
-          const matchIndex = nodeText.indexOf(searchStr, searchIndex);
-          if (matchIndex === -1) break;
-          foundMatches.push({
-            from: pos + matchIndex,
-            to: pos + matchIndex + searchTerm.length,
-          });
-          searchIndex = matchIndex + 1;
-        }
-        return;
-      }
-      if (node.type.name === "ruby") {
-        const baseRaw = (node.attrs.base as string) ?? "";
-        const baseText = caseSensitive ? baseRaw : baseRaw.toLowerCase();
-        let i = 0;
-        while ((i = baseText.indexOf(searchStr, i)) !== -1) {
-          foundMatches.push({ from: pos, to: pos + node.nodeSize });
-          i += searchStr.length; // advance past matched chars to avoid spurious overlapping matches
-        }
-        return false; // atom — do not recurse into ruby internals
-      }
-    });
+    const foundMatches = findSearchMatches(doc, searchTerm, caseSensitive);
     setMatches(foundMatches);
     setCurrentMatchIndex(foundMatches.length > 0 ? 0 : -1);
   }, [searchTerm, caseSensitive, editorView]);

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -6,11 +6,7 @@ import { EditorView, Decoration } from "@milkdown/prose/view";
 import { TextSelection } from "@milkdown/prose/state";
 import clsx from "clsx";
 import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
-
-interface SearchMatch {
-  from: number;
-  to: number;
-}
+import { findSearchMatches, type SearchMatch } from "@/lib/editor-page/find-search-matches";
 
 // #1507: After tab switch, the parent's editorViewInstance may still
 // reference a destroyed EditorView for a short window before the new
@@ -85,41 +81,11 @@ export default function SearchResults({
 
     const { state, dispatch } = editorView;
     const { doc } = state;
-    const foundMatches: SearchMatch[] = [];
-    const searchStr = caseSensitive ? searchTerm : searchTerm.toLowerCase();
 
-    // Full document text search
-    const fullText = doc.textContent;
-    const searchText = caseSensitive ? fullText : fullText.toLowerCase();
-
-    let searchIndex = 0;
-    while (searchIndex < searchText.length) {
-      const matchIndex = searchText.indexOf(searchStr, searchIndex);
-      if (matchIndex === -1) break;
-
-      // Convert text position to document position
-      let pos = 0;
-      let textOffset = 0;
-
-      doc.descendants((node, nodePos) => {
-        if (pos !== 0) return false; // Found, stop traversal
-
-        if (node.isText && node.text) {
-          const nodeEnd = textOffset + node.text.length;
-          if (matchIndex >= textOffset && matchIndex < nodeEnd) {
-            pos = nodePos + (matchIndex - textOffset);
-            return false;
-          }
-          textOffset = nodeEnd;
-        }
-        return true;
-      });
-
-      if (pos > 0) {
-        foundMatches.push({ from: pos, to: pos + searchTerm.length });
-      }
-      searchIndex = matchIndex + 1;
-    }
+    // Use the shared ProseMirror-position-aware matcher. A previous
+    // textContent-based implementation drifted past hardbreaks (leafText "\n")
+    // and ruby atoms, highlighting the wrong characters.
+    const foundMatches = findSearchMatches(doc, searchTerm, caseSensitive);
 
     setMatches(foundMatches);
 

--- a/components/__tests__/SearchResults-position.test.tsx
+++ b/components/__tests__/SearchResults-position.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Regression test for the search-highlight position-drift bug.
+ *
+ * Symptom: searching "俺" highlighted nearby-but-wrong characters (裸 / 定 / 筆)
+ * in documents containing hardbreaks. SearchResults mapped `doc.textContent`
+ * offsets back to ProseMirror positions, but Milkdown's hardbreak defines
+ * `leafText: () => "\n"`, so it contributes a newline to textContent while
+ * occupying a position the text-offset mapping never accounted for. Every match
+ * after a hardbreak drifted forward by the number of preceding hardbreaks.
+ *
+ * The fix replaces that logic with `findSearchMatches`, which walks the document
+ * and uses each text node's real ProseMirror position — immune to hardbreaks,
+ * ruby atoms, and any other leaf node.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Schema, Node } from "prosemirror-model";
+import { findSearchMatches } from "@/lib/editor-page/find-search-matches";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    heading: {
+      group: "block",
+      content: "inline*",
+      attrs: { level: { default: 1 } },
+      toDOM: () => ["h1", 0] as [string, 0],
+      parseDOM: [{ tag: "h1" }],
+    },
+    paragraph: {
+      group: "block",
+      content: "inline*",
+      toDOM: () => ["p", 0] as [string, 0],
+      parseDOM: [{ tag: "p" }],
+    },
+    text: { group: "inline" },
+    ruby: {
+      group: "inline",
+      inline: true,
+      atom: true,
+      attrs: { base: { default: "" }, text: { default: "" } },
+      toDOM: (node) => ["ruby", {}, ["rb", {}, node.attrs.base as string]] as unknown as [string],
+      parseDOM: [{ tag: "ruby" }],
+    },
+    // Mirrors Milkdown's hardbreak: leafText makes it leak a "\n" into textContent.
+    hardbreak: {
+      group: "inline",
+      inline: true,
+      selectable: false,
+      leafText: () => "\n",
+      toDOM: () => ["br"],
+      parseDOM: [{ tag: "br" }],
+    },
+  },
+  marks: {},
+});
+
+// ruby-aware slice for assertions
+function sliceAt(doc: Node, m: { from: number; to: number }): string {
+  return doc.textBetween(m.from, m.to, "", (n) =>
+    n.type.name === "ruby" ? (n.attrs.base as string) : "",
+  );
+}
+
+describe("findSearchMatches — hardbreak / ruby position correctness", () => {
+  it('search "俺" after a hardbreak lands exactly on 俺 (was drifting onto だ)', () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("退勤後"),
+        schema.node("hardbreak"),
+        schema.text("彼は俺だ"),
+      ]),
+    ]);
+    expect(doc.textContent).toBe("退勤後\n彼は俺だ");
+
+    const matches = findSearchMatches(doc, "俺", false);
+    expect(matches).toHaveLength(1);
+    expect(sliceAt(doc, matches[0])).toBe("俺");
+  });
+
+  it("multiple hardbreaks before the match do not accumulate drift", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("A"),
+        schema.node("hardbreak"),
+        schema.text("B"),
+        schema.node("hardbreak"),
+        schema.text("C"),
+        schema.node("hardbreak"),
+        schema.text("D俺E"),
+      ]),
+    ]);
+    const matches = findSearchMatches(doc, "俺", false);
+    expect(matches).toHaveLength(1);
+    expect(sliceAt(doc, matches[0])).toBe("俺");
+  });
+
+  it("ruby atoms in a heading do not shift body matches", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("heading", { level: 1 }, [
+        schema.node("ruby", { base: "花", text: "か" }),
+        schema.node("ruby", { base: "様", text: "よう" }),
+        schema.node("ruby", { base: "年", text: "ねん" }),
+        schema.node("ruby", { base: "華", text: "か" }),
+      ]),
+      schema.node("paragraph", null, [schema.text("映画のタイトルは『花様年華』だった。")]),
+    ]);
+    const matches = findSearchMatches(doc, "映画", false);
+    expect(matches).toHaveLength(1);
+    expect(sliceAt(doc, matches[0])).toBe("映画");
+  });
+
+  it("ruby base text is searchable and highlights the whole atom", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("heading", { level: 1 }, [schema.node("ruby", { base: "華", text: "か" })]),
+    ]);
+    const matches = findSearchMatches(doc, "華", false);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].to - matches[0].from).toBe(1); // ruby atom nodeSize
+    expect(sliceAt(doc, matches[0])).toBe("華");
+  });
+});

--- a/lib/editor-page/find-search-matches.ts
+++ b/lib/editor-page/find-search-matches.ts
@@ -1,0 +1,69 @@
+import type { Node } from "@milkdown/prose/model";
+
+export interface SearchMatch {
+  from: number;
+  to: number;
+}
+
+/**
+ * Find every occurrence of `searchTerm` in a ProseMirror document and return
+ * their positions in ProseMirror coordinates.
+ *
+ * Why this walks the document with `doc.descendants` instead of searching
+ * `doc.textContent`:
+ *
+ *   `doc.textContent` flattens the document to a plain string, but that string
+ *   is NOT aligned 1:1 with ProseMirror positions. Nodes that are not text but
+ *   define a `leafText` spec (most importantly Milkdown's `hardbreak`, whose
+ *   spec is `leafText: () => "\n"`) contribute characters to `textContent`
+ *   while occupying a position that a naive text-offset → position mapping
+ *   never accounts for. The result is that every match after a hardbreak (or
+ *   any other leafText node) drifts forward by the number of such nodes before
+ *   it, so the highlight lands on the wrong character.
+ *
+ * By visiting each text node directly we use its real `pos`, so the returned
+ * positions are always correct regardless of hardbreaks, ruby atoms, or other
+ * inline leaf nodes.
+ *
+ * Ruby (`atom: true`) nodes are not recursed into by `descendants`, so their
+ * `base` text is matched explicitly and the whole atom is highlighted.
+ */
+export function findSearchMatches(
+  doc: Node,
+  searchTerm: string,
+  caseSensitive: boolean,
+): SearchMatch[] {
+  const foundMatches: SearchMatch[] = [];
+  if (!searchTerm) return foundMatches;
+
+  const searchStr = caseSensitive ? searchTerm : searchTerm.toLowerCase();
+
+  doc.descendants((node, pos) => {
+    if (node.isText && node.text) {
+      const nodeText = caseSensitive ? node.text : node.text.toLowerCase();
+      let searchIndex = 0;
+      while (searchIndex < nodeText.length) {
+        const matchIndex = nodeText.indexOf(searchStr, searchIndex);
+        if (matchIndex === -1) break;
+        foundMatches.push({
+          from: pos + matchIndex,
+          to: pos + matchIndex + searchTerm.length,
+        });
+        searchIndex = matchIndex + 1;
+      }
+      return;
+    }
+    if (node.type.name === "ruby") {
+      const baseRaw = (node.attrs.base as string) ?? "";
+      const baseText = caseSensitive ? baseRaw : baseRaw.toLowerCase();
+      let i = 0;
+      while ((i = baseText.indexOf(searchStr, i)) !== -1) {
+        foundMatches.push({ from: pos, to: pos + node.nodeSize });
+        i += searchStr.length; // advance past matched chars to avoid spurious overlapping matches
+      }
+      return false; // atom — do not recurse into ruby internals
+    }
+  });
+
+  return foundMatches;
+}


### PR DESCRIPTION
## Summary

- 検索結果のハイライトが、本文に強制改行 (hardbreak) を含む文書で**別の文字にずれる**バグを修正（例: 「俺」を検索すると近接する「裸 / 定 / 筆」が光る）
- 原因は SearchResults が `doc.textContent` のオフセットを ProseMirror position に変換していたこと。Milkdown の hardbreak は `leafText: () => "\n"` を持つため `textContent` に改行を出すが、変換側の `textOffset` 積算（text ノードのみ加算）には入らない。結果、hardbreak より後ろのマッチが hardbreak の個数ぶん後方にずれていた
- ruby (atom) は無実だった（`leafText` を持たず `textContent` から漏れるため `nodePos` が吸収しずれない）。`#1455` で SearchDialog 側だけ正しい実装に直り、SearchResults は壊れた `textContent` ベースのまま放置されていた

## Changes

| ファイル | 内容 |
| --- | --- |
| `lib/editor-page/find-search-matches.ts` | **新規**。各テキストノードの実 `pos` を使う descendants ベースの共通マッチャ `findSearchMatches()`（ruby atom 対応・`textContent` 非依存） |
| `components/SearchResults.tsx` | 壊れた `textContent` ベースの位置変換を削除し共通マッチャに置換 |
| `components/SearchDialog.tsx` | 同一ロジックの重複を共通マッチャに統一（挙動不変）。`SearchMatch` 型は共通定義から re-export |
| `components/__tests__/SearchResults-position.test.tsx` | **新規**。hardbreak / ruby を含む文書で位置が正しいことを検証する回帰テスト |

## Test plan

- [x] 新規回帰テスト 4 件パス（hardbreak 後・複数 hardbreak・heading 内 ruby・ruby base 検索）
- [x] 既存検索テスト 10 件パス（SearchDialog-ruby-match / SearchResults-prop-sync）
- [x] `tsc --noEmit` エラー 0、ESLint エラー 0
- [ ] 実機で `花様年華.mdi`（強制改行を含む中文メモ部分）を開き「俺」を検索 → ハイライトが正しい文字に当たることを目視確認

関連 issue なし（検索ハイライトのずれに該当する Open Issue は存在せず。`#1455` は ruby 由来の別事象で既にクローズ済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)