### PR TITLE
feat(linting): 設定UIにルール検出レベル(L1/L2/L3)タグを表示

### DIFF
--- a/components/settings/LintingSettings.tsx
+++ b/components/settings/LintingSettings.tsx
@@ -20,7 +20,16 @@ import {
   CORRECTION_MODES,
   MODE_TO_PRESET,
 } from "@/lib/linting/correction-modes";
+import { getRuleLevelMap } from "@/lib/linting/rule-registry";
+import type { RuleLevel } from "@/lib/linting/types";
 import GuidelineList from "@/components/GuidelineList";
+
+/** Tooltip text describing each detection level. */
+const RULE_LEVEL_LABELS: Record<RuleLevel, string> = {
+  L1: "L1：正規表現による検出",
+  L2: "L2：形態素解析による検出",
+  L3: "L3：LLM 補助による検出",
+};
 
 /** Map of rule ID -> supportsSkipDialogue from metadata */
 const SKIP_DIALOGUE_SUPPORT = new Map(
@@ -142,6 +151,9 @@ export default function LintingSettings({
 
   // Memoized map to avoid recreation on every render (LINT_RULES_META is a module-level constant)
   const ruleMetaMap = useMemo(() => new Map(LINT_RULES_META.map((r) => [r.id, r])), []);
+
+  // Rule ID -> detection level (L1/L2/L3), derived from the actual rule instances
+  const ruleLevelMap = useMemo(() => getRuleLevelMap(), []);
 
   /** Handle correction mode change: update mode, guidelines, and apply corresponding preset */
   const handleModeChange = useCallback(
@@ -332,6 +344,7 @@ export default function LintingSettings({
                     if (!meta) return null;
                     const config = getConfig(ruleId, lintingRuleConfigs);
                     const showDialogueToggle = SKIP_DIALOGUE_SUPPORT.get(ruleId) ?? false;
+                    const level = ruleLevelMap.get(ruleId);
 
                     return (
                       <div
@@ -339,11 +352,17 @@ export default function LintingSettings({
                         className={clsx("flex items-center gap-2 px-3 py-2")}
                         title={undefined}
                       >
-                        {/* Rule name */}
-                        <div className="flex-1 min-w-0">
-                          <span className="text-sm text-foreground truncate block">
-                            {meta.nameJa}
-                          </span>
+                        {/* Rule name + level tag */}
+                        <div className="flex-1 min-w-0 flex items-center gap-1.5">
+                          {level && (
+                            <span
+                              className="flex-shrink-0 text-[10px] font-medium leading-none px-1 py-0.5 rounded border border-border-secondary text-foreground-tertiary bg-background-tertiary/50"
+                              title={RULE_LEVEL_LABELS[level]}
+                            >
+                              {level}
+                            </span>
+                          )}
+                          <span className="text-sm text-foreground truncate">{meta.nameJa}</span>
                         </div>
 
                         {/* Skip dialogue toggle */}

--- a/lib/linting/__tests__/rule-level-map.test.ts
+++ b/lib/linting/__tests__/rule-level-map.test.ts
@@ -6,7 +6,9 @@ describe("getRuleLevelMap", () => {
   test("covers every rule produced by the factories", () => {
     const rules = createJsonDrivenRules();
     const levels = getRuleLevelMap();
-    expect(levels.size).toBe(rules.length);
+    // The map may grow beyond the JSON-driven factories once hand-written
+    // (e.g. L2 morphological) rules are re-added via getAllRules().
+    expect(levels.size).toBeGreaterThanOrEqual(rules.length);
     for (const rule of rules) {
       expect(levels.get(rule.id)).toBe(rule.level);
     }

--- a/lib/linting/__tests__/rule-level-map.test.ts
+++ b/lib/linting/__tests__/rule-level-map.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { getRuleLevelMap, createJsonDrivenRules } from "@/lib/linting/rule-registry";
+import { LINT_RULES_META } from "@/lib/linting/lint-presets";
+
+describe("getRuleLevelMap", () => {
+  test("covers every rule produced by the factories", () => {
+    const rules = createJsonDrivenRules();
+    const levels = getRuleLevelMap();
+    expect(levels.size).toBe(rules.length);
+    for (const rule of rules) {
+      expect(levels.get(rule.id)).toBe(rule.level);
+    }
+  });
+
+  test("every settings metadata entry has a known level", () => {
+    const levels = getRuleLevelMap();
+    const missing = LINT_RULES_META.filter((m) => !levels.has(m.id)).map((m) => m.id);
+    expect(missing).toEqual([]);
+  });
+
+  test("returns a memoized identical reference", () => {
+    expect(getRuleLevelMap()).toBe(getRuleLevelMap());
+  });
+});

--- a/lib/linting/rule-registry.ts
+++ b/lib/linting/rule-registry.ts
@@ -31,7 +31,7 @@ export function createJsonDrivenRules(): LintRule[] {
   return [...createJtfL1Rules(), ...createManuscriptL1Rules(), ...createNihongoHyoukiL1Rules()];
 }
 
-/** Lazily-built map of rule ID -> detection level, derived from the rule factories. */
+/** Lazily-built map of rule ID -> detection level, covering ALL registered rule instances (hand-written via getAllRules + JSON-driven factories). */
 let ruleLevelMap: ReadonlyMap<string, RuleLevel> | null = null;
 
 /**

--- a/lib/linting/rule-registry.ts
+++ b/lib/linting/rule-registry.ts
@@ -1,4 +1,4 @@
-import type { LintRule } from "@/lib/linting/types";
+import type { LintRule, RuleLevel } from "@/lib/linting/types";
 
 // ---------------------------------------------------------------------------
 // L1 JSON-driven factory rules from Japanese-Style-Sheet
@@ -7,7 +7,21 @@ import { createJtfL1Rules } from "@/lib/linting/rules/json-l1/jtf-l1-rules";
 import { createManuscriptL1Rules } from "@/lib/linting/rules/json-l1/manuscript-l1-rules";
 import { createNihongoHyoukiL1Rules } from "@/lib/linting/rules/json-l1";
 
-/** Return all hand-written rules (currently none — all moved to JSON-driven). */
+/**
+ * Return all hand-written rule instances (morphological L2 rules and other
+ * non-JSON-driven rules).
+ *
+ * Currently empty: the hand-written L2 (kuromoji) rules were removed when dev
+ * was re-aligned to the v1.2.7 rollback baseline — they were NOT migrated to
+ * the JSON-driven factories, which cover L1 (regex) rules only.
+ *
+ * This is a live registration point, not dead code: `RuleRunnerProxy`
+ * (packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts)
+ * registers any morphological rules returned here onto its main-thread
+ * RuleRunner. Re-add future L2 rules HERE — not in the JSON-driven factories —
+ * so they run on the main thread, where kuromoji tokenization is available
+ * (it is not available inside the lint worker).
+ */
 export function getAllRules(): LintRule[] {
   return [];
 }
@@ -15,4 +29,20 @@ export function getAllRules(): LintRule[] {
 /** Return all JSON-driven L1 rules from the style-sheet factories. */
 export function createJsonDrivenRules(): LintRule[] {
   return [...createJtfL1Rules(), ...createManuscriptL1Rules(), ...createNihongoHyoukiL1Rules()];
+}
+
+/** Lazily-built map of rule ID -> detection level, derived from the rule factories. */
+let ruleLevelMap: ReadonlyMap<string, RuleLevel> | null = null;
+
+/**
+ * Return a map of rule ID -> detection level (L1/L2/L3), built from the actual
+ * rule instances so the UI never drifts from what the engine runs. Memoized.
+ */
+export function getRuleLevelMap(): ReadonlyMap<string, RuleLevel> {
+  if (ruleLevelMap === null) {
+    ruleLevelMap = new Map(
+      [...getAllRules(), ...createJsonDrivenRules()].map((rule) => [rule.id, rule.level]),
+    );
+  }
+  return ruleLevelMap;
 }


### PR DESCRIPTION
## Summary
- 校正設定のルール一覧に検出レベル(L1=正規表現 / L2=形態素解析 / L3=LLM)のタグを表示
- `getRuleLevelMap()` をルール実体(factory 出力)から導出し、UI とエンジンの乖離を構造的に防止
- rule-registry の「all moved to JSON-driven」コメントが事実と異なる点を修正(#1567 item 14): L2 (kuromoji) ルールは v1.2.7 ロールバックで削除されたものであり、将来の L2 ルールは JSON ファクトリではなく `getAllRules` に追加しないと main-thread 実行系に乗らない罠を文書化

## Test plan
- [x] `rule-level-map.test.ts` ×3 (factory 全網羅 / LINT_RULES_META 全項目レベル付与 / メモ化)
- [x] tsc --noEmit / eslint クリーン

関連 issue: #1567 (item 14 — Linting)