### PR TITLE
fix(editor): TOCのMDIルビ解析とルビ見出し下の空行を修正

### DIFF
--- a/lib/utils/__tests__/utils.test.ts
+++ b/lib/utils/__tests__/utils.test.ts
@@ -531,6 +531,14 @@ describe("parseMarkdownChapters", () => {
     const chapters = parseMarkdownChapters("# 第一章 {序|じょ}");
     expect(chapters[0].title).toBe("第一章 序");
   });
+
+  it("should normalize [[br]] in a heading to a single-line title and anchorId", () => {
+    const chapters = parseMarkdownChapters("# 前編[[br]]後編");
+    expect(chapters[0].title).toBe("前編 後編");
+    // anchorId must not contain an encoded newline (%0A)
+    expect(chapters[0].anchorId).not.toContain("%0A");
+    expect(chapters[0].anchorId).toBe(encodeURIComponent("前編 後編"));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/lib/utils/__tests__/utils.test.ts
+++ b/lib/utils/__tests__/utils.test.ts
@@ -519,6 +519,18 @@ describe("parseMarkdownChapters", () => {
     const chapters = parseMarkdownChapters("###### Deep");
     expect(chapters[0].level).toBe(6);
   });
+
+  it("should strip MDI ruby syntax from the title (keep base only)", () => {
+    const chapters = parseMarkdownChapters("# {花|か}{様|よう}{年|ねん}{華|か}");
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0].title).toBe("花様年華");
+    expect(chapters[0].anchorId).toBe(encodeURIComponent("花様年華"));
+  });
+
+  it("should strip ruby mixed with plain text in the title", () => {
+    const chapters = parseMarkdownChapters("# 第一章 {序|じょ}");
+    expect(chapters[0].title).toBe("第一章 序");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -867,6 +879,28 @@ describe("getChaptersFromDOM", () => {
     const chapters = getChaptersFromDOM();
     expect(chapters).toHaveLength(1);
     expect(chapters[0].title).toBe("");
+
+    // Cleanup
+    document.body.removeChild(container);
+  });
+
+  it("should exclude ruby reading (<rt>) and keep only the base text", () => {
+    const container = document.createElement("div");
+    container.className = "milkdown";
+
+    // Mirrors the editor's rendered ruby heading: <ruby><rb>base</rb><rt>reading</rt></ruby>
+    const h1 = document.createElement("h1");
+    h1.id = "hanayonenka";
+    h1.innerHTML =
+      "<ruby><rb>花</rb><rt>か</rt></ruby><ruby><rb>様</rb><rt>よう</rt></ruby>" +
+      "<ruby><rb>年</rb><rt>ねん</rt></ruby><ruby><rb>華</rb><rt>か</rt></ruby>";
+    container.appendChild(h1);
+
+    document.body.appendChild(container);
+
+    const chapters = getChaptersFromDOM();
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0].title).toBe("花様年華");
 
     // Cleanup
     document.body.removeChild(container);

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -228,7 +228,11 @@ export function parseMarkdownChapters(markdown: string): Chapter[] {
       const level = match[1].length;
       // MDI インライン記法（ルビ {base|ruby} 等）をプレーンテキストに変換する。
       // 目次にはルビ読みを含まない base テキストのみを表示する。
-      const title = stripMdiInlineSyntax(match[2].trim()).trim();
+      // stripMdiInlineSyntax は [[br]] を改行へ変換するため、見出し行に改行が
+      // 混入し anchorId が %0A 化するのを防ぐべく単一行へ正規化する。
+      const title = stripMdiInlineSyntax(match[2].trim())
+        .replace(/[\r\n]+/g, " ")
+        .trim();
       const anchorId = generateHeadingId(title);
 
       chapters.push({

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { analyzeReadability, cleanMarkdown } from "./readability";
+import { stripMdiInlineSyntax } from "@/lib/export/mdi-parser";
 export type { EnhancedReadabilityAnalysis, ReadabilitySubScores } from "./readability-types";
 export { analyzeReadability, enrichReadabilityWithMorphology, cleanMarkdown } from "./readability";
 
@@ -225,7 +226,9 @@ export function parseMarkdownChapters(markdown: string): Chapter[] {
     const match = line.match(/^(#{1,6})\s+(.+)$/);
     if (match) {
       const level = match[1].length;
-      const title = match[2].trim();
+      // MDI インライン記法（ルビ {base|ruby} 等）をプレーンテキストに変換する。
+      // 目次にはルビ読みを含まない base テキストのみを表示する。
+      const title = stripMdiInlineSyntax(match[2].trim()).trim();
       const anchorId = generateHeadingId(title);
 
       chapters.push({
@@ -353,6 +356,18 @@ export function calculateReadabilityScore(text: string): ReadabilityAnalysis {
 }
 
 /**
+ * 見出し要素から目次表示用のプレーンテキストを抽出する。
+ * ルビ（<ruby><rb>base</rb><rt>reading</rt></ruby>）の読み（<rt>）を除外し、
+ * base テキストのみを残す。これがないと textContent が "花様年華かようねんか" の
+ * ように base とルビ読みが連結された文字列になってしまう。
+ */
+function extractHeadingPlainText(heading: Element): string {
+  const clone = heading.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll("rt").forEach((rt) => rt.remove());
+  return (clone.textContent || "").trim();
+}
+
+/**
  * エディタのDOMから章情報を抽出する
  * レンダリング後の実IDが取れるため、Markdown解析より確実
  */
@@ -374,7 +389,7 @@ export function getChaptersFromDOM(): Chapter[] {
   headings.forEach((heading, index) => {
     const level = parseInt(heading.tagName[1]);
     const anchorId = heading.id;
-    const title = heading.textContent || "";
+    const title = extractHeadingPlainText(heading);
 
     chapters.push({
       level,

--- a/packages/milkdown-plugin-japanese-novel/__tests__/ruby-heading-trailing-break.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/ruby-heading-trailing-break.test.ts
@@ -12,7 +12,7 @@
  * separator `<img>`. This test verifies the DOM shape the CSS relies on and that
  * the selector targets only the atom case — never a genuine empty paragraph.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { Editor, rootCtx, defaultValueCtx, editorViewCtx } from "@milkdown/core";
 import { commonmark } from "@milkdown/preset-commonmark";
 import type { Node } from "@milkdown/prose/model";
@@ -21,9 +21,17 @@ import { japaneseNovel } from "../index";
 
 const SELECTOR = "img.ProseMirror-separator + br.ProseMirror-trailingBreak";
 
+// Track mounted roots so each test fully cleans up its DOM, even on failure.
+const mountedRoots: HTMLElement[] = [];
+afterEach(() => {
+  mountedRoots.forEach((r) => r.remove());
+  mountedRoots.length = 0;
+});
+
 async function makeView(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
   const root = document.createElement("div");
   document.body.appendChild(root);
+  mountedRoots.push(root);
   const editor = await Editor.make()
     .config((ctx) => {
       ctx.set(rootCtx, root);

--- a/packages/milkdown-plugin-japanese-novel/__tests__/ruby-heading-trailing-break.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/ruby-heading-trailing-break.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression test for the "undeletable empty line below a ruby heading" bug.
+ *
+ * Root cause: `ruby` is an inline atom node. When it is the last inline node of a
+ * block (e.g. a heading made entirely of ruby), ProseMirror appends
+ * `<img class="ProseMirror-separator"><br class="ProseMirror-trailingBreak">` so
+ * the caret can be placed after the atom. The default stylesheet renders that
+ * trailing `<br>` as a visible line break, producing a phantom empty line under
+ * the heading that the user cannot delete (it is not a real paragraph node).
+ *
+ * Fix (styles/index.css): hide the trailing `<br>` that directly follows a
+ * separator `<img>`. This test verifies the DOM shape the CSS relies on and that
+ * the selector targets only the atom case — never a genuine empty paragraph.
+ */
+import { describe, it, expect } from "vitest";
+import { Editor, rootCtx, defaultValueCtx, editorViewCtx } from "@milkdown/core";
+import { commonmark } from "@milkdown/preset-commonmark";
+import type { Node } from "@milkdown/prose/model";
+import type { EditorView } from "@milkdown/prose/view";
+import { japaneseNovel } from "../index";
+
+const SELECTOR = "img.ProseMirror-separator + br.ProseMirror-trailingBreak";
+
+async function makeView(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, markdown);
+    })
+    .use(commonmark)
+    .use(
+      japaneseNovel({
+        isVertical: false,
+        showManuscriptLine: false,
+        enableRuby: true,
+        enableTcy: true,
+        enableMdiBreak: true,
+      }),
+    )
+    .create();
+
+  let view!: EditorView;
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx);
+  });
+  return { editor, view };
+}
+
+function blockTypes(doc: Node): string[] {
+  const types: string[] = [];
+  doc.forEach((node) => types.push(node.type.name));
+  return types;
+}
+
+describe("ruby heading trailing break", () => {
+  it("does NOT introduce an empty paragraph node for a ruby-only heading", async () => {
+    const { editor, view } = await makeView("# {花|か}{様|よう}{年|ねん}{華|か}\n\n本文。");
+    const types = blockTypes(view.state.doc);
+    await editor.destroy();
+    // heading directly followed by the body paragraph — no phantom empty block.
+    expect(types).toEqual(["heading", "paragraph"]);
+  });
+
+  it("renders a separator + trailing break inside the ruby heading", async () => {
+    const { editor, view } = await makeView("# {花|か}{様|よう}{年|ねん}{華|か}\n\n本文。");
+    const h1 = view.dom.querySelector("h1")!;
+    const targeted = h1.querySelector(SELECTOR);
+    await editor.destroy();
+    // The CSS fix targets exactly this element; it must exist so the rule applies.
+    expect(targeted).not.toBeNull();
+  });
+
+  it("plain heading has no trailing break to hide", async () => {
+    const { editor, view } = await makeView("# 普通の見出し\n\n本文。");
+    const h1 = view.dom.querySelector("h1")!;
+    const targeted = h1.querySelector(SELECTOR);
+    await editor.destroy();
+    expect(targeted).toBeNull();
+  });
+
+  it("genuine empty paragraph trailing break is NOT matched by the selector", async () => {
+    const { editor, view } = await makeView("# 見出し\n\n本文。");
+    // Insert an empty paragraph after the heading (transient just-pressed-Enter state).
+    const afterHeading = view.state.doc.child(0).nodeSize;
+    view.dispatch(view.state.tr.insert(afterHeading, view.state.schema.nodes.paragraph!.create()));
+
+    const emptyParagraphEl = view.dom.querySelectorAll("p")[0]!;
+    const matchedInEmpty = emptyParagraphEl.querySelector(SELECTOR);
+    const hasOwnBreak = emptyParagraphEl.querySelector("br.ProseMirror-trailingBreak");
+    await editor.destroy();
+
+    // The empty paragraph keeps its trailing break (needed for caret height) but
+    // it is NOT preceded by a separator, so the fix leaves it visible.
+    expect(hasOwnBreak).not.toBeNull();
+    expect(matchedInEmpty).toBeNull();
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/styles/index.css
+++ b/packages/milkdown-plugin-japanese-novel/styles/index.css
@@ -29,6 +29,22 @@
   letter-spacing: 0;
 }
 
+/*
+ * Suppress the phantom blank line below a block (e.g. a heading) whose last
+ * inline node is an atom such as ruby. ProseMirror appends a zero-width
+ * `<img class="ProseMirror-separator">` followed by a `<br class="ProseMirror-trailingBreak">`
+ * after a trailing inline leaf so the caret can sit after it. The default
+ * stylesheet leaves that <br> visible, so a ruby-only heading renders an
+ * undeletable empty line underneath. Hiding only the trailing <br> that directly
+ * follows a separator removes the phantom line while keeping the caret position
+ * (handled by the separator <img>). Genuine empty blocks have no separator
+ * sibling, so their trailing break — and intentional `[[blank]]` paragraphs
+ * (handled separately via `p.mdi-blank::before`) — are unaffected.
+ */
+.milkdown-japanese-base img.ProseMirror-separator + br.ProseMirror-trailingBreak {
+  display: none;
+}
+
 /* Tate-chu-yoko: horizontal digits/punctuation */
 .milkdown-japanese-base .tcy {
   text-combine-upright: all;


### PR DESCRIPTION
## Summary

- 目次（章一覧）が見出しの MDI ルビ記法を解析できず、`{花|か}` のような生記法やルビ読みを連結した `花様年華かようねんか` が表示されていた問題を修正。base テキストのみ（例：**花様年華**）を表示するようにした。
- ルビ付き見出しの直下に「削除できない奇妙な空行」が表示される問題を修正。これは実段落ではなく、ProseMirror がルビ atom の後に挿入するカーソル配置用の `<br>` が見えていたもの。

## 原因と修正

### 1. 目次の MDI 解析
`lib/utils/index.ts` の章抽出が2経路ともルビを素通ししていた。
- **Markdown 経路** (`parseMarkdownChapters`)：`stripMdiInlineSyntax()` で `{base|ruby}` → `base` に変換
- **DOM 経路** (`getChaptersFromDOM`)：`heading.textContent` がルビ読み（`<rt>`）を連結していたため、`<rt>` を除外する `extractHeadingPlainText()` を追加

### 2. ルビ見出し下の空行（実機再現で真因を特定）
実際に Milkdown エディタを jsdom で動かして検証：
- 読込時・ルビ適用時とも空段落は**生成されない**／仮にあっても Backspace で削除可能
- レンダリング DOM をダンプし真因を特定：ルビは `atom:true` の inline leaf で、ブロック末尾に来ると ProseMirror が `<img class="ProseMirror-separator"><br class="ProseMirror-trailingBreak">` を挿入する。既定 CSS がこの `<br>` を可視のまま残すため、幻の空行になっていた。

修正（`styles/index.css`）は **separator 直後の trailing break のみ**を非表示にする1ルール。カーソル位置は separator `<img>` が担保するため維持され、意図的な `[[blank]]` 空段落（`p.mdi-blank::before` で別途高さ確保）や通常の空段落（separator 兄弟なし）には影響しない。

| File | 役割 |
|------|------|
| `lib/utils/index.ts` | 目次抽出でルビをプレーン化（Markdown/DOM 両経路） |
| `packages/milkdown-plugin-japanese-novel/styles/index.css` | trailing break 由来の幻の空行を抑止 |
| `lib/utils/__tests__/utils.test.ts` | 目次ルビ除去のテスト追加 |
| `packages/milkdown-plugin-japanese-novel/__tests__/ruby-heading-trailing-break.test.ts` | 実エディタで DOM 構造を検証する回帰テスト（新規） |

## Test plan

- [ ] ルビ付き見出しを含む `.mdi` を開く → 目次に base テキストのみ表示される
- [ ] ルビ付き見出しの下に空行が表示されない／普通の見出しは従来通り
- [ ] 意図的な `[[blank]]` 空段落は従来通り高さを保つ
- [x] `npx tsc --noEmit` 0 エラー
- [x] 関連テスト全合格（目次2件＋ルビ見出し4件、ESLint clean）

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)