### PR TITLE
fix(project): QA監査フォローアップ — 検証エラー報告の正確化 2 件 (#1567)

### DIFF
--- a/lib/editor-page/__tests__/project-file-utils.test.ts
+++ b/lib/editor-page/__tests__/project-file-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import { MAX_SNAPSHOTS, RETENTION_DAYS } from "@/lib/services/history-policy";
 
@@ -255,6 +255,60 @@ describe("ensureProjectFiles", () => {
       create: false,
     });
     expect(await backupHandle.read()).toBe('{"version":"1.0');
+  });
+
+  it("破損 project.json: バックアップ成功時の warn は退避先を正しく報告する", async () => {
+    const root = makeRoot("CorruptOk", ["CorruptOk.mdi"]);
+    await seedIllusionsFile(root, "project.json", '{"version":"1.0');
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await ensureProjectFiles(asHandle(root), { projectId: "regen-ok" });
+
+      const corruptWarn = warnSpy.mock.calls
+        .map((call) => String(call[0]))
+        .find((message) => message.includes("project.json が破損"));
+      expect(corruptWarn).toBeDefined();
+      expect(corruptWarn).toContain("に退避し、");
+      expect(corruptWarn).not.toContain("失敗");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("破損 project.json: バックアップ作成に失敗 → 退避成功と偽らない warn を出して再生成 (#1567)", async () => {
+    const root = makeRoot("CorruptNoBackup", ["CorruptNoBackup.mdi"]);
+    await seedIllusionsFile(root, "project.json", '{"version":"1.0');
+
+    // Make backup-file creation fail (e.g. read-only / quota error) while
+    // project.json itself stays writable for regeneration.
+    const illusionsDir = await root.getDirectoryHandle(".illusions", { create: false });
+    const originalGetFileHandle = illusionsDir.getFileHandle.bind(illusionsDir);
+    illusionsDir.getFileHandle = async (name, opts): Promise<FakeFile> => {
+      if (name.startsWith("project.json.corrupt-")) {
+        throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+      }
+      return originalGetFileHandle(name, opts);
+    };
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = await ensureProjectFiles(asHandle(root), { projectId: "regen-id" });
+
+      // Regeneration still succeeds despite the backup failure.
+      expect(result.repaired).toBe(true);
+      expect(result.metadata.projectId).toBe("regen-id");
+
+      // The warn must NOT claim the backup succeeded (「...に退避し、...」).
+      const corruptWarn = warnSpy.mock.calls
+        .map((call) => String(call[0]))
+        .find((message) => message.includes("project.json が破損"));
+      expect(corruptWarn).toBeDefined();
+      expect(corruptWarn).toContain("失敗");
+      expect(corruptWarn).not.toContain("に退避し、");
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/lib/editor-page/project-file-utils.ts
+++ b/lib/editor-page/project-file-utils.ts
@@ -166,14 +166,19 @@ export async function ensureProjectFiles(
     } catch {
       // project.json exists but is corrupted — back it up and regenerate.
       const backupName = `project.json.corrupt-${Date.now()}`;
+      let backupSucceeded = false;
       try {
         const backupHandle = await illusionsDir.getFileHandle(backupName, { create: true });
         await writeHandleText(backupHandle, raw);
+        backupSucceeded = true;
       } catch {
         // Backup failure is non-fatal; proceed with regeneration.
       }
+      // #1567 item 16: report the backup outcome accurately.
       console.warn(
-        `[Project] project.json が破損しています。${backupName} に退避し、デフォルト設定で再生成します。`,
+        backupSucceeded
+          ? `[Project] project.json が破損しています。${backupName} に退避し、デフォルト設定で再生成します。`
+          : `[Project] project.json が破損しています。バックアップ (${backupName}) の作成に失敗したため、退避せずにデフォルト設定で再生成します。`,
       );
     }
   }

--- a/lib/project/__tests__/project-service.test.ts
+++ b/lib/project/__tests__/project-service.test.ts
@@ -156,28 +156,79 @@ describe("getProjectService", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Tests: validateProjectStructure — no side-effect creation
+// Tests: validateProjectStructure — no side-effect creation, real existence
+// check via entries() (#1567 item 15)
 // ---------------------------------------------------------------------------
+
+type VFSEntryLike = { name: string; kind: "file" | "directory"; path: string };
+
+/** Build an entries() implementation yielding the given [name, entry] pairs. */
+function makeEntries(items: VFSEntryLike[]): () => AsyncIterable<[string, VFSEntryLike]> {
+  return async function* entries(): AsyncGenerator<[string, VFSEntryLike]> {
+    for (const item of items) {
+      yield [item.name, item];
+    }
+  };
+}
 
 describe("validateProjectStructure", () => {
   it("returns invalid when .illusions directory does not exist (no directory created)", async () => {
-    // Mock a directory handle where .illusions is absent
+    // Web-shaped handle: getDirectoryHandle rejects with NotFoundError
     const getDirectoryHandleMock = vi
       .fn<(name: string, opts?: { create?: boolean }) => Promise<never>>()
       .mockRejectedValue(new DOMException("Not found", "NotFoundError"));
 
     const fakeRoot = {
       getDirectoryHandle: getDirectoryHandleMock,
+      entries: makeEntries([{ name: "novel.mdi", kind: "file", path: "novel.mdi" }]),
     } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
 
     const result = await getProjectService().validateProjectStructure(fakeRoot);
 
-    // Must report invalid
+    // Must report invalid with the accurate error
     expect(result.valid).toBe(false);
     expect(result.errors).toContain(".illusions directory not found");
 
-    // The call must have used create: false (not create: true)
-    expect(getDirectoryHandleMock).toHaveBeenCalledWith(".illusions", { create: false });
+    // Must never create the directory as a side effect
+    expect(getDirectoryHandleMock).not.toHaveBeenCalledWith(
+      ".illusions",
+      expect.objectContaining({ create: true }),
+    );
+  });
+
+  it("Electron-shaped handle: getDirectoryHandle resolves for missing dirs — still reports '.illusions directory not found'", async () => {
+    // ElectronVFSDirectoryHandle.getDirectoryHandle({create:false}) NEVER
+    // throws for a missing directory; it just wraps the path. The validator
+    // must therefore detect absence via entries(), not via a thrown error.
+    const getFileHandleMock = vi
+      .fn<(name: string) => Promise<never>>()
+      .mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+
+    const fakeIllusionsDir = {
+      getFileHandle: getFileHandleMock,
+    } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
+
+    const getDirectoryHandleMock = vi
+      .fn<
+        (
+          name: string,
+          opts?: { create?: boolean },
+        ) => Promise<import("@/lib/vfs/types").VFSDirectoryHandle>
+      >()
+      .mockResolvedValue(fakeIllusionsDir);
+
+    const fakeRoot = {
+      getDirectoryHandle: getDirectoryHandleMock,
+      // .illusions is NOT among the entries — directory is missing on disk
+      entries: makeEntries([{ name: "novel.mdi", kind: "file", path: "novel.mdi" }]),
+    } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
+
+    const result = await getProjectService().validateProjectStructure(fakeRoot);
+
+    expect(result.valid).toBe(false);
+    // The accurate error — NOT the misleading project.json error
+    expect(result.errors).toContain(".illusions directory not found");
+    expect(result.errors.some((e) => e.includes("project.json"))).toBe(false);
   });
 
   it("returns invalid when project.json is missing inside .illusions", async () => {
@@ -200,6 +251,7 @@ describe("validateProjectStructure", () => {
 
     const fakeRoot = {
       getDirectoryHandle: getDirectoryHandleMock,
+      entries: makeEntries([{ name: ".illusions", kind: "directory", path: ".illusions" }]),
     } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
 
     const result = await getProjectService().validateProjectStructure(fakeRoot);
@@ -208,5 +260,45 @@ describe("validateProjectStructure", () => {
     expect(result.errors.some((e) => e.includes("project.json"))).toBe(true);
     // Still must not have created the directory
     expect(getDirectoryHandleMock).toHaveBeenCalledWith(".illusions", { create: false });
+  });
+
+  it("returns valid for a complete project structure", async () => {
+    const projectJson = JSON.stringify({
+      version: "1.0.0",
+      projectId: "id-1",
+      name: "Novel",
+      mainFile: "Novel.mdi",
+    });
+
+    const fakeIllusionsDir = {
+      getFileHandle: vi.fn().mockResolvedValue({
+        read: vi.fn().mockResolvedValue(projectJson),
+      }),
+    } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
+
+    const fakeRoot = {
+      getDirectoryHandle: vi.fn().mockResolvedValue(fakeIllusionsDir),
+      entries: makeEntries([
+        { name: "Novel.mdi", kind: "file", path: "Novel.mdi" },
+        { name: ".illusions", kind: "directory", path: ".illusions" },
+      ]),
+    } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
+
+    const result = await getProjectService().validateProjectStructure(fakeRoot);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("a '.illusions' FILE entry does not count as the metadata directory", async () => {
+    const fakeRoot = {
+      getDirectoryHandle: vi.fn(),
+      entries: makeEntries([{ name: ".illusions", kind: "file", path: ".illusions" }]),
+    } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
+
+    const result = await getProjectService().validateProjectStructure(fakeRoot);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(".illusions directory not found");
   });
 });

--- a/lib/project/__tests__/project-service.test.ts
+++ b/lib/project/__tests__/project-service.test.ts
@@ -301,4 +301,49 @@ describe("validateProjectStructure", () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain(".illusions directory not found");
   });
+
+  it("an unreadable root (entries() throws) is reported as inaccessible, not missing", async () => {
+    // Copilot review: a permission/transient read failure must not be
+    // misreported as ".illusions directory not found".
+    const fakeRoot = {
+      getDirectoryHandle: vi
+        .fn<(name: string, opts?: { create?: boolean }) => Promise<never>>()
+        .mockRejectedValue(new DOMException("denied", "NotAllowedError")),
+      entries: () => {
+        throw new Error("read failure");
+      },
+    } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
+
+    const result = await getProjectService().validateProjectStructure(fakeRoot);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(".illusions directory is not accessible");
+    expect(result.errors).not.toContain(".illusions directory not found");
+  });
+
+  it("entries() failure on Electron still validates via the handle probe", async () => {
+    // Electron-shaped handle: getDirectoryHandle resolves even when the scan
+    // failed — validation proceeds to project.json instead of false-reporting
+    // a missing directory.
+    const projectJson = JSON.stringify({
+      version: "1.0",
+      projectId: "p-1",
+      name: "n",
+      mainFile: "m.mdi",
+    });
+    const fakeIllusionsDir = {
+      getFileHandle: vi.fn().mockResolvedValue({ read: vi.fn().mockResolvedValue(projectJson) }),
+    } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
+    const fakeRoot = {
+      getDirectoryHandle: vi.fn().mockResolvedValue(fakeIllusionsDir),
+      entries: () => {
+        throw new Error("scan failure");
+      },
+    } as unknown as import("@/lib/vfs/types").VFSDirectoryHandle;
+
+    const result = await getProjectService().validateProjectStructure(fakeRoot);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
 });

--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -391,7 +391,30 @@ export class ProjectService {
   async validateProjectStructure(rootDirHandle: VFSDirectoryHandle): Promise<ValidationResult> {
     const errors: string[] = [];
 
-    // Check .illusions directory
+    // Check .illusions directory existence by scanning the root entries.
+    // On Electron, getDirectoryHandle(name, { create: false }) never throws for
+    // a missing directory (it just wraps the path — see electron-vfs.ts), so a
+    // real existence check is required to report the error accurately on both
+    // platforms (#1567 item 15).
+    // Electron の getDirectoryHandle は存在しないディレクトリでも throw しない
+    // ため、entries() の走査で .illusions の実在を確認する。
+    let illusionsDirExists = false;
+    try {
+      for await (const [name, entry] of rootDirHandle.entries()) {
+        if (name === ".illusions" && entry.kind === "directory") {
+          illusionsDirExists = true;
+          break;
+        }
+      }
+    } catch {
+      // Root directory unreadable — treated as .illusions missing below.
+    }
+    if (!illusionsDirExists) {
+      errors.push(".illusions directory not found");
+      return { valid: false, errors };
+    }
+
+    // Obtain the handle (Web may still throw natively, e.g. permission loss)
     let illusionsDir: VFSDirectoryHandle | null = null;
     try {
       illusionsDir = await rootDirHandle.getDirectoryHandle(".illusions", { create: false });

--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -399,6 +399,7 @@ export class ProjectService {
     // Electron の getDirectoryHandle は存在しないディレクトリでも throw しない
     // ため、entries() の走査で .illusions の実在を確認する。
     let illusionsDirExists = false;
+    let entriesScanFailed = false;
     try {
       for await (const [name, entry] of rootDirHandle.entries()) {
         if (name === ".illusions" && entry.kind === "directory") {
@@ -407,9 +408,12 @@ export class ProjectService {
         }
       }
     } catch {
-      // Root directory unreadable — treated as .illusions missing below.
+      // Root unreadable (permission loss, transient I/O): existence is UNKNOWN.
+      // Do not conclude absence here — fall through to the handle probe so a
+      // read failure is not misreported as a missing directory.
+      entriesScanFailed = true;
     }
-    if (!illusionsDirExists) {
+    if (!illusionsDirExists && !entriesScanFailed) {
       errors.push(".illusions directory not found");
       return { valid: false, errors };
     }
@@ -419,7 +423,11 @@ export class ProjectService {
     try {
       illusionsDir = await rootDirHandle.getDirectoryHandle(".illusions", { create: false });
     } catch {
-      errors.push(".illusions directory not found");
+      errors.push(
+        entriesScanFailed
+          ? ".illusions directory is not accessible"
+          : ".illusions directory not found",
+      );
       return { valid: false, errors };
     }
 


### PR DESCRIPTION
## 概要

#1567 の 2026-06-10 patrol 追記分 (items 15-16) のうち、project 系 2 件を修正する。
References #1567 (項目 15-16 のみの部分対応のため Closes ではない)

### Item 15: `validateProjectStructure` の Electron での誤報告

`ElectronVFSDirectoryHandle.getDirectoryHandle(name, { create: false })` は存在しないディレクトリでも throw しない (`lib/vfs/electron-vfs.ts` — パスをラップするだけ) ため、`.illusions` 欠落時に catch 節へ到達せず、誤って `.illusions/project.json not found or invalid` と報告されていた。

**修正**: `rootDirHandle.entries()` を走査して `.illusions` ディレクトリエントリの実在を確認する方式に変更。VFS インターフェースへの変更なしで両プラットフォームで動作する。Web の native NotFoundError 経路 (permission 喪失等) も第二段の try/catch で維持。`.illusions` という名前の **ファイル** が在ってもディレクトリとは見なさない。

### Item 16: `ensureProjectFiles` のバックアップ失敗時の不正確な warn

破損 project.json の `project.json.corrupt-<ts>` への退避書き込みが失敗しても、warn が「…に退避し、デフォルト設定で再生成します」と退避成功を偽っていた。

**修正**: バックアップ成否を `backupSucceeded` フラグで追跡し、失敗時は「バックアップ (…) の作成に失敗したため、退避せずに…再生成します」と正確に報告する。

## テスト

新規テストは修正前のコードに対して fail することを確認済み (3 failed → 修正後 all green)。

- `lib/project/__tests__/project-service.test.ts`
  - Electron-shaped handle (getDirectoryHandle が欠落 dir でも resolve) で `.illusions directory not found` を報告し、project.json エラーを出さない
  - `.illusions` が FILE エントリの場合もディレクトリ欠落として扱う
  - 完全なプロジェクト構造で valid:true (entries チェックのリグレッションガード)
  - 既存 2 テストへ entries() を追加適合 (existence check が entries 走査になったため)
- `lib/editor-page/__tests__/project-file-utils.test.ts`
  - バックアップ作成失敗時: warn が「失敗」を含み「に退避し、」を含まない + 再生成自体は成功
  - バックアップ成功時: warn が退避先を正しく報告する

## Test Plan

- [x] `npx tsc --noEmit` パス
- [x] `npm run lint` 0 errors
- [x] `npx vitest run lib/project/__tests__ lib/editor-page/__tests__` 全件パス
- [x] `npm test` 全件パス (tab-registry の fail は worktree に generated/credits.json が無いだけの環境要因、`npm run generate:credits` 後にパス確認済み)
- [x] 新規テストが修正前コードで fail することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)