### PR TITLE
refactor(electron): file-ipc / vfs-ipc のパス安全ヘルパーを共通化 (#1435)

### DIFF
--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -4,48 +4,26 @@
 const { ipcMain, dialog } = require("electron");
 const path = require("path");
 const fs = require("fs/promises");
-const os = require("os");
 const log = require("electron-log");
-const { getWindowsDenyPrefixes } = require("../lib/path-utils");
+const { createApprovedPathRegistry } = require("../lib/approved-paths");
+const { normalizeSeparators } = require("../lib/path-utils");
+const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
 
 // --- save-file path security validation ---
 // Tracks file paths that have been approved via native dialog or system file association,
 // scoped per BrowserWindow (webContentsId) to prevent cross-window path reuse.
-// Each window maintains its own bounded LRU set to prevent unbounded memory growth.
-const MAX_APPROVED_PATHS = 200;
-/** @type {Map<number, Map<string, true>>} webContentsId → (path → true) LRU map */
-const dialogApprovedPaths = new Map();
-
-/**
- * Get or create the per-window LRU path map for a given webContentsId.
- * @param {number} webContentsId - The webContents ID of the BrowserWindow
- * @returns {Map<string, true>}
- */
-function getWindowApprovedPaths(webContentsId) {
-  if (!dialogApprovedPaths.has(webContentsId)) {
-    dialogApprovedPaths.set(webContentsId, new Map());
-  }
-  return dialogApprovedPaths.get(webContentsId);
-}
+// LRU semantics (bounded per-window set) live in electron/lib/approved-paths.js.
+// Intentional difference vs vfs-ipc.js: this registry is module-level so save-file
+// approvals persist for the whole app lifetime (until the window is destroyed).
+const dialogApprovedPaths = createApprovedPathRegistry();
 
 /**
  * Add a path to the dialog-approved set for a specific window, with LRU eviction.
- * When the per-window set exceeds MAX_APPROVED_PATHS, the oldest entry is evicted.
  * @param {number} webContentsId - The webContents ID of the approving window
  * @param {string} p - The resolved file path to approve
  */
 function approveDialogPath(webContentsId, p) {
-  const windowPaths = getWindowApprovedPaths(webContentsId);
-  // Delete first so re-insertion moves it to the end (most recent)
-  windowPaths.delete(p);
-  windowPaths.set(p, true);
-  // Evict oldest entry if over capacity
-  if (windowPaths.size > MAX_APPROVED_PATHS) {
-    const oldest = windowPaths.keys().next().value;
-    if (oldest !== undefined) {
-      windowPaths.delete(oldest);
-    }
-  }
+  dialogApprovedPaths.approve(webContentsId, p);
 }
 
 /**
@@ -53,74 +31,26 @@ function approveDialogPath(webContentsId, p) {
  * @param {number} webContentsId - The webContents ID of the destroyed window
  */
 function revokeWindowApprovedPaths(webContentsId) {
-  dialogApprovedPaths.delete(webContentsId);
+  dialogApprovedPaths.revokeWindow(webContentsId);
 }
 
 /**
  * Check whether a normalized path points to a system-sensitive location.
- * Mirrors the deny-list logic in electron-vfs-ipc-handlers.js.
+ * Delegates to the shared policy in electron/lib/path-policy.js.
+ *
+ * Intentional difference vs vfs-ipc.js (isDeniedPath): the save-file policy uses
+ * the base deny list with NO extra home suffixes, because save-file writes are
+ * additionally gated by per-window dialog approval and an extension allowlist.
+ * vfs-ipc.js adds Windows credential-store suffixes on top of the base policy.
+ *
  * @param {string} normalizedPath - Forward-slash normalized absolute path
  * @returns {boolean} true if the path should be denied
  */
 function isSavePathDenied(normalizedPath) {
-  const homedir = os.homedir().split(path.sep).join("/");
-
-  // System root directories (Unix + macOS + Windows)
-  const denyExact = new Set([
-    "/",
-    "/etc",
-    "/usr",
-    "/bin",
-    "/sbin",
-    "/var",
-    "/tmp",
-    "/System",
-    "/private",
-    "/private/etc",
-    "/private/var",
-  ]);
-
-  // Bare Windows drive root (C:/ or C:)
-  const driveLetterMatch = normalizedPath.match(/^([a-zA-Z]):?\/?$/);
-  if (driveLetterMatch) return true;
-
-  const windowsDenyPrefixes = getWindowsDenyPrefixes();
-
-  // Sensitive directories within home
-  const homeSensitiveSuffixes = [
-    "/.ssh",
-    "/.gnupg",
-    "/.aws",
-    "/.kube",
-    "/.docker",
-    "/.config/gcloud",
-    "/Library/Keychains",
-  ];
-
-  // Treat denied roots as prefixes — block any nested path under them
-  if ([...denyExact].some((dir) => normalizedPath === dir || normalizedPath.startsWith(`${dir}/`)))
-    return true;
-  if (normalizedPath === homedir || normalizedPath.startsWith(`${homedir}/`)) {
-    // Allow writes inside home, but block sensitive subdirectories
-    if (normalizedPath === homedir) return true;
-    if (homeSensitiveSuffixes.some((s) => normalizedPath.startsWith(homedir + s))) return true;
-  }
-  const normalizedLower = normalizedPath.toLowerCase();
-  if (
-    windowsDenyPrefixes.some((p) => {
-      const pLower = p.toLowerCase();
-      return normalizedLower === pLower || normalizedLower.startsWith(`${pLower}/`);
-    })
-  )
-    return true;
-
-  return false;
+  return isSensitiveSystemPath(normalizedPath);
 }
 
 const VALID_SAVE_FILE_TYPES = [".mdi", ".md", ".txt"];
-
-/** Maximum allowed content size in bytes (50 MB) */
-const MAX_CONTENT_BYTES = 50 * 1024 * 1024;
 
 /**
  * Validate a file path provided by the renderer for the save-file IPC handler.
@@ -134,7 +64,9 @@ const MAX_CONTENT_BYTES = 50 * 1024 * 1024;
 function validateSaveFilePath(filePath, { skipApproval = false, webContentsId } = {}) {
   // Reject paths containing '..' to prevent directory traversal
   const resolved = path.resolve(filePath);
-  const normalized = resolved.split(path.sep).join("/");
+  // Intentional difference vs vfs-ipc.js: no trailing-slash trim here — the bare
+  // root "/" must stay "/" so the system deny list matches it (fail closed).
+  const normalized = normalizeSeparators(resolved);
   if (filePath.includes("..")) {
     log.warn(`save-file path rejected (directory traversal): ${filePath}`);
     return {
@@ -148,7 +80,7 @@ function validateSaveFilePath(filePath, { skipApproval = false, webContentsId } 
   // Check both the file itself and its parent directory
   if (
     isSavePathDenied(normalized) ||
-    isSavePathDenied(path.dirname(normalized).split(path.sep).join("/"))
+    isSavePathDenied(normalizeSeparators(path.dirname(normalized)))
   ) {
     log.warn(`save-file path rejected (denied location): ${filePath}`);
     return {
@@ -162,8 +94,8 @@ function validateSaveFilePath(filePath, { skipApproval = false, webContentsId } 
   // Approval is scoped to the requesting window to prevent cross-window reuse.
   // Dialog-approved paths bypass the extension check because the user already
   // consented to the file (e.g. they opened a .json or .log file via the open dialog).
-  const windowPaths = webContentsId != null ? dialogApprovedPaths.get(webContentsId) : undefined;
-  const isApproved = skipApproval || (windowPaths != null && windowPaths.has(resolved));
+  const isApproved =
+    skipApproval || (webContentsId != null && dialogApprovedPaths.has(webContentsId, resolved));
 
   // Validate file extension — skip for dialog-approved paths
   if (!isApproved) {

--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -7,19 +7,18 @@
 const { ipcMain, dialog, app, BrowserWindow, webContents } = require("electron");
 const fs = require("fs/promises");
 const path = require("path");
-const os = require("os");
+const { createApprovedPathRegistry } = require("../lib/approved-paths");
 const {
   toForwardSlash,
   assertPathInsideRoot,
-  getWindowsDenyPrefixes,
+  normalizeSeparators,
+  trimTrailingSlashes,
   resolveRealPath,
 } = require("../lib/path-utils");
+const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
 // #1476: rehydration — begin
 const { loadApprovals, saveApprovals } = require("../lib/vfs-approvals");
 // #1476: rehydration — end
-
-/** Maximum content size accepted by write-file (same limit as file-ipc.js) */
-const MAX_CONTENT_BYTES = 50 * 1024 * 1024; // 50 MB
 
 function registerVFSHandlers() {
   // Track the opened root directory per window for path validation.
@@ -43,11 +42,12 @@ function registerVFSHandlers() {
   }
 
   // Track paths that were selected via the native file dialog.
-  // Uses a bounded LRU map per window to prevent unbounded memory growth
-  // and to avoid cross-window path reuse (consistent with file-ipc.js).
-  const MAX_APPROVED_PATHS = 200;
-  /** @type {Map<number, Map<string, true>>} webContentsId -> (path -> true) LRU map */
-  const dialogApprovedPaths = new Map();
+  // Per-window bounded LRU semantics live in electron/lib/approved-paths.js
+  // (same registry as file-ipc.js — prevents unbounded memory growth and
+  // cross-window path reuse). Intentional difference vs file-ipc.js: this
+  // registry is created per registerVFSHandlers() call and stays encapsulated
+  // inside the VFS handler closure.
+  const dialogApprovedPaths = createApprovedPathRegistry();
 
   // #1476: rehydration — begin
   /**
@@ -88,44 +88,24 @@ function registerVFSHandlers() {
   // #1476: rehydration — end
 
   /**
-   * Get or create the per-window LRU path map for a given webContentsId.
-   * @param {number} webContentsId - The webContents ID of the BrowserWindow
-   * @returns {Map<string, true>}
-   */
-  function getWindowApprovedPaths(webContentsId) {
-    if (!dialogApprovedPaths.has(webContentsId)) {
-      dialogApprovedPaths.set(webContentsId, new Map());
-    }
-    return dialogApprovedPaths.get(webContentsId);
-  }
-
-  /**
    * Add a path to the dialog-approved set for a specific window, with LRU eviction.
-   * When the per-window set exceeds MAX_APPROVED_PATHS, the oldest entry is evicted.
+   * Delegates to the shared per-window registry (electron/lib/approved-paths.js).
    * @param {number} senderId - The webContents ID of the approving window
    * @param {string} p - The path to approve
    */
   function approveDialogPath(senderId, p) {
-    const windowPaths = getWindowApprovedPaths(senderId);
-    // Delete first so re-insertion moves it to the end (most recent)
-    windowPaths.delete(p);
-    windowPaths.set(p, true);
-    // Evict oldest entry if over capacity
-    if (windowPaths.size > MAX_APPROVED_PATHS) {
-      const oldest = windowPaths.keys().next().value;
-      if (oldest !== undefined) {
-        windowPaths.delete(oldest);
-      }
-    }
+    dialogApprovedPaths.approve(senderId, p);
   }
 
   /**
    * Normalize path separators to forward slashes for cross-platform compatibility.
-   * This ensures Windows backslashes (\) and Unix forward slashes (/) are handled consistently.
+   * Intentional difference vs file-ipc.js: trailing slashes are trimmed here
+   * because VFS roots are prefix-matched (`${root}/`) by assertPathInsideRoot.
+   * @param {string} p
+   * @returns {string}
    */
   function normalizePath(p) {
-    // Replace all backslashes with forward slashes and remove trailing slashes
-    return p.replace(/\\/g, "/").replace(/\/+$/, "");
+    return trimTrailingSlashes(normalizeSeparators(p));
   }
 
   /**
@@ -186,8 +166,9 @@ function registerVFSHandlers() {
     };
   });
 
-  // Maximum file size allowed for VFS read (50 MB, same as file-ipc.js)
-  const MAX_READ_BYTES = 50 * 1024 * 1024;
+  // Maximum file size allowed for VFS read — intentionally the same 50 MB limit
+  // as the shared write/save limit (electron/lib/path-policy.js)
+  const MAX_READ_BYTES = MAX_CONTENT_BYTES;
 
   // Read file content
   ipcMain.handle("vfs:read-file", async (event, filePath) => {
@@ -331,67 +312,31 @@ function registerVFSHandlers() {
   });
 
   /**
+   * Extra home-relative deny prefixes specific to the VFS policy (forward-slash
+   * normalized Windows credential stores). Intentional difference vs
+   * file-ipc.js (isSavePathDenied): the VFS exposes read access to a whole
+   * approved tree, so credential stores are denied in addition to the shared
+   * base policy in electron/lib/path-policy.js.
+   * @type {readonly string[]}
+   */
+  const VFS_EXTRA_HOME_SENSITIVE_SUFFIXES = [
+    "/AppData/Roaming/Microsoft/Credentials",
+    "/AppData/Roaming/Microsoft/Protect",
+    "/AppData/Local/Microsoft/Credentials",
+  ];
+
+  /**
    * Check if a path is in the system-sensitive denylist.
    * Prevents access to critical system directories and credential stores.
+   * Delegates to the shared policy plus the VFS-specific extras above.
    *
    * @param {string} normalizedPath - Forward-slash normalized absolute path
    * @returns {boolean} true if the path should be denied
    */
   function isDeniedPath(normalizedPath) {
-    const homedir = normalizePath(os.homedir());
-
-    // System root directories (Unix + macOS + Windows)
-    // Treated as prefixes — block the directory itself AND any nested path
-    const denyPrefixes = [
-      "/",
-      "/etc",
-      "/usr",
-      "/bin",
-      "/sbin",
-      "/var",
-      "/tmp",
-      "/System",
-      "/private",
-      "/private/etc",
-      "/private/var",
-    ];
-
-    // Add Windows drive roots and system directories
-    const driveLetterMatch = normalizedPath.match(/^([a-zA-Z]):?\/?$/);
-    if (driveLetterMatch) return true; // Bare drive root (C:/ or C:)
-
-    const windowsDenyPrefixes = getWindowsDenyPrefixes();
-
-    // Sensitive directories within home
-    const homeSensitiveSuffixes = [
-      "/.ssh",
-      "/.gnupg",
-      "/.aws",
-      "/.kube",
-      "/.docker",
-      "/.config/gcloud",
-      "/Library/Keychains",
-      // Windows (forward-slash normalized)
-      "/AppData/Roaming/Microsoft/Credentials",
-      "/AppData/Roaming/Microsoft/Protect",
-      "/AppData/Local/Microsoft/Credentials",
-    ];
-
-    // Treat denied roots as prefixes — block any nested path under them
-    if (denyPrefixes.some((dir) => normalizedPath === dir || normalizedPath.startsWith(`${dir}/`)))
-      return true;
-    if (normalizedPath === homedir) return true;
-    const normalizedLower = normalizedPath.toLowerCase();
-    if (
-      windowsDenyPrefixes.some((p) => {
-        const pLower = p.toLowerCase();
-        return normalizedLower === pLower || normalizedLower.startsWith(`${pLower}/`);
-      })
-    )
-      return true;
-    if (homeSensitiveSuffixes.some((s) => normalizedPath.startsWith(homedir + s))) return true;
-
-    return false;
+    return isSensitiveSystemPath(normalizedPath, {
+      extraHomeSensitiveSuffixes: VFS_EXTRA_HOME_SENSITIVE_SUFFIXES,
+    });
   }
 
   // Set root directory programmatically (for restoring a recent project without dialog)
@@ -434,7 +379,7 @@ function registerVFSHandlers() {
 
     // 4. Check approval: in-session dialog approval OR persisted project approval
     // #1476: rehydration — load persisted approvals so re-prompting is skipped on restart
-    const alreadyApprovedInSession = dialogApprovedPaths.get(event.sender.id)?.has(resolved);
+    const alreadyApprovedInSession = dialogApprovedPaths.has(event.sender.id, resolved);
     let alreadyApprovedFromDisk = false;
     if (!alreadyApprovedInSession && effectiveProjectId) {
       const persistedSet = await loadApprovals(APPROVED_PATHS_FILE, effectiveProjectId);
@@ -474,8 +419,8 @@ function registerVFSHandlers() {
 
       // #1476: rehydration — persist the newly approved path so restart skips the dialog
       if (effectiveProjectId) {
-        const windowPaths = dialogApprovedPaths.get(event.sender.id);
-        const pathsToSave = new Set(windowPaths ? [...windowPaths.keys()] : [confirmedPath]);
+        const windowPaths = dialogApprovedPaths.listWindowPaths(event.sender.id);
+        const pathsToSave = new Set(windowPaths.length > 0 ? windowPaths : [confirmedPath]);
         scheduleSaveApprovals(effectiveProjectId, pathsToSave);
       }
     }
@@ -490,7 +435,7 @@ function registerVFSHandlers() {
   app.on("web-contents-created", (_, contents) => {
     contents.on("destroyed", () => {
       allowedRoots.delete(contents.id);
-      dialogApprovedPaths.delete(contents.id);
+      dialogApprovedPaths.revokeWindow(contents.id);
       // #1476: rehydration — clean up projectId association
       senderProjectId.delete(contents.id);
     });

--- a/electron/lib/__tests__/approved-paths.test.ts
+++ b/electron/lib/__tests__/approved-paths.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for the shared per-window approved-path LRU registry (#1435).
+ *
+ * This registry backs the dialog-approval tracking in BOTH
+ * electron/ipc/file-ipc.js and electron/ipc/vfs-ipc.js, so its invariants
+ * are security-relevant:
+ * - approvals must be isolated per window (no cross-window reuse)
+ * - per-window sets must be bounded (LRU eviction at capacity)
+ * - unknown windows / unapproved paths must fail closed (has() === false)
+ */
+
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { createApprovedPathRegistry, DEFAULT_MAX_APPROVED_PATHS } =
+  require("../../../electron/lib/approved-paths") as {
+    createApprovedPathRegistry: (maxEntries?: number) => {
+      approve: (webContentsId: number, p: string) => void;
+      has: (webContentsId: number | undefined, p: string) => boolean;
+      listWindowPaths: (webContentsId: number) => string[];
+      revokeWindow: (webContentsId: number) => void;
+    };
+    DEFAULT_MAX_APPROVED_PATHS: number;
+  };
+
+describe("createApprovedPathRegistry()", () => {
+  it("exposes the historical default capacity of 200", () => {
+    expect(DEFAULT_MAX_APPROVED_PATHS).toBe(200);
+  });
+
+  it("returns false for a path that was never approved (fail closed)", () => {
+    const registry = createApprovedPathRegistry();
+    expect(registry.has(1, "/home/user/doc.mdi")).toBe(false);
+  });
+
+  it("returns false for an unknown window id, including undefined", () => {
+    const registry = createApprovedPathRegistry();
+    registry.approve(1, "/home/user/doc.mdi");
+    expect(registry.has(99, "/home/user/doc.mdi")).toBe(false);
+    expect(registry.has(undefined, "/home/user/doc.mdi")).toBe(false);
+  });
+
+  it("approves a path for the requesting window only (per-window scoping)", () => {
+    const registry = createApprovedPathRegistry();
+    registry.approve(1, "/home/user/a.mdi");
+    expect(registry.has(1, "/home/user/a.mdi")).toBe(true);
+    // Cross-window reuse must be denied
+    expect(registry.has(2, "/home/user/a.mdi")).toBe(false);
+  });
+
+  it("evicts the oldest entry when the per-window capacity is exceeded", () => {
+    const registry = createApprovedPathRegistry(3);
+    registry.approve(1, "/p/1");
+    registry.approve(1, "/p/2");
+    registry.approve(1, "/p/3");
+    registry.approve(1, "/p/4"); // evicts /p/1
+    expect(registry.has(1, "/p/1")).toBe(false);
+    expect(registry.has(1, "/p/2")).toBe(true);
+    expect(registry.has(1, "/p/3")).toBe(true);
+    expect(registry.has(1, "/p/4")).toBe(true);
+  });
+
+  it("re-approving a path refreshes its LRU position", () => {
+    const registry = createApprovedPathRegistry(3);
+    registry.approve(1, "/p/1");
+    registry.approve(1, "/p/2");
+    registry.approve(1, "/p/3");
+    registry.approve(1, "/p/1"); // refresh: /p/2 is now oldest
+    registry.approve(1, "/p/4"); // evicts /p/2
+    expect(registry.has(1, "/p/1")).toBe(true);
+    expect(registry.has(1, "/p/2")).toBe(false);
+  });
+
+  it("eviction in one window does not affect another window", () => {
+    const registry = createApprovedPathRegistry(2);
+    registry.approve(1, "/p/1");
+    registry.approve(2, "/p/1");
+    registry.approve(1, "/p/2");
+    registry.approve(1, "/p/3"); // evicts /p/1 in window 1 only
+    expect(registry.has(1, "/p/1")).toBe(false);
+    expect(registry.has(2, "/p/1")).toBe(true);
+  });
+
+  it("listWindowPaths returns approved paths oldest → newest", () => {
+    const registry = createApprovedPathRegistry();
+    registry.approve(1, "/p/a");
+    registry.approve(1, "/p/b");
+    registry.approve(1, "/p/a"); // refresh to most-recent
+    expect(registry.listWindowPaths(1)).toEqual(["/p/b", "/p/a"]);
+  });
+
+  it("listWindowPaths returns an empty array for an unknown window", () => {
+    const registry = createApprovedPathRegistry();
+    expect(registry.listWindowPaths(42)).toEqual([]);
+  });
+
+  it("revokeWindow removes all approvals for that window only", () => {
+    const registry = createApprovedPathRegistry();
+    registry.approve(1, "/p/a");
+    registry.approve(2, "/p/b");
+    registry.revokeWindow(1);
+    expect(registry.has(1, "/p/a")).toBe(false);
+    expect(registry.listWindowPaths(1)).toEqual([]);
+    expect(registry.has(2, "/p/b")).toBe(true);
+  });
+
+  it("re-approval after revokeWindow works (window id reuse)", () => {
+    const registry = createApprovedPathRegistry();
+    registry.approve(1, "/p/a");
+    registry.revokeWindow(1);
+    registry.approve(1, "/p/c");
+    expect(registry.has(1, "/p/a")).toBe(false);
+    expect(registry.has(1, "/p/c")).toBe(true);
+  });
+});

--- a/electron/lib/__tests__/path-policy.test.ts
+++ b/electron/lib/__tests__/path-policy.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for the shared path-security policy (#1435).
+ *
+ * isSensitiveSystemPath() is the single source of truth behind:
+ * - file-ipc.js  isSavePathDenied()  — base policy, no extras
+ * - vfs-ipc.js   isDeniedPath()      — base policy + Windows credential extras
+ *
+ * These tests pin the deny/allow behavior that both modules relied on before
+ * the extraction, so policy drift between the two IPC boundaries is caught here.
+ */
+
+import os from "os";
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { isSensitiveSystemPath, MAX_CONTENT_BYTES, SYSTEM_DENY_PREFIXES, HOME_SENSITIVE_SUFFIXES } =
+  require("../../../electron/lib/path-policy") as {
+    isSensitiveSystemPath: (
+      normalizedPath: string,
+      options?: { extraHomeSensitiveSuffixes?: readonly string[] },
+    ) => boolean;
+    MAX_CONTENT_BYTES: number;
+    SYSTEM_DENY_PREFIXES: readonly string[];
+    HOME_SENSITIVE_SUFFIXES: readonly string[];
+  };
+
+const { normalizeSeparators, trimTrailingSlashes } =
+  require("../../../electron/lib/path-utils") as {
+    normalizeSeparators: (p: string) => string;
+    trimTrailingSlashes: (p: string) => string;
+  };
+
+const home = trimTrailingSlashes(normalizeSeparators(os.homedir()));
+
+// Same extras as vfs-ipc.js — duplicated here on purpose so a silent change
+// to the vfs extras would not silently change these expectations.
+const VFS_EXTRAS = [
+  "/AppData/Roaming/Microsoft/Credentials",
+  "/AppData/Roaming/Microsoft/Protect",
+  "/AppData/Local/Microsoft/Credentials",
+] as const;
+
+describe("MAX_CONTENT_BYTES", () => {
+  it("is the historical 50 MB limit shared by file-ipc and vfs-ipc", () => {
+    expect(MAX_CONTENT_BYTES).toBe(50 * 1024 * 1024);
+  });
+});
+
+describe("isSensitiveSystemPath() — system roots", () => {
+  it("denies the filesystem root and every listed system directory", () => {
+    for (const dir of SYSTEM_DENY_PREFIXES) {
+      expect(isSensitiveSystemPath(dir)).toBe(true);
+    }
+  });
+
+  it("denies nested paths under system directories", () => {
+    expect(isSensitiveSystemPath("/etc/passwd")).toBe(true);
+    expect(isSensitiveSystemPath("/usr/local/bin/evil")).toBe(true);
+    expect(isSensitiveSystemPath("/private/etc/hosts")).toBe(true);
+    expect(isSensitiveSystemPath("/tmp/anything.mdi")).toBe(true);
+  });
+
+  it("denies bare Windows drive roots (C: and C:/)", () => {
+    expect(isSensitiveSystemPath("C:")).toBe(true);
+    expect(isSensitiveSystemPath("C:/")).toBe(true);
+    expect(isSensitiveSystemPath("d:/")).toBe(true);
+  });
+
+  it("does not deny a sibling whose name merely starts with a denied dir", () => {
+    // "/etc" is denied as a prefix-with-slash, not as a string prefix
+    expect(isSensitiveSystemPath("/etcetera/file.txt")).toBe(false);
+  });
+});
+
+describe("isSensitiveSystemPath() — home directory rules", () => {
+  it("denies the home directory itself", () => {
+    expect(isSensitiveSystemPath(home)).toBe(true);
+  });
+
+  it("allows ordinary documents inside home", () => {
+    expect(isSensitiveSystemPath(`${home}/Documents/novel.mdi`)).toBe(false);
+    expect(isSensitiveSystemPath(`${home}/Desktop/draft.md`)).toBe(false);
+  });
+
+  it("denies every base sensitive directory under home (and nested paths)", () => {
+    for (const suffix of HOME_SENSITIVE_SUFFIXES) {
+      expect(isSensitiveSystemPath(`${home}${suffix}`)).toBe(true);
+      expect(isSensitiveSystemPath(`${home}${suffix}/nested/file`)).toBe(true);
+    }
+  });
+
+  it("includes the historical base suffixes used by both IPC modules", () => {
+    expect(HOME_SENSITIVE_SUFFIXES).toEqual([
+      "/.ssh",
+      "/.gnupg",
+      "/.aws",
+      "/.kube",
+      "/.docker",
+      "/.config/gcloud",
+      "/Library/Keychains",
+    ]);
+  });
+});
+
+describe("isSensitiveSystemPath() — caller-specific extras (vfs-ipc difference)", () => {
+  it("base policy (file-ipc) allows Windows credential paths under home", () => {
+    // Intentional difference: save-file writes are gated by dialog approval +
+    // extension allowlist, so the base policy does not include these.
+    expect(isSensitiveSystemPath(`${home}/AppData/Roaming/Microsoft/Credentials/x`)).toBe(false);
+  });
+
+  it("vfs extras deny Windows credential stores under home", () => {
+    for (const extra of VFS_EXTRAS) {
+      expect(
+        isSensitiveSystemPath(`${home}${extra}/blob`, {
+          extraHomeSensitiveSuffixes: VFS_EXTRAS,
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("extras do not affect unrelated home paths", () => {
+    expect(
+      isSensitiveSystemPath(`${home}/AppData/Roaming/illusions/config.json`, {
+        extraHomeSensitiveSuffixes: VFS_EXTRAS,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("normalizeSeparators() / trimTrailingSlashes()", () => {
+  it("normalizeSeparators converts backslashes and keeps trailing slashes", () => {
+    expect(normalizeSeparators("C:\\Users\\me\\doc.mdi")).toBe("C:/Users/me/doc.mdi");
+    expect(normalizeSeparators("/foo/bar/")).toBe("/foo/bar/");
+  });
+
+  it("trimTrailingSlashes removes trailing slashes only", () => {
+    expect(trimTrailingSlashes("/foo/bar//")).toBe("/foo/bar");
+    expect(trimTrailingSlashes("/foo/bar")).toBe("/foo/bar");
+  });
+
+  it("documents the bare-root edge: trimming '/' yields '' (vfs-ipc historical behavior)", () => {
+    expect(trimTrailingSlashes("/")).toBe("");
+  });
+});

--- a/electron/lib/__tests__/path-policy.test.ts
+++ b/electron/lib/__tests__/path-policy.test.ts
@@ -140,7 +140,26 @@ describe("normalizeSeparators() / trimTrailingSlashes()", () => {
     expect(trimTrailingSlashes("/foo/bar")).toBe("/foo/bar");
   });
 
-  it("documents the bare-root edge: trimming '/' yields '' (vfs-ipc historical behavior)", () => {
-    expect(trimTrailingSlashes("/")).toBe("");
+  it("preserves the bare filesystem root instead of collapsing it to ''", () => {
+    // Historical vfs-ipc behavior trimmed "/" to "", which made
+    // assertPathInsideRoot accept every absolute path when "/" was approved
+    // as a root (fail-open found in Codex review of #1435). Fail closed.
+    expect(trimTrailingSlashes("/")).toBe("/");
+    expect(trimTrailingSlashes("///")).toBe("/");
+  });
+});
+
+describe("isSensitiveSystemPath() — degenerate inputs (fail closed)", () => {
+  it("denies the empty string", () => {
+    expect(isSensitiveSystemPath("")).toBe(true);
+  });
+
+  it("denies relative / non-absolute inputs", () => {
+    expect(isSensitiveSystemPath("relative/path.mdi")).toBe(true);
+    expect(isSensitiveSystemPath("./x")).toBe(true);
+  });
+
+  it("still denies the bare root now that trimming preserves it", () => {
+    expect(isSensitiveSystemPath(trimTrailingSlashes("/"))).toBe(true);
   });
 });

--- a/electron/lib/approved-paths.js
+++ b/electron/lib/approved-paths.js
@@ -1,0 +1,99 @@
+"use strict";
+/**
+ * Per-window approved-path tracking shared by file-ipc.js and vfs-ipc.js (#1435).
+ *
+ * Tracks file/directory paths that were approved via a native dialog (or system
+ * file association), scoped per BrowserWindow (webContentsId) to prevent
+ * cross-window path reuse. Each window keeps its own bounded LRU map so a
+ * compromised renderer cannot grow main-process memory without bound.
+ *
+ * Intentional usage difference between the two consumers (kept explicit):
+ * - file-ipc.js creates ONE module-level registry (save-file approvals survive
+ *   for the whole app lifetime, until the window is destroyed).
+ * - vfs-ipc.js creates a registry per registerVFSHandlers() call, keeping the
+ *   approval state encapsulated inside the VFS handler closure.
+ */
+
+/** Maximum approved paths retained per window before LRU eviction kicks in. */
+const DEFAULT_MAX_APPROVED_PATHS = 200;
+
+/**
+ * Create a per-window approved-path registry with bounded LRU eviction.
+ * @param {number} [maxEntries=DEFAULT_MAX_APPROVED_PATHS] - Per-window capacity
+ * @returns {{
+ *   approve: (webContentsId: number, p: string) => void,
+ *   has: (webContentsId: number | undefined, p: string) => boolean,
+ *   listWindowPaths: (webContentsId: number) => string[],
+ *   revokeWindow: (webContentsId: number) => void,
+ * }}
+ */
+function createApprovedPathRegistry(maxEntries = DEFAULT_MAX_APPROVED_PATHS) {
+  /** @type {Map<number, Map<string, true>>} webContentsId → (path → true) LRU map */
+  const windows = new Map();
+
+  /**
+   * Get or create the per-window LRU path map for a given webContentsId.
+   * @param {number} webContentsId
+   * @returns {Map<string, true>}
+   */
+  function getWindowPaths(webContentsId) {
+    if (!windows.has(webContentsId)) {
+      windows.set(webContentsId, new Map());
+    }
+    return windows.get(webContentsId);
+  }
+
+  return {
+    /**
+     * Add a path to the dialog-approved set for a specific window, with LRU eviction.
+     * When the per-window set exceeds maxEntries, the oldest entry is evicted.
+     * @param {number} webContentsId - The webContents ID of the approving window
+     * @param {string} p - The path to approve
+     */
+    approve(webContentsId, p) {
+      const windowPaths = getWindowPaths(webContentsId);
+      // Delete first so re-insertion moves it to the end (most recent)
+      windowPaths.delete(p);
+      windowPaths.set(p, true);
+      // Evict oldest entry if over capacity
+      if (windowPaths.size > maxEntries) {
+        const oldest = windowPaths.keys().next().value;
+        if (oldest !== undefined) {
+          windowPaths.delete(oldest);
+        }
+      }
+    },
+
+    /**
+     * Check whether a path was approved for the given window.
+     * Returns false for unknown windows (fail closed).
+     * @param {number | undefined} webContentsId
+     * @param {string} p
+     * @returns {boolean}
+     */
+    has(webContentsId, p) {
+      const windowPaths = windows.get(webContentsId);
+      return windowPaths != null && windowPaths.has(p);
+    },
+
+    /**
+     * List all currently approved paths for a window (oldest → newest).
+     * @param {number} webContentsId
+     * @returns {string[]}
+     */
+    listWindowPaths(webContentsId) {
+      const windowPaths = windows.get(webContentsId);
+      return windowPaths ? [...windowPaths.keys()] : [];
+    },
+
+    /**
+     * Remove the approved-path set for a destroyed window to prevent memory leaks.
+     * @param {number} webContentsId - The webContents ID of the destroyed window
+     */
+    revokeWindow(webContentsId) {
+      windows.delete(webContentsId);
+    },
+  };
+}
+
+module.exports = { createApprovedPathRegistry, DEFAULT_MAX_APPROVED_PATHS };

--- a/electron/lib/path-policy.js
+++ b/electron/lib/path-policy.js
@@ -85,6 +85,16 @@ const HOME_SENSITIVE_SUFFIXES = Object.freeze([
 function isSensitiveSystemPath(normalizedPath, { extraHomeSensitiveSuffixes = [] } = {}) {
   const homedir = trimTrailingSlashes(normalizeSeparators(os.homedir()));
 
+  // Empty or non-absolute input cannot be meaningfully containment-checked —
+  // deny outright (fail closed). An empty string reaches here if a caller
+  // trimmed a bare root before the shared trim helper preserved "/" (#1435).
+  if (
+    normalizedPath === "" ||
+    (!normalizedPath.startsWith("/") && !/^[a-zA-Z]:/.test(normalizedPath))
+  ) {
+    return true;
+  }
+
   // Bare Windows drive root (C:/ or C:)
   if (/^([a-zA-Z]):?\/?$/.test(normalizedPath)) return true;
 

--- a/electron/lib/path-policy.js
+++ b/electron/lib/path-policy.js
@@ -1,0 +1,126 @@
+"use strict";
+/**
+ * Shared path-security policy for the Electron main process (#1435).
+ *
+ * Single source of truth for the system-sensitive deny rules and the IPC
+ * content-size limit that were previously duplicated between
+ * electron/ipc/file-ipc.js (isSavePathDenied) and
+ * electron/ipc/vfs-ipc.js (isDeniedPath).
+ *
+ * Intentional differences between the two consumers are NOT hidden here —
+ * they are passed in explicitly:
+ * - vfs-ipc.js adds Windows credential-store suffixes via
+ *   `extraHomeSensitiveSuffixes` (VFS grants read access to a whole tree).
+ * - file-ipc.js uses the base policy as-is (save-file writes are additionally
+ *   gated by dialog approval and an extension allowlist).
+ */
+const os = require("os");
+const {
+  normalizeSeparators,
+  trimTrailingSlashes,
+  getWindowsDenyPrefixes,
+} = require("./path-utils");
+
+/**
+ * Maximum UTF-8 content size in bytes (50 MB) accepted by save/export/write
+ * IPC handlers. Intentionally the same value for file-ipc.js and vfs-ipc.js.
+ * Comparisons MUST use Buffer.byteLength(content, "utf-8") — see #1573 and
+ * the regression guard in electron/ipc/__tests__/file-ipc-size-validation.test.ts.
+ */
+const MAX_CONTENT_BYTES = 50 * 1024 * 1024;
+
+/**
+ * System root directories (Unix + macOS) denied as prefixes:
+ * the directory itself AND any nested path under it are blocked.
+ * Identical for the save-file and VFS policies.
+ * @type {readonly string[]}
+ */
+const SYSTEM_DENY_PREFIXES = Object.freeze([
+  "/",
+  "/etc",
+  "/usr",
+  "/bin",
+  "/sbin",
+  "/var",
+  "/tmp",
+  "/System",
+  "/private",
+  "/private/etc",
+  "/private/var",
+]);
+
+/**
+ * Credential / sensitive directories inside the user home, denied as prefixes.
+ * Base list shared by both modules. vfs-ipc.js extends it with Windows
+ * credential stores via the `extraHomeSensitiveSuffixes` option.
+ * @type {readonly string[]}
+ */
+const HOME_SENSITIVE_SUFFIXES = Object.freeze([
+  "/.ssh",
+  "/.gnupg",
+  "/.aws",
+  "/.kube",
+  "/.docker",
+  "/.config/gcloud",
+  "/Library/Keychains",
+]);
+
+/**
+ * Check whether a forward-slash normalized absolute path points to a
+ * system-sensitive location that IPC handlers must never touch.
+ *
+ * Denies (in fail-closed order, result is a pure boolean):
+ * 1. Bare Windows drive roots (C: / C:/)
+ * 2. System root directories and anything nested under them
+ * 3. The user home directory itself (subpaths of home stay allowed)
+ * 4. Sensitive directories under home (base list + caller extras)
+ * 5. Windows system directories (case-insensitive, actual system drive)
+ *
+ * @param {string} normalizedPath - Forward-slash normalized absolute path
+ * @param {{ extraHomeSensitiveSuffixes?: readonly string[] }} [options]
+ * @param {readonly string[]} [options.extraHomeSensitiveSuffixes] - Additional
+ *   home-relative prefixes to deny (caller-specific policy, kept explicit)
+ * @returns {boolean} true if the path must be denied
+ */
+function isSensitiveSystemPath(normalizedPath, { extraHomeSensitiveSuffixes = [] } = {}) {
+  const homedir = trimTrailingSlashes(normalizeSeparators(os.homedir()));
+
+  // Bare Windows drive root (C:/ or C:)
+  if (/^([a-zA-Z]):?\/?$/.test(normalizedPath)) return true;
+
+  // Treat denied system roots as prefixes — block any nested path under them
+  if (
+    SYSTEM_DENY_PREFIXES.some(
+      (dir) => normalizedPath === dir || normalizedPath.startsWith(`${dir}/`),
+    )
+  ) {
+    return true;
+  }
+
+  // The home directory itself is denied; ordinary subpaths of home are allowed
+  if (normalizedPath === homedir) return true;
+
+  // Sensitive directories within home (prefix match implies the path is inside home)
+  if (HOME_SENSITIVE_SUFFIXES.some((s) => normalizedPath.startsWith(homedir + s))) return true;
+  if (extraHomeSensitiveSuffixes.some((s) => normalizedPath.startsWith(homedir + s))) return true;
+
+  // Windows system directories on the actual system drive (case-insensitive)
+  const normalizedLower = normalizedPath.toLowerCase();
+  if (
+    getWindowsDenyPrefixes().some((p) => {
+      const pLower = p.toLowerCase();
+      return normalizedLower === pLower || normalizedLower.startsWith(`${pLower}/`);
+    })
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+module.exports = {
+  MAX_CONTENT_BYTES,
+  SYSTEM_DENY_PREFIXES,
+  HOME_SENSITIVE_SUFFIXES,
+  isSensitiveSystemPath,
+};

--- a/electron/lib/path-utils.js
+++ b/electron/lib/path-utils.js
@@ -3,6 +3,29 @@ const fs = require("fs/promises");
 const path = require("path");
 
 /**
+ * Normalize path separators to forward slashes (no path.resolve, no trailing-slash trim).
+ * Shared primitive used by both file-ipc.js and vfs-ipc.js so separator handling
+ * cannot drift between the two security boundaries (#1435).
+ * @param {string} p
+ * @returns {string}
+ */
+function normalizeSeparators(p) {
+  return p.replace(/\\/g, "/");
+}
+
+/**
+ * Remove trailing slashes ("/foo//" → "/foo").
+ * NOTE: this turns the bare filesystem root "/" into "" — callers that may receive
+ * the bare root must apply deny checks compatible with that representation
+ * (vfs-ipc.js has always done this; file-ipc.js intentionally does NOT trim).
+ * @param {string} p
+ * @returns {string}
+ */
+function trimTrailingSlashes(p) {
+  return p.replace(/\/+$/, "");
+}
+
+/**
  * Resolves a path and normalizes all separators to forward slashes.
  * Also strips Windows extended-path prefix (\\?\, //./), and UNC paths become //server/share/...
  * @param {string} p
@@ -104,6 +127,8 @@ async function resolveRealPath(p) {
 }
 
 module.exports = {
+  normalizeSeparators,
+  trimTrailingSlashes,
   toForwardSlash,
   assertPathInsideRoot,
   getWindowsDenyPrefixes,

--- a/electron/lib/path-utils.js
+++ b/electron/lib/path-utils.js
@@ -22,7 +22,11 @@ function normalizeSeparators(p) {
  * @returns {string}
  */
 function trimTrailingSlashes(p) {
-  return p.replace(/\/+$/, "");
+  const trimmed = p.replace(/\/+$/, "");
+  // Never collapse the filesystem root to an empty string: an empty root would
+  // make prefix-based containment checks (assertPathInsideRoot) accept every
+  // absolute path — fail closed by preserving "/" (#1435 / Codex review).
+  return trimmed === "" && p.startsWith("/") ? "/" : trimmed;
 }
 
 /**


### PR DESCRIPTION
Closes #1435

(親 epic #1450 の一部。epic 全体は本 PR では完了しないため Closes 対象外)

## 概要

`electron/ipc/file-ipc.js` と `electron/ipc/vfs-ipc.js` がコピーベースで重複保持していたパス安全性ロジックを、共有モジュールに抽出しました。deny/allow ルール・per-window approval scoping・LRU eviction の挙動は一切変更していません。

### 抽出した共有 primitive

| モジュール | 内容 |
| --- | --- |
| `electron/lib/approved-paths.js` (新規) | per-window approved-path LRU registry (`createApprovedPathRegistry`, 上限 200 件 / window, oldest eviction, fail-closed `has()`) |
| `electron/lib/path-policy.js` (新規) | システム機微パス deny ポリシー `isSensitiveSystemPath()`、`MAX_CONTENT_BYTES` (50 MB)、`SYSTEM_DENY_PREFIXES` / `HOME_SENSITIVE_SUFFIXES` |
| `electron/lib/path-utils.js` (拡張) | `normalizeSeparators()` / `trimTrailingSlashes()` を追加 |

## 意図的差分（共通化後も各モジュール側に明示的に残したもの）

| 観点 | file-ipc.js | vfs-ipc.js | 残した理由 |
| --- | --- | --- | --- |
| home 配下の追加 deny suffix | なし（base policy のみ） | `VFS_EXTRA_HOME_SENSITIVE_SUFFIXES` で Windows credential store 3 件を追加 | VFS は承認ツリー全体への read を許すため credential store を拒否。save-file はダイアログ承認 + 拡張子 allowlist で別途ゲートされる |
| trailing-slash trim | しない（`normalizeSeparators` のみ） | する（`trimTrailingSlashes` 併用） | vfs はルートを `${root}/` prefix 照合するため trim が必要。file-ipc で trim すると bare root `"/"` が `""` になり deny list を素通りするため fail closed を維持 |
| registry の生成スコープ | module-level（アプリ生存期間中、window 破棄まで承認保持） | `registerVFSHandlers()` 内 closure | 既存のライフサイクルをそのまま維持 |
| size limit の適用 | save/export 4 箇所で `Buffer.byteLength > MAX_CONTENT_BYTES` をインライン比較 | write-file 1 箇所 + `MAX_READ_BYTES = MAX_CONTENT_BYTES` | 定数のみ共有。比較式は `file-ipc-size-validation.test.ts` の source-scan regression guard が要求するパターンを維持 (#1573) |
| 拡張子 allowlist / dialog 承認チェック | `VALID_SAVE_FILE_TYPES` + per-window 承認必須 | root containment (`assertPathInsideRoot` + realpath, #1576) | 両者のセキュリティモデルが異なる（save 先承認 vs ツリー封じ込め）ため共通化しない |

## 必ず維持すべき既存挙動の確認

- [x] deny / allow ルール不変（deny list・drive root・home suffix とも文字列単位で同一。判定順序の違いは boolean OR のため結果に影響なし）
- [x] per-window approval scoping + LRU eviction (200 件) を維持
- [x] #1573 の `Buffer.byteLength` 比較を全 5 箇所で維持（source-scan テスト green）
- [x] #1576 の `resolveRealPath()` + realpath containment を維持（無変更）
- [x] `vfs:set-root` の #1476 rehydration（projectId 永続化・debounce 保存）を維持

## Test Plan

- [x] 新規 `electron/lib/__tests__/approved-paths.test.ts` — LRU eviction / per-window 隔離 / revoke / fail-closed `has()` (11 tests)
- [x] 新規 `electron/lib/__tests__/path-policy.test.ts` — システム deny prefix・home ルール・vfs extras 有無の差分・50 MB 定数 (13 tests)
- [x] 既存 `electron/ipc/__tests__/file-ipc-size-validation.test.ts` green（source-scan regression guard）
- [x] 既存 `electron/ipc/__tests__/vfs-path-validation.test.ts` / `vfs-approved-paths-persist.test.ts` green（無変更）
- [x] `npx tsc --noEmit` / `npm run lint` (0 errors) / `npx vitest run` 全 1221 tests green（`components/settings/tab-registry` の失敗は未生成 `generated/credits.json` による環境要因で本 PR と無関係、生成後 green）

🤖 Generated with [Claude Code](https://claude.com/claude-code)