### PR TITLE
feat(editor): power-aware throttling を新アーキテクチャへ配線 (#1466)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -219,6 +219,7 @@ export default function EditorPage() {
   const tabManager = useTabManager({
     skipAutoRestore,
     autoSave,
+    powerSaveMode,
     vfsReadyPromise: vfsGate.promise,
     flushLayoutState: stableFlushLayoutState,
     windowKey,

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -44,8 +44,10 @@ import {
   useTypographySettings,
   useLintingSettings,
   usePosHighlightSettings,
+  usePowerSettings,
   useScrollSettings,
 } from "@/contexts/EditorSettingsContext";
+import { usePosHighlightActivation } from "@/lib/editor-page/use-pos-highlight-activation";
 
 interface MilkdownEditorProps {
   initialContent: string;
@@ -116,6 +118,7 @@ export default function MilkdownEditor({
   const { lintingEnabled } = useLintingSettings();
   const { posHighlightEnabled, posHighlightColors, posHighlightDisabledTypes } =
     usePosHighlightSettings();
+  const { powerSaveMode } = usePowerSettings();
   const { verticalScrollBehavior, scrollSensitivity } = useScrollSettings();
   const { measureRef: charMeasureRef, charWidth } = useCharWidth({
     fontFamily,
@@ -344,23 +347,16 @@ export default function MilkdownEditor({
     }
   }, [externalContent, get, isVertical, scrollContainerRef]);
 
-  // posHighlight 設定を動的に更新（Editor を再作成せずに）
-  useEffect(() => {
-    if (!editorViewInstance) return;
-
-    // 動的に設定を更新
-    import("@/packages/milkdown-plugin-japanese-novel/pos-highlight")
-      .then(({ updatePosHighlightSettings }) => {
-        updatePosHighlightSettings(editorViewInstance, {
-          enabled: posHighlightEnabled,
-          colors: posHighlightColors,
-          disabledTypes: posHighlightDisabledTypes,
-        });
-      })
-      .catch((err) => {
-        console.error("[Editor] Failed to update POS highlight settings:", err);
-      });
-  }, [editorViewInstance, posHighlightEnabled, posHighlightColors, posHighlightDisabledTypes]);
+  // posHighlight 設定を動的に更新（Editor を再作成せずに）。
+  // enabled は power policy 由来の実効値（バックグラウンド中は停止、
+  // フォーカス復帰でユーザー設定どおりに復元、#1466）。
+  usePosHighlightActivation({
+    view: editorViewInstance,
+    posHighlightEnabled,
+    powerSaveMode,
+    posHighlightColors,
+    posHighlightDisabledTypes,
+  });
 
   // linting 設定を動的に更新（Editor を再作成せずに）
   useEffect(() => {

--- a/lib/editor-page/__tests__/pos-highlight-activation.test.tsx
+++ b/lib/editor-page/__tests__/pos-highlight-activation.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Regression tests for the window-activity → POS-highlight wiring
+ * (#1466, guarding against a #1445 recurrence).
+ *
+ * The hook derives an EFFECTIVE enabled flag (`shouldEnablePosHighlight`)
+ * and applies it via `updatePosHighlightSettings` — a meta-only transaction
+ * that toggles decorations and never touches the document. These tests
+ * drive the REAL hook (createRoot + act, repo pattern) with the plugin
+ * module mocked, and verify:
+ *
+ * 1. the effective enabled is FALSE while blurred even when the user
+ *    setting is true, and returns to the user setting on focus,
+ * 2. the user's setting object is never mutated by a focus round-trip,
+ * 3. a user setting of false stays false in the foreground (no surprise
+ *    enabling on focus),
+ * 4. only the settings-update entry point is called — nothing that could
+ *    reload content or move the cursor.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Mocks (must precede importing the module under test)
+// ---------------------------------------------------------------------------
+
+const updatePosHighlightSettings = vi.fn();
+vi.mock("@/packages/milkdown-plugin-japanese-novel/pos-highlight", () => ({
+  updatePosHighlightSettings: (...args: unknown[]) => updatePosHighlightSettings(...args),
+}));
+
+import { usePosHighlightActivation } from "../use-pos-highlight-activation";
+import type { UsePosHighlightActivationParams } from "../use-pos-highlight-activation";
+import type { EditorView } from "@milkdown/prose/view";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const fakeView = {} as EditorView;
+
+function makeParams(
+  overrides: Partial<UsePosHighlightActivationParams> = {},
+): UsePosHighlightActivationParams {
+  return {
+    view: fakeView,
+    posHighlightEnabled: true,
+    powerSaveMode: false,
+    posHighlightColors: { 名詞: "#ff0000" },
+    posHighlightDisabledTypes: ["助詞"],
+    ...overrides,
+  };
+}
+
+function HookHost({ params }: { params: UsePosHighlightActivationParams }): null {
+  usePosHighlightActivation(params);
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+async function mountHook(params: UsePosHighlightActivationParams): Promise<void> {
+  await act(async () => {
+    root.render(<HookHost params={params} />);
+  });
+  // Let the hook's dynamic import of the plugin module resolve
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function dispatchActivity(type: "blur" | "focus"): Promise<void> {
+  await act(async () => {
+    window.dispatchEvent(new Event(type));
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+/** The `enabled` flag of the most recent settings application. */
+function lastAppliedEnabled(): boolean {
+  const calls = updatePosHighlightSettings.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const [, settings] = calls[calls.length - 1] as [EditorView, { enabled: boolean }];
+  return settings.enabled;
+}
+
+beforeEach(() => {
+  // jsdom's document.hasFocus() is unreliable in headless runs; pin the
+  // initial activity state to "focused", as in the real app.
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  updatePosHighlightSettings.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("#1466 — effective POS highlight follows window activity", () => {
+  it("is false while blurred even when the user setting is true, and returns on focus", async () => {
+    const params = makeParams({ posHighlightEnabled: true });
+    await mountHook(params);
+
+    // Foreground: the user's setting applies
+    expect(lastAppliedEnabled()).toBe(true);
+
+    // Blur: highlighting is suspended (effective value only)
+    await dispatchActivity("blur");
+    expect(lastAppliedEnabled()).toBe(false);
+
+    // Focus: restored to exactly the user's setting — which was never mutated
+    await dispatchActivity("focus");
+    expect(lastAppliedEnabled()).toBe(true);
+    expect(params.posHighlightEnabled).toBe(true);
+  });
+
+  it("stays false on focus when the user setting is false (no surprise enabling)", async () => {
+    await mountHook(makeParams({ posHighlightEnabled: false }));
+    expect(lastAppliedEnabled()).toBe(false);
+
+    await dispatchActivity("blur");
+    await dispatchActivity("focus");
+    expect(lastAppliedEnabled()).toBe(false);
+  });
+
+  it("stays false in power-save mode even in the foreground", async () => {
+    await mountHook(makeParams({ powerSaveMode: true }));
+    expect(lastAppliedEnabled()).toBe(false);
+
+    await dispatchActivity("blur");
+    await dispatchActivity("focus");
+    expect(lastAppliedEnabled()).toBe(false);
+  });
+
+  it("passes colors/disabledTypes through and applies to the given view only", async () => {
+    await mountHook(makeParams());
+    const [view, settings] = updatePosHighlightSettings.mock.calls[0] as [
+      EditorView,
+      { enabled: boolean; colors: Record<string, string>; disabledTypes: string[] },
+    ];
+    // Only the decoration-settings entry point is used; the call targets the
+    // editor view and contains nothing that could replace content.
+    expect(view).toBe(fakeView);
+    expect(settings.colors).toEqual({ 名詞: "#ff0000" });
+    expect(settings.disabledTypes).toEqual(["助詞"]);
+  });
+
+  it("does nothing while the view is not ready", async () => {
+    await mountHook(makeParams({ view: null }));
+    expect(updatePosHighlightSettings).not.toHaveBeenCalled();
+  });
+});

--- a/lib/editor-page/__tests__/power-policy.test.ts
+++ b/lib/editor-page/__tests__/power-policy.test.ts
@@ -53,18 +53,38 @@ describe("getAutoSaveIntervalMs", () => {
 });
 
 describe("shouldEnablePosHighlight", () => {
-  it("follows the user setting when power-save mode is off", () => {
-    expect(shouldEnablePosHighlight({ posHighlightEnabled: true, powerSaveMode: false })).toBe(
-      true,
-    );
-    expect(shouldEnablePosHighlight({ posHighlightEnabled: false, powerSaveMode: false })).toBe(
-      false,
-    );
+  it("follows the user setting in the foreground when power-save mode is off", () => {
+    expect(
+      shouldEnablePosHighlight(foreground, { posHighlightEnabled: true, powerSaveMode: false }),
+    ).toBe(true);
+    expect(
+      shouldEnablePosHighlight(foreground, { posHighlightEnabled: false, powerSaveMode: false }),
+    ).toBe(false);
   });
 
-  it("disables highlighting in power-save mode", () => {
-    expect(shouldEnablePosHighlight({ posHighlightEnabled: true, powerSaveMode: true })).toBe(
-      false,
-    );
+  it("disables highlighting in power-save mode even in the foreground", () => {
+    expect(
+      shouldEnablePosHighlight(foreground, { posHighlightEnabled: true, powerSaveMode: true }),
+    ).toBe(false);
+  });
+
+  it("disables highlighting while backgrounded even when the user setting is true (#1466)", () => {
+    expect(
+      shouldEnablePosHighlight(blurred, { posHighlightEnabled: true, powerSaveMode: false }),
+    ).toBe(false);
+    expect(
+      shouldEnablePosHighlight(hidden, { posHighlightEnabled: true, powerSaveMode: false }),
+    ).toBe(false);
+    expect(
+      shouldEnablePosHighlight(background, { posHighlightEnabled: true, powerSaveMode: false }),
+    ).toBe(false);
+  });
+
+  it("restores exactly the user's setting on focus (no mutation of the setting)", () => {
+    const settings = { posHighlightEnabled: true, powerSaveMode: false };
+    expect(shouldEnablePosHighlight(blurred, settings)).toBe(false);
+    // The settings object is untouched; the foreground decision returns to it.
+    expect(settings.posHighlightEnabled).toBe(true);
+    expect(shouldEnablePosHighlight(foreground, settings)).toBe(true);
   });
 });

--- a/lib/editor-page/power-policy.ts
+++ b/lib/editor-page/power-policy.ts
@@ -13,10 +13,12 @@
  * window activity 信号と設定から「何を停止/抑制すべきか」の判断だけを返す。
  *
  * Wiring status:
- * - `shouldPauseFileWatchers` — wired in this PR
+ * - `shouldPauseFileWatchers` — wired in #1594
  *   (lib/tab-manager/use-file-watch-integration.ts).
- * - `getAutoSaveIntervalMs` / `shouldEnablePosHighlight` — consumers are
- *   wired in a follow-up PR (#1466) to keep this change reviewable.
+ * - `getAutoSaveIntervalMs` — wired in #1466
+ *   (lib/tab-manager/use-auto-save.ts).
+ * - `shouldEnablePosHighlight` — wired in #1466
+ *   (lib/editor-page/use-pos-highlight-activation.ts).
  */
 
 import { AUTO_SAVE_INTERVAL } from "../tab-manager/types";
@@ -99,16 +101,28 @@ export function getAutoSaveIntervalMs(
 /**
  * Whether part-of-speech highlighting should run.
  *
- * Deliberately NOT focus-dependent: toggling editor decorations on every
- * focus switch is exactly the churn class that produced #1445. The
- * decision depends only on the user setting and power-save mode.
+ * Focus-dependent (#1466, restoring the PR #1427 CPU-saving requirement):
+ * the expensive morphological highlighting is suspended while the window
+ * is backgrounded or power-save mode is on, and resumes when the user
+ * setting allows it. This is safe with respect to #1445 because the sole
+ * consumer (use-pos-highlight-activation.ts) subscribes to the
+ * framework-free window-activity service — no React re-render on focus
+ * switches — and applies the decision via `updatePosHighlightSettings`,
+ * which dispatches a meta-only transaction: decorations toggle, the
+ * document, selection, and scroll are never touched.
  *
- * 品詞ハイライトを有効にすべきかどうか。フォーカス切替で装飾を
- * 付け外しする揺れ（#1445 と同種の churn）を避けるため、意図的に
- * activity には依存させず、設定と省電力モードのみで判断する。
+ * The user setting itself is never mutated; this returns an EFFECTIVE
+ * value, so regaining focus restores exactly the user's choice.
+ *
+ * 品詞ハイライトを有効にすべきかどうか（#1466）。バックグラウンド中
+ * または省電力モード中は重い形態素ハイライトを一時停止し、フォーカス
+ * 復帰時にユーザー設定どおりの状態へ戻す。判断の適用は meta 専用
+ * transaction による装飾の付け外しのみで、本文・選択・スクロールには
+ * 一切触れない（#1445 ガード）。ユーザー設定自体は変更しない。
  */
 export function shouldEnablePosHighlight(
+  activity: WindowActivityState,
   settings: PowerPolicySettings & { posHighlightEnabled: boolean },
 ): boolean {
-  return settings.posHighlightEnabled && !settings.powerSaveMode;
+  return settings.posHighlightEnabled && !settings.powerSaveMode && !isBackground(activity);
 }

--- a/lib/editor-page/use-pos-highlight-activation.ts
+++ b/lib/editor-page/use-pos-highlight-activation.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect } from "react";
+import { shouldEnablePosHighlight } from "./power-policy";
+import { getWindowActivitySnapshot, subscribeWindowActivity } from "./window-activity";
+import type { WindowActivityState } from "./window-activity";
+import type { EditorView } from "@milkdown/prose/view";
+
+// ---------------------------------------------------------------------------
+// Params
+// ---------------------------------------------------------------------------
+
+export interface UsePosHighlightActivationParams {
+  /** The ProseMirror view of the active editor, or null while mounting. */
+  view: EditorView | null;
+  /** The user's POS-highlight setting. Never mutated by this hook. */
+  posHighlightEnabled: boolean;
+  /** Power-save mode (user setting / battery auto-enable). */
+  powerSaveMode: boolean;
+  /** POS color map (passed through to the plugin). */
+  posHighlightColors: Record<string, string>;
+  /** POS types the user disabled (passed through to the plugin). */
+  posHighlightDisabledTypes: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies the POS-highlight settings to the editor, with the `enabled` flag
+ * derived from the power policy (`shouldEnablePosHighlight`, #1466): the
+ * expensive morphological highlighting is suspended while the window is
+ * backgrounded (or power-save mode is on) and restored to exactly the
+ * user's setting on focus.
+ *
+ * #1445 safety:
+ * - Subscribes directly to the framework-free window-activity service —
+ *   focus switches never go through React state, so nothing re-renders.
+ * - `updatePosHighlightSettings` dispatches a META-ONLY transaction; only
+ *   decorations toggle. The document, selection, and scroll position are
+ *   never touched, so a focus round-trip cannot move the cursor or reload
+ *   content.
+ *
+ * 品詞ハイライト設定の適用フック（#1466）。enabled は power policy 由来の
+ * 実効値（effectivePosHighlightEnabled）で、バックグラウンド中は重い
+ * ハイライトを停止し、フォーカス復帰でユーザー設定どおりに戻す。
+ * 適用は meta 専用 transaction による装飾の付け外しのみで、本文・選択・
+ * スクロールには一切触れない（#1445 ガード）。ユーザー設定は変更しない。
+ */
+export function usePosHighlightActivation(params: UsePosHighlightActivationParams): void {
+  const {
+    view,
+    posHighlightEnabled,
+    powerSaveMode,
+    posHighlightColors,
+    posHighlightDisabledTypes,
+  } = params;
+
+  useEffect(() => {
+    if (!view) return;
+
+    let disposed = false;
+
+    const apply = (activity: WindowActivityState): void => {
+      // 動的 import で plugin 本体（kuromoji 含む）を初期バンドルから外す
+      import("@/packages/milkdown-plugin-japanese-novel/pos-highlight")
+        .then(({ updatePosHighlightSettings }) => {
+          if (disposed) return;
+          updatePosHighlightSettings(view, {
+            enabled: shouldEnablePosHighlight(activity, { posHighlightEnabled, powerSaveMode }),
+            colors: posHighlightColors,
+            disabledTypes: posHighlightDisabledTypes,
+          });
+        })
+        .catch((err) => {
+          console.error("[Editor] Failed to update POS highlight settings:", err);
+        });
+    };
+
+    apply(getWindowActivitySnapshot());
+    const unsubscribe = subscribeWindowActivity(apply);
+
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, [view, posHighlightEnabled, powerSaveMode, posHighlightColors, posHighlightDisabledTypes]);
+}

--- a/lib/tab-manager/__tests__/auto-save-activity-throttle.test.tsx
+++ b/lib/tab-manager/__tests__/auto-save-activity-throttle.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * Regression tests for the window-activity → auto-save interval wiring
+ * (#1466, guarding against a #1445 recurrence).
+ *
+ * The hook subscribes to the framework-free window-activity service and
+ * re-arms its setInterval per the power policy (`getAutoSaveIntervalMs`):
+ * 5s foreground, 20s while the window is backgrounded with power-save mode
+ * on. These tests drive the REAL hook (createRoot + act, repo pattern,
+ * matching file-watch-activity-pause.test.tsx) with fake timers and verify:
+ *
+ * 1. the interval switches 5s → 20s on blur and back to 5s on focus
+ *    (power-save mode on),
+ * 2. without power-save mode, blur does NOT throttle (foreground behavior
+ *    everywhere),
+ * 3. editing during a blur → focus round-trip preserves the tab content —
+ *    the hook only saves; it never writes back into the buffer
+ *    (no replaceAll-like behavior, the #1445 symptom guard),
+ * 4. unmounting unsubscribes from the activity service (no leaks).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Mocks (must precede importing the modules under test)
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: {
+    warning: vi.fn(),
+    info: vi.fn(),
+    showMessage: vi.fn(),
+  },
+}));
+
+// use-auto-save imports the save-executor (only used for non-active dirty
+// tabs); mock its VFS-facing dependencies so importing it is side-effect free.
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => ({
+    getFileMetadata: vi.fn(),
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/project/mdi-file", () => ({
+  saveMdiFile: vi.fn(),
+}));
+
+import { AUTO_SAVE_INTERVAL } from "../types";
+import { BACKGROUND_AUTO_SAVE_INTERVAL_MS } from "../../editor-page/power-policy";
+import { useAutoSave } from "../use-auto-save";
+import { isEditorTab } from "../tab-types";
+import type { UseAutoSaveParams } from "../use-auto-save";
+import type { Dispatch, SetStateAction } from "react";
+import type { EditorTabState, TabId, TabState } from "../tab-types";
+
+// ---------------------------------------------------------------------------
+// Harness (pattern shared with file-watch-activity-pause.test.tsx)
+// ---------------------------------------------------------------------------
+
+const FILE_PATH = "/project/test.mdi";
+
+function makeTab(overrides: Partial<EditorTabState> = {}): EditorTabState {
+  return {
+    tabKind: "editor",
+    id: "tab-1",
+    file: { path: FILE_PATH, handle: null, name: "test.mdi" },
+    content: "initial content",
+    lastSavedContent: "initial content",
+    isDirty: true,
+    lastSavedTime: null,
+    lastSaveWasAuto: false,
+    isSaving: false,
+    isPreview: false,
+    fileType: ".mdi",
+    fileSyncStatus: "dirty",
+    conflictDiskContent: null,
+    ...overrides,
+  };
+}
+
+interface Harness {
+  params: UseAutoSaveParams;
+  tabsRef: { current: TabState[] };
+  saveFile: ReturnType<typeof vi.fn>;
+  getTab: (id: TabId) => EditorTabState;
+  setTabs: Dispatch<SetStateAction<TabState[]>>;
+}
+
+function makeHarness(tab: EditorTabState, powerSaveMode: boolean): Harness {
+  const tabsRef = { current: [tab] as TabState[] };
+  const setTabs: Dispatch<SetStateAction<TabState[]>> = (updater) => {
+    tabsRef.current =
+      typeof updater === "function"
+        ? (updater as (prev: TabState[]) => TabState[])(tabsRef.current)
+        : updater;
+  };
+  // The active-tab auto-save path: behaves like the real saveFile — marks
+  // the tab clean WITHOUT touching its content (saving never edits).
+  const saveFile = vi.fn(async () => {
+    tabsRef.current = tabsRef.current.map((t) =>
+      isEditorTab(t) ? { ...t, isDirty: false, lastSavedContent: t.content } : t,
+    );
+  });
+  return {
+    tabsRef,
+    setTabs,
+    saveFile,
+    getTab: (id: TabId): EditorTabState => {
+      const found = tabsRef.current.find((t) => t.id === id);
+      if (!found || !isEditorTab(found)) throw new Error(`editor tab not found: ${id}`);
+      return found;
+    },
+    params: {
+      tabs: tabsRef.current,
+      setTabs,
+      activeTabId: tab.id,
+      setActiveTabId: vi.fn(),
+      tabsRef,
+      activeTabIdRef: { current: tab.id },
+      isProjectRef: { current: true },
+      isElectron: true,
+      autoSaveEnabled: true,
+      powerSaveMode,
+      saveFileRef: { current: (_isAutoSave?: boolean) => saveFile() },
+      tryCreateSnapshot: vi.fn(async () => undefined),
+    },
+  };
+}
+
+function HookHost({ params }: { params: UseAutoSaveParams }): null {
+  useAutoSave(params);
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+async function mountHook(params: UseAutoSaveParams): Promise<void> {
+  await act(async () => {
+    root.render(<HookHost params={params} />);
+  });
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+function dispatchBlur(): void {
+  window.dispatchEvent(new Event("blur"));
+}
+
+function dispatchFocus(): void {
+  window.dispatchEvent(new Event("focus"));
+}
+
+/** Mark the tab dirty again (the saveFile mock cleans it after each save). */
+function makeDirty(harness: Harness, content?: string): void {
+  harness.tabsRef.current = harness.tabsRef.current.map((t) =>
+    isEditorTab(t)
+      ? { ...t, content: content ?? t.content, isDirty: true, fileSyncStatus: "dirty" }
+      : t,
+  );
+}
+
+beforeEach(() => {
+  // jsdom's document.hasFocus() is unreliable in headless runs; pin the
+  // initial activity state to "focused", as in the real app.
+  vi.spyOn(document, "hasFocus").mockReturnValue(true);
+  vi.useFakeTimers();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("#1466 — auto-save interval follows the power policy", () => {
+  it("switches 5s → 20s on blur and back to 5s on focus (power-save mode on)", async () => {
+    const harness = makeHarness(makeTab(), true);
+    await mountHook(harness.params);
+
+    // Foreground: normal 5s interval
+    await advance(AUTO_SAVE_INTERVAL);
+    expect(harness.saveFile).toHaveBeenCalledTimes(1);
+
+    // Background: the timer is re-armed to 20s
+    makeDirty(harness);
+    await act(async () => {
+      dispatchBlur();
+    });
+    await advance(BACKGROUND_AUTO_SAVE_INTERVAL_MS - 1);
+    expect(harness.saveFile).toHaveBeenCalledTimes(1);
+    await advance(1);
+    expect(harness.saveFile).toHaveBeenCalledTimes(2);
+
+    // Focus regained: back to the normal 5s interval
+    makeDirty(harness);
+    await act(async () => {
+      dispatchFocus();
+    });
+    await advance(AUTO_SAVE_INTERVAL);
+    expect(harness.saveFile).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not throttle on blur when power-save mode is off", async () => {
+    const harness = makeHarness(makeTab(), false);
+    await mountHook(harness.params);
+
+    await act(async () => {
+      dispatchBlur();
+    });
+    await advance(AUTO_SAVE_INTERVAL);
+    expect(harness.saveFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not save dirty content early when blurred (no tick before 20s)", async () => {
+    const harness = makeHarness(makeTab(), true);
+    await mountHook(harness.params);
+
+    await act(async () => {
+      dispatchBlur();
+    });
+    // Multiple 5s foreground periods pass without a tick
+    await advance(AUTO_SAVE_INTERVAL * 3);
+    expect(harness.saveFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("#1466 — focus round-trip preserves edits (#1445 symptom guard)", () => {
+  it("keeps the edited buffer intact across blur → background save → focus", async () => {
+    const harness = makeHarness(makeTab({ content: "initial content", isDirty: false }), true);
+    await mountHook(harness.params);
+
+    // User edits, then the window is backgrounded mid-edit
+    makeDirty(harness, "edited while focused");
+    await act(async () => {
+      dispatchBlur();
+    });
+
+    // Edit continues in the background (e.g. dictation), then the throttled
+    // background save fires
+    makeDirty(harness, "edited while blurred");
+    await advance(BACKGROUND_AUTO_SAVE_INTERVAL_MS);
+    expect(harness.saveFile).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      dispatchFocus();
+    });
+    await advance(AUTO_SAVE_INTERVAL);
+
+    // Content is exactly the user's edit — nothing reloaded or replaced it
+    const after = harness.getTab("tab-1");
+    expect(after.content).toBe("edited while blurred");
+    expect(after.pendingExternalContent ?? null).toBeNull();
+  });
+});
+
+describe("#1466 — activity subscription lifecycle", () => {
+  it("unsubscribes from the window-activity service on unmount (no leak)", async () => {
+    const windowRemove = vi.spyOn(window, "removeEventListener");
+    const harness = makeHarness(makeTab(), true);
+    await mountHook(harness.params);
+
+    await act(async () => {
+      root.unmount();
+    });
+
+    expect(
+      windowRemove.mock.calls.filter(([type]) => String(type) === "blur").length,
+    ).toBeGreaterThan(0);
+    expect(
+      windowRemove.mock.calls.filter(([type]) => String(type) === "focus").length,
+    ).toBeGreaterThan(0);
+    windowRemove.mockRestore();
+  });
+});

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -24,6 +24,11 @@ export type { UseTabManagerReturn } from "./types";
 export function useTabManager(options?: {
   skipAutoRestore?: boolean;
   autoSave?: boolean;
+  /**
+   * Power-save mode; throttles the auto-save interval while the window is
+   * backgrounded (#1466). Defaults to false (no throttling).
+   */
+  powerSaveMode?: boolean;
   vfsReadyPromise?: Promise<void>;
   /** External flush callback for dockview layout persistence. */
   flushLayoutState?: () => Promise<void>;
@@ -86,6 +91,7 @@ export function useTabManager(options?: {
     isProjectRef: tabState.isProjectRef,
     isElectron: tabState.isElectron,
     autoSaveEnabled,
+    powerSaveMode: options?.powerSaveMode ?? false,
     saveFileRef: fileIO.saveFileRef,
     tryCreateSnapshot: fileIO.tryCreateSnapshot,
   });

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { getAutoSaveIntervalMs } from "../editor-page/power-policy";
+import { getWindowActivitySnapshot, subscribeWindowActivity } from "../editor-page/window-activity";
 import { notificationManager } from "../services/notification-manager";
 import { executeTabSave } from "./save-executor";
 import { isEditorTab } from "./tab-types";
-import { AUTO_SAVE_INTERVAL } from "./types";
+import type { WindowActivityState } from "../editor-page/window-activity";
 import type { SnapshotType } from "../services/history-policy";
 import type { TabManagerCore } from "./types";
 
@@ -15,6 +17,15 @@ import type { TabManagerCore } from "./types";
 export interface UseAutoSaveParams extends TabManagerCore {
   /** Whether auto-save is enabled. */
   autoSaveEnabled: boolean;
+  /**
+   * Power-save mode (user setting / battery auto-enable). When true and the
+   * window is backgrounded, the auto-save interval is throttled to 20s by
+   * the power policy (#1466). Foreground behavior is unchanged.
+   *
+   * 省電力モード。有効かつバックグラウンド時のみ自動保存間隔を 20 秒に
+   * 間引く（#1466）。フォアグラウンドの挙動は変わらない。
+   */
+  powerSaveMode?: boolean;
   /** Ref holding the latest saveFile function (for active tab). */
   saveFileRef: React.MutableRefObject<(isAutoSave?: boolean) => Promise<void>>;
   /**
@@ -40,6 +51,18 @@ export interface UseAutoSaveParams extends TabManagerCore {
  * Orchestration only: the actual save pipeline (lock, sanitize, VFS vs
  * standalone write, watch suppression, tab-state update, snapshot) lives in
  * the shared executor (save-executor.ts, #1432).
+ *
+ * Power-aware throttling (#1466): the timer interval follows the power
+ * policy (`getAutoSaveIntervalMs`) — 5s in the foreground, 20s while the
+ * window is backgrounded with power-save mode on. Activity transitions
+ * re-arm the interval via a direct subscription to the framework-free
+ * window-activity service, so focus switches never re-render React
+ * (#1427 lesson / #1445 guard).
+ *
+ * 電源対応スロットリング（#1466）：自動保存間隔は power policy に従う
+ * （フォアグラウンド 5 秒 / 省電力モード有効かつバックグラウンド 20 秒）。
+ * activity 変化時はタイマーを張り直す。React state を介さないため
+ * フォーカス切替で再レンダーは発生しない（#1445 ガード）。
  */
 export function useAutoSave(params: UseAutoSaveParams): void {
   const {
@@ -48,6 +71,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
     activeTabIdRef,
     isProjectRef,
     autoSaveEnabled,
+    powerSaveMode = false,
     saveFileRef,
     tryCreateSnapshot,
   } = params;
@@ -71,7 +95,7 @@ export function useAutoSave(params: UseAutoSaveParams): void {
       return;
     }
 
-    autoSaveTimerRef.current = setInterval(() => {
+    const runAutoSave = (): void => {
       const currentTabs = tabsRef.current;
       for (const tab of currentTabs) {
         // Skip non-editor tabs (terminal, diff) and conflicted editor tabs
@@ -113,15 +137,39 @@ export function useAutoSave(params: UseAutoSaveParams): void {
           }
         })();
       }
-    }, AUTO_SAVE_INTERVAL);
+    };
 
-    return () => {
+    /**
+     * (Re-)arm the timer for the interval the power policy decides for the
+     * given activity state. No-op when the interval is unchanged so repeated
+     * notifications never reset the countdown unnecessarily.
+     */
+    let currentIntervalMs: number | null = null;
+    const arm = (activity: WindowActivityState): void => {
+      const intervalMs = getAutoSaveIntervalMs(activity, { powerSaveMode });
+      if (intervalMs === currentIntervalMs) return;
+      currentIntervalMs = intervalMs;
       if (autoSaveTimerRef.current) {
         clearInterval(autoSaveTimerRef.current);
+      }
+      autoSaveTimerRef.current = setInterval(runAutoSave, intervalMs);
+    };
+
+    // Subscribe directly to the framework-free signal source — no React
+    // state, so focus switches never re-render the page (#1427 lesson).
+    arm(getWindowActivitySnapshot());
+    const unsubscribe = subscribeWindowActivity(arm);
+
+    return () => {
+      unsubscribe();
+      if (autoSaveTimerRef.current) {
+        clearInterval(autoSaveTimerRef.current);
+        autoSaveTimerRef.current = null;
       }
     };
   }, [
     autoSaveEnabled,
+    powerSaveMode,
     setTabs,
     tabsRef,
     activeTabIdRef,


### PR DESCRIPTION
## 概要

#1594 で導入した window-activity / power-policy アーキテクチャに、未配線のまま残っていた 2 つのポリシー判断を接続します。watcher pause は #1594 で配線・regression test 済みのため本 PR では一切触れていません。

Closes #1466

## 変更内容

### 1. auto-save throttle（`lib/tab-manager/use-auto-save.ts`）
- `use-file-watch-integration` と同じパターンで、framework-free な window-activity サービスを effect 内で直接購読（React state 不使用 → フォーカス切替で再レンダーなし、#1427 の教訓）
- `getAutoSaveIntervalMs` に従い、**省電力モード有効かつバックグラウンド時のみ 20 秒**に間引き。フォアグラウンドは従来どおり 5 秒（CLAUDE.md §6 記載の挙動）
- activity 遷移時にタイマーを張り直す（同一間隔なら no-op）
- `powerSaveMode` は `app/page.tsx → useTabManager → useAutoSave` と props で受け渡し（デフォルト false = 従来挙動）

### 2. posHighlight focus 連動（`lib/editor-page/use-pos-highlight-activation.ts` 新規）
- `shouldEnablePosHighlight(activity, settings)` に activity 依存を追加（元 PR #1427 のセマンティクスを復元）
- MilkdownEditor の posHighlight 設定 effect を新フックに置換。実効値（effectivePosHighlightEnabled）を `updatePosHighlightSettings` で適用
- **ユーザー設定は変更しない**。focus 復帰で設定どおりの状態に自動復元
- `updatePosHighlightSettings` は meta 専用 transaction（装飾の付け外しのみ）。本文・選択・スクロールには一切触れない → #1445 チェーン（content reload / scroll / cursor 移動）は構造的に発生しない

## Test Plan

- [x] `power-policy.test.ts` — blur/hidden 時に実効 posHighlight が false、設定オブジェクト非変異、focus で復元
- [x] `auto-save-activity-throttle.test.tsx`（新規・fake timers）— blur で 5s→20s、focus で 5s に復帰 / 省電力モード OFF なら blur でも 5s / focus 往復をまたぐ編集内容の保持（replaceAll 様の挙動なし）/ unmount で購読解除
- [x] `pos-highlight-activation.test.tsx`（新規）— blur 中は設定 true でも実効 false、focus でユーザー設定に復元 / 設定 false は focus でも false / 省電力モード中は常に false / view 未準備時は no-op
- [x] `file-watch-activity-pause.test.tsx`（既存 #1594 regression suite）green のまま
- [x] `npx tsc --noEmit` / `npm run lint`（0 errors）
- [x] `npx vitest run lib/tab-manager lib/editor-page components` — 427 passed（tab-registry/credits.json の失敗は既存）

## 備考

- watcher pause（`shouldPauseFileWatchers`）の配線は #1594 で完了済み。本 PR は issue #1466 の再実装方針（段階分割・regression test 必須）に従う最終段
- 元 PR #1427 / regression #1445, #1457 / rollback v1.2.7 の経緯は issue 参照

🤖 Generated with [Claude Code](https://claude.com/claude-code)
