### PR TITLE
refactor(menu): Web/Electron メニュー定義を単一ソースへ集約 (#1433)

### DIFF
--- a/electron/menu.js
+++ b/electron/menu.js
@@ -1,9 +1,19 @@
 /* eslint-disable no-console */
 // Application menu construction and management
+//
+// The menu structure (sections, items, labels, ordering, default
+// accelerators, checkbox-state mappings) is derived from the shared
+// template in lib/menu/menu-template.js (#1433), which is also the source
+// for the Web menu bar. Electron-only entries (macOS app menu, devtools,
+// quit, window roles, update check) are added here.
 
 const { app, BrowserWindow, Menu, shell } = require("electron");
+const {
+  MENU_TEMPLATE,
+  formatVersionLabel,
+  getNativeDefaultAccelerators,
+} = require("../lib/menu/menu-template");
 const { APP_NAME, isDev } = require("./app-constants");
-const { getStorageManager } = require("./ipc/storage-ipc");
 
 // Default UI state for menu checked states
 const DEFAULT_MENU_UI_STATE = {
@@ -25,21 +35,9 @@ let activeWindowId = null;
 
 /**
  * Default Electron accelerator strings keyed by CommandId.
- * Mirrors the defaults in lib/keymap/shortcut-registry.ts.
+ * Derived from the shared menu template (single source with the Web menu).
  */
-const DEFAULT_ACCELERATORS = {
-  "file.save": "CmdOrCtrl+S",
-  "file.saveAs": "CmdOrCtrl+Shift+S",
-  "file.open": "CmdOrCtrl+O",
-  "file.newWindow": "CmdOrCtrl+N",
-  "file.newTab": "CmdOrCtrl+T",
-  "file.closeTab": "CmdOrCtrl+W",
-  "edit.undo": "CmdOrCtrl+Z",
-  "edit.redo": "CmdOrCtrl+Y",
-  "edit.pasteAsPlaintext": "CmdOrCtrl+Shift+V",
-  "edit.selectAll": "CmdOrCtrl+A",
-  "view.compactMode": "CmdOrCtrl+Shift+M",
-};
+const DEFAULT_ACCELERATORS = getNativeDefaultAccelerators();
 
 /**
  * Returns the UI state for the currently active window.
@@ -131,8 +129,188 @@ function resolveAccelerator(commandId) {
   return DEFAULT_ACCELERATORS[commandId];
 }
 
-function buildApplicationMenu(recentProjects = []) {
-  const isMac = process.platform === "darwin";
+/**
+ * Builds the click handler for a shared template item, or undefined for
+ * items without click semantics (separators, containers).
+ * @param {import("../lib/menu/menu-template").MenuTemplateItem} item
+ * @param {(channel: string, ...args: unknown[]) => void} sendToFocused
+ * @returns {(() => void) | undefined}
+ */
+function buildClickHandler(item, sendToFocused) {
+  if (item.electronHandler === "new-window") {
+    return () => {
+      // Defer require to avoid circular dependency with window-manager.js
+      const { createWindow } = require("./window-manager");
+      createWindow({ showWelcome: true });
+    };
+  }
+  if (item.electronOpenExternal) {
+    const url = item.electronOpenExternal;
+    return () => {
+      shell.openExternal(url);
+    };
+  }
+  if (item.electronChannel) {
+    const channel = item.electronChannel;
+    const args = item.electronArgs ?? [];
+    return () => {
+      sendToFocused(channel, ...args);
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Converts a shared template item into an Electron menu template item.
+ * @param {import("../lib/menu/menu-template").MenuTemplateItem} item
+ * @param {{
+ *   sendToFocused: (channel: string, ...args: unknown[]) => void,
+ *   menuUiState: typeof DEFAULT_MENU_UI_STATE,
+ *   recentProjects: Array<{ id: string, name: string }>,
+ * }} ctx
+ * @returns {object}
+ */
+function toNativeMenuItem(item, ctx) {
+  if (item.type === "separator") {
+    return { type: "separator" };
+  }
+
+  const label = item.dynamicLabel === "version" ? formatVersionLabel(app.getVersion()) : item.label;
+
+  // Role-based items delegate behavior to Electron (macOS conventions intact)
+  if (item.electronRole) {
+    return { role: item.electronRole, label };
+  }
+
+  /** @type {Record<string, unknown>} */
+  const native = { label };
+
+  // Dynamic submenu insertion point: recent projects
+  if (item.dynamicSubmenu === "recent-projects") {
+    native.submenu =
+      ctx.recentProjects.length > 0
+        ? ctx.recentProjects.map((project) => ({
+            label: project.name,
+            click: () => {
+              ctx.sendToFocused(item.electronChannel, project.id);
+            },
+          }))
+        : [{ label: "項目なし", enabled: false }];
+    return native;
+  }
+
+  if (item.submenu) {
+    native.submenu = item.submenu.map((child) => toNativeMenuItem(child, ctx));
+    return native;
+  }
+
+  // Accelerator: user keymap override (via commandId) > shared default
+  if (item.commandId) {
+    const accelerator = resolveAccelerator(item.commandId);
+    if (accelerator) native.accelerator = accelerator;
+  } else if (item.nativeAccelerator) {
+    native.accelerator = item.nativeAccelerator;
+  }
+
+  // Checkbox / radio state mapped from the renderer-reported UI state
+  if (item.checkedState) {
+    native.type = item.electronType ?? item.type;
+    const stateValue = ctx.menuUiState[item.checkedState.key];
+    native.checked =
+      item.checkedState.value !== undefined
+        ? stateValue === item.checkedState.value
+        : Boolean(stateValue);
+  }
+
+  if (item.enabledWhenNotState) {
+    native.enabled = !ctx.menuUiState[item.enabledWhenNotState];
+  }
+
+  if (item.enabled === false) {
+    native.enabled = false;
+  }
+
+  const click = buildClickHandler(item, ctx.sendToFocused);
+  if (click) native.click = click;
+
+  return native;
+}
+
+/**
+ * Electron-only menu entries inserted around the shared core items.
+ * @param {"file" | "edit" | "format" | "view" | "window" | "help"} sectionId
+ * @param {boolean} isMac
+ * @returns {{ prepend: object[], append: object[] }}
+ */
+function getElectronSectionExtras(sectionId, isMac) {
+  switch (sectionId) {
+    case "file":
+      return {
+        prepend: [],
+        append: isMac ? [] : [{ type: "separator" }, { role: "quit", label: "終了" }],
+      };
+    case "view":
+      return {
+        prepend: [
+          ...(isDev
+            ? [
+                { role: "reload", label: "再読み込み" },
+                { role: "forceReload", label: "強制再読み込み" },
+                { type: "separator" },
+              ]
+            : []),
+          { role: "toggleDevTools", label: "開発者ツールを切り替え" },
+        ],
+        append: [
+          { type: "separator" },
+          { role: "togglefullscreen", label: "全画面表示を切り替え" },
+        ],
+      };
+    case "window":
+      return {
+        prepend: [],
+        append: [
+          { type: "separator" },
+          ...(isMac
+            ? [
+                { role: "minimize", label: "最小化" },
+                { role: "zoom", label: "拡大/縮小" },
+                { type: "separator" },
+                { role: "front", label: "すべてを手前に移動" },
+                { type: "separator" },
+                { role: "window", label: "ウィンドウ" },
+              ]
+            : [{ role: "minimize", label: "最小化" }]),
+        ],
+      };
+    case "help":
+      return {
+        prepend: [
+          {
+            label: "アップデートを確認",
+            click: () => {
+              // Defer require to avoid circular dependency with auto-updater.js
+              const { checkForUpdates } = require("./auto-updater");
+              checkForUpdates(true);
+            },
+          },
+          { type: "separator" },
+        ],
+        append: [],
+      };
+    default:
+      return { prepend: [], append: [] };
+  }
+}
+
+/**
+ * Builds the full native menu template from the shared menu template.
+ * @param {Array<{ id: string, name: string }>} recentProjects
+ * @param {string} platform - process.platform (injectable for tests)
+ * @returns {object[]}
+ */
+function buildApplicationMenu(recentProjects = [], platform = process.platform) {
+  const isMac = platform === "darwin";
   // Snapshot the active window's UI state once for this build
   const menuUiState = getMenuUiState();
 
@@ -142,9 +320,11 @@ function buildApplicationMenu(recentProjects = []) {
     if (win) win.webContents.send(channel, ...args);
   };
 
+  const ctx = { sendToFocused, menuUiState, recentProjects };
+
   const template = [];
 
-  // アプリ（macOSのみ）
+  // アプリ（macOSのみ・role ベースの実装を維持）
   if (isMac) {
     template.push({
       label: APP_NAME,
@@ -162,314 +342,13 @@ function buildApplicationMenu(recentProjects = []) {
     });
   }
 
-  // ファイル
-  template.push({
-    label: "ファイル",
-    submenu: [
-      {
-        label: "新規ウィンドウ",
-        accelerator: resolveAccelerator("file.newWindow"),
-        click: () => {
-          // Defer require to avoid circular dependency with window-manager.js
-          const { createWindow } = require("./window-manager");
-          createWindow({ showWelcome: true });
-        },
-      },
-      {
-        label: "最近のプロジェクトを開く",
-        submenu:
-          recentProjects.length > 0
-            ? recentProjects.map((project) => ({
-                label: project.name,
-                click: () => {
-                  sendToFocused("menu-open-recent-project", project.id);
-                },
-              }))
-            : [{ label: "項目なし", enabled: false }],
-      },
-      {
-        label: "プロジェクトを開く",
-        click: () => {
-          sendToFocused("menu-open-project");
-        },
-      },
-      { type: "separator" },
-      {
-        label: "ファイルを開く...",
-        accelerator: resolveAccelerator("file.open"),
-        click: () => {
-          sendToFocused("menu-open-triggered");
-        },
-      },
-      {
-        label: "保存",
-        accelerator: resolveAccelerator("file.save"),
-        click: () => {
-          sendToFocused("menu-save-triggered");
-        },
-      },
-      {
-        label: "別名で保存...",
-        accelerator: resolveAccelerator("file.saveAs"),
-        click: () => {
-          sendToFocused("menu-save-as-triggered");
-        },
-      },
-      { type: "separator" },
-      {
-        label: "印刷...",
-        accelerator: resolveAccelerator("file.print"),
-        click: () => sendToFocused("menu-print"),
-      },
-      {
-        label: "エクスポート",
-        submenu: [
-          {
-            label: "テキスト（プレーン）としてエクスポート...",
-            click: () => sendToFocused("menu-export-txt"),
-          },
-          {
-            label: "テキスト（ルビ付き）としてエクスポート...",
-            click: () => sendToFocused("menu-export-txt-ruby"),
-          },
-          { type: "separator" },
-          {
-            label: "PDF としてエクスポート...",
-            click: () => sendToFocused("menu-export-pdf"),
-          },
-          {
-            label: "EPUB としてエクスポート...",
-            click: () => sendToFocused("menu-export-epub"),
-          },
-          {
-            label: "DOCX としてエクスポート...",
-            click: () => sendToFocused("menu-export-docx"),
-          },
-        ],
-      },
-      { type: "separator" },
-      {
-        label: "新しいタブ",
-        accelerator: resolveAccelerator("file.newTab"),
-        click: () => {
-          sendToFocused("menu-new-tab");
-        },
-      },
-      {
-        label: "タブを閉じる",
-        accelerator: resolveAccelerator("file.closeTab"),
-        click: () => {
-          sendToFocused("menu-close-tab");
-        },
-      },
-      ...(isMac ? [] : [{ type: "separator" }]),
-      ...(isMac ? [] : [{ role: "quit", label: "終了" }]),
-    ],
-  });
-
-  // 編集
-  template.push({
-    label: "編集",
-    submenu: [
-      { role: "undo", label: "元に戻す" },
-      { role: "redo", label: "やり直す" },
-      { type: "separator" },
-      { role: "cut", label: "切り取り" },
-      { role: "copy", label: "コピー" },
-      { role: "paste", label: "貼り付け" },
-      {
-        label: "プレーンテキストとして貼り付け",
-        accelerator: resolveAccelerator("edit.pasteAsPlaintext"),
-        click: () => {
-          sendToFocused("menu-paste-as-plaintext");
-        },
-      },
-      { type: "separator" },
-      { role: "selectAll", label: "すべて選択" },
-    ],
-  });
-
-  // 書式
-  template.push({
-    label: "書式",
-    submenu: [
-      {
-        label: "行間",
-        submenu: [
-          {
-            label: "広くする",
-            accelerator: "CmdOrCtrl+]",
-            click: () => sendToFocused("menu-format", "lineHeight", "increase"),
-          },
-          {
-            label: "狭くする",
-            accelerator: "CmdOrCtrl+[",
-            click: () => sendToFocused("menu-format", "lineHeight", "decrease"),
-          },
-        ],
-      },
-      {
-        label: "段落間隔",
-        submenu: [
-          {
-            label: "広くする",
-            click: () => sendToFocused("menu-format", "paragraphSpacing", "increase"),
-          },
-          {
-            label: "狭くする",
-            click: () => sendToFocused("menu-format", "paragraphSpacing", "decrease"),
-          },
-        ],
-      },
-      {
-        label: "字下げ",
-        submenu: [
-          {
-            label: "深くする",
-            click: () => sendToFocused("menu-format", "textIndent", "increase"),
-          },
-          {
-            label: "浅くする",
-            click: () => sendToFocused("menu-format", "textIndent", "decrease"),
-          },
-          { label: "なし", click: () => sendToFocused("menu-format", "textIndent", "none") },
-        ],
-      },
-      { type: "separator" },
-      {
-        label: "1行あたりの文字数",
-        submenu: [
-          {
-            label: "自動",
-            type: "checkbox",
-            checked: menuUiState.autoCharsPerLine,
-            click: () => sendToFocused("menu-format", "charsPerLine", "auto"),
-          },
-          { type: "separator" },
-          {
-            label: "増やす",
-            enabled: !menuUiState.autoCharsPerLine,
-            click: () => sendToFocused("menu-format", "charsPerLine", "increase"),
-          },
-          {
-            label: "減らす",
-            enabled: !menuUiState.autoCharsPerLine,
-            click: () => sendToFocused("menu-format", "charsPerLine", "decrease"),
-          },
-        ],
-      },
-      { type: "separator" },
-      {
-        label: "段落番号を表示",
-        type: "checkbox",
-        checked: menuUiState.showParagraphNumbers,
-        click: () => sendToFocused("menu-format", "paragraphNumbers", "toggle"),
-      },
-    ],
-  });
-
-  // 表示
-  template.push({
-    label: "表示",
-    submenu: [
-      ...(isDev
-        ? [
-            { role: "reload", label: "再読み込み" },
-            { role: "forceReload", label: "強制再読み込み" },
-            { type: "separator" },
-          ]
-        : []),
-      { role: "toggleDevTools", label: "開発者ツールを切り替え" },
-      { role: "resetZoom", label: "実際のサイズ" },
-      { role: "zoomIn", label: "拡大" },
-      { role: "zoomOut", label: "縮小" },
-      { type: "separator" },
-      { role: "togglefullscreen", label: "全画面表示を切り替え" },
-    ],
-  });
-
-  // ウィンドウ
-  template.push({
-    label: "ウィンドウ",
-    submenu: [
-      {
-        label: "コンパクトモード",
-        type: "checkbox",
-        checked: menuUiState.compactMode,
-        accelerator: resolveAccelerator("view.compactMode"),
-        click: () => {
-          sendToFocused("menu-toggle-compact-mode");
-        },
-      },
-      {
-        label: "ダークモード",
-        submenu: [
-          {
-            label: "自動",
-            type: "radio",
-            checked: menuUiState.themeMode === "auto",
-            click: () => sendToFocused("menu-theme", "auto"),
-          },
-          {
-            label: "オフ",
-            type: "radio",
-            checked: menuUiState.themeMode === "light",
-            click: () => sendToFocused("menu-theme", "light"),
-          },
-          {
-            label: "オン",
-            type: "radio",
-            checked: menuUiState.themeMode === "dark",
-            click: () => sendToFocused("menu-theme", "dark"),
-          },
-        ],
-      },
-      { type: "separator" },
-      ...(isMac
-        ? [
-            { role: "minimize", label: "最小化" },
-            { role: "zoom", label: "拡大/縮小" },
-            { type: "separator" },
-            { role: "front", label: "すべてを手前に移動" },
-            { type: "separator" },
-            { role: "window", label: "ウィンドウ" },
-          ]
-        : [{ role: "minimize", label: "最小化" }]),
-    ],
-  });
-
-  // ヘルプ
-  template.push({
-    label: "ヘルプ",
-    submenu: [
-      {
-        label: "アップデートを確認",
-        click: () => {
-          // Defer require to avoid circular dependency with auto-updater.js
-          const { checkForUpdates } = require("./auto-updater");
-          checkForUpdates(true);
-        },
-      },
-      { type: "separator" },
-      {
-        label: `バージョン ${app.getVersion()}`,
-        enabled: false,
-      },
-      { type: "separator" },
-      {
-        label: "公式サイトへ",
-        click: () => {
-          shell.openExternal("https://www.illusions.app/");
-        },
-      },
-      {
-        label: "AI回答の不適切を報告",
-        click: () => {
-          shell.openExternal("https://github.com/Iktahana/illusions/issues/new");
-        },
-      },
-    ],
-  });
+  for (const section of MENU_TEMPLATE) {
+    const { prepend, append } = getElectronSectionExtras(section.id, isMac);
+    template.push({
+      label: section.label,
+      submenu: [...prepend, ...section.items.map((item) => toNativeMenuItem(item, ctx)), ...append],
+    });
+  }
 
   return template;
 }
@@ -477,6 +356,9 @@ function buildApplicationMenu(recentProjects = []) {
 /** Rebuild the application menu with fresh recent projects from SQLite */
 async function rebuildApplicationMenu() {
   try {
+    // Defer require so that menu construction stays importable without the
+    // storage stack (also avoids loading better-sqlite3 in tests)
+    const { getStorageManager } = require("./ipc/storage-ipc");
     const manager = getStorageManager();
     const projects = await manager.getRecentProjects();
     const menu = Menu.buildFromTemplate(buildApplicationMenu(projects));

--- a/lib/menu/__tests__/menu-template-drift.test.ts
+++ b/lib/menu/__tests__/menu-template-drift.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Drift-prevention tests for the shared menu template (#1433).
+ *
+ * The Web menu (lib/menu/menu-definitions.ts) and the Electron native menu
+ * (electron/menu.js) are both derived from lib/menu/menu-template.js. These
+ * tests assert that both sides derive an identical core structure (ids,
+ * order, labels, accelerators) from the shared source, and that the existing
+ * behavior pinned in #1433 (recent-project submenu, checked states, keymap
+ * overrides, macOS role-based app menu) is preserved.
+ */
+import { createRequire } from "module";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WEB_MENU_STRUCTURE, ACTION_TO_COMMAND_ID } from "@/lib/menu/menu-definitions";
+import { MENU_TEMPLATE } from "@/lib/menu/menu-template";
+import { isMacOS } from "@/lib/utils/runtime-env";
+
+import type { MenuItem } from "@/lib/menu/menu-definitions";
+import type { MenuTemplateItem } from "@/lib/menu/menu-template";
+
+// ---------------------------------------------------------------------------
+// Electron main-process stub (electron/menu.js is a CJS module).
+// vi.mock("electron") does not intercept require() inside externalized CJS
+// modules, so the stub is injected directly into Node's require cache.
+// ---------------------------------------------------------------------------
+
+const nodeRequire = createRequire(import.meta.url);
+const electronId = nodeRequire.resolve("electron");
+nodeRequire.cache[electronId] = {
+  id: electronId,
+  filename: electronId,
+  loaded: true,
+  exports: {
+    app: { getVersion: () => "9.9.9" },
+    BrowserWindow: { getFocusedWindow: () => null },
+    Menu: { buildFromTemplate: vi.fn(), setApplicationMenu: vi.fn() },
+    shell: { openExternal: vi.fn() },
+  },
+} as unknown as NodeJS.Module;
+
+interface NativeMenuItem {
+  label?: string;
+  type?: string;
+  role?: string;
+  accelerator?: string;
+  enabled?: boolean;
+  checked?: boolean;
+  submenu?: NativeMenuItem[];
+  click?: () => void;
+}
+
+interface ElectronMenuModule {
+  buildApplicationMenu: (
+    recentProjects?: Array<{ id: string; name: string }>,
+    platform?: string,
+  ) => NativeMenuItem[];
+  setMenuUiState: (state: Record<string, unknown>, windowId: number) => void;
+  setKeymapOverrides: (overrides: Record<string, unknown>, windowId: number) => void;
+  setActiveWindowId: (windowId: number | null) => void;
+  removeWindowState: (windowId: number) => void;
+}
+
+async function loadElectronMenu(): Promise<ElectronMenuModule> {
+  return (await import("../../../electron/menu.js")) as unknown as ElectronMenuModule;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Normalizes an accelerator for cross-platform comparison (modifier order/name). */
+function normalizeAccelerator(accel: string): string {
+  const tokens = accel.endsWith("++")
+    ? [...accel.slice(0, -2).split("+").filter(Boolean), "+"]
+    : accel.split("+");
+  const key = tokens[tokens.length - 1];
+  const modifiers = tokens
+    .slice(0, -1)
+    .map((m) => (m === "CmdOrCtrl" || m === "Cmd" ? "Ctrl" : m))
+    .sort();
+  return [...modifiers, key].join("+");
+}
+
+function nonSeparator<T extends { type?: string }>(items: T[]): T[] {
+  return items.filter((i) => i.type !== "separator");
+}
+
+/** Asserts the shared labels appear in order within the native labels. */
+function assertOrderedSubsequence(sharedLabels: string[], nativeLabels: string[]): number[] {
+  const indexes: number[] = [];
+  let cursor = 0;
+  for (const label of sharedLabels) {
+    const found = nativeLabels.indexOf(label, cursor);
+    expect(
+      found,
+      `label "${label}" missing or out of order in [${nativeLabels.join(", ")}]`,
+    ).toBeGreaterThanOrEqual(0);
+    indexes.push(found);
+    cursor = found + 1;
+  }
+  return indexes;
+}
+
+function templateLabel(item: MenuTemplateItem): string {
+  // The version row is dynamic on both platforms; compare by marker
+  return item.dynamicLabel === "version" ? "__version__" : (item.label ?? "");
+}
+
+function labelOf(item: { label?: string }): string {
+  return (item.label ?? "").startsWith("バージョン ") ? "__version__" : (item.label ?? "");
+}
+
+// ---------------------------------------------------------------------------
+// Core structure: Web and Electron derive identical ids / order / labels
+// ---------------------------------------------------------------------------
+
+describe("shared menu template drift prevention", () => {
+  let electronMenu: ElectronMenuModule;
+
+  beforeEach(async () => {
+    electronMenu = await loadElectronMenu();
+    electronMenu.removeWindowState(1);
+    electronMenu.removeWindowState(2);
+    electronMenu.setActiveWindowId(null);
+  });
+
+  it("Web sections mirror the shared template (labels and order)", () => {
+    expect(WEB_MENU_STRUCTURE.map((s) => s.label)).toEqual(MENU_TEMPLATE.map((s) => s.label));
+  });
+
+  it("Electron sections mirror the shared template (labels and order, no app menu on win32)", () => {
+    const native = electronMenu.buildApplicationMenu([], "win32");
+    expect(native.map((s) => s.label)).toEqual(MENU_TEMPLATE.map((s) => s.label));
+  });
+
+  it("Web and Electron derive identical core items (ids, order, labels) per section", () => {
+    const native = electronMenu.buildApplicationMenu([], "win32");
+
+    MENU_TEMPLATE.forEach((section, sectionIndex) => {
+      const sharedItems = nonSeparator(section.items);
+      const webItems = nonSeparator(WEB_MENU_STRUCTURE[sectionIndex].items);
+      const nativeItems = nonSeparator(native[sectionIndex].submenu ?? []);
+
+      // Web: exact one-to-one match with the shared core
+      expect(webItems.map(labelOf)).toEqual(sharedItems.map(templateLabel));
+      // Electron: shared core appears as an ordered subsequence
+      // (electron-only items such as devtools/quit are allowed around it)
+      const indexes = assertOrderedSubsequence(
+        sharedItems.map(templateLabel),
+        nativeItems.map(labelOf),
+      );
+
+      // Recurse one level into static submenus: nested levels must match exactly
+      sharedItems.forEach((sharedItem, i) => {
+        if (!sharedItem.submenu || sharedItem.dynamicSubmenu) return;
+        const sharedChildren = nonSeparator(sharedItem.submenu);
+        const webChildren = nonSeparator(webItems[i].submenu ?? []);
+        const nativeChildren = nonSeparator(nativeItems[indexes[i]].submenu ?? []);
+        expect(webChildren.map(labelOf)).toEqual(sharedChildren.map(templateLabel));
+        expect(nativeChildren.map(labelOf)).toEqual(sharedChildren.map(templateLabel));
+      });
+    });
+  });
+
+  it("Web actions use the shared item ids", () => {
+    MENU_TEMPLATE.forEach((section, sectionIndex) => {
+      const sharedItems = nonSeparator(section.items);
+      const webItems = nonSeparator(WEB_MENU_STRUCTURE[sectionIndex].items);
+      sharedItems.forEach((sharedItem, i) => {
+        if (sharedItem.submenu && !sharedItem.dynamicSubmenu) return; // containers
+        if (sharedItem.enabled === false) return; // version row has no action
+        expect(webItems[i].action).toBe(sharedItem.id);
+      });
+    });
+  });
+
+  it("default accelerators agree between Web and Electron for shared items", () => {
+    const native = electronMenu.buildApplicationMenu([], "win32");
+
+    const collectShared: Array<{ item: MenuTemplateItem }> = [];
+    const walk = (items: MenuTemplateItem[]): void => {
+      for (const item of items) {
+        collectShared.push({ item });
+        if (item.submenu) walk(item.submenu);
+      }
+    };
+    MENU_TEMPLATE.forEach((s) => walk(s.items));
+
+    const nativeByLabel = new Map<string, NativeMenuItem[]>();
+    const walkNative = (items: NativeMenuItem[]): void => {
+      for (const item of items) {
+        if (item.label) {
+          const list = nativeByLabel.get(item.label) ?? [];
+          list.push(item);
+          nativeByLabel.set(item.label, list);
+        }
+        if (item.submenu) walkNative(item.submenu);
+      }
+    };
+    walkNative(native);
+
+    for (const { item } of collectShared) {
+      if (!item.nativeAccelerator || !item.label) continue;
+      const candidates = nativeByLabel.get(item.label) ?? [];
+      const accelerators = candidates.map((c) => c.accelerator).filter(Boolean);
+      expect(accelerators, `native accelerator for ${item.id}`).toContain(item.nativeAccelerator);
+      if (typeof item.webAccelerator === "string") {
+        expect(normalizeAccelerator(item.webAccelerator)).toBe(
+          normalizeAccelerator(item.nativeAccelerator),
+        );
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // recent-project dynamic submenu
+  // -------------------------------------------------------------------------
+
+  it("Electron injects recent projects into the dynamic submenu", () => {
+    const native = electronMenu.buildApplicationMenu([{ id: "p1", name: "小説A" }], "win32");
+    const fileSection = native.find((s) => s.label === "ファイル");
+    const recent = fileSection?.submenu?.find((i) => i.label === "最近のプロジェクトを開く");
+    expect(recent?.submenu?.map((i) => i.label)).toEqual(["小説A"]);
+  });
+
+  it("Electron shows 項目なし when there are no recent projects", () => {
+    const native = electronMenu.buildApplicationMenu([], "win32");
+    const fileSection = native.find((s) => s.label === "ファイル");
+    const recent = fileSection?.submenu?.find((i) => i.label === "最近のプロジェクトを開く");
+    expect(recent?.submenu).toEqual([{ label: "項目なし", enabled: false }]);
+  });
+
+  it("Web keeps the recent-project injection marker (action + empty submenu)", () => {
+    const fileSection = WEB_MENU_STRUCTURE.find((s) => s.label === "ファイル");
+    const recent = fileSection?.items.find((i) => i.label === "最近のプロジェクトを開く");
+    expect(recent?.action).toBe("open-recent-project");
+    expect(recent?.submenu).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // checked states reflect renderer UI state
+  // -------------------------------------------------------------------------
+
+  it("checkbox/radio checked states reflect the renderer-reported UI state", () => {
+    electronMenu.setMenuUiState(
+      {
+        compactMode: true,
+        showParagraphNumbers: false,
+        themeMode: "dark",
+        autoCharsPerLine: false,
+      },
+      1,
+    );
+    electronMenu.setActiveWindowId(1);
+    const native = electronMenu.buildApplicationMenu([], "win32");
+
+    const windowSection = native.find((s) => s.label === "ウィンドウ");
+    const compact = windowSection?.submenu?.find((i) => i.label === "コンパクトモード");
+    expect(compact?.type).toBe("checkbox");
+    expect(compact?.checked).toBe(true);
+
+    const darkMode = windowSection?.submenu?.find((i) => i.label === "ダークモード");
+    const themes = darkMode?.submenu ?? [];
+    expect(themes.map((t) => [t.label, t.type, t.checked])).toEqual([
+      ["自動", "radio", false],
+      ["オフ", "radio", false],
+      ["オン", "radio", true],
+    ]);
+
+    const formatSection = native.find((s) => s.label === "書式");
+    const paragraphNumbers = formatSection?.submenu?.find((i) => i.label === "段落番号を表示");
+    expect(paragraphNumbers?.type).toBe("checkbox");
+    expect(paragraphNumbers?.checked).toBe(false);
+
+    const charsPerLine = formatSection?.submenu?.find((i) => i.label === "1行あたりの文字数");
+    const auto = charsPerLine?.submenu?.find((i) => i.label === "自動");
+    expect(auto?.type).toBe("checkbox");
+    expect(auto?.checked).toBe(false);
+    // increase/decrease are enabled only when auto is off
+    const increase = charsPerLine?.submenu?.find((i) => i.label === "増やす");
+    const decrease = charsPerLine?.submenu?.find((i) => i.label === "減らす");
+    expect(increase?.enabled).toBe(true);
+    expect(decrease?.enabled).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // user keymap overrides affect the native accelerator
+  // -------------------------------------------------------------------------
+
+  it("user keymap overrides replace the default native accelerator", () => {
+    electronMenu.setKeymapOverrides(
+      { "file.save": { modifiers: ["CmdOrCtrl", "Shift"], key: "p" } },
+      2,
+    );
+    electronMenu.setActiveWindowId(2);
+    const native = electronMenu.buildApplicationMenu([], "win32");
+    const fileSection = native.find((s) => s.label === "ファイル");
+    const save = fileSection?.submenu?.find((i) => i.label === "保存");
+    expect(save?.accelerator).toBe("CmdOrCtrl+Shift+P");
+  });
+
+  it("a null override unbinds the native accelerator", () => {
+    electronMenu.setKeymapOverrides({ "file.save": null }, 2);
+    electronMenu.setActiveWindowId(2);
+    const native = electronMenu.buildApplicationMenu([], "win32");
+    const fileSection = native.find((s) => s.label === "ファイル");
+    const save = fileSection?.submenu?.find((i) => i.label === "保存");
+    expect(save?.accelerator).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // macOS app menu (role-based) and platform-only items
+  // -------------------------------------------------------------------------
+
+  it("macOS keeps the role-based app menu and drops the file-menu quit item", () => {
+    const native = electronMenu.buildApplicationMenu([], "darwin");
+    expect(native[0].label).toBe("illusions");
+    expect(native[0].submenu?.every((i) => i.role || i.type === "separator")).toBe(true);
+
+    const fileSection = native.find((s) => s.label === "ファイル");
+    expect(fileSection?.submenu?.some((i) => i.role === "quit")).toBe(false);
+  });
+
+  it("non-macOS appends quit to the file menu", () => {
+    const native = electronMenu.buildApplicationMenu([], "win32");
+    const fileSection = native.find((s) => s.label === "ファイル");
+    const last = fileSection?.submenu?.[fileSection.submenu.length - 1];
+    expect(last).toMatchObject({ role: "quit", label: "終了" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Behavior pinning: the derived Web structure equals the pre-refactor literal
+// ---------------------------------------------------------------------------
+
+describe("WEB_MENU_STRUCTURE preserves the pre-#1433 structure", () => {
+  it("matches the previous hardcoded definition exactly", () => {
+    const APP_VERSION = (() => {
+      const v = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
+      const parts = v.split(".");
+      if (parts.length >= 3 && parts[2] !== "0") return v;
+      return parts.slice(0, 2).join(".");
+    })();
+
+    const expected: Array<{ label: string; items: MenuItem[] }> = [
+      {
+        label: "ファイル",
+        items: [
+          { label: "新規ウィンドウ", accelerator: "Ctrl+N", action: "new-window" },
+          { label: "最近のプロジェクトを開く", action: "open-recent-project", submenu: [] },
+          { label: "プロジェクトを開く", action: "open-project" },
+          { type: "separator" },
+          { label: "ファイルを開く...", accelerator: "Ctrl+O", action: "open-file" },
+          { label: "保存", accelerator: "Ctrl+S", action: "save-file" },
+          { label: "別名で保存...", accelerator: "Shift+Ctrl+S", action: "save-as" },
+          { type: "separator" },
+          {
+            label: "印刷...",
+            accelerator: isMacOS() ? "Cmd+P" : "Ctrl+P",
+            action: "print",
+          },
+          {
+            label: "エクスポート",
+            submenu: [
+              { label: "テキスト（プレーン）としてエクスポート...", action: "export-txt" },
+              { label: "テキスト（ルビ付き）としてエクスポート...", action: "export-txt-ruby" },
+              { type: "separator" },
+              { label: "PDF としてエクスポート...", action: "export-pdf" },
+              { label: "EPUB としてエクスポート...", action: "export-epub" },
+              { label: "DOCX としてエクスポート...", action: "export-docx" },
+            ],
+          },
+          { type: "separator" },
+          { label: "新しいタブ", accelerator: "Ctrl+T", action: "new-tab" },
+          { label: "タブを閉じる", accelerator: "Ctrl+W", action: "close-tab" },
+        ],
+      },
+      {
+        label: "編集",
+        items: [
+          { label: "元に戻す", accelerator: "Ctrl+Z", action: "undo" },
+          { label: "やり直す", accelerator: "Ctrl+Y", action: "redo" },
+          { type: "separator" },
+          { label: "切り取り", accelerator: "Ctrl+X", action: "cut" },
+          { label: "コピー", accelerator: "Ctrl+C", action: "copy" },
+          { label: "貼り付け", accelerator: "Ctrl+V", action: "paste" },
+          {
+            label: "プレーンテキストとして貼り付け",
+            accelerator: "Shift+Ctrl+V",
+            action: "paste-plaintext",
+          },
+          { type: "separator" },
+          { label: "すべて選択", accelerator: "Ctrl+A", action: "select-all" },
+        ],
+      },
+      {
+        label: "書式",
+        items: [
+          {
+            label: "行間",
+            submenu: [
+              { label: "広くする", accelerator: "Ctrl+]", action: "format-line-height-increase" },
+              { label: "狭くする", accelerator: "Ctrl+[", action: "format-line-height-decrease" },
+            ],
+          },
+          {
+            label: "段落間隔",
+            submenu: [
+              { label: "広くする", action: "format-paragraph-spacing-increase" },
+              { label: "狭くする", action: "format-paragraph-spacing-decrease" },
+            ],
+          },
+          {
+            label: "字下げ",
+            submenu: [
+              { label: "深くする", action: "format-text-indent-increase" },
+              { label: "浅くする", action: "format-text-indent-decrease" },
+              { label: "なし", action: "format-text-indent-none" },
+            ],
+          },
+          { type: "separator" },
+          {
+            label: "1行あたりの文字数",
+            submenu: [
+              { label: "自動", type: "checkbox", action: "format-chars-per-line-auto" },
+              { type: "separator" },
+              { label: "増やす", action: "format-chars-per-line-increase" },
+              { label: "減らす", action: "format-chars-per-line-decrease" },
+            ],
+          },
+          { type: "separator" },
+          { label: "段落番号を表示", type: "checkbox", action: "format-paragraph-numbers-toggle" },
+        ],
+      },
+      {
+        label: "表示",
+        items: [
+          { label: "実際のサイズ", accelerator: "Ctrl+0", action: "reset-zoom" },
+          { label: "拡大", accelerator: "Ctrl++", action: "zoom-in" },
+          { label: "縮小", accelerator: "Ctrl+-", action: "zoom-out" },
+        ],
+      },
+      {
+        label: "ウィンドウ",
+        items: [
+          { label: "コンパクトモード", type: "checkbox", action: "toggle-compact-mode" },
+          {
+            label: "ダークモード",
+            submenu: [
+              { label: "自動", type: "checkbox", action: "theme-auto" },
+              { label: "オフ", type: "checkbox", action: "theme-light" },
+              { label: "オン", type: "checkbox", action: "theme-dark" },
+            ],
+          },
+        ],
+      },
+      {
+        label: "ヘルプ",
+        items: [
+          { label: `バージョン ${APP_VERSION}`, enabled: false },
+          { type: "separator" },
+          { label: "公式サイトへ", action: "open-website" },
+          { label: "AI回答の不適切を報告", action: "report-ai-inappropriate" },
+        ],
+      },
+    ];
+
+    expect(WEB_MENU_STRUCTURE).toEqual(expected);
+  });
+
+  it("ACTION_TO_COMMAND_ID preserves the pre-#1433 mapping exactly", () => {
+    expect(ACTION_TO_COMMAND_ID).toEqual({
+      "new-window": "file.newWindow",
+      "open-file": "file.open",
+      "save-file": "file.save",
+      "save-as": "file.saveAs",
+      "new-tab": "file.newTab",
+      "close-tab": "file.closeTab",
+      undo: "edit.undo",
+      redo: "edit.redo",
+      "paste-plaintext": "edit.pasteAsPlaintext",
+      "select-all": "edit.selectAll",
+      "reset-zoom": "view.resetZoom",
+      "zoom-in": "view.zoomIn",
+      "zoom-out": "view.zoomOut",
+      "toggle-compact-mode": "view.compactMode",
+    });
+  });
+});

--- a/lib/menu/menu-definitions.ts
+++ b/lib/menu/menu-definitions.ts
@@ -1,9 +1,13 @@
 /**
  * Menu definitions for Web menu bar
- * Mirrors Electron native menu structure
+ * Derived from the shared template in lib/menu/menu-template.ts (#1433),
+ * which is also the source for the Electron native menu (electron/menu.js).
  */
-import type { CommandId } from "@/lib/keymap/command-ids";
 import { isMacOS } from "@/lib/utils/runtime-env";
+import { MENU_TEMPLATE, formatVersionLabel, forEachTemplateItem } from "./menu-template";
+
+import type { MenuTemplateItem } from "./menu-template";
+import type { CommandId } from "@/lib/keymap/command-ids";
 
 const APP_VERSION = (() => {
   const v = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
@@ -27,149 +31,65 @@ export interface MenuSection {
   items: MenuItem[];
 }
 
-export const WEB_MENU_STRUCTURE: MenuSection[] = [
-  {
-    label: "ファイル",
-    items: [
-      { label: "新規ウィンドウ", accelerator: "Ctrl+N", action: "new-window" },
-      { label: "最近のプロジェクトを開く", action: "open-recent-project", submenu: [] },
-      { label: "プロジェクトを開く", action: "open-project" },
-      { type: "separator" },
-      { label: "ファイルを開く...", accelerator: "Ctrl+O", action: "open-file" },
-      { label: "保存", accelerator: "Ctrl+S", action: "save-file" },
-      { label: "別名で保存...", accelerator: "Shift+Ctrl+S", action: "save-as" },
-      { type: "separator" },
-      {
-        label: "印刷...",
-        accelerator: isMacOS() ? "Cmd+P" : "Ctrl+P",
-        action: "print",
-      },
-      {
-        label: "エクスポート",
-        submenu: [
-          { label: "テキスト（プレーン）としてエクスポート...", action: "export-txt" },
-          { label: "テキスト（ルビ付き）としてエクスポート...", action: "export-txt-ruby" },
-          { type: "separator" },
-          { label: "PDF としてエクスポート...", action: "export-pdf" },
-          { label: "EPUB としてエクスポート...", action: "export-epub" },
-          { label: "DOCX としてエクスポート...", action: "export-docx" },
-        ],
-      },
-      { type: "separator" },
-      { label: "新しいタブ", accelerator: "Ctrl+T", action: "new-tab" },
-      { label: "タブを閉じる", accelerator: "Ctrl+W", action: "close-tab" },
-    ],
-  },
-  {
-    label: "編集",
-    items: [
-      { label: "元に戻す", accelerator: "Ctrl+Z", action: "undo" },
-      { label: "やり直す", accelerator: "Ctrl+Y", action: "redo" },
-      { type: "separator" },
-      { label: "切り取り", accelerator: "Ctrl+X", action: "cut" },
-      { label: "コピー", accelerator: "Ctrl+C", action: "copy" },
-      { label: "貼り付け", accelerator: "Ctrl+V", action: "paste" },
-      {
-        label: "プレーンテキストとして貼り付け",
-        accelerator: "Shift+Ctrl+V",
-        action: "paste-plaintext",
-      },
-      { type: "separator" },
-      { label: "すべて選択", accelerator: "Ctrl+A", action: "select-all" },
-    ],
-  },
-  {
-    label: "書式",
-    items: [
-      {
-        label: "行間",
-        submenu: [
-          { label: "広くする", accelerator: "Ctrl+]", action: "format-line-height-increase" },
-          { label: "狭くする", accelerator: "Ctrl+[", action: "format-line-height-decrease" },
-        ],
-      },
-      {
-        label: "段落間隔",
-        submenu: [
-          { label: "広くする", action: "format-paragraph-spacing-increase" },
-          { label: "狭くする", action: "format-paragraph-spacing-decrease" },
-        ],
-      },
-      {
-        label: "字下げ",
-        submenu: [
-          { label: "深くする", action: "format-text-indent-increase" },
-          { label: "浅くする", action: "format-text-indent-decrease" },
-          { label: "なし", action: "format-text-indent-none" },
-        ],
-      },
-      { type: "separator" },
-      {
-        label: "1行あたりの文字数",
-        submenu: [
-          { label: "自動", type: "checkbox", action: "format-chars-per-line-auto" },
-          { type: "separator" },
-          { label: "増やす", action: "format-chars-per-line-increase" },
-          { label: "減らす", action: "format-chars-per-line-decrease" },
-        ],
-      },
-      { type: "separator" },
-      { label: "段落番号を表示", type: "checkbox", action: "format-paragraph-numbers-toggle" },
-    ],
-  },
-  {
-    label: "表示",
-    items: [
-      { label: "実際のサイズ", accelerator: "Ctrl+0", action: "reset-zoom" },
-      { label: "拡大", accelerator: "Ctrl++", action: "zoom-in" },
-      { label: "縮小", accelerator: "Ctrl+-", action: "zoom-out" },
-    ],
-  },
-  {
-    label: "ウィンドウ",
-    items: [
-      { label: "コンパクトモード", type: "checkbox", action: "toggle-compact-mode" },
-      {
-        label: "ダークモード",
-        submenu: [
-          { label: "自動", type: "checkbox", action: "theme-auto" },
-          { label: "オフ", type: "checkbox", action: "theme-light" },
-          { label: "オン", type: "checkbox", action: "theme-dark" },
-        ],
-      },
-    ],
-  },
-  {
-    label: "ヘルプ",
-    items: [
-      { label: `バージョン ${APP_VERSION}`, enabled: false },
-      { type: "separator" },
-      { label: "公式サイトへ", action: "open-website" },
-      { label: "AI回答の不適切を報告", action: "report-ai-inappropriate" },
-    ],
-  },
-];
+/** Resolves the static Web accelerator display string for a template item. */
+function resolveWebAccelerator(item: MenuTemplateItem): string | undefined {
+  if (!item.webAccelerator) return undefined;
+  if (typeof item.webAccelerator === "string") return item.webAccelerator;
+  return isMacOS() ? item.webAccelerator.mac : item.webAccelerator.other;
+}
+
+/** Converts a shared template item into the Web menu item shape. */
+function toWebMenuItem(item: MenuTemplateItem): MenuItem {
+  if (item.type === "separator") {
+    return { type: "separator" };
+  }
+
+  const result: MenuItem = {
+    label: item.dynamicLabel === "version" ? formatVersionLabel(APP_VERSION) : item.label,
+  };
+
+  if (item.type === "checkbox") result.type = "checkbox";
+
+  const accelerator = resolveWebAccelerator(item);
+  if (accelerator) result.accelerator = accelerator;
+
+  if (item.enabled === false) result.enabled = false;
+
+  if (item.dynamicSubmenu) {
+    // Dynamic submenus (recent projects) are injected at runtime by WebMenuBar;
+    // the action id doubles as the injection marker.
+    result.action = item.id;
+    result.submenu = [];
+  } else if (item.submenu) {
+    // Static submenu containers carry no action of their own
+    result.submenu = item.submenu.map(toWebMenuItem);
+  } else if (item.enabled !== false && item.id) {
+    result.action = item.id;
+  }
+
+  return result;
+}
+
+export const WEB_MENU_STRUCTURE: MenuSection[] = MENU_TEMPLATE.map((section) => ({
+  label: section.label,
+  items: section.items.map(toWebMenuItem),
+}));
 
 /**
  * Maps menu action strings to their corresponding CommandIds in the keymap registry.
  * Used by WebMenuBar to inject dynamic accelerator strings from user overrides.
+ * Derived from the shared template (items flagged webCommandLookup: false keep
+ * their static accelerator, e.g. print).
  */
-export const ACTION_TO_COMMAND_ID: Partial<Record<string, CommandId>> = {
-  "new-window": "file.newWindow",
-  "open-file": "file.open",
-  "save-file": "file.save",
-  "save-as": "file.saveAs",
-  "new-tab": "file.newTab",
-  "close-tab": "file.closeTab",
-  undo: "edit.undo",
-  redo: "edit.redo",
-  "paste-plaintext": "edit.pasteAsPlaintext",
-  "select-all": "edit.selectAll",
-  "reset-zoom": "view.resetZoom",
-  "zoom-in": "view.zoomIn",
-  "zoom-out": "view.zoomOut",
-  "toggle-compact-mode": "view.compactMode",
-};
+export const ACTION_TO_COMMAND_ID: Partial<Record<string, CommandId>> = (() => {
+  const map: Partial<Record<string, CommandId>> = {};
+  forEachTemplateItem((item) => {
+    if (item.id && item.commandId && item.webCommandLookup !== false) {
+      map[item.id] = item.commandId;
+    }
+  });
+  return map;
+})();
 
 /**
  * Format accelerator for display

--- a/lib/menu/menu-template.d.ts
+++ b/lib/menu/menu-template.d.ts
@@ -1,0 +1,76 @@
+/**
+ * Type declarations for the shared menu template (#1433).
+ * See menu-template.js for the data and rationale.
+ */
+import type { CommandId } from "../keymap/command-ids";
+
+/** Renderer-reported UI state keys used for checkbox/radio menu items. */
+export type MenuStateKey = "compactMode" | "showParagraphNumbers" | "autoCharsPerLine";
+
+/** Mapping between a checkbox/radio item and the renderer UI state. */
+export interface MenuCheckedBinding {
+  /** Key in the menu UI state object */
+  key: MenuStateKey | "themeMode";
+  /** For radio-like bindings: checked when state[key] === value */
+  value?: string;
+}
+
+export interface MenuTemplateItem {
+  /** Stable item id; doubles as the Web menu action string */
+  id?: string;
+  type?: "separator" | "checkbox";
+  /** Japanese display label (shared by Web and Electron) */
+  label?: string;
+  /** Items whose label is computed at build time (see formatVersionLabel) */
+  dynamicLabel?: "version";
+  /** Keymap command backing this item (user override resolution) */
+  commandId?: CommandId;
+  /** When false, the Web menu keeps its static accelerator (no override lookup) */
+  webCommandLookup?: false;
+  /** Default native (Electron) accelerator; user overrides take precedence */
+  nativeAccelerator?: string;
+  /** Static Web accelerator display string */
+  webAccelerator?: string | { mac: string; other: string };
+  /** Electron menu role (platform-native behavior, e.g. undo/copy/zoom) */
+  electronRole?: string;
+  /** IPC channel sent to the focused window when clicked (Electron) */
+  electronChannel?: string;
+  /** Extra arguments sent with electronChannel */
+  electronArgs?: string[];
+  /** Electron main-process special handler id */
+  electronHandler?: "new-window";
+  /** External URL opened by the Electron main process when clicked */
+  electronOpenExternal?: string;
+  /** Electron item type override (theme items are radio natively) */
+  electronType?: "radio";
+  /** Checked-state mapping for checkbox/radio items */
+  checkedState?: MenuCheckedBinding;
+  /** Electron-only: item is enabled while state[key] is falsy */
+  enabledWhenNotState?: MenuStateKey;
+  /** Static enabled flag (e.g. version info row) */
+  enabled?: false;
+  /** Marker for dynamically generated submenus */
+  dynamicSubmenu?: "recent-projects";
+  submenu?: MenuTemplateItem[];
+}
+
+export interface MenuTemplateSection {
+  id: "file" | "edit" | "format" | "view" | "window" | "help";
+  /** Japanese menu bar label */
+  label: string;
+  items: MenuTemplateItem[];
+}
+
+export declare const MENU_TEMPLATE: MenuTemplateSection[];
+
+/** Shared label format for the version info row in the help menu. */
+export declare function formatVersionLabel(version: string): string;
+
+/** Visits every item (including nested submenus) in the shared template. */
+export declare function forEachTemplateItem(visit: (item: MenuTemplateItem) => void): void;
+
+/**
+ * Default Electron accelerator strings keyed by CommandId, derived from the
+ * shared template.
+ */
+export declare function getNativeDefaultAccelerators(): Partial<Record<CommandId, string>>;

--- a/lib/menu/menu-template.js
+++ b/lib/menu/menu-template.js
@@ -1,0 +1,436 @@
+/**
+ * Single source of truth for the application menu (#1433).
+ *
+ * The Web menu bar (lib/menu/menu-definitions.ts) and the Electron native
+ * menu (electron/menu.js) are both derived from MENU_TEMPLATE so that menu
+ * structure, labels, ordering, action ids, and default accelerators can no
+ * longer drift between the two platforms.
+ *
+ * Platform-only entries stay on each side:
+ * - Electron-only items (macOS app menu, devtools, quit, window roles,
+ *   update check) are appended/prepended in electron/menu.js.
+ * - Click handling stays platform-side: the Web menu dispatches `id` as the
+ *   action string, Electron uses `electronChannel`/`electronRole`/etc.
+ *
+ * NOTE: this module is a plain CommonJS file (not TypeScript) because it is
+ * required by both the Electron main process (bundled via esbuild without
+ * path aliases) and the Next.js renderer. Types live in menu-template.d.ts.
+ *
+ * @typedef {import("./menu-template").MenuTemplateItem} MenuTemplateItem
+ * @typedef {import("./menu-template").MenuTemplateSection} MenuTemplateSection
+ */
+
+/** @type {MenuTemplateItem} */
+const SEPARATOR = { type: "separator" };
+
+/** @type {MenuTemplateSection[]} */
+const MENU_TEMPLATE = [
+  {
+    id: "file",
+    label: "ファイル",
+    items: [
+      {
+        id: "new-window",
+        label: "新規ウィンドウ",
+        commandId: "file.newWindow",
+        nativeAccelerator: "CmdOrCtrl+N",
+        webAccelerator: "Ctrl+N",
+        electronHandler: "new-window",
+      },
+      {
+        id: "open-recent-project",
+        label: "最近のプロジェクトを開く",
+        dynamicSubmenu: "recent-projects",
+        electronChannel: "menu-open-recent-project",
+      },
+      {
+        id: "open-project",
+        label: "プロジェクトを開く",
+        electronChannel: "menu-open-project",
+      },
+      SEPARATOR,
+      {
+        id: "open-file",
+        label: "ファイルを開く...",
+        commandId: "file.open",
+        nativeAccelerator: "CmdOrCtrl+O",
+        webAccelerator: "Ctrl+O",
+        electronChannel: "menu-open-triggered",
+      },
+      {
+        id: "save-file",
+        label: "保存",
+        commandId: "file.save",
+        nativeAccelerator: "CmdOrCtrl+S",
+        webAccelerator: "Ctrl+S",
+        electronChannel: "menu-save-triggered",
+      },
+      {
+        id: "save-as",
+        label: "別名で保存...",
+        commandId: "file.saveAs",
+        nativeAccelerator: "CmdOrCtrl+Shift+S",
+        webAccelerator: "Shift+Ctrl+S",
+        electronChannel: "menu-save-as-triggered",
+      },
+      SEPARATOR,
+      {
+        id: "print",
+        label: "印刷...",
+        // Electron resolves user overrides for file.print but has no default
+        // native accelerator; the Web menu shows a static platform string.
+        commandId: "file.print",
+        webCommandLookup: false,
+        webAccelerator: { mac: "Cmd+P", other: "Ctrl+P" },
+        electronChannel: "menu-print",
+      },
+      {
+        id: "export",
+        label: "エクスポート",
+        submenu: [
+          {
+            id: "export-txt",
+            label: "テキスト（プレーン）としてエクスポート...",
+            electronChannel: "menu-export-txt",
+          },
+          {
+            id: "export-txt-ruby",
+            label: "テキスト（ルビ付き）としてエクスポート...",
+            electronChannel: "menu-export-txt-ruby",
+          },
+          SEPARATOR,
+          {
+            id: "export-pdf",
+            label: "PDF としてエクスポート...",
+            electronChannel: "menu-export-pdf",
+          },
+          {
+            id: "export-epub",
+            label: "EPUB としてエクスポート...",
+            electronChannel: "menu-export-epub",
+          },
+          {
+            id: "export-docx",
+            label: "DOCX としてエクスポート...",
+            electronChannel: "menu-export-docx",
+          },
+        ],
+      },
+      SEPARATOR,
+      {
+        id: "new-tab",
+        label: "新しいタブ",
+        commandId: "file.newTab",
+        nativeAccelerator: "CmdOrCtrl+T",
+        webAccelerator: "Ctrl+T",
+        electronChannel: "menu-new-tab",
+      },
+      {
+        id: "close-tab",
+        label: "タブを閉じる",
+        commandId: "file.closeTab",
+        nativeAccelerator: "CmdOrCtrl+W",
+        webAccelerator: "Ctrl+W",
+        electronChannel: "menu-close-tab",
+      },
+    ],
+  },
+  {
+    id: "edit",
+    label: "編集",
+    items: [
+      {
+        id: "undo",
+        label: "元に戻す",
+        commandId: "edit.undo",
+        webAccelerator: "Ctrl+Z",
+        electronRole: "undo",
+      },
+      {
+        id: "redo",
+        label: "やり直す",
+        commandId: "edit.redo",
+        webAccelerator: "Ctrl+Y",
+        electronRole: "redo",
+      },
+      SEPARATOR,
+      { id: "cut", label: "切り取り", webAccelerator: "Ctrl+X", electronRole: "cut" },
+      { id: "copy", label: "コピー", webAccelerator: "Ctrl+C", electronRole: "copy" },
+      { id: "paste", label: "貼り付け", webAccelerator: "Ctrl+V", electronRole: "paste" },
+      {
+        id: "paste-plaintext",
+        label: "プレーンテキストとして貼り付け",
+        commandId: "edit.pasteAsPlaintext",
+        nativeAccelerator: "CmdOrCtrl+Shift+V",
+        webAccelerator: "Shift+Ctrl+V",
+        electronChannel: "menu-paste-as-plaintext",
+      },
+      SEPARATOR,
+      {
+        id: "select-all",
+        label: "すべて選択",
+        commandId: "edit.selectAll",
+        webAccelerator: "Ctrl+A",
+        electronRole: "selectAll",
+      },
+    ],
+  },
+  {
+    id: "format",
+    label: "書式",
+    items: [
+      {
+        id: "line-height",
+        label: "行間",
+        submenu: [
+          {
+            id: "format-line-height-increase",
+            label: "広くする",
+            nativeAccelerator: "CmdOrCtrl+]",
+            webAccelerator: "Ctrl+]",
+            electronChannel: "menu-format",
+            electronArgs: ["lineHeight", "increase"],
+          },
+          {
+            id: "format-line-height-decrease",
+            label: "狭くする",
+            nativeAccelerator: "CmdOrCtrl+[",
+            webAccelerator: "Ctrl+[",
+            electronChannel: "menu-format",
+            electronArgs: ["lineHeight", "decrease"],
+          },
+        ],
+      },
+      {
+        id: "paragraph-spacing",
+        label: "段落間隔",
+        submenu: [
+          {
+            id: "format-paragraph-spacing-increase",
+            label: "広くする",
+            electronChannel: "menu-format",
+            electronArgs: ["paragraphSpacing", "increase"],
+          },
+          {
+            id: "format-paragraph-spacing-decrease",
+            label: "狭くする",
+            electronChannel: "menu-format",
+            electronArgs: ["paragraphSpacing", "decrease"],
+          },
+        ],
+      },
+      {
+        id: "text-indent",
+        label: "字下げ",
+        submenu: [
+          {
+            id: "format-text-indent-increase",
+            label: "深くする",
+            electronChannel: "menu-format",
+            electronArgs: ["textIndent", "increase"],
+          },
+          {
+            id: "format-text-indent-decrease",
+            label: "浅くする",
+            electronChannel: "menu-format",
+            electronArgs: ["textIndent", "decrease"],
+          },
+          {
+            id: "format-text-indent-none",
+            label: "なし",
+            electronChannel: "menu-format",
+            electronArgs: ["textIndent", "none"],
+          },
+        ],
+      },
+      SEPARATOR,
+      {
+        id: "chars-per-line",
+        label: "1行あたりの文字数",
+        submenu: [
+          {
+            id: "format-chars-per-line-auto",
+            label: "自動",
+            type: "checkbox",
+            checkedState: { key: "autoCharsPerLine" },
+            electronChannel: "menu-format",
+            electronArgs: ["charsPerLine", "auto"],
+          },
+          SEPARATOR,
+          {
+            id: "format-chars-per-line-increase",
+            label: "増やす",
+            enabledWhenNotState: "autoCharsPerLine",
+            electronChannel: "menu-format",
+            electronArgs: ["charsPerLine", "increase"],
+          },
+          {
+            id: "format-chars-per-line-decrease",
+            label: "減らす",
+            enabledWhenNotState: "autoCharsPerLine",
+            electronChannel: "menu-format",
+            electronArgs: ["charsPerLine", "decrease"],
+          },
+        ],
+      },
+      SEPARATOR,
+      {
+        id: "format-paragraph-numbers-toggle",
+        label: "段落番号を表示",
+        type: "checkbox",
+        checkedState: { key: "showParagraphNumbers" },
+        electronChannel: "menu-format",
+        electronArgs: ["paragraphNumbers", "toggle"],
+      },
+    ],
+  },
+  {
+    id: "view",
+    label: "表示",
+    items: [
+      {
+        id: "reset-zoom",
+        label: "実際のサイズ",
+        commandId: "view.resetZoom",
+        webAccelerator: "Ctrl+0",
+        electronRole: "resetZoom",
+      },
+      {
+        id: "zoom-in",
+        label: "拡大",
+        commandId: "view.zoomIn",
+        webAccelerator: "Ctrl++",
+        electronRole: "zoomIn",
+      },
+      {
+        id: "zoom-out",
+        label: "縮小",
+        commandId: "view.zoomOut",
+        webAccelerator: "Ctrl+-",
+        electronRole: "zoomOut",
+      },
+    ],
+  },
+  {
+    id: "window",
+    label: "ウィンドウ",
+    items: [
+      {
+        id: "toggle-compact-mode",
+        label: "コンパクトモード",
+        type: "checkbox",
+        commandId: "view.compactMode",
+        nativeAccelerator: "CmdOrCtrl+Shift+M",
+        checkedState: { key: "compactMode" },
+        electronChannel: "menu-toggle-compact-mode",
+      },
+      {
+        id: "dark-mode",
+        label: "ダークモード",
+        submenu: [
+          {
+            id: "theme-auto",
+            label: "自動",
+            type: "checkbox",
+            electronType: "radio",
+            checkedState: { key: "themeMode", value: "auto" },
+            electronChannel: "menu-theme",
+            electronArgs: ["auto"],
+          },
+          {
+            id: "theme-light",
+            label: "オフ",
+            type: "checkbox",
+            electronType: "radio",
+            checkedState: { key: "themeMode", value: "light" },
+            electronChannel: "menu-theme",
+            electronArgs: ["light"],
+          },
+          {
+            id: "theme-dark",
+            label: "オン",
+            type: "checkbox",
+            electronType: "radio",
+            checkedState: { key: "themeMode", value: "dark" },
+            electronChannel: "menu-theme",
+            electronArgs: ["dark"],
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "help",
+    label: "ヘルプ",
+    items: [
+      { id: "app-version", dynamicLabel: "version", enabled: false },
+      SEPARATOR,
+      {
+        id: "open-website",
+        label: "公式サイトへ",
+        electronOpenExternal: "https://www.illusions.app/",
+      },
+      {
+        id: "report-ai-inappropriate",
+        label: "AI回答の不適切を報告",
+        electronOpenExternal: "https://github.com/Iktahana/illusions/issues/new",
+      },
+    ],
+  },
+];
+
+/**
+ * Shared label format for the version info row in the help menu.
+ * @param {string} version
+ * @returns {string}
+ */
+function formatVersionLabel(version) {
+  return `バージョン ${version}`;
+}
+
+/**
+ * @param {MenuTemplateItem[]} items
+ * @param {(item: MenuTemplateItem) => void} visit
+ * @returns {void}
+ */
+function walkItems(items, visit) {
+  for (const item of items) {
+    visit(item);
+    if (item.submenu) walkItems(item.submenu, visit);
+  }
+}
+
+/**
+ * Visits every item (including nested submenus) in the shared template.
+ * @param {(item: MenuTemplateItem) => void} visit
+ * @returns {void}
+ */
+function forEachTemplateItem(visit) {
+  for (const section of MENU_TEMPLATE) {
+    walkItems(section.items, visit);
+  }
+}
+
+/**
+ * Default Electron accelerator strings keyed by CommandId, derived from the
+ * shared template. Used by electron/menu.js as the fallback when the user
+ * has no keymap override for a command.
+ * @returns {Record<string, string>}
+ */
+function getNativeDefaultAccelerators() {
+  /** @type {Record<string, string>} */
+  const map = {};
+  forEachTemplateItem((item) => {
+    if (item.commandId && item.nativeAccelerator) {
+      map[item.commandId] = item.nativeAccelerator;
+    }
+  });
+  return map;
+}
+
+module.exports = {
+  MENU_TEMPLATE,
+  formatVersionLabel,
+  forEachTemplateItem,
+  getNativeDefaultAccelerators,
+};


### PR DESCRIPTION
## 概要

Closes #1433

メニュー構造・ラベル・順序・action id・デフォルト accelerator・checkbox state mapping・dynamic submenu 差し込みポイントを **`lib/menu/menu-template.js`**（共有 CJS モジュール + `menu-template.d.ts`）に集約し、Web メニューと Electron ネイティブメニューを同一テンプレートから派生させました。

### 設計

| ファイル | 役割 |
| --- | --- |
| `lib/menu/menu-template.js` (+`.d.ts`) | 単一ソース。section/item/action id、accelerator (native/web)、`commandId`、checkbox-state mapping、dynamic submenu マーカー |
| `lib/menu/menu-definitions.ts` | テンプレートから `WEB_MENU_STRUCTURE` / `ACTION_TO_COMMAND_ID` を導出（公開 API・形状は完全互換、`WebMenuBar.tsx` は無変更） |
| `electron/menu.js` | テンプレートからネイティブテンプレートを構築。Electron 専用項目（macOS app menu、devtools、quit、window roles、アップデート確認）は prepend/append として本ファイル側に残置 |

- 共有モジュールを plain CJS にしたのは、esbuild (`bundle:electron`)・Next.js・vitest のすべてが**追加ビルドステップなし**で読み込めるため
- `DEFAULT_ACCELERATORS` は `getNativeDefaultAccelerators()` でテンプレートから導出（実効値は従来と同一。従来の `edit.undo`/`edit.redo`/`edit.selectAll` エントリは role 項目のため未参照のデッドデータであり、導出結果から消えますが挙動差なし）
- `storage-ipc` の require を `rebuildApplicationMenu` 内へ遅延化（既存の deferred-require パターンに合わせた変更。menu.js 単体がテストから import 可能に）
- `buildApplicationMenu(recentProjects, platform = process.platform)` に省略可能な platform 引数を追加（テスト用。既存呼び出し元は無変更）

### ドリフト防止テスト（`lib/menu/__tests__/menu-template-drift.test.ts`、15 件）

- Web / Electron が共有ソースから**同一のコア構造（ids・順序・ラベル・accelerator）**を導出すること（ネスト submenu 含む）
- リファクタ前の `WEB_MENU_STRUCTURE` / `ACTION_TO_COMMAND_ID` リテラルとの**完全一致**（挙動固定スナップショット）
- recent-project の動的 submenu（注入・「項目なし」フォールバック・Web 側マーカー）
- compact mode / theme / paragraph numbers / chars-per-line の checked / enabled state が UI state を反映
- keymap override が native accelerator に反映（置換・null=unbind）
- macOS app menu が role ベースのまま、quit の platform 分岐

## テストプラン

- [x] `npx tsc --noEmit` green
- [x] `npm run lint` 0 errors（新規警告なし）
- [x] `npx vitest run` 全体 98 files / 1274 tests green（新規 15 件含む）
- [x] `npm run bundle:electron` 成功（esbuild が共有テンプレートを main bundle に取り込むことを確認）

## 手動確認項目（マージ前推奨）

- [ ] メニューの順序・ラベルが従来と同一（Web / Electron 両方、macOS / Windows）
- [ ] 最近のプロジェクト submenu が動的生成される（0 件時「項目なし」）
- [ ] エクスポート 5 種（txt / txt+ルビ / PDF / EPUB / DOCX）と印刷が発火する
- [ ] コンパクトモード / ダークモード / 段落番号 / 1行あたりの文字数の checked state が renderer state を反映
- [ ] キーマップ設定の override が Web メニューの表示 accelerator と Electron native accelerator の両方へ反映、解除 (null) で unbind
- [ ] macOS app menu（illusions について / 隠す / 終了 等）が従来どおり動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)