### PR TITLE
fix(editor): 縦書きモードの組版品質を改善

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -354,6 +354,7 @@ html:not(.dark) {
 .milkdown ul,
 .milkdown ol {
   margin-block: 0.5em;
+  margin-inline: 0;
   padding-inline-start: 2em;
 }
 
@@ -388,6 +389,7 @@ html:not(.dark) {
 /* Blockquote styles */
 .milkdown blockquote {
   margin-block: 0.5em;
+  margin-inline: 0;
   padding-inline-start: 1em;
   border-inline-start: 3px solid rgb(var(--border-secondary));
   color: rgb(var(--foreground-secondary));

--- a/app/globals.css
+++ b/app/globals.css
@@ -347,14 +347,14 @@ html:not(.dark) {
 }
 
 .milkdown p {
-  margin-bottom: 0.5em;
+  margin-block-end: 0.5em;
 }
 
 /* List styles */
 .milkdown ul,
 .milkdown ol {
-  margin: 0.5em 0;
-  padding-left: 2em;
+  margin-block: 0.5em;
+  padding-inline-start: 2em;
 }
 
 .milkdown ul {
@@ -366,7 +366,7 @@ html:not(.dark) {
 }
 
 .milkdown li {
-  margin: 0.25em 0;
+  margin-block: 0.25em;
 }
 
 .milkdown ul ul {
@@ -387,46 +387,46 @@ html:not(.dark) {
 
 /* Blockquote styles */
 .milkdown blockquote {
-  margin: 0.5em 0;
-  padding-left: 1em;
-  border-left: 3px solid rgb(var(--border-secondary));
+  margin-block: 0.5em;
+  padding-inline-start: 1em;
+  border-inline-start: 3px solid rgb(var(--border-secondary));
   color: rgb(var(--foreground-secondary));
 }
 
 .milkdown h1 {
   font-size: 2em;
   font-weight: bold;
-  margin-bottom: 0.5em;
+  margin-block-end: 0.5em;
 }
 
 .milkdown h2 {
   font-size: 1.5em;
   font-weight: bold;
-  margin-bottom: 0.4em;
+  margin-block-end: 0.4em;
 }
 
 .milkdown h3 {
   font-size: 1.25em;
   font-weight: bold;
-  margin-bottom: 0.3em;
+  margin-block-end: 0.3em;
 }
 
 .milkdown h4 {
   font-size: 1.1em;
   font-weight: bold;
-  margin-bottom: 0.25em;
+  margin-block-end: 0.25em;
 }
 
 .milkdown h5 {
   font-size: 1em;
   font-weight: bold;
-  margin-bottom: 0.2em;
+  margin-block-end: 0.2em;
 }
 
 .milkdown h6 {
   font-size: 0.9em;
   font-weight: bold;
-  margin-bottom: 0.2em;
+  margin-block-end: 0.2em;
 }
 
 .milkdown h1,

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -345,6 +345,37 @@ export default function NovelEditor({
     }
   }, [isVertical]);
 
+  // 縦書き: コンテンツ幅の変化（Web フォント読込・行字数再計算など）後も読書位置を維持する。
+  // scrollLeft は数値のまま据え置かれるため、コンテンツが伸びると文書先頭（右端）が
+  // ビューポート外へ隠れてしまう。進捗（0=先頭）ベースで再固定してドリフトを防ぐ。
+  useEffect(() => {
+    if (!isVertical) return;
+    const container = scrollContainerRef.current;
+    const contentDom = editorViewInstance?.dom;
+    if (!container || !contentDom) return;
+
+    let lastProgress = getScrollProgress({ container, isVertical: true });
+    // 自前の再固定スクロールで lastProgress を上書きしないための猶予期限
+    let suppressScrollUntil = 0;
+
+    const handleScroll = () => {
+      if (performance.now() < suppressScrollUntil) return;
+      lastProgress = getScrollProgress({ container, isVertical: true });
+    };
+
+    const observer = new ResizeObserver(() => {
+      suppressScrollUntil = performance.now() + 100;
+      setScrollProgress({ container, isVertical: true }, lastProgress);
+    });
+
+    container.addEventListener("scroll", handleScroll, { passive: true });
+    observer.observe(contentDom);
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+      observer.disconnect();
+    };
+  }, [isVertical, editorViewInstance, scrollContainerRef]);
+
   // Per-pane local state for auto-calculated chars per line (avoids split panes overwriting each other)
   const [localAutoCharsPerLine, setLocalAutoCharsPerLine] = useState<number | null>(null);
   const effectiveCharsPerLine =
@@ -369,7 +400,7 @@ export default function NovelEditor({
     // Skip calculation when container is not visible (e.g., hidden dockview panel)
     if (container.clientWidth <= 0 || container.clientHeight <= 0) return;
 
-    // charWidth is measured by the persistent hidden element (includes letter-spacing, palt, etc.)
+    // charWidth is measured by the persistent hidden element (includes letter-spacing, font features, etc.)
     if (autoCharWidth <= 0) return;
 
     // Get available space (subtract padding)
@@ -451,7 +482,8 @@ export default function NovelEditor({
           overflowAnchor: "none",
           // In vertical-rl, padding on child elements causes Chromium to miscalculate scrollWidth.
           // Move horizontal padding to the scroll container itself, where the browser handles it correctly.
-          ...(isVertical ? { paddingLeft: 64, paddingRight: 64 } : {}),
+          // scrollbar-gutter keeps the bottom line clear of the horizontal scrollbar (non-overlay platforms).
+          ...(isVertical ? { paddingLeft: 64, paddingRight: 64, scrollbarGutter: "stable" } : {}),
         }}
       >
         {/* Hidden character width measurement element for auto chars-per-line calculation */}

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -867,14 +867,19 @@ export default function MilkdownEditor({
         }
         div :global(.milkdown .ProseMirror.milkdown-japanese-horizontal p) {
           text-indent: ${textIndent}em;
-          margin-bottom: ${paragraphSpacing}em;
-          ${showParagraphNumbers ? "counter-increment: paragraph;" : ""}
-          ${showParagraphNumbers ? "position: relative;" : ""}
+          margin-block-end: ${paragraphSpacing}em;
         }
         div :global(.milkdown .ProseMirror.milkdown-japanese-vertical p) {
           text-indent: ${textIndent}em;
-          margin-left: ${paragraphSpacing}em;
-          margin-bottom: 0;
+          margin-block-end: ${paragraphSpacing}em;
+        }
+        /* 行頭起こし括弧の段落（会話文など）は字下げしない */
+        div :global(.milkdown .ProseMirror p.mdi-dialogue) {
+          text-indent: 0;
+        }
+        /* 段落番号: 空行 (.mdi-blank) は数えない・表示しない。
+           .mdi-blank の ::before は \\200B 表示（package CSS）に予約されている */
+        div :global(.milkdown .ProseMirror p:not(.mdi-blank)) {
           ${showParagraphNumbers ? "counter-increment: paragraph;" : ""}
           ${showParagraphNumbers ? "position: relative;" : ""}
         }
@@ -883,7 +888,7 @@ export default function MilkdownEditor({
           display: inline-block;
           width: ${textIndent}em;
         }
-        div :global(.milkdown .ProseMirror.milkdown-japanese-horizontal p::before) {
+        div :global(.milkdown .ProseMirror.milkdown-japanese-horizontal p:not(.mdi-blank)::before) {
           ${showParagraphNumbers
             ? `
               content: counter(paragraph);
@@ -897,7 +902,7 @@ export default function MilkdownEditor({
             `
             : "content: none;"}
         }
-        div :global(.milkdown .ProseMirror.milkdown-japanese-vertical p::before) {
+        div :global(.milkdown .ProseMirror.milkdown-japanese-vertical p:not(.mdi-blank)::before) {
           ${showParagraphNumbers
             ? `
               content: counter(paragraph);
@@ -923,15 +928,6 @@ export default function MilkdownEditor({
         div :global(.milkdown .ProseMirror li),
         div :global(.milkdown .ProseMirror blockquote) {
           text-indent: 0;
-        }
-        /* 見出しも段落としてカウントするが番号は非表示 */
-        div :global(.milkdown .ProseMirror h1),
-        div :global(.milkdown .ProseMirror h2),
-        div :global(.milkdown .ProseMirror h3),
-        div :global(.milkdown .ProseMirror h4),
-        div :global(.milkdown .ProseMirror h5),
-        div :global(.milkdown .ProseMirror h6) {
-          ${showParagraphNumbers ? "counter-increment: paragraph;" : ""}
         }
       `}</style>
       <style jsx global>{`

--- a/packages/milkdown-plugin-japanese-novel/__tests__/dialogue-indent.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/dialogue-indent.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import type { Node } from "@milkdown/prose/model";
+import { getParagraphLeadingChar, isDialogueParagraph } from "../plugins/dialogue-indent";
+
+type MockChild = {
+  isText: boolean;
+  text?: string | null;
+  type: { name: string };
+  attrs: Record<string, unknown>;
+};
+
+function makeParagraph(firstChild: MockChild | null): Node {
+  return { firstChild } as unknown as Node;
+}
+
+function textChild(text: string): MockChild {
+  return { isText: true, text, type: { name: "text" }, attrs: {} };
+}
+
+function rubyChild(base: string): MockChild {
+  return { isText: false, type: { name: "ruby" }, attrs: { base, text: "" } };
+}
+
+describe("getParagraphLeadingChar", () => {
+  it("returns the first character of a leading text node", () => {
+    expect(getParagraphLeadingChar(makeParagraph(textChild("「あなたは」")))).toBe("「");
+  });
+
+  it("returns the first base character of a leading ruby node", () => {
+    expect(getParagraphLeadingChar(makeParagraph(rubyChild("花様年華")))).toBe("花");
+  });
+
+  it("returns empty string for an empty paragraph", () => {
+    expect(getParagraphLeadingChar(makeParagraph(null))).toBe("");
+  });
+
+  it("returns empty string for a non-text non-ruby leading node", () => {
+    const atom: MockChild = { isText: false, type: { name: "mdibreak" }, attrs: {} };
+    expect(getParagraphLeadingChar(makeParagraph(atom))).toBe("");
+  });
+});
+
+describe("isDialogueParagraph", () => {
+  it.each(["「", "『", "（", "〈", "《", "【", "〔"])(
+    "treats a paragraph starting with %s as dialogue",
+    (bracket) => {
+      expect(isDialogueParagraph(makeParagraph(textChild(`${bracket}台詞`)))).toBe(true);
+    },
+  );
+
+  it("does not treat a normal narrative paragraph as dialogue", () => {
+    expect(isDialogueParagraph(makeParagraph(textChild("退勤後、彼はいつも")))).toBe(false);
+  });
+
+  it("does not treat closing brackets as dialogue openers", () => {
+    expect(isDialogueParagraph(makeParagraph(textChild("」から始まる")))).toBe(false);
+  });
+
+  it("does not treat an empty paragraph as dialogue", () => {
+    expect(isDialogueParagraph(makeParagraph(null))).toBe(false);
+  });
+
+  it("treats a paragraph whose leading ruby base starts with a bracket as dialogue", () => {
+    expect(isDialogueParagraph(makeParagraph(rubyChild("「かっこ」")))).toBe(true);
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/index.ts
@@ -24,6 +24,7 @@ import {
 } from "./syntax";
 import { createHeadingIdFixerPlugin } from "./plugins/heading-id-fixer";
 import { createHardbreakIndentPlugin } from "./plugins/hardbreak-indent";
+import { createDialogueIndentPlugin } from "./plugins/dialogue-indent";
 import { defaultJapaneseNovelOptions, type JapaneseNovelOptions } from "./config";
 
 export type { JapaneseNovelOptions } from "./config";
@@ -111,6 +112,10 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     return createHardbreakIndentPlugin();
   });
 
+  const dialogueIndentPlugin = $prose(() => {
+    return createDialogueIndentPlugin();
+  });
+
   const plugins: MilkdownPlugin[] = [
     ...(enableRuby ? [remarkRuby, rubySchema] : []),
     ...(enableTcy ? [remarkTcy, tcySchema] : []),
@@ -123,6 +128,7 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     headingAnchorSchema,
     headingIdFixerPlugin,
     hardbreakIndentPlugin,
+    dialogueIndentPlugin,
     stylePlugin,
   ].flat();
 

--- a/packages/milkdown-plugin-japanese-novel/plugins/dialogue-indent.ts
+++ b/packages/milkdown-plugin-japanese-novel/plugins/dialogue-indent.ts
@@ -1,0 +1,57 @@
+import { Plugin, PluginKey } from "@milkdown/prose/state";
+import { Decoration, DecorationSet } from "@milkdown/prose/view";
+import type { Node } from "@milkdown/prose/model";
+
+/**
+ * 行頭の起こし括弧。これらで始まる段落（会話文など）は
+ * 日本語小説組版の慣例に従い字下げしない。
+ */
+const OPENING_BRACKETS = new Set(["「", "『", "（", "〈", "《", "【", "〔", "“", "‘"]);
+
+/**
+ * 段落の見た目上の先頭文字を返す。
+ * 先頭がルビの場合は親文字（base）の先頭を見る。
+ */
+export function getParagraphLeadingChar(node: Node): string {
+  const first = node.firstChild;
+  if (!first) return "";
+  if (first.isText) return first.text?.charAt(0) ?? "";
+  if (first.type.name === "ruby") {
+    return ((first.attrs.base as string) ?? "").charAt(0);
+  }
+  return "";
+}
+
+/**
+ * 起こし括弧で始まる段落（= 字下げ対象外）かどうか。
+ */
+export function isDialogueParagraph(node: Node): boolean {
+  return OPENING_BRACKETS.has(getParagraphLeadingChar(node));
+}
+
+/**
+ * 起こし括弧で始まる段落に `mdi-dialogue` クラスを付与する
+ * デコレーションプラグイン。CSS 側で `text-indent: 0` を適用し、
+ * 会話文の行頭を天付きにする。ドキュメント内容は変更しない。
+ */
+export function createDialogueIndentPlugin(): Plugin {
+  return new Plugin({
+    key: new PluginKey("dialogueIndent"),
+    props: {
+      decorations(state) {
+        const decorations: Decoration[] = [];
+
+        state.doc.descendants((node: Node, pos: number) => {
+          if (node.type.name !== "paragraph") return;
+          if (isDialogueParagraph(node)) {
+            decorations.push(Decoration.node(pos, pos + node.nodeSize, { class: "mdi-dialogue" }));
+          }
+          // 段落内のインラインまで降りる必要はない
+          return false;
+        });
+
+        return DecorationSet.create(state.doc, decorations);
+      },
+    },
+  });
+}

--- a/packages/milkdown-plugin-japanese-novel/styles/horizontal.css
+++ b/packages/milkdown-plugin-japanese-novel/styles/horizontal.css
@@ -15,8 +15,8 @@
   font-size: 1em;
   letter-spacing: 0.05em;
   word-spacing: 0.1em;
-  -webkit-font-feature-settings: "palt" 1;
-  font-feature-settings: "palt" 1;
+  /* No "palt": novel typesetting uses full-width pitch (JIS X 4051 べた組み) */
+  font-feature-settings: normal;
 }
 
 /* Tate-chu-yoko styling in horizontal mode (normally not used, but for completeness) */

--- a/packages/milkdown-plugin-japanese-novel/styles/index.css
+++ b/packages/milkdown-plugin-japanese-novel/styles/index.css
@@ -15,8 +15,8 @@
   font-size: 1em;
   letter-spacing: 0.05em;
   word-spacing: 0.1em;
-  -webkit-font-feature-settings: "palt" 1;
-  font-feature-settings: "palt" 1;
+  /* No "palt": novel typesetting uses full-width pitch (JIS X 4051 べた組み) */
+  font-feature-settings: normal;
 }
 
 /* Ruby (振仮名) unified base styling */

--- a/packages/milkdown-plugin-japanese-novel/styles/vertical.css
+++ b/packages/milkdown-plugin-japanese-novel/styles/vertical.css
@@ -19,8 +19,8 @@
   font-size: 1em;
   letter-spacing: 0.05em;
   word-spacing: 0.1em;
-  -webkit-font-feature-settings: "palt" 1;
-  font-feature-settings: "palt" 1;
+  /* No "palt": novel typesetting uses full-width pitch (JIS X 4051 べた組み) */
+  font-feature-settings: normal;
 }
 
 /* Tate-chu-yoko: horizontal digits/punctuation in vertical flow */
@@ -38,20 +38,25 @@
   letter-spacing: 0;
 }
 
-/* List styles in vertical mode */
+/* List styles in vertical mode.
+   Logical properties resolve to the correct physical sides under vertical-rl
+   (block = horizontal, inline = vertical). */
 .milkdown-japanese-vertical ul,
 .milkdown-japanese-vertical ol {
-  margin: 0 0.5em;
-  padding-top: 2em;
+  margin-block: 0.5em;
+  margin-inline: 0;
+  padding-inline-start: 2em;
 }
 
 .milkdown-japanese-vertical li {
-  margin: 0.25em 0;
+  margin-block: 0.25em;
+  margin-inline: 0;
 }
 
 /* Blockquote styles in vertical mode */
 .milkdown-japanese-vertical blockquote {
-  margin: 0 0.5em;
-  padding-top: 1em;
-  border-top: 3px solid rgb(var(--border-secondary));
+  margin-block: 0.5em;
+  margin-inline: 0;
+  padding-inline-start: 1em;
+  border-inline-start: 3px solid rgb(var(--border-secondary));
 }


### PR DESCRIPTION
## 概要

縦書きモードのスクリーンショット検証で確認された組版品質問題（8件）のうち、コード起因の5件を修正する。

## 確認された問題と修正

| # | 問題 | 根本原因 | 修正 |
|---|------|---------|------|
| 1 | 段落番号の欠番・「2」始まり | 空行 `p.mdi-blank` と見出しが番号を不可視のまま消費 | カウンター対象を `p:not(.mdi-blank)` に限定し、h1-h6 の increment を削除。可視本文段落のみ 1 から連番 |
| 2 | 見出しと本文の段間隔が縦書きで効かない | `margin-bottom` 等の物理プロパティは vertical-rl で段方向に作用しない | `margin-block-end` / `padding-inline-start` / `border-inline-start` へ論理プロパティ化（横書きでは同値） |
| 3 | 字送りが不均一（約物の半角詰め） | `font-feature-settings: "palt"` が常時有効 | palt を削除し JIS X 4051 のべた組み（全角字送り）に統一 |
| 4 | 文書先頭（タイトル列＋ルビ）が右パネル境界に密着・見切れ | レイアウト確定後の content 幅変化（Web フォント読込・行字数再計算）で scrollLeft が据え置かれ、先頭列がビューポート外へドリフト | ProseMirror DOM の ResizeObserver で読書進捗（0=先頭）ベースに再固定。`scrollbar-gutter: stable` も追加 |
| 5 | 会話文「…」行にも 1em 字下げ | 全段落一律の `text-indent` | 行頭起こし括弧（「『（〈《【〔“‘）で始まる段落に `mdi-dialogue` クラスを付与する decoration plugin を追加し `text-indent: 0` |

なお「見出しルビの間延び」は Electron 実測でルビ CSS は正常（密着レンダリング）と確認でき、ソース側のルビ分割単位（モノルビ）由来のためコード修正対象外。太字に見える行はソースの強調マーク由来。

## 検証

- `npm run type-check` ✅ / `npm run test` ✅ 84 files / 1127 tests（新規 dialogue-indent テスト 15 件含む）
- Electron (Chromium) 最小再現環境での実測:
  - 段落番号 1〜8 連番・欠番なし、空行は番号非表示
  - 会話文の天付き、見出し margin、右端 64px 余白、ルビ密着を目視確認

## 関連 issue

関連 issue なし（縦書き/組版/ルビ/字下げ/typography で open issue を検索済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)