### PR TITLE
fix(tab-manager): unify per-path save lock and close conflicted TOCTOU (#1562)

### DIFF
--- a/lib/tab-manager/__tests__/save-lock.test.ts
+++ b/lib/tab-manager/__tests__/save-lock.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for fix #1562: concurrent-save guards in the auto-save flow.
+ *
+ * (a) Unified per-path save lock — the active-tab save (use-file-io) and the
+ *     background auto-save (use-auto-save) previously used independent guards
+ *     (isSavingRef / savingTabIdsRef) that could not see each other, allowing
+ *     two concurrent writes to the same path. Both paths now share the
+ *     synchronous per-path lock in save-lock.ts.
+ *
+ * (b) conflicted-transition TOCTOU — tabsRef is only reassigned from React
+ *     state on the next render, so the auto-save interval could read a stale
+ *     non-conflicted snapshot right after the file watcher flagged a conflict
+ *     and overwrite the external change. buildOnChanged now eagerly mirrors
+ *     the conflicted transition into tabsRef before React re-renders.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { acquireSaveLock, releaseSaveLock, isSaveLocked, clearSaveLocks } from "../save-lock";
+import { buildOnChanged } from "../use-file-watch-integration";
+import { isEditorTab } from "../tab-types";
+import type { Dispatch, SetStateAction } from "react";
+import type { EditorTabState, TabState } from "../tab-types";
+import type { UseFileWatchIntegrationParams } from "../use-file-watch-integration";
+
+type SetTabs = Dispatch<SetStateAction<TabState[]>>;
+type OpenDiffTab = UseFileWatchIntegrationParams["openDiffTab"];
+
+// Mock notificationManager so its actions are captured rather than rendered
+vi.mock("../../services/notification-manager", () => ({
+  notificationManager: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    showMessage: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEditorTab(overrides: Partial<EditorTabState> = {}): EditorTabState {
+  return {
+    tabKind: "editor",
+    id: "tab-1",
+    file: { path: "/p/main.mdi", handle: null, name: "main.mdi" },
+    content: "in-memory edited content",
+    lastSavedContent: "original disk content",
+    isDirty: true,
+    lastSavedTime: 1_000_000,
+    lastSaveWasAuto: false,
+    isSaving: false,
+    isPreview: false,
+    fileType: ".mdi",
+    fileSyncStatus: "dirty",
+    conflictDiskContent: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// (a) Per-path save lock
+// ---------------------------------------------------------------------------
+
+describe("save-lock: unified per-path guard (#1562 a)", () => {
+  beforeEach(() => {
+    clearSaveLocks();
+  });
+
+  it("acquires a free lock and reports it as held", () => {
+    expect(acquireSaveLock("/p/a.mdi")).toBe(true);
+    expect(isSaveLocked("/p/a.mdi")).toBe(true);
+  });
+
+  it("rejects a second acquire for the same path while held", () => {
+    // Simulates: background auto-save in flight, then the active-tab
+    // saveFile (or the next interval) tries to write the same path.
+    expect(acquireSaveLock("/p/a.mdi")).toBe(true);
+    expect(acquireSaveLock("/p/a.mdi")).toBe(false);
+  });
+
+  it("allows re-acquire after release", () => {
+    expect(acquireSaveLock("/p/a.mdi")).toBe(true);
+    releaseSaveLock("/p/a.mdi");
+    expect(isSaveLocked("/p/a.mdi")).toBe(false);
+    expect(acquireSaveLock("/p/a.mdi")).toBe(true);
+  });
+
+  it("locks are independent per path", () => {
+    expect(acquireSaveLock("/p/a.mdi")).toBe(true);
+    expect(acquireSaveLock("/p/b.mdi")).toBe(true);
+    releaseSaveLock("/p/a.mdi");
+    expect(isSaveLocked("/p/a.mdi")).toBe(false);
+    expect(isSaveLocked("/p/b.mdi")).toBe(true);
+  });
+
+  it("releasing an unheld path is a no-op", () => {
+    expect(() => releaseSaveLock("/p/never-acquired.mdi")).not.toThrow();
+    expect(isSaveLocked("/p/never-acquired.mdi")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (b) conflicted-transition TOCTOU: eager tabsRef mirror
+// ---------------------------------------------------------------------------
+
+describe("buildOnChanged: eagerly mirrors conflicted into tabsRef (#1562 b)", () => {
+  let setTabs: SetTabs;
+  let openDiffTab: OpenDiffTab;
+  let tabsRef: { current: TabState[] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setTabs = vi.fn<SetTabs>();
+    openDiffTab = vi.fn<OpenDiffTab>();
+  });
+
+  it("dirty tab: tabsRef shows conflicted before React re-renders", () => {
+    const tab = makeEditorTab({ fileSyncStatus: "dirty", isDirty: true });
+    tabsRef = { current: [tab] };
+    const onChanged = buildOnChanged(tab.id, setTabs, tabsRef, openDiffTab);
+
+    // External change arrives on a dirty tab. setTabs is only queued (mock
+    // does not apply the updater), simulating the window before the next
+    // render commits — tabsRef must already reflect the conflict so the
+    // auto-save interval guard skips the tab.
+    onChanged("external disk content", 2_000_000);
+
+    const latest = tabsRef.current.find((t) => t.id === tab.id);
+    expect(latest && isEditorTab(latest)).toBe(true);
+    if (latest && isEditorTab(latest)) {
+      expect(latest.fileSyncStatus).toBe("conflicted");
+      expect(latest.conflictDiskContent).toBe("external disk content");
+    }
+  });
+
+  it("auto-save guard skips the tab right after the watcher fires (TOCTOU scenario)", () => {
+    const tab = makeEditorTab({ fileSyncStatus: "dirty", isDirty: true });
+    tabsRef = { current: [tab] };
+    const onChanged = buildOnChanged(tab.id, setTabs, tabsRef, openDiffTab);
+
+    onChanged("external disk content", 2_000_000);
+
+    // Mirrors the guard in useAutoSave: it reads the tabsRef snapshot.
+    const snapshot = tabsRef.current.find((t) => t.id === tab.id);
+    const shouldAutoSave =
+      snapshot !== undefined &&
+      isEditorTab(snapshot) &&
+      snapshot.fileSyncStatus !== "conflicted" &&
+      snapshot.isDirty &&
+      snapshot.file !== null &&
+      !snapshot.isSaving;
+
+    expect(shouldAutoSave).toBe(false);
+  });
+
+  it("does not touch other tabs in tabsRef", () => {
+    const tab = makeEditorTab({ id: "tab-1", fileSyncStatus: "dirty" });
+    const other = makeEditorTab({
+      id: "tab-2",
+      file: { path: "/p/other.mdi", handle: null, name: "other.mdi" },
+      fileSyncStatus: "dirty",
+    });
+    tabsRef = { current: [tab, other] };
+    const onChanged = buildOnChanged(tab.id, setTabs, tabsRef, openDiffTab);
+
+    onChanged("external disk content", 2_000_000);
+
+    const untouched = tabsRef.current.find((t) => t.id === "tab-2");
+    if (untouched && isEditorTab(untouched)) {
+      expect(untouched.fileSyncStatus).toBe("dirty");
+      expect(untouched.conflictDiskContent).toBeNull();
+    }
+  });
+
+  it("clean tab: auto-reload path leaves tabsRef status untouched (no false conflict)", () => {
+    const tab = makeEditorTab({
+      fileSyncStatus: "clean",
+      isDirty: false,
+      content: "original disk content",
+    });
+    tabsRef = { current: [tab] };
+    const onChanged = buildOnChanged(tab.id, setTabs, tabsRef, openDiffTab);
+
+    onChanged("external disk content", 2_000_000);
+
+    const latest = tabsRef.current.find((t) => t.id === tab.id);
+    if (latest && isEditorTab(latest)) {
+      expect(latest.fileSyncStatus).toBe("clean");
+    }
+  });
+});

--- a/lib/tab-manager/save-lock.ts
+++ b/lib/tab-manager/save-lock.ts
@@ -1,0 +1,41 @@
+/**
+ * Unified per-path save lock (fix #1562).
+ *
+ * The active-tab save path (use-file-io: `isSavingRef`) and the background
+ * auto-save path (use-auto-save: `savingTabIdsRef`) previously used
+ * independent guards that could not see each other. When a background save
+ * was still in flight for a tab that became active, the next auto-save
+ * interval could start a second concurrent write to the same path, and the
+ * stale write could land last — silently dropping newer edits from disk.
+ *
+ * This module provides a single synchronous guard keyed by file path that
+ * all save paths share. Locks are acquired synchronously before any async
+ * write starts and must be released in a `finally` block.
+ */
+
+const savingPaths = new Set<string>();
+
+/**
+ * Try to acquire the save lock for a file path.
+ * Returns false if a save for the same path is already in flight.
+ */
+export function acquireSaveLock(path: string): boolean {
+  if (savingPaths.has(path)) return false;
+  savingPaths.add(path);
+  return true;
+}
+
+/** Release the save lock for a file path. */
+export function releaseSaveLock(path: string): void {
+  savingPaths.delete(path);
+}
+
+/** Whether a save is currently in flight for the given path. */
+export function isSaveLocked(path: string): boolean {
+  return savingPaths.has(path);
+}
+
+/** Test-only helper: clear all locks. */
+export function clearSaveLocks(): void {
+  savingPaths.clear();
+}

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -7,6 +7,7 @@ import { suppressFileWatch } from "../services/file-watcher";
 import { notificationManager } from "../services/notification-manager";
 import type { SnapshotType } from "../services/history-policy";
 import { isEditorTab } from "./tab-types";
+import { acquireSaveLock, releaseSaveLock } from "./save-lock";
 import type { TabManagerCore } from "./types";
 import { AUTO_SAVE_INTERVAL, sanitizeMdiContent } from "./types";
 
@@ -85,6 +86,11 @@ export function useAutoSave(params: UseAutoSaveParams): void {
         }
         // Synchronous guard to prevent concurrent saves for the same tab
         if (savingTabIdsRef.current.has(tab.id)) continue;
+        // Fix #1562 (a): unified per-path lock shared with the active-tab
+        // save path (use-file-io.saveFile) so two writes can never target
+        // the same path concurrently.
+        const lockPath = tab.file.path ?? null;
+        if (lockPath && !acquireSaveLock(lockPath)) continue;
         savingTabIdsRef.current.add(tab.id);
 
         // Non-active dirty tabs: save directly
@@ -92,6 +98,14 @@ export function useAutoSave(params: UseAutoSaveParams): void {
         setTabs((prev) => prev.map((t) => (t.id === tab.id ? { ...t, isSaving: true } : t)));
         void (async () => {
           try {
+            // Fix #1562 (b): re-check the latest sync status right before
+            // writing — a file watcher may have flagged a conflict after the
+            // interval snapshot was taken (buildOnChanged mirrors the
+            // conflicted transition into tabsRef synchronously).
+            const latest = tabsRef.current.find((t) => t.id === tab.id);
+            if (!latest || !isEditorTab(latest) || latest.fileSyncStatus === "conflicted") {
+              return;
+            }
             const sanitized = sanitizeMdiContent(tab.content, { fileType: tab.fileType });
             if (isProjectRef.current && tab.file?.path) {
               const vfs = getProjectFileService();
@@ -159,6 +173,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
             );
           } finally {
             savingTabIdsRef.current.delete(tab.id);
+            if (lockPath) releaseSaveLock(lockPath);
             if (!mountedRef.current) return;
             setTabs((prev) => prev.map((t) => (t.id === tab.id ? { ...t, isSaving: false } : t)));
           }

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -13,6 +13,7 @@ import { getHistoryService } from "../services/history-service";
 import type { SnapshotType } from "../services/history-policy";
 import { getProjectFileService } from "../services/project-file-service";
 import { suppressFileWatch } from "../services/file-watcher";
+import { acquireSaveLock, releaseSaveLock } from "./save-lock";
 import type { TabId, EditorTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
 import { generateTabId, inferFileType, sanitizeMdiContent, getErrorMessage } from "./types";
@@ -273,6 +274,12 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         return;
       }
 
+      // Fix #1562 (a): unified per-path lock shared with the background
+      // auto-save path (use-auto-save). Skip if a save for the same path is
+      // already in flight so two writes can never target the same file at once.
+      const lockPath = tab.file?.path ?? null;
+      if (lockPath && !acquireSaveLock(lockPath)) return;
+
       isSavingRef.current = true;
       updateTab(tabId, { isSaving: true });
 
@@ -368,6 +375,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         const message = getErrorMessage(error);
         notificationManager.error(`保存に失敗しました: ${message}`);
       } finally {
+        if (lockPath) releaseSaveLock(lockPath);
         isSavingRef.current = false;
       }
     },

--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -106,6 +106,20 @@ export function buildOnChanged(
       // Dirty tab: do NOT touch buffer; enter conflicted state
       const localContent = tab.content;
 
+      // Fix #1562 (b): eagerly mirror the conflicted transition into tabsRef.
+      // tabsRef is only reassigned from React state on the next render, so
+      // the synchronous save guards (auto-save interval / saveFile) would
+      // otherwise read a stale non-conflicted snapshot and overwrite the
+      // external change on disk before the setTabs update below commits.
+      tabsRef.current = tabsRef.current.map((t) => {
+        if (t.id !== tabId || !isEditorTab(t)) return t;
+        return {
+          ...t,
+          fileSyncStatus: "conflicted",
+          conflictDiskContent: diskContent,
+        } satisfies EditorTabState;
+      });
+
       setTabs((prev) =>
         prev.map((t) => {
           if (t.id !== tabId || !isEditorTab(t)) return t;


### PR DESCRIPTION
Closes #1562

## Summary

auto-save に存在した2つの競合バグ（QA audit で verified）を修正する。

### (a) 二重保存ガード非連動
アクティブタブ保存（`use-file-io` の `isSavingRef`）とバックグラウンド auto-save（`use-auto-save` の `savingTabIdsRef`）は互いを認識しないガードを使っており、同一パスへ2つの `vfs.writeFile` が並走し得た（古い書き込みが後着すると新しい編集がディスクから消える）。

- 新規モジュール `lib/tab-manager/save-lock.ts` に同期的な per-path ロックを実装
- `saveFile`（use-file-io）と background auto-save（use-auto-save）の両方が書き込み開始前に同じロックを取得し、`finally` で解放する

### (b) conflicted 判定の TOCTOU
`tabsRef.current` は次の render でしか React state から再代入されないため、watcher が conflicted へ遷移させた直後に auto-save interval が発火すると、stale な snapshot を読んで外部変更を上書きし得た。

- `buildOnChanged`（use-file-watch-integration）が conflicted 遷移を `tabsRef` へ即時ミラーし、render 前でも同期ガードが競合を観測できるようにした
- background auto-save は書き込み直前に `tabsRef` の最新 `fileSyncStatus` を再確認する

## Test plan

- [x] `lib/tab-manager/__tests__/save-lock.test.ts` 追加（9 tests）— 修正なしでは TOCTOU 系 2 件が fail することを確認済み
- [x] `npx vitest run lib/tab-manager/__tests__/` — 15 files / 154 tests passed
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors（warning は既存のもののみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
## レビューで特定された残存ギャップ(本 PR のスコープ外)
- メニュー保存 (`use-electron-menu-bindings.ts`) / クローズダイアログ保存 (`use-close-dialog.ts`) はロック未適用
- handle ベース保存(web, `path === null`)はロックキーが path のためスキップされる

→ #1579 で追跡(保存フロー共通化 #1432 と合わせて対応予定)