### PR TITLE
fix(history): auto スナップショットのスロットル判定をロック内で再検査 (#1438)

### DIFF
--- a/lib/services/__tests__/history-service.test.ts
+++ b/lib/services/__tests__/history-service.test.ts
@@ -284,6 +284,68 @@ describe("HistoryService", () => {
       }
     });
 
+    it("re-checks the auto throttle inside the index lock (TOCTOU, #1438)", async () => {
+      // Simulate two concurrent auto createSnapshot calls for the same
+      // sourcePath that BOTH pass the outer (pre-lock) throttle check, and
+      // are then serialized by the index lock. Without the in-lock re-check,
+      // both would write a snapshot; with the fix, exactly one is written.
+      type LockFn = <T>(fn: () => Promise<T>) => Promise<T>;
+      const store = (service as unknown as { store: { withIndexLock: LockFn } }).store;
+      const realWithIndexLock = store.withIndexLock.bind(store) as LockFn;
+
+      interface PendingJob {
+        fn: () => Promise<unknown>;
+        resolve: (value: unknown) => void;
+        reject: (reason: unknown) => void;
+      }
+
+      // Hold every locked callback until both calls have reached the lock
+      // (i.e. both have already passed the outer throttle check), then run
+      // them strictly one after another through the real lock.
+      const pending: PendingJob[] = [];
+      let draining = false;
+      store.withIndexLock = (<T>(fn: () => Promise<T>): Promise<T> => {
+        return new Promise<T>((resolve, reject) => {
+          pending.push({
+            fn: fn as () => Promise<unknown>,
+            resolve: resolve as (value: unknown) => void,
+            reject,
+          });
+          if (pending.length === 2 && !draining) {
+            draining = true;
+            void (async () => {
+              while (pending.length > 0) {
+                const job = pending.shift()!;
+                try {
+                  job.resolve(await realWithIndexLock(job.fn));
+                } catch (err) {
+                  job.reject(err);
+                }
+              }
+            })();
+          }
+        });
+      }) as LockFn;
+
+      const [first, second] = await Promise.all([
+        service.createSnapshot({ sourcePath: "main.mdi", content: "v1" }),
+        service.createSnapshot({ sourcePath: "main.mdi", content: "v2" }),
+      ]);
+
+      // The first serialized call wins; the second must be throttled.
+      expect(first).not.toBeNull();
+      expect(second).toBeNull();
+
+      // Exactly ONE snapshot entry in the index.
+      const indexKey = Array.from(fileStore.keys()).find((k) => k.includes("index.json"))!;
+      const index = JSON.parse(fileStore.get(indexKey)!) as HistoryIndex;
+      expect(index.snapshots).toHaveLength(1);
+
+      // Exactly ONE snapshot file written.
+      const historyFiles = Array.from(fileStore.keys()).filter((k) => k.endsWith(".history"));
+      expect(historyFiles).toHaveLength(1);
+    });
+
     it("emits onSnapshotCreated listener when a snapshot is created", async () => {
       const listener = vi.fn();
       service.onSnapshotCreated(listener);

--- a/lib/services/history-service.ts
+++ b/lib/services/history-service.ts
@@ -89,12 +89,14 @@ export class HistoryService {
    * Create a history snapshot.
    *
    * Flow:
-   *   a) HistoryPolicy.shouldCreateSnapshot — return null if throttled (auto only)
+   *   a) HistoryPolicy.shouldCreateSnapshot — fast-path: return null if
+   *      obviously throttled (auto only), without taking the lock
    *   b) Build SnapshotEntry (timestamp, filename, checksum, size, type)
-   *   c) withIndexLock → loadIndex → writeSnapshotFile → update index
-   *      (add entry, prune via Policy.getPruneSet) → saveIndex → releaseLock
+   *   c) withIndexLock → loadIndex → re-run throttle check (TOCTOU safety;
+   *      auto only) → writeSnapshotFile → update index (add entry, prune via
+   *      Policy.getPruneSet) → saveIndex → releaseLock
    *   d) Emit onSnapshotCreated listeners
-   *   e) Return new entry
+   *   e) Return new entry (or null if throttled inside the lock)
    *
    * 履歴スナップショットを作成する。
    *
@@ -105,7 +107,9 @@ export class HistoryService {
     const { sourcePath, displayName: displayNameOption, content, type = "auto", label } = options;
 
     try {
-      // a) Throttle check — only "auto" is throttled
+      // a) Throttle fast-path — only "auto" is throttled. This pre-check is a
+      // cheap optimization that avoids taking the lock when obviously
+      // throttled; the authoritative check is re-run inside the lock (step c).
       const index = await this.store.loadIndex();
       const lastEntry = index.snapshots.find((s) => getSnapshotSourceKey(s) === sourcePath);
       const lastSnapshotAt = lastEntry?.timestamp;
@@ -142,12 +146,25 @@ export class HistoryService {
       }
 
       // c) Write file + update index under lock
-      await this.store.withIndexLock(async () => {
-        // Write the snapshot file first
+      const created = await this.store.withIndexLock(async (): Promise<boolean> => {
+        // Re-read index inside lock FIRST (TOCTOU safety): another caller may
+        // have created a snapshot between the fast-path check (a) and
+        // acquiring this lock, so the throttle must be re-checked here.
+        const lockedIndex = await this.store.loadIndex();
+
+        if (type === "auto") {
+          const lockedLastEntry = lockedIndex.snapshots.find(
+            (s) => getSnapshotSourceKey(s) === sourcePath,
+          );
+          if (!policyCheckThrottle(sourcePath, lockedLastEntry?.timestamp, type)) {
+            // Throttled inside the lock — skip the write entirely.
+            return false;
+          }
+        }
+
+        // Write the snapshot file
         await this.store.writeSnapshotFile(sourcePath, filename, content);
 
-        // Re-read index inside lock (TOCTOU safety)
-        const lockedIndex = await this.store.loadIndex();
         lockedIndex.snapshots.unshift(entry);
 
         // Prune according to policy
@@ -161,7 +178,12 @@ export class HistoryService {
         }
 
         await this.store.saveIndex(lockedIndex);
+        return true;
       });
+
+      if (!created) {
+        return null;
+      }
 
       // d) Notify listeners
       this.notifySnapshotCreated(entry);


### PR DESCRIPTION
## 概要

`HistoryService.createSnapshot()` の auto スナップショットスロットル判定が `withIndexLock` の外でのみ実行されていたため、2 つの呼び出しが同時に事前チェックを通過すると、ロック内で直列化された後に重複 auto スナップショットが作成される TOCTOU バグを修正する。

#1438 の本体である Policy/Store 分解は 6eb60fa (Phase 8) で実装済み。本 PR は残存していたロック外スロットル判定の TOCTOU を解消し、issue の受け入れ条件を完了させる。#1567 の最終未対応項目にも該当。

## 変更内容

- `withIndexLock` 内で index を**先に**再読込するよう順序を変更（従来は `writeSnapshotFile` 後に再読込）
- `type === "auto"` の場合、ロック内の最新エントリのタイムスタンプで `policyCheckThrottle` を再検査。throttled ならファイル書き込みをスキップし `createSnapshot` は `null` を返す
- ロック外の事前チェックは高速パスとして維持（明白に throttled な場合のロック取得を回避）
- manual / milestone 等の非 auto 種別は従来どおりスロットル対象外

## テスト

- 回帰テスト追加: 同一 sourcePath への 2 つの並行 auto `createSnapshot` 呼び出しが両方とも事前チェックを通過し、ロックで直列化されるケース。書き込まれるスナップショットは厳密に 1 件、2 つ目は `null` を返すことを検証
- 修正を stash した状態でテストが fail することを確認済み（修正前: 2 件書き込み）
- `npx tsc --noEmit` / `npm run lint` / `npx vitest run lib/services` (294 tests) すべて green、既存の history テストは無変更

Closes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)