### PR TITLE
fix(electron): QA監査 S3 — Electron/IPC ハードニング 3 件 (#1567)

### DIFF
--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -18,6 +18,7 @@ const {
 const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
 // #1476: rehydration — begin
 const { loadApprovals, saveApprovals } = require("../lib/vfs-approvals");
+const { createIndexLockManager } = require("../lib/index-lock");
 // #1476: rehydration — end
 
 function registerVFSHandlers() {
@@ -464,84 +465,29 @@ function registerVFSHandlers() {
   // ---------------------------------------------------------------------------
   // Cross-window history index lock (HistoryService)
   // ---------------------------------------------------------------------------
-  // In-memory lock registry — atomic because the main-process event loop is
-  // single-threaded. Each entry maps a lock key to the webContents id that
-  // holds it. A queue of { resolve } entries handles waiters.
-  const indexLockOwner = new Map(); // key -> webContentsId
-  const indexLockQueue = new Map(); // key -> Array<{ resolve: () => void, senderId: number }>
+  // Lock logic lives in electron/lib/index-lock.js (#1567 S3 hardening):
+  // renderer-supplied keys are validated and acquire() times out instead of
+  // hanging forever when another window holds the lock.
+  const indexLocks = createIndexLockManager({
+    isSenderAlive: (senderId) => {
+      const wc = webContents.fromId(senderId);
+      return Boolean(wc) && !wc.isDestroyed();
+    },
+  });
 
-  /**
-   * Dequeue the next waiter for a lock key, if any.
-   * Skips waiters whose webContents have been destroyed to prevent stuck locks.
-   * The dequeued entry's resolve() will set the owner itself.
-   * @param {string} key
-   */
-  function processIndexLockQueue(key) {
-    const queue = indexLockQueue.get(key) || [];
-    while (queue.length > 0 && !indexLockOwner.has(key)) {
-      const next = queue.shift();
-      if (queue.length === 0) {
-        indexLockQueue.delete(key);
-      }
-      // Skip waiters whose webContents have been destroyed
-      const wc = webContents.fromId(next.senderId);
-      if (!wc || wc.isDestroyed()) {
-        continue;
-      }
-      next.resolve();
-      return;
-    }
-    if (queue.length === 0) {
-      indexLockQueue.delete(key);
-    }
-  }
-
-  ipcMain.handle("vfs:index-lock:acquire", async (event, key) => {
-    const senderId = event.sender.id;
-
-    if (!indexLockOwner.has(key)) {
-      // Lock is free — acquire immediately
-      indexLockOwner.set(key, senderId);
-      return;
-    }
-
-    // Lock is held — enqueue this waiter and suspend until released
-    await new Promise((resolve) => {
-      const queue = indexLockQueue.get(key) || [];
-      queue.push({ resolve, senderId });
-      indexLockQueue.set(key, queue);
-    });
-
-    // Now the lock is free for us (processIndexLockQueue verified this before calling resolve)
-    indexLockOwner.set(key, senderId);
+  ipcMain.handle("vfs:index-lock:acquire", (event, key) => {
+    return indexLocks.acquire(key, event.sender.id);
   });
 
   ipcMain.handle("vfs:index-lock:release", (event, key) => {
-    const senderId = event.sender.id;
-    if (indexLockOwner.get(key) === senderId) {
-      indexLockOwner.delete(key);
-      processIndexLockQueue(key);
-    }
+    indexLocks.release(key, event.sender.id);
   });
-
-  /**
-   * Release all locks held by a specific window (called when the window closes).
-   * @param {number} webContentsId
-   */
-  function releaseLocksForWindow(webContentsId) {
-    for (const [key, ownerId] of indexLockOwner) {
-      if (ownerId === webContentsId) {
-        indexLockOwner.delete(key);
-        processIndexLockQueue(key);
-      }
-    }
-  }
 
   // Release index locks automatically when a window is destroyed
   app.on("browser-window-created", (_, win) => {
     const wcId = win.webContents.id;
     win.webContents.on("destroyed", () => {
-      releaseLocksForWindow(wcId);
+      indexLocks.releaseAllForSender(wcId);
     });
   });
 }

--- a/electron/lib/__tests__/index-lock.test.ts
+++ b/electron/lib/__tests__/index-lock.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the cross-window history index lock manager (#1567 S3).
+ *
+ * Covers the hardening added to the vfs:index-lock:acquire IPC handler:
+ * - key validation (type, emptiness, length, control characters)
+ * - acquisition timeout (a renderer can never hang forever on a held lock)
+ * - unchanged FIFO lock semantics for valid keys
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { validateIndexLockKey, createIndexLockManager, INDEX_LOCK_KEY_MAX_LENGTH } =
+  require("../../../electron/lib/index-lock") as {
+    validateIndexLockKey: (key: unknown) => void;
+    createIndexLockManager: (options?: {
+      isSenderAlive?: (senderId: number) => boolean;
+      acquireTimeoutMs?: number;
+    }) => {
+      acquire: (key: unknown, senderId: number) => Promise<void>;
+      release: (key: unknown, senderId: number) => void;
+      releaseAllForSender: (senderId: number) => void;
+    };
+    INDEX_LOCK_KEY_MAX_LENGTH: number;
+  };
+
+// -----------------------------------------------------------------------
+// validateIndexLockKey
+// -----------------------------------------------------------------------
+describe("validateIndexLockKey()", () => {
+  it("accepts a typical history index lock key", () => {
+    expect(() => validateIndexLockKey("history-index:/Users/me/novel")).not.toThrow();
+  });
+
+  it("accepts a key at exactly the max length", () => {
+    expect(() => validateIndexLockKey("k".repeat(INDEX_LOCK_KEY_MAX_LENGTH))).not.toThrow();
+  });
+
+  it("rejects non-string keys", () => {
+    for (const bad of [undefined, null, 42, {}, ["key"], Symbol("k")]) {
+      expect(() => validateIndexLockKey(bad)).toThrow(/ロックキーが不正/);
+    }
+  });
+
+  it("rejects an empty string", () => {
+    expect(() => validateIndexLockKey("")).toThrow(/空でない文字列/);
+  });
+
+  it("rejects keys longer than the max length", () => {
+    expect(() => validateIndexLockKey("k".repeat(INDEX_LOCK_KEY_MAX_LENGTH + 1))).toThrow(
+      /文字以内/,
+    );
+  });
+
+  it("rejects keys containing control characters", () => {
+    expect(() => validateIndexLockKey("bad\tkey")).toThrow(/制御文字/);
+    expect(() => validateIndexLockKey("bad\nkey")).toThrow(/制御文字/);
+    expect(() => validateIndexLockKey("bad\u0000key")).toThrow(/制御文字/);
+    expect(() => validateIndexLockKey("bad\u001Bkey")).toThrow(/制御文字/);
+    expect(() => validateIndexLockKey("bad\u007Fkey")).toThrow(/制御文字/);
+  });
+
+  it("accepts Japanese and path-like characters", () => {
+    expect(() => validateIndexLockKey("履歴インデックス:/プロジェクト/小説.mdi")).not.toThrow();
+  });
+});
+
+// -----------------------------------------------------------------------
+// createIndexLockManager — lock semantics (unchanged for valid keys)
+// -----------------------------------------------------------------------
+describe("createIndexLockManager() — lock semantics", () => {
+  it("acquires a free lock immediately", async () => {
+    const locks = createIndexLockManager();
+    await expect(locks.acquire("key", 1)).resolves.toBeUndefined();
+  });
+
+  it("hands the lock to the next waiter on release (FIFO)", async () => {
+    const locks = createIndexLockManager({ acquireTimeoutMs: 1000 });
+    await locks.acquire("key", 1);
+
+    const order: number[] = [];
+    const w2 = locks.acquire("key", 2).then(() => order.push(2));
+    const w3 = locks.acquire("key", 3).then(() => order.push(3));
+
+    locks.release("key", 1);
+    await w2;
+    locks.release("key", 2);
+    await w3;
+    expect(order).toEqual([2, 3]);
+  });
+
+  it("release by a non-owner is a no-op", async () => {
+    const locks = createIndexLockManager({ acquireTimeoutMs: 50 });
+    await locks.acquire("key", 1);
+    locks.release("key", 999); // not the owner
+    // Lock still held by 1 — a second acquire must time out
+    await expect(locks.acquire("key", 2)).rejects.toThrow(/タイムアウト/);
+  });
+
+  it("releaseAllForSender frees every lock held by that sender", async () => {
+    const locks = createIndexLockManager({ acquireTimeoutMs: 1000 });
+    await locks.acquire("a", 1);
+    await locks.acquire("b", 1);
+    const wa = locks.acquire("a", 2);
+    const wb = locks.acquire("b", 2);
+    locks.releaseAllForSender(1);
+    await expect(wa).resolves.toBeUndefined();
+    await expect(wb).resolves.toBeUndefined();
+  });
+
+  it("skips waiters whose sender is no longer alive", async () => {
+    const dead = new Set([2]);
+    const locks = createIndexLockManager({
+      acquireTimeoutMs: 1000,
+      isSenderAlive: (id) => !dead.has(id),
+    });
+    await locks.acquire("key", 1);
+    // Waiter 2 dies while waiting; waiter 3 should get the lock
+    locks.acquire("key", 2).catch(() => undefined);
+    const w3 = locks.acquire("key", 3);
+    locks.release("key", 1);
+    await expect(w3).resolves.toBeUndefined();
+  });
+
+  it("rejects invalid keys without touching the registry", async () => {
+    const locks = createIndexLockManager();
+    await expect(locks.acquire("", 1)).rejects.toThrow(/ロックキーが不正/);
+    await expect(locks.acquire(42, 1)).rejects.toThrow(/ロックキーが不正/);
+  });
+});
+
+// -----------------------------------------------------------------------
+// createIndexLockManager — acquisition timeout (#1567 S3)
+// -----------------------------------------------------------------------
+describe("createIndexLockManager() — acquisition timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("times out with a Japanese error when the lock is never released", async () => {
+    const locks = createIndexLockManager({ acquireTimeoutMs: 10_000 });
+    await locks.acquire("key", 1);
+
+    const waiter = locks.acquire("key", 2);
+    const assertion = expect(waiter).rejects.toThrow(/インデックスロックの取得がタイムアウト/);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await assertion;
+  });
+
+  it("a timed-out waiter is removed from the queue (later release skips it)", async () => {
+    const locks = createIndexLockManager({ acquireTimeoutMs: 1000 });
+    await locks.acquire("key", 1);
+
+    const timedOut = locks.acquire("key", 2);
+    const timedOutAssertion = expect(timedOut).rejects.toThrow(/タイムアウト/);
+    await vi.advanceTimersByTimeAsync(1000);
+    await timedOutAssertion;
+
+    // Sender 3 enqueues after 2 timed out; release must hand the lock to 3
+    const w3 = locks.acquire("key", 3);
+    locks.release("key", 1);
+    await expect(w3).resolves.toBeUndefined();
+
+    // 3 now owns the lock: 2 must not have stolen it back
+    locks.release("key", 2); // no-op — 2 never became owner
+    const w4 = locks.acquire("key", 4);
+    locks.release("key", 3);
+    await expect(w4).resolves.toBeUndefined();
+  });
+
+  it("does not time out when the lock is released in time", async () => {
+    const locks = createIndexLockManager({ acquireTimeoutMs: 10_000 });
+    await locks.acquire("key", 1);
+    const waiter = locks.acquire("key", 2);
+    await vi.advanceTimersByTimeAsync(5000);
+    locks.release("key", 1);
+    await expect(waiter).resolves.toBeUndefined();
+    // Advancing past the original deadline must not throw anywhere
+    await vi.advanceTimersByTimeAsync(10_000);
+  });
+});

--- a/electron/lib/__tests__/url-policy.test.ts
+++ b/electron/lib/__tests__/url-policy.test.ts
@@ -16,6 +16,15 @@ const { isSafeExternalUrl } = require("../../../electron/lib/url-policy") as {
 };
 
 describe("isSafeExternalUrl()", () => {
+  it("normalizes opaque special-scheme forms per WHATWG (http:evil.com is a web URL)", () => {
+    // WHATWG URL force-normalizes special schemes: "http:evil.com" parses as
+    // "http://evil.com/" — a genuine hierarchical web URL, allowed by design.
+    expect(isSafeExternalUrl("http:evil.com")).toBe(true);
+    // Authority-less forms fail to parse at all -> denied (fail closed).
+    expect(isSafeExternalUrl("http://")).toBe(false);
+    expect(isSafeExternalUrl("https:")).toBe(false);
+  });
+
   it("allows a plain https URL", () => {
     expect(isSafeExternalUrl("https://illusions.app/")).toBe(true);
   });

--- a/electron/lib/__tests__/url-policy.test.ts
+++ b/electron/lib/__tests__/url-policy.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the external-URL open policy (#1567 S3).
+ *
+ * window-manager.js setWindowOpenHandler previously passed any URL matching
+ * url.startsWith("http") to shell.openExternal. isSafeExternalUrl() must
+ * allow ONLY strictly-parsed http(s) URLs and fail closed on everything
+ * else (other schemes, parse failures, non-strings).
+ */
+
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { isSafeExternalUrl } = require("../../../electron/lib/url-policy") as {
+  isSafeExternalUrl: (url: unknown) => boolean;
+};
+
+describe("isSafeExternalUrl()", () => {
+  it("allows a plain https URL", () => {
+    expect(isSafeExternalUrl("https://illusions.app/")).toBe(true);
+  });
+
+  it("allows a plain http URL", () => {
+    expect(isSafeExternalUrl("http://localhost:3000/docs")).toBe(true);
+  });
+
+  it("allows https URLs with query/fragment/userinfo noise", () => {
+    expect(isSafeExternalUrl("https://example.com/path?q=1#frag")).toBe(true);
+  });
+
+  it("denies file: URLs", () => {
+    expect(isSafeExternalUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  it("denies smb: URLs", () => {
+    expect(isSafeExternalUrl("smb://attacker.example/share")).toBe(false);
+  });
+
+  it("denies javascript: URLs", () => {
+    // eslint-disable-next-line no-script-url
+    expect(isSafeExternalUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("denies custom app schemes", () => {
+    expect(isSafeExternalUrl("ms-msdt:/id PCWDiagnostic")).toBe(false);
+    expect(isSafeExternalUrl("vscode://open?url=x")).toBe(false);
+  });
+
+  it("denies scheme-smuggling via http prefix (httpx:, https+evil:)", () => {
+    // These pass a naive startsWith("http") check but are NOT web URLs
+    expect(isSafeExternalUrl("httpx://evil.example/")).toBe(false);
+    expect(isSafeExternalUrl("https+evil://evil.example/")).toBe(false);
+  });
+
+  it("fails closed on unparseable URLs", () => {
+    expect(isSafeExternalUrl("https://")).toBe(false);
+    expect(isSafeExternalUrl("not a url")).toBe(false);
+    expect(isSafeExternalUrl("")).toBe(false);
+  });
+
+  it("fails closed on non-string input", () => {
+    expect(isSafeExternalUrl(undefined)).toBe(false);
+    expect(isSafeExternalUrl(null)).toBe(false);
+    expect(isSafeExternalUrl(42)).toBe(false);
+    expect(isSafeExternalUrl({ href: "https://example.com" })).toBe(false);
+  });
+
+  it("denies protocol-relative and schemeless strings", () => {
+    expect(isSafeExternalUrl("//example.com/path")).toBe(false);
+    expect(isSafeExternalUrl("example.com")).toBe(false);
+  });
+});

--- a/electron/lib/index-lock.js
+++ b/electron/lib/index-lock.js
@@ -1,0 +1,172 @@
+"use strict";
+/**
+ * Cross-window history index lock (HistoryService) — pure lock manager
+ * extracted from electron/ipc/vfs-ipc.js for hardening + testability
+ * (#1567 S3).
+ *
+ * Hardening added on top of the original semantics:
+ * - Lock keys are validated (string, non-empty, max length, no control chars).
+ * - acquire() has a timeout so a renderer can never hang forever waiting on
+ *   a lock held by another window. On timeout a Japanese error is thrown.
+ *
+ * The lock semantics for valid keys are unchanged: an in-memory registry,
+ * atomic because the main-process event loop is single-threaded; each entry
+ * maps a lock key to the sender (webContents id) that holds it, with a FIFO
+ * queue of waiters per key.
+ */
+
+/** Maximum accepted lock key length (characters). */
+const INDEX_LOCK_KEY_MAX_LENGTH = 256;
+
+/** Default acquisition timeout (ms) before acquire() fails. */
+const INDEX_LOCK_ACQUIRE_TIMEOUT_MS = 10_000;
+
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS_RE = /[\u0000-\u001F\u007F]/;
+
+/**
+ * Validate a renderer-supplied lock key. Throws on invalid input.
+ * @param {unknown} key
+ * @returns {asserts key is string}
+ */
+function validateIndexLockKey(key) {
+  if (typeof key !== "string" || key.length === 0) {
+    throw new Error("ロックキーが不正です: 空でない文字列を指定してください");
+  }
+  if (key.length > INDEX_LOCK_KEY_MAX_LENGTH) {
+    throw new Error(
+      `ロックキーが不正です: ${INDEX_LOCK_KEY_MAX_LENGTH} 文字以内で指定してください`,
+    );
+  }
+  if (CONTROL_CHARS_RE.test(key)) {
+    throw new Error("ロックキーが不正です: 制御文字は使用できません");
+  }
+}
+
+/**
+ * Create an index lock manager.
+ * @param {object} [options]
+ * @param {(senderId: number) => boolean} [options.isSenderAlive]
+ *   Returns false for waiters whose webContents have been destroyed,
+ *   so they are skipped when dequeuing (prevents stuck locks).
+ * @param {number} [options.acquireTimeoutMs] Acquisition timeout in ms.
+ */
+function createIndexLockManager({
+  isSenderAlive = () => true,
+  acquireTimeoutMs = INDEX_LOCK_ACQUIRE_TIMEOUT_MS,
+} = {}) {
+  const owners = new Map(); // key -> senderId
+  const queues = new Map(); // key -> Array<{ resolve: () => void, senderId: number }>
+
+  /**
+   * Dequeue the next waiter for a lock key, if any.
+   * Skips waiters whose sender is no longer alive.
+   * The dequeued entry's resolve() will set the owner itself.
+   * @param {string} key
+   */
+  function processQueue(key) {
+    const queue = queues.get(key) || [];
+    while (queue.length > 0 && !owners.has(key)) {
+      const next = queue.shift();
+      if (queue.length === 0) {
+        queues.delete(key);
+      }
+      // Skip waiters whose webContents have been destroyed
+      if (!isSenderAlive(next.senderId)) {
+        continue;
+      }
+      next.resolve();
+      return;
+    }
+    if (queue.length === 0) {
+      queues.delete(key);
+    }
+  }
+
+  /**
+   * Acquire the lock for `key` on behalf of `senderId`.
+   * Resolves when the lock is held; throws on invalid key or timeout.
+   * @param {unknown} key
+   * @param {number} senderId
+   * @returns {Promise<void>}
+   */
+  async function acquire(key, senderId) {
+    validateIndexLockKey(key);
+
+    if (!owners.has(key)) {
+      // Lock is free — acquire immediately
+      owners.set(key, senderId);
+      return;
+    }
+
+    // Lock is held — enqueue this waiter and suspend until released,
+    // but never longer than acquireTimeoutMs (fail instead of hanging).
+    const acquired = await new Promise((resolve) => {
+      const entry = {
+        senderId,
+        resolve: () => {
+          clearTimeout(timer);
+          resolve(true);
+        },
+      };
+      const timer = setTimeout(() => {
+        // Remove this waiter from the queue so a later release cannot
+        // resolve an already-failed acquire.
+        const queue = queues.get(key);
+        if (queue) {
+          const idx = queue.indexOf(entry);
+          if (idx !== -1) queue.splice(idx, 1);
+          if (queue.length === 0) queues.delete(key);
+        }
+        resolve(false);
+      }, acquireTimeoutMs);
+      if (typeof timer.unref === "function") timer.unref();
+      const queue = queues.get(key) || [];
+      queue.push(entry);
+      queues.set(key, queue);
+    });
+
+    if (!acquired) {
+      throw new Error(
+        `インデックスロックの取得がタイムアウトしました（${Math.round(acquireTimeoutMs / 1000)}秒）。他のウィンドウがロックを保持し続けている可能性があります。`,
+      );
+    }
+
+    // Now the lock is free for us (processQueue verified this before calling resolve)
+    owners.set(key, senderId);
+  }
+
+  /**
+   * Release the lock for `key` if held by `senderId` (no-op otherwise).
+   * @param {unknown} key
+   * @param {number} senderId
+   */
+  function release(key, senderId) {
+    if (owners.get(key) === senderId) {
+      owners.delete(key);
+      processQueue(key);
+    }
+  }
+
+  /**
+   * Release all locks held by a sender (called when its window closes).
+   * @param {number} senderId
+   */
+  function releaseAllForSender(senderId) {
+    for (const [key, ownerId] of owners) {
+      if (ownerId === senderId) {
+        owners.delete(key);
+        processQueue(key);
+      }
+    }
+  }
+
+  return { acquire, release, releaseAllForSender };
+}
+
+module.exports = {
+  validateIndexLockKey,
+  createIndexLockManager,
+  INDEX_LOCK_KEY_MAX_LENGTH,
+  INDEX_LOCK_ACQUIRE_TIMEOUT_MS,
+};

--- a/electron/lib/url-policy.js
+++ b/electron/lib/url-policy.js
@@ -1,0 +1,33 @@
+"use strict";
+/**
+ * URL policy for opening external links from the renderer (#1567 S3).
+ *
+ * setWindowOpenHandler passes renderer-controlled URLs to shell.openExternal,
+ * which on macOS/Windows can launch arbitrary protocol handlers (file:,
+ * smb:, javascript:, custom app schemes, ...). Only web URLs are allowed.
+ *
+ * Fail-closed: any URL that cannot be parsed by `new URL()` is denied.
+ */
+
+/** Protocols allowed to be opened in the default browser. */
+const ALLOWED_EXTERNAL_PROTOCOLS = Object.freeze(["https:", "http:"]);
+
+/**
+ * Returns true only when the URL parses and its protocol is exactly
+ * "https:" or "http:". Anything else (including parse failures) is denied.
+ * @param {unknown} url
+ * @returns {boolean}
+ */
+function isSafeExternalUrl(url) {
+  if (typeof url !== "string") return false;
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    // Fail closed on unparseable URLs
+    return false;
+  }
+  return ALLOWED_EXTERNAL_PROTOCOLS.includes(parsed.protocol);
+}
+
+module.exports = { isSafeExternalUrl, ALLOWED_EXTERNAL_PROTOCOLS };

--- a/electron/lib/url-policy.js
+++ b/electron/lib/url-policy.js
@@ -27,7 +27,22 @@ function isSafeExternalUrl(url) {
     // Fail closed on unparseable URLs
     return false;
   }
-  return ALLOWED_EXTERNAL_PROTOCOLS.includes(parsed.protocol);
+  // Defense in depth: require a hostname. Note WHATWG URL force-normalizes
+  // special schemes ("http:evil.com" parses as "http://evil.com/", hostname
+  // "evil.com"), so for http(s) this is currently always true when parsing
+  // succeeded — the check guards against future relaxations of the allowlist.
+  return ALLOWED_EXTERNAL_PROTOCOLS.includes(parsed.protocol) && parsed.hostname.length > 0;
 }
 
-module.exports = { isSafeExternalUrl, ALLOWED_EXTERNAL_PROTOCOLS };
+/**
+ * Normalized string form of a validated URL. Call only after
+ * isSafeExternalUrl() returned true — opening the normalized form avoids
+ * passing the raw renderer-controlled string to the OS.
+ * @param {string} url
+ * @returns {string}
+ */
+function normalizeExternalUrl(url) {
+  return new URL(url).toString();
+}
+
+module.exports = { isSafeExternalUrl, normalizeExternalUrl, ALLOWED_EXTERNAL_PROTOCOLS };

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -229,15 +229,15 @@ contextBridge.exposeInMainWorld("electronAPI", {
     isAvailable: () => ipcRenderer.invoke("safe-storage:is-available"),
   },
   power: {
+    // Returns an unsubscribe function that removes ONLY this wrapper.
+    // (removeOnPowerStateChange was removed in #1567 S3: it used
+    // removeAllListeners, which nuked other components' listeners.)
     onPowerStateChange: (callback) => {
       const handler = (_event, state) => callback(state);
       ipcRenderer.on("power:state-changed", handler);
       return () => ipcRenderer.removeListener("power:state-changed", handler);
     },
     getPowerState: () => ipcRenderer.invoke("power:get-state"),
-    removeOnPowerStateChange: () => {
-      ipcRenderer.removeAllListeners("power:state-changed");
-    },
   },
   editor: {
     popoutPanel: (bufferId, content, fileName, fileType) =>

--- a/electron/window-manager.js
+++ b/electron/window-manager.js
@@ -4,6 +4,7 @@
 const { app, BrowserWindow, dialog, shell } = require("electron");
 const path = require("path");
 const { isDev } = require("./app-constants");
+const { isSafeExternalUrl } = require("./lib/url-policy");
 
 let mainWindow = null;
 const allWindows = new Set();
@@ -60,9 +61,13 @@ async function createWindow({ showWelcome = false, hasPendingFile = false } = {}
 
   // Block new window creation from renderer
   newWindow.webContents.setWindowOpenHandler(({ url }) => {
-    // Allow opening external URLs in the default browser
-    if (url.startsWith("https://") || url.startsWith("http://")) {
+    // Only allow strictly-parsed http(s) URLs in the default browser.
+    // All other schemes (file:, smb:, javascript:, ...) and unparseable
+    // URLs are denied — fail closed (#1567 S3).
+    if (isSafeExternalUrl(url)) {
       shell.openExternal(url);
+    } else {
+      console.warn("[Security] Blocked external open of non-http(s) URL:", url);
     }
     return { action: "deny" };
   });

--- a/electron/window-manager.js
+++ b/electron/window-manager.js
@@ -4,7 +4,7 @@
 const { app, BrowserWindow, dialog, shell } = require("electron");
 const path = require("path");
 const { isDev } = require("./app-constants");
-const { isSafeExternalUrl } = require("./lib/url-policy");
+const { isSafeExternalUrl, normalizeExternalUrl } = require("./lib/url-policy");
 
 let mainWindow = null;
 const allWindows = new Set();
@@ -65,7 +65,12 @@ async function createWindow({ showWelcome = false, hasPendingFile = false } = {}
     // All other schemes (file:, smb:, javascript:, ...) and unparseable
     // URLs are denied — fail closed (#1567 S3).
     if (isSafeExternalUrl(url)) {
-      shell.openExternal(url);
+      // Open the normalized form, not the raw renderer string; handle the
+      // returned promise so OS handler failures cannot become unhandled
+      // rejections in the main process.
+      shell.openExternal(normalizeExternalUrl(url)).catch((error) => {
+        console.warn("[Security] shell.openExternal failed:", error);
+      });
     } else {
       console.warn("[Security] Blocked external open of non-http(s) URL:", url);
     }

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -244,12 +244,13 @@ declare global {
       isAvailable: () => Promise<boolean>;
     };
     power?: {
-      /** Listen for debounced power state changes from main process */
+      /**
+       * Listen for debounced power state changes from main process.
+       * Returns an unsubscribe function that removes only this listener.
+       */
       onPowerStateChange: (callback: (state: "ac" | "battery") => void) => () => void;
       /** Get current power state */
       getPowerState: () => Promise<"ac" | "battery">;
-      /** Remove all power state change listeners */
-      removeOnPowerStateChange: () => void;
     };
     /** Split editor popout window IPC */
     editor?: {


### PR DESCRIPTION
## 概要

QA 監査 issue #1567 の S3 (Electron/IPC 領域) で確認された 3 件のハードニング修正。
参照: #1567（本 PR は S3 の 3 項目のみを対象とし、issue 全体は close しない）

## 対応項目

### 1. `setWindowOpenHandler` の外部 URL オープンを厳格化 (`electron/window-manager.js`)
- 旧実装は `url.startsWith("https://") || url.startsWith("http://")` のみで `shell.openExternal` に渡していた
- `new URL` で厳密にパースし、`protocol` が `https:` / `http:` の場合のみ許可。パース失敗・その他スキーム（`file:`, `smb:`, `javascript:`, カスタムスキーム等）は fail-closed で拒否
- ウィンドウ生成自体は従来どおり常に `{ action: "deny" }`
- 判定ロジックは `electron/lib/url-policy.js` に抽出（#1583 の lib ヘルパー方式を踏襲）

### 2. `vfs:index-lock:acquire` の入力検証と取得タイムアウト (`electron/ipc/vfs-ipc.js`)
- key 検証を追加: string・非空・256 文字以内・制御文字 (U+0000–U+001F, U+007F) 拒否。違反時は日本語エラー
- 取得タイムアウト 10 秒を追加。他ウィンドウがロックを保持し続けても renderer が永久に待たされない。タイムアウト時は日本語メッセージで reject し、待機キューからも除去（後続の release が失効済み waiter を resolve しないことをテストで保証）
- ロック本体を `electron/lib/index-lock.js` に抽出（FIFO・destroyed sender スキップ・window close 時の全解放など、有効キーのセマンティクスは不変）

### 3. `removeOnPowerStateChange` の `removeAllListeners` を撤去 (`electron/preload.js`)
- 旧実装は `ipcRenderer.removeAllListeners("power:state-changed")` で他コンポーネントのリスナーまで除去していた
- `onPowerStateChange` が返す unsubscribe 関数（本ファイルの既存パターン）に一本化し、`removeOnPowerStateChange` を削除
- renderer 呼び出し箇所を grep で確認: `lib/editor-page/use-power-saving.ts` のみで、既に unsubscribe 戻り値を使用しており変更不要。`types/electron.d.ts` から型定義を削除

## テスト計画

- [x] `electron/lib/__tests__/url-policy.test.ts` 新規 — http(s) 許可 / file・smb・javascript・カスタムスキーム拒否 / `httpx:` 等の prefix smuggling 拒否 / パース失敗・非 string の fail-closed
- [x] `electron/lib/__tests__/index-lock.test.ts` 新規 — key 検証（型・空・長さ・制御文字）/ FIFO セマンティクス維持 / タイムアウト reject（fake timers）/ タイムアウト済み waiter のキュー除去 / destroyed sender スキップ / `releaseAllForSender`
- [x] `npx tsc --noEmit` green
- [x] `npm run lint` 0 errors
- [x] `npx vitest run electron lib` — 71 files / 1106 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)