### PR TITLE
refactor(electron): IPC ブリッジ registry 化を全名前空間へ展開 (#1434)

### DIFF
--- a/electron/ipc/auth-ipc.js
+++ b/electron/ipc/auth-ipc.js
@@ -1,5 +1,6 @@
 const { ipcMain, shell, BrowserWindow, app } = require("electron");
 const crypto = require("crypto");
+const { AUTH_CHANNELS } = require("../lib/ipc-channels");
 
 const PROVIDER_URL = "https://my.illusions.app";
 const OAUTH_CLIENT_ID = "illusions";
@@ -17,7 +18,7 @@ function generateCodeChallenge(verifier) {
 }
 
 function registerAuthHandlers() {
-  ipcMain.handle("auth:start-login", async (event) => {
+  ipcMain.handle(AUTH_CHANNELS.invoke.startLogin, async (event) => {
     const state = crypto.randomBytes(16).toString("hex");
     const codeVerifier = generateCodeVerifier();
     const codeChallenge = generateCodeChallenge(codeVerifier);
@@ -41,7 +42,7 @@ function registerAuthHandlers() {
     return { state };
   });
 
-  ipcMain.handle("auth:exchange-code", async (_event, { code, state }) => {
+  ipcMain.handle(AUTH_CHANNELS.invoke.exchangeCode, async (_event, { code, state }) => {
     const entry = pendingAuthByState.get(state);
     if (!entry) {
       throw new Error("Invalid state parameter");
@@ -69,7 +70,7 @@ function registerAuthHandlers() {
     return response.json();
   });
 
-  ipcMain.handle("auth:refresh-token", async (_event, refreshToken) => {
+  ipcMain.handle(AUTH_CHANNELS.invoke.refreshToken, async (_event, refreshToken) => {
     const response = await fetch(`${PROVIDER_URL}/api/oauth/token`, {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -92,7 +93,7 @@ function registerAuthHandlers() {
     return response.json();
   });
 
-  ipcMain.handle("auth:get-userinfo", async (_event, accessToken) => {
+  ipcMain.handle(AUTH_CHANNELS.invoke.getUserInfo, async (_event, accessToken) => {
     const response = await fetch(`${PROVIDER_URL}/api/oauth/userinfo`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
@@ -106,7 +107,7 @@ function registerAuthHandlers() {
     return response.json();
   });
 
-  ipcMain.handle("auth:logout", async (event) => {
+  ipcMain.handle(AUTH_CHANNELS.invoke.logout, async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender);
     if (win) {
       const winId = win.id;
@@ -167,7 +168,7 @@ function handleAuthCallback(url) {
     if (targetWindow) {
       if (targetWindow.isMinimized()) targetWindow.restore();
       targetWindow.focus();
-      targetWindow.webContents.send("auth:callback", { code, state, error });
+      targetWindow.webContents.send(AUTH_CHANNELS.event.callback, { code, state, error });
     }
   } catch (err) {
     console.error("[auth] Failed to handle callback URL:", err);

--- a/electron/ipc/editor-ipc.js
+++ b/electron/ipc/editor-ipc.js
@@ -4,6 +4,7 @@
 const { ipcMain, BrowserWindow, app } = require("electron");
 const path = require("path");
 const { isDev } = require("../app-constants");
+const { EDITOR_CHANNELS } = require("../lib/ipc-channels");
 
 /**
  * Register IPC handlers for editor popout windows and cross-window buffer sync.
@@ -16,7 +17,7 @@ const { isDev } = require("../app-constants");
 function registerEditorHandlers() {
   // Open a new popout editor window for the given buffer
   ipcMain.handle(
-    "editor:popout-panel",
+    EDITOR_CHANNELS.invoke.popoutPanel,
     async (event, { bufferId, content, fileName, fileType }) => {
       // Validate required input
       if (!bufferId || typeof bufferId !== "string") {
@@ -73,7 +74,7 @@ function registerEditorHandlers() {
 
       // Send initial content after page has loaded
       if (content !== undefined && content !== null) {
-        popout.webContents.send("editor:buffer-sync-broadcast", { bufferId, content });
+        popout.webContents.send(EDITOR_CHANNELS.event.bufferSyncBroadcast, { bufferId, content });
       }
 
       return { success: true };
@@ -81,19 +82,19 @@ function registerEditorHandlers() {
   );
 
   // Broadcast buffer content update to all windows except the sender
-  ipcMain.on("editor:buffer-sync", (event, data) => {
+  ipcMain.on(EDITOR_CHANNELS.send.bufferSync, (event, data) => {
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed() && win.webContents !== event.sender) {
-        win.webContents.send("editor:buffer-sync-broadcast", data);
+        win.webContents.send(EDITOR_CHANNELS.event.bufferSyncBroadcast, data);
       }
     }
   });
 
   // Broadcast buffer close notification to all windows except the sender
-  ipcMain.on("editor:buffer-close", (event, bufferId) => {
+  ipcMain.on(EDITOR_CHANNELS.send.bufferClose, (event, bufferId) => {
     for (const win of BrowserWindow.getAllWindows()) {
       if (!win.isDestroyed() && win.webContents !== event.sender) {
-        win.webContents.send("editor:buffer-close-broadcast", bufferId);
+        win.webContents.send(EDITOR_CHANNELS.event.bufferCloseBroadcast, bufferId);
       }
     }
   });

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -8,6 +8,7 @@ const log = require("electron-log");
 const { createApprovedPathRegistry } = require("../lib/approved-paths");
 const { normalizeSeparators } = require("../lib/path-utils");
 const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
+const { FILE_CHANNELS, EXPORT_CHANNELS } = require("../lib/ipc-channels");
 
 // --- save-file path security validation ---
 // Tracks file paths that have been approved via native dialog or system file association,
@@ -171,7 +172,7 @@ async function handleMdiFileOpen(filePath) {
       // Open as project with this file as initial file (relative to project root)
       const relativePath = path.relative(projectRoot, filePath);
       log.info("Opening as project:", projectRoot, "Initial file:", relativePath);
-      targetWindow.webContents.send("open-as-project", {
+      targetWindow.webContents.send(FILE_CHANNELS.event.openAsProject, {
         projectPath: projectRoot,
         initialFile: relativePath,
       });
@@ -181,7 +182,10 @@ async function handleMdiFileOpen(filePath) {
       // Approve system-opened file path for future saves, scoped to the target window
       approveDialogPath(targetWindow.webContents.id, path.resolve(filePath));
       const content = await fs.readFile(filePath, "utf-8");
-      targetWindow.webContents.send("open-file-from-system", { path: filePath, content });
+      targetWindow.webContents.send(FILE_CHANNELS.event.openFileFromSystem, {
+        path: filePath,
+        content,
+      });
     }
     return true;
   } catch (err) {
@@ -205,7 +209,7 @@ function setPendingFilePath(p) {
 }
 
 function registerFileHandlers() {
-  ipcMain.handle("open-file", async (event) => {
+  ipcMain.handle(FILE_CHANNELS.invoke.openFile, async (event) => {
     const { canceled, filePaths } = await dialog.showOpenDialog({
       properties: ["openFile"],
       filters: [
@@ -223,7 +227,7 @@ function registerFileHandlers() {
     return { path: filePath, content };
   });
 
-  ipcMain.handle("save-file", async (event, filePath, content, fileType) => {
+  ipcMain.handle(FILE_CHANNELS.invoke.saveFile, async (event, filePath, content, fileType) => {
     const senderWebContentsId = event.sender.id;
 
     // Validate inputs
@@ -318,7 +322,7 @@ function registerFileHandlers() {
     }
   });
 
-  ipcMain.handle("get-pending-file", async (event) => {
+  ipcMain.handle(FILE_CHANNELS.invoke.getPendingFile, async (event) => {
     if (pendingFilePaths.length === 0) return [];
 
     // Drain the queue and resolve each path
@@ -357,7 +361,7 @@ function registerFileHandlers() {
 
   // --- Export handlers ---
 
-  ipcMain.handle("generate-pdf-preview", async (_event, content, options) => {
+  ipcMain.handle(EXPORT_CHANNELS.invoke.generatePdfPreview, async (_event, content, options) => {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content" };
     }
@@ -371,7 +375,7 @@ function registerFileHandlers() {
     }
   });
 
-  ipcMain.handle("export-pdf", async (_event, content, options) => {
+  ipcMain.handle(EXPORT_CHANNELS.invoke.exportPdf, async (_event, content, options) => {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content" };
     }
@@ -402,7 +406,7 @@ function registerFileHandlers() {
     }
   });
 
-  ipcMain.handle("print-document", async (_event, content, options) => {
+  ipcMain.handle(EXPORT_CHANNELS.invoke.printDocument, async (_event, content, options) => {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content" };
     }
@@ -517,7 +521,7 @@ function registerFileHandlers() {
     }
   });
 
-  ipcMain.handle("export-epub", async (_event, content, options) => {
+  ipcMain.handle(EXPORT_CHANNELS.invoke.exportEpub, async (_event, content, options) => {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content" };
     }
@@ -573,7 +577,7 @@ function registerFileHandlers() {
     }
   });
 
-  ipcMain.handle("export-docx", async (_event, content, options) => {
+  ipcMain.handle(EXPORT_CHANNELS.invoke.exportDocx, async (_event, content, options) => {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content" };
     }

--- a/electron/ipc/nlp-ipc.js
+++ b/electron/ipc/nlp-ipc.js
@@ -14,6 +14,7 @@
 const { ipcMain } = require("electron");
 const path = require("path");
 const { nlpProcessor } = require("../../lib/nlp-backend/nlp-processor");
+const { NLP_CHANNELS } = require("../lib/ipc-channels");
 
 /**
  * Get default dictionary path for Electron environment.
@@ -52,7 +53,7 @@ function registerNlpHandlers() {
    * Initialize NLP service
    * Handler: nlp:init
    */
-  ipcMain.handle("nlp:init", async () => {
+  ipcMain.handle(NLP_CHANNELS.invoke.init, async () => {
     try {
       const resolvedPath = getDefaultDicPath();
       await nlpProcessor.init(resolvedPath);
@@ -67,7 +68,7 @@ function registerNlpHandlers() {
    * Tokenize single paragraph
    * Handler: nlp:tokenize-paragraph
    */
-  ipcMain.handle("nlp:tokenize-paragraph", async (event, text) => {
+  ipcMain.handle(NLP_CHANNELS.invoke.tokenizeParagraph, async (event, text) => {
     try {
       if (typeof text !== "string" || text.length === 0 || text.length > 1_000_000) {
         throw new Error("Invalid text parameter");
@@ -87,7 +88,7 @@ function registerNlpHandlers() {
    * Tokenize document in batch
    * Handler: nlp:tokenize-document
    */
-  ipcMain.handle("nlp:tokenize-document", async (event, request) => {
+  ipcMain.handle(NLP_CHANNELS.invoke.tokenizeDocument, async (event, request) => {
     try {
       const { paragraphs } = request;
 
@@ -116,7 +117,7 @@ function registerNlpHandlers() {
 
         // Send progress event every 10 paragraphs
         if ((i + 1) % 10 === 0 || i === total - 1) {
-          event.sender.send("nlp:tokenize-progress", {
+          event.sender.send(NLP_CHANNELS.event.tokenizeProgress, {
             requestId,
             completed: i + 1,
             total: total,
@@ -136,7 +137,7 @@ function registerNlpHandlers() {
    * Analyze word frequency
    * Handler: nlp:analyze-word-frequency
    */
-  ipcMain.handle("nlp:analyze-word-frequency", async (event, text) => {
+  ipcMain.handle(NLP_CHANNELS.invoke.analyzeWordFrequency, async (event, text) => {
     try {
       if (typeof text !== "string" || text.length === 0 || text.length > 10_000_000) {
         throw new Error("Invalid text parameter");

--- a/electron/ipc/pty-ipc.js
+++ b/electron/ipc/pty-ipc.js
@@ -25,6 +25,7 @@ const {
   removeSession,
   killSession,
 } = require("./terminal-session-registry");
+const { PTY_CHANNELS } = require("../lib/ipc-channels");
 
 // -----------------------------------------------------------------------
 // node-pty availability guard
@@ -211,7 +212,7 @@ function sendPtyData(webContentsId, sessionId, data) {
     .map((w) => w.webContents)
     .find((wc) => wc.id === webContentsId);
   if (wc && !wc.isDestroyed()) {
-    wc.send("pty:data", { sessionId, data });
+    wc.send(PTY_CHANNELS.event.data, { sessionId, data });
   }
 }
 
@@ -226,7 +227,7 @@ function sendPtyExit(webContentsId, sessionId, exitCode) {
     .map((w) => w.webContents)
     .find((wc) => wc.id === webContentsId);
   if (wc && !wc.isDestroyed()) {
-    wc.send("pty:exit", { sessionId, exitCode });
+    wc.send(PTY_CHANNELS.event.exit, { sessionId, exitCode });
   }
 }
 
@@ -240,7 +241,7 @@ function registerPtyHandlers() {
   // Payload: { cwd?, shell?, cols?, rows? }
   // Returns: { sessionId } | { error: string }
   // -------------------------------------------------------------------
-  ipcMain.handle("pty:spawn", (event, options = {}) => {
+  ipcMain.handle(PTY_CHANNELS.invoke.spawn, (event, options = {}) => {
     if (!ptyAvailable) {
       return { error: "node-pty is not available on this installation" };
     }
@@ -330,7 +331,7 @@ function registerPtyHandlers() {
   // Payload: sessionId (string)
   // Returns: { status, exitCode, outputBuffer } | { error: string }
   // -------------------------------------------------------------------
-  ipcMain.handle("pty:attach", (event, sessionId) => {
+  ipcMain.handle(PTY_CHANNELS.invoke.attach, (event, sessionId) => {
     if (typeof sessionId !== "string") {
       return { error: "sessionId must be a string" };
     }
@@ -362,7 +363,7 @@ function registerPtyHandlers() {
   // Payload: { sessionId, data }
   // Returns: { ok: boolean }
   // -------------------------------------------------------------------
-  ipcMain.handle("pty:write", (event, { sessionId, data } = {}) => {
+  ipcMain.handle(PTY_CHANNELS.invoke.write, (event, { sessionId, data } = {}) => {
     if (typeof sessionId !== "string") return { ok: false };
 
     const entry = getSession(sessionId);
@@ -403,7 +404,7 @@ function registerPtyHandlers() {
   // Payload: { sessionId, cols, rows }
   // Returns: { ok: boolean }
   // -------------------------------------------------------------------
-  ipcMain.handle("pty:resize", (event, { sessionId, cols, rows } = {}) => {
+  ipcMain.handle(PTY_CHANNELS.invoke.resize, (event, { sessionId, cols, rows } = {}) => {
     if (typeof sessionId !== "string") return { ok: false };
 
     const entry = getSession(sessionId);
@@ -453,7 +454,7 @@ function registerPtyHandlers() {
   // Payload: sessionId (string)
   // Returns: { ok: boolean }
   // -------------------------------------------------------------------
-  ipcMain.handle("pty:kill", (event, sessionId) => {
+  ipcMain.handle(PTY_CHANNELS.invoke.kill, (event, sessionId) => {
     if (typeof sessionId !== "string") return { ok: false };
 
     const entry = getSession(sessionId);
@@ -482,7 +483,7 @@ function registerPtyHandlers() {
   // Payload: sessionId (string)
   // Returns: { sessionId, status, exitCode, shell, cwd, createdAt } | { error: string }
   // -------------------------------------------------------------------
-  ipcMain.handle("pty:status", (event, sessionId) => {
+  ipcMain.handle(PTY_CHANNELS.invoke.status, (event, sessionId) => {
     if (typeof sessionId !== "string") {
       return { error: "sessionId must be a string" };
     }

--- a/electron/ipc/shell-ipc.js
+++ b/electron/ipc/shell-ipc.js
@@ -4,9 +4,10 @@
 const { ipcMain, BrowserWindow, Menu, shell } = require("electron");
 const path = require("path");
 const log = require("electron-log");
+const { SHELL_CHANNELS } = require("../lib/ipc-channels");
 
 function registerShellHandlers() {
-  ipcMain.handle("show-in-file-manager", async (_event, dirPath) => {
+  ipcMain.handle(SHELL_CHANNELS.invoke.showInFileManager, async (_event, dirPath) => {
     if (!dirPath || typeof dirPath !== "string") return false;
     // Reject relative paths and paths containing traversal sequences
     if (!path.isAbsolute(dirPath) || dirPath.includes("..")) {
@@ -18,7 +19,7 @@ function registerShellHandlers() {
     return result === ""; // empty string = success
   });
 
-  ipcMain.handle("reveal-in-file-manager", async (_event, filePath) => {
+  ipcMain.handle(SHELL_CHANNELS.invoke.revealInFileManager, async (_event, filePath) => {
     if (!filePath || typeof filePath !== "string") return false;
     // Reject relative paths and paths containing traversal sequences
     if (!path.isAbsolute(filePath) || filePath.includes("..")) {
@@ -30,7 +31,7 @@ function registerShellHandlers() {
     return true;
   });
 
-  ipcMain.handle("open-with-default-app", async (_event, filePath) => {
+  ipcMain.handle(SHELL_CHANNELS.invoke.openWithDefaultApp, async (_event, filePath) => {
     if (!filePath || typeof filePath !== "string") return false;
     if (!path.isAbsolute(filePath) || filePath.includes("..")) {
       console.warn("[Security] Invalid path in open-with-default-app:", filePath);
@@ -40,7 +41,7 @@ function registerShellHandlers() {
     return result === ""; // empty string = success on macOS/Windows
   });
 
-  ipcMain.handle("open-external", async (_event, url) => {
+  ipcMain.handle(SHELL_CHANNELS.invoke.openExternal, async (_event, url) => {
     if (typeof url !== "string") return false;
     // Only allow http/https URLs
     if (!url.startsWith("https://") && !url.startsWith("http://")) return false;
@@ -49,7 +50,7 @@ function registerShellHandlers() {
   });
 
   // 辞書ポップアップウィンドウを開く
-  ipcMain.handle("open-dictionary-popup", (_event, url, title) => {
+  ipcMain.handle(SHELL_CHANNELS.invoke.openDictionaryPopup, (_event, url, title) => {
     // Validate URL: only allow https
     if (typeof url !== "string") return false;
     let parsedUrl;
@@ -105,7 +106,7 @@ function registerShellHandlers() {
   });
 
   // ネイティブコンテキストメニューを表示
-  ipcMain.handle("show-context-menu", (_event, items) => {
+  ipcMain.handle(SHELL_CHANNELS.invoke.showContextMenu, (_event, items) => {
     // Input validation
     if (!Array.isArray(items) || items.length === 0 || items.length > 50) return null;
     for (const item of items) {

--- a/electron/ipc/system-ipc.js
+++ b/electron/ipc/system-ipc.js
@@ -2,15 +2,21 @@
 // System, window, and safe-storage IPC handlers
 
 const { ipcMain, BrowserWindow, safeStorage, powerMonitor } = require("electron");
+const {
+  SYSTEM_CHANNELS,
+  MENU_CHANNELS,
+  SAFE_STORAGE_CHANNELS,
+  POWER_CHANNELS,
+} = require("../lib/ipc-channels");
 
 function registerSystemHandlers() {
-  ipcMain.handle("get-chrome-version", () => {
+  ipcMain.handle(SYSTEM_CHANNELS.invoke.getChromeVersion, () => {
     const v = process.versions.chrome || "0";
     const major = Number.parseInt(String(v).split(".")[0] || "0", 10);
     return Number.isFinite(major) ? major : 0;
   });
 
-  ipcMain.handle("set-dirty", (event, dirty) => {
+  ipcMain.handle(SYSTEM_CHANNELS.invoke.setDirty, (event, dirty) => {
     // イベントを送信したウィンドウの dirty 状態を保持する
     const webContents = event.sender;
     const win = BrowserWindow.fromWebContents(webContents);
@@ -22,7 +28,7 @@ function registerSystemHandlers() {
   // Phase 2: save 経路は削除されたが、この IPC は close handshake の終端トリガ
   // として引き続き使う（renderer は flush 完了後に呼んで window を destroy する）。
   // 命名は歴史的なため Phase 8 で必要に応じて改名する。
-  ipcMain.handle("save-before-close-done", (event) => {
+  ipcMain.handle(SYSTEM_CHANNELS.invoke.saveBeforeCloseDone, (event) => {
     const webContents = event.sender;
     const win = BrowserWindow.fromWebContents(webContents);
     if (win) {
@@ -30,21 +36,21 @@ function registerSystemHandlers() {
     }
   });
 
-  ipcMain.handle("new-window", async () => {
+  ipcMain.handle(SYSTEM_CHANNELS.invoke.newWindow, async () => {
     // 新しいウィンドウを作成（ウェルカム画面を表示）
     const { createWindow } = require("../window-manager");
     const newWin = await createWindow({ showWelcome: true });
     return newWin ? true : false;
   });
 
-  ipcMain.handle("menu:rebuild", async () => {
+  ipcMain.handle(MENU_CHANNELS.invoke.rebuild, async () => {
     const { rebuildApplicationMenu } = require("../menu");
     await rebuildApplicationMenu();
     return true;
   });
 
   // Sync UI state from renderer to update menu checked states (per-window)
-  ipcMain.handle("menu:sync-ui-state", async (event, state) => {
+  ipcMain.handle(MENU_CHANNELS.invoke.syncUiState, async (event, state) => {
     const { setMenuUiState, rebuildApplicationMenu } = require("../menu");
     const win = BrowserWindow.fromWebContents(event.sender);
     if (win) {
@@ -55,7 +61,7 @@ function registerSystemHandlers() {
   });
 
   // Sync keymap overrides from renderer to update menu accelerators (per-window)
-  ipcMain.handle("menu:update-keymap-overrides", async (event, overrides) => {
+  ipcMain.handle(MENU_CHANNELS.invoke.updateKeymapOverrides, async (event, overrides) => {
     const { setKeymapOverrides, rebuildApplicationMenu } = require("../menu");
     const win = BrowserWindow.fromWebContents(event.sender);
     if (win) {
@@ -66,14 +72,14 @@ function registerSystemHandlers() {
   });
 
   // safeStorage: OS-level encryption (macOS Keychain / Windows DPAPI)
-  ipcMain.handle("safe-storage:encrypt", (_event, plaintext) => {
+  ipcMain.handle(SAFE_STORAGE_CHANNELS.invoke.encrypt, (_event, plaintext) => {
     if (typeof plaintext !== "string" || !plaintext) return null;
     if (!safeStorage.isEncryptionAvailable()) return null;
     const encrypted = safeStorage.encryptString(plaintext);
     return encrypted.toString("base64");
   });
 
-  ipcMain.handle("safe-storage:decrypt", (_event, base64Cipher) => {
+  ipcMain.handle(SAFE_STORAGE_CHANNELS.invoke.decrypt, (_event, base64Cipher) => {
     if (typeof base64Cipher !== "string" || !base64Cipher) return null;
     if (!safeStorage.isEncryptionAvailable()) return null;
     try {
@@ -84,12 +90,12 @@ function registerSystemHandlers() {
     }
   });
 
-  ipcMain.handle("safe-storage:is-available", () => {
+  ipcMain.handle(SAFE_STORAGE_CHANNELS.invoke.isAvailable, () => {
     return safeStorage.isEncryptionAvailable();
   });
 
   // Power state IPC handlers
-  ipcMain.handle("power:get-state", () => {
+  ipcMain.handle(POWER_CHANNELS.invoke.getState, () => {
     return powerMonitor.isOnBatteryPower() ? "battery" : "ac";
   });
 }

--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -16,6 +16,7 @@ const {
   resolveRealPath,
 } = require("../lib/path-utils");
 const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
+const { VFS_CHANNELS } = require("../lib/ipc-channels");
 // #1476: rehydration — begin
 const { loadApprovals, saveApprovals } = require("../lib/vfs-approvals");
 const { createIndexLockManager } = require("../lib/index-lock");
@@ -141,7 +142,7 @@ function registerVFSHandlers() {
   }
 
   // Open directory picker
-  ipcMain.handle("vfs:open-directory", async (event) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.openDirectory, async (event) => {
     const result = await dialog.showOpenDialog({
       properties: ["openDirectory", "createDirectory"],
     });
@@ -172,7 +173,7 @@ function registerVFSHandlers() {
   const MAX_READ_BYTES = MAX_CONTENT_BYTES;
 
   // Read file content
-  ipcMain.handle("vfs:read-file", async (event, filePath) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.readFile, async (event, filePath) => {
     try {
       const resolved = await validateVFSPath(event, filePath);
       const stats = await fs.stat(resolved);
@@ -190,7 +191,7 @@ function registerVFSHandlers() {
   });
 
   // Write file content
-  ipcMain.handle("vfs:write-file", async (event, filePath, content) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.writeFile, async (event, filePath, content) => {
     // Validate content type and size before touching disk
     if (typeof content !== "string") {
       throw new Error("Invalid content: expected string");
@@ -222,7 +223,7 @@ function registerVFSHandlers() {
   });
 
   // Read directory entries
-  ipcMain.handle("vfs:read-directory", async (event, dirPath) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.readDirectory, async (event, dirPath) => {
     try {
       const resolved = await validateVFSPath(event, dirPath);
       const entries = await fs.readdir(resolved, { withFileTypes: true });
@@ -237,7 +238,7 @@ function registerVFSHandlers() {
   });
 
   // Get file stats
-  ipcMain.handle("vfs:stat", async (event, filePath) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.stat, async (event, filePath) => {
     try {
       const resolved = await validateVFSPath(event, filePath);
       const stats = await fs.stat(resolved);
@@ -259,7 +260,7 @@ function registerVFSHandlers() {
   // Returns false for missing paths; re-throws genuine errors (e.g. EACCES)
   // so real problems stay visible. Use this for existence checks instead of
   // relying on stat/readFile rejections, which Electron logs as handler errors.
-  ipcMain.handle("vfs:exists", async (event, filePath) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.exists, async (event, filePath) => {
     try {
       const resolved = await validateVFSPath(event, filePath);
       await fs.stat(resolved);
@@ -274,7 +275,7 @@ function registerVFSHandlers() {
   });
 
   // Create directory (with parents)
-  ipcMain.handle("vfs:mkdir", async (event, dirPath) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.mkdir, async (event, dirPath) => {
     try {
       const resolved = await validateVFSPath(event, dirPath);
       await fs.mkdir(resolved, { recursive: true });
@@ -285,7 +286,7 @@ function registerVFSHandlers() {
   });
 
   // Delete file or directory
-  ipcMain.handle("vfs:delete", async (event, targetPath, options = {}) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.delete, async (event, targetPath, options = {}) => {
     try {
       const resolved = await validateVFSPath(event, targetPath);
       const stats = await fs.stat(resolved);
@@ -301,7 +302,7 @@ function registerVFSHandlers() {
   });
 
   // Rename file or directory
-  ipcMain.handle("vfs:rename", async (event, oldPath, newPath) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.rename, async (event, oldPath, newPath) => {
     try {
       const resolvedOld = await validateVFSPath(event, oldPath);
       const resolvedNew = await validateVFSPath(event, newPath);
@@ -342,7 +343,7 @@ function registerVFSHandlers() {
 
   // Set root directory programmatically (for restoring a recent project without dialog)
   // #1476: rehydration — extended to accept projectId for project-scoped approval persistence
-  ipcMain.handle("vfs:set-root", async (event, rootPath, projectId) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.setRoot, async (event, rootPath, projectId) => {
     const resolved = path.resolve(rootPath);
     const normalizedResolved = normalizePath(resolved);
 
@@ -445,7 +446,7 @@ function registerVFSHandlers() {
   // Open a single file via native file dialog
   // Returns { path, name, buf } where buf is the raw file bytes (Buffer).
   // The caller is responsible for decoding (e.g., via text-codec.ts).
-  ipcMain.handle("vfs:open-file", async (event, opts) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.openFile, async (event, opts) => {
     const result = await dialog.showOpenDialog({
       properties: ["openFile"],
       filters: opts?.filters ?? [{ name: "テキスト", extensions: ["txt"] }],
@@ -475,11 +476,11 @@ function registerVFSHandlers() {
     },
   });
 
-  ipcMain.handle("vfs:index-lock:acquire", (event, key) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.indexLockAcquire, (event, key) => {
     return indexLocks.acquire(key, event.sender.id);
   });
 
-  ipcMain.handle("vfs:index-lock:release", (event, key) => {
+  ipcMain.handle(VFS_CHANNELS.invoke.indexLockRelease, (event, key) => {
     indexLocks.release(key, event.sender.id);
   });
 

--- a/electron/lib/__tests__/ipc-bridge.test.ts
+++ b/electron/lib/__tests__/ipc-bridge.test.ts
@@ -1,15 +1,18 @@
 /**
  * Drift-prevention tests for the IPC bridge registry (#1434).
  *
- * Three guarantees for the migrated namespaces (storage, dict):
+ * Three guarantees, now covering ALL namespaces (Phase 2):
  * 1. Channel string values are pinned — the renderer/main contract must never
  *    change silently (backward compatibility with existing callers).
  * 2. Every channel the preload bridge uses is registered on the main-process
  *    side through the SAME shared constant (string-level check of the
- *    modules), so preload and ipcMain.handle cannot drift apart.
+ *    modules), so preload and ipcMain.handle/on cannot drift apart.
+ *    Exception: MENU event channels are dispatched data-driven from
+ *    lib/menu/menu-template.js (`electronChannel` literals shared with the
+ *    Next.js renderer); for those, the literal value itself is pinned.
  * 3. The bridge helpers preserve the hand-written wrapper semantics:
- *    invoke arg forwarding / payload mapping, and unsubscribe removing only
- *    its own listener.
+ *    invoke/send arg forwarding / payload mapping, event callback arity,
+ *    and unsubscribe removing only its own listener.
  */
 
 import fs from "fs";
@@ -19,20 +22,34 @@ import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 
-const { STORAGE_CHANNELS, DICT_CHANNELS } = require("../../../electron/lib/ipc-channels") as {
-  STORAGE_CHANNELS: {
-    invoke: Record<string, string>;
-    event: Record<string, string>;
-  };
-  DICT_CHANNELS: {
-    invoke: Record<string, string>;
-    event: Record<string, string>;
-  };
+type ChannelGroup = {
+  invoke: Record<string, string>;
+  send?: Record<string, string>;
+  event: Record<string, string>;
 };
+
+const channels = require("../../../electron/lib/ipc-channels") as Record<string, ChannelGroup>;
+const {
+  STORAGE_CHANNELS,
+  DICT_CHANNELS,
+  FILE_CHANNELS,
+  EXPORT_CHANNELS,
+  SHELL_CHANNELS,
+  SYSTEM_CHANNELS,
+  MENU_CHANNELS,
+  VFS_CHANNELS,
+  AUTH_CHANNELS,
+  SAFE_STORAGE_CHANNELS,
+  POWER_CHANNELS,
+  EDITOR_CHANNELS,
+  NLP_CHANNELS,
+  PTY_CHANNELS,
+} = channels;
 
 const { createIpcBridge } = require("../../../electron/lib/ipc-bridge") as {
   createIpcBridge: (renderer: {
     invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+    send: (channel: string, ...args: unknown[]) => void;
     on: (channel: string, handler: (...args: unknown[]) => void) => void;
     removeListener: (channel: string, handler: (...args: unknown[]) => void) => void;
   }) => {
@@ -40,7 +57,14 @@ const { createIpcBridge } = require("../../../electron/lib/ipc-bridge") as {
       channel: string,
       shape?: ((...args: unknown[]) => unknown) | { arity: number },
     ) => (...args: unknown[]) => Promise<unknown>;
-    eventChannel: (channel: string) => (callback: (payload: unknown) => void) => () => void;
+    sendChannel: (
+      channel: string,
+      shape?: ((...args: unknown[]) => unknown) | { arity: number },
+    ) => (...args: unknown[]) => void;
+    eventChannel: (
+      channel: string,
+      shape?: { arity: number },
+    ) => (callback: (...payload: unknown[]) => void) => () => void;
   };
 };
 
@@ -86,42 +110,301 @@ describe("ipc-channels: pinned channel names (public IPC contract)", () => {
       updateAvailable: "dict:update-available",
     });
   });
+
+  it("file invoke/event channels keep their historical string values", () => {
+    expect(FILE_CHANNELS.invoke).toEqual({
+      openFile: "open-file",
+      saveFile: "save-file",
+      getPendingFile: "get-pending-file",
+    });
+    expect(FILE_CHANNELS.event).toEqual({
+      openFileFromSystem: "open-file-from-system",
+      openAsProject: "open-as-project",
+    });
+  });
+
+  it("export invoke channels keep their historical string values", () => {
+    expect(EXPORT_CHANNELS.invoke).toEqual({
+      generatePdfPreview: "generate-pdf-preview",
+      exportPdf: "export-pdf",
+      exportEpub: "export-epub",
+      exportDocx: "export-docx",
+      printDocument: "print-document",
+    });
+    expect(EXPORT_CHANNELS.event).toEqual({});
+  });
+
+  it("shell invoke channels keep their historical string values", () => {
+    expect(SHELL_CHANNELS.invoke).toEqual({
+      showInFileManager: "show-in-file-manager",
+      revealInFileManager: "reveal-in-file-manager",
+      openWithDefaultApp: "open-with-default-app",
+      openExternal: "open-external",
+      openDictionaryPopup: "open-dictionary-popup",
+      showContextMenu: "show-context-menu",
+    });
+    expect(SHELL_CHANNELS.event).toEqual({});
+  });
+
+  it("system invoke/event channels keep their historical string values", () => {
+    expect(SYSTEM_CHANNELS.invoke).toEqual({
+      getChromeVersion: "get-chrome-version",
+      setDirty: "set-dirty",
+      saveBeforeCloseDone: "save-before-close-done",
+      newWindow: "new-window",
+    });
+    expect(SYSTEM_CHANNELS.event).toEqual({
+      requestSaveBeforeClose: "electron-request-save-before-close",
+      requestFlushStateBeforeClose: "electron-request-flush-state-before-close",
+    });
+  });
+
+  it("menu invoke/event channels keep their historical string values", () => {
+    expect(MENU_CHANNELS.invoke).toEqual({
+      rebuild: "menu:rebuild",
+      syncUiState: "menu:sync-ui-state",
+      updateKeymapOverrides: "menu:update-keymap-overrides",
+    });
+    expect(MENU_CHANNELS.event).toEqual({
+      newTriggered: "menu-new-triggered",
+      openTriggered: "menu-open-triggered",
+      saveTriggered: "menu-save-triggered",
+      saveAsTriggered: "menu-save-as-triggered",
+      closeTab: "menu-close-tab",
+      newTab: "menu-new-tab",
+      pasteAsPlaintext: "menu-paste-as-plaintext",
+      openProject: "menu-open-project",
+      openRecentProject: "menu-open-recent-project",
+      showInFileManager: "menu-show-in-file-manager",
+      toggleCompactMode: "menu-toggle-compact-mode",
+      format: "menu-format",
+      theme: "menu-theme",
+      print: "menu-print",
+      exportTxt: "menu-export-txt",
+      exportTxtRuby: "menu-export-txt-ruby",
+      exportPdf: "menu-export-pdf",
+      exportEpub: "menu-export-epub",
+      exportDocx: "menu-export-docx",
+    });
+  });
+
+  it("vfs invoke channels keep their historical string values", () => {
+    expect(VFS_CHANNELS.invoke).toEqual({
+      openDirectory: "vfs:open-directory",
+      openFile: "vfs:open-file",
+      setRoot: "vfs:set-root",
+      readFile: "vfs:read-file",
+      writeFile: "vfs:write-file",
+      readDirectory: "vfs:read-directory",
+      stat: "vfs:stat",
+      exists: "vfs:exists",
+      mkdir: "vfs:mkdir",
+      delete: "vfs:delete",
+      rename: "vfs:rename",
+      indexLockAcquire: "vfs:index-lock:acquire",
+      indexLockRelease: "vfs:index-lock:release",
+    });
+    expect(VFS_CHANNELS.event).toEqual({});
+  });
+
+  it("auth invoke/event channels keep their historical string values", () => {
+    expect(AUTH_CHANNELS.invoke).toEqual({
+      startLogin: "auth:start-login",
+      exchangeCode: "auth:exchange-code",
+      refreshToken: "auth:refresh-token",
+      getUserInfo: "auth:get-userinfo",
+      logout: "auth:logout",
+    });
+    expect(AUTH_CHANNELS.event).toEqual({
+      callback: "auth:callback",
+    });
+  });
+
+  it("safe-storage invoke channels keep their historical string values", () => {
+    expect(SAFE_STORAGE_CHANNELS.invoke).toEqual({
+      encrypt: "safe-storage:encrypt",
+      decrypt: "safe-storage:decrypt",
+      isAvailable: "safe-storage:is-available",
+    });
+    expect(SAFE_STORAGE_CHANNELS.event).toEqual({});
+  });
+
+  it("power invoke/event channels keep their historical string values", () => {
+    expect(POWER_CHANNELS.invoke).toEqual({
+      getState: "power:get-state",
+    });
+    expect(POWER_CHANNELS.event).toEqual({
+      stateChanged: "power:state-changed",
+    });
+  });
+
+  it("editor invoke/send/event channels keep their historical string values", () => {
+    expect(EDITOR_CHANNELS.invoke).toEqual({
+      popoutPanel: "editor:popout-panel",
+    });
+    expect(EDITOR_CHANNELS.send).toEqual({
+      bufferSync: "editor:buffer-sync",
+      bufferClose: "editor:buffer-close",
+    });
+    expect(EDITOR_CHANNELS.event).toEqual({
+      bufferSyncBroadcast: "editor:buffer-sync-broadcast",
+      bufferCloseBroadcast: "editor:buffer-close-broadcast",
+    });
+  });
+
+  it("nlp invoke/event channels keep their historical string values", () => {
+    expect(NLP_CHANNELS.invoke).toEqual({
+      init: "nlp:init",
+      tokenizeParagraph: "nlp:tokenize-paragraph",
+      tokenizeDocument: "nlp:tokenize-document",
+      analyzeWordFrequency: "nlp:analyze-word-frequency",
+    });
+    expect(NLP_CHANNELS.event).toEqual({
+      tokenizeProgress: "nlp:tokenize-progress",
+    });
+  });
+
+  it("pty invoke/event channels keep their historical string values", () => {
+    expect(PTY_CHANNELS.invoke).toEqual({
+      spawn: "pty:spawn",
+      attach: "pty:attach",
+      write: "pty:write",
+      resize: "pty:resize",
+      kill: "pty:kill",
+      status: "pty:status",
+    });
+    expect(PTY_CHANNELS.event).toEqual({
+      data: "pty:data",
+      exit: "pty:exit",
+    });
+  });
 });
 
 describe("ipc bridge: preload ↔ main handler registration cannot drift", () => {
   const preloadSrc = readSource("preload.js");
-  const storageIpcSrc = readSource("ipc/storage-ipc.js");
-  const dictIpcSrc = readSource("ipc/dict-ipc.js");
-  const mainSrc = readSource("main.js");
 
-  it("every storage invoke channel used by preload is registered via the shared constant", () => {
-    for (const key of Object.keys(STORAGE_CHANNELS.invoke)) {
-      // preload bridges the channel…
-      expect(preloadSrc).toContain(`STORAGE_CHANNELS.invoke.${key}`);
-      // …and main registers a handler for the same constant
-      expect(storageIpcSrc).toContain(`ipcMain.handle(STORAGE_CHANNELS.invoke.${key},`);
+  /**
+   * Registration matrix: for every namespace, the main-process source file
+   * that must register each invoke (ipcMain.handle) / send (ipcMain.on)
+   * channel via the SAME shared constant the preload bridge uses.
+   */
+  const invokeRegistrations: Array<{
+    constName: string;
+    group: ChannelGroup;
+    mainFile: string;
+    /** invoke keys handled in a different file than `mainFile` */
+    overrides?: Record<string, string>;
+  }> = [
+    { constName: "STORAGE_CHANNELS", group: STORAGE_CHANNELS, mainFile: "ipc/storage-ipc.js" },
+    { constName: "DICT_CHANNELS", group: DICT_CHANNELS, mainFile: "ipc/dict-ipc.js" },
+    { constName: "FILE_CHANNELS", group: FILE_CHANNELS, mainFile: "ipc/file-ipc.js" },
+    { constName: "EXPORT_CHANNELS", group: EXPORT_CHANNELS, mainFile: "ipc/file-ipc.js" },
+    { constName: "SHELL_CHANNELS", group: SHELL_CHANNELS, mainFile: "ipc/shell-ipc.js" },
+    { constName: "SYSTEM_CHANNELS", group: SYSTEM_CHANNELS, mainFile: "ipc/system-ipc.js" },
+    { constName: "MENU_CHANNELS", group: MENU_CHANNELS, mainFile: "ipc/system-ipc.js" },
+    { constName: "VFS_CHANNELS", group: VFS_CHANNELS, mainFile: "ipc/vfs-ipc.js" },
+    { constName: "AUTH_CHANNELS", group: AUTH_CHANNELS, mainFile: "ipc/auth-ipc.js" },
+    {
+      constName: "SAFE_STORAGE_CHANNELS",
+      group: SAFE_STORAGE_CHANNELS,
+      mainFile: "ipc/system-ipc.js",
+    },
+    { constName: "POWER_CHANNELS", group: POWER_CHANNELS, mainFile: "ipc/system-ipc.js" },
+    { constName: "EDITOR_CHANNELS", group: EDITOR_CHANNELS, mainFile: "ipc/editor-ipc.js" },
+    { constName: "NLP_CHANNELS", group: NLP_CHANNELS, mainFile: "ipc/nlp-ipc.js" },
+    { constName: "PTY_CHANNELS", group: PTY_CHANNELS, mainFile: "ipc/pty-ipc.js" },
+  ];
+
+  it.each(invokeRegistrations)(
+    "$constName: every invoke channel bridged in preload is registered via ipcMain.handle($constName.invoke.*)",
+    ({ constName, group, mainFile }) => {
+      const mainSrc = readSource(mainFile);
+      for (const key of Object.keys(group.invoke)) {
+        // preload bridges the channel…
+        expect(preloadSrc).toContain(`${constName}.invoke.${key}`);
+        // …and main registers a handler for the same constant
+        // (multi-line call sites collapse to "constant," after the paren)
+        expect(mainSrc.replace(/\(\s+/g, "(")).toContain(
+          `ipcMain.handle(${constName}.invoke.${key},`,
+        );
+      }
+    },
+  );
+
+  it("editor send channels (fire-and-forget) are received via ipcMain.on with the shared constant", () => {
+    const editorIpcSrc = readSource("ipc/editor-ipc.js");
+    for (const key of Object.keys(EDITOR_CHANNELS.send ?? {})) {
+      expect(preloadSrc).toContain(`EDITOR_CHANNELS.send.${key}`);
+      expect(editorIpcSrc).toContain(`ipcMain.on(EDITOR_CHANNELS.send.${key},`);
     }
   });
 
-  it("every dict invoke channel used by preload is registered via the shared constant", () => {
-    for (const key of Object.keys(DICT_CHANNELS.invoke)) {
-      expect(preloadSrc).toContain(`DICT_CHANNELS.invoke.${key}`);
-      expect(dictIpcSrc).toContain(`ipcMain.handle(DICT_CHANNELS.invoke.${key},`);
+  /**
+   * Event (main → renderer push) channels: each subscribed constant in
+   * preload must have a main-process sender referencing the same constant.
+   */
+  const eventSenders: Array<{ constName: string; key: string; senderFile: string }> = [
+    { constName: "DICT_CHANNELS", key: "downloadProgress", senderFile: "ipc/dict-ipc.js" },
+    { constName: "DICT_CHANNELS", key: "updateAvailable", senderFile: "main.js" },
+    { constName: "FILE_CHANNELS", key: "openFileFromSystem", senderFile: "ipc/file-ipc.js" },
+    { constName: "FILE_CHANNELS", key: "openAsProject", senderFile: "ipc/file-ipc.js" },
+    {
+      constName: "SYSTEM_CHANNELS",
+      key: "requestSaveBeforeClose",
+      senderFile: "window-manager.js",
+    },
+    {
+      constName: "SYSTEM_CHANNELS",
+      key: "requestFlushStateBeforeClose",
+      senderFile: "window-manager.js",
+    },
+    { constName: "AUTH_CHANNELS", key: "callback", senderFile: "ipc/auth-ipc.js" },
+    { constName: "POWER_CHANNELS", key: "stateChanged", senderFile: "window-manager.js" },
+    { constName: "EDITOR_CHANNELS", key: "bufferSyncBroadcast", senderFile: "ipc/editor-ipc.js" },
+    { constName: "EDITOR_CHANNELS", key: "bufferCloseBroadcast", senderFile: "ipc/editor-ipc.js" },
+    { constName: "NLP_CHANNELS", key: "tokenizeProgress", senderFile: "ipc/nlp-ipc.js" },
+    { constName: "PTY_CHANNELS", key: "data", senderFile: "ipc/pty-ipc.js" },
+    { constName: "PTY_CHANNELS", key: "exit", senderFile: "ipc/pty-ipc.js" },
+  ];
+
+  it.each(eventSenders)(
+    "$constName event $key: preload subscribes and $senderFile sends via the shared constant",
+    ({ constName, key, senderFile }) => {
+      expect(preloadSrc).toContain(`${constName}.event.${key}`);
+      // payload-less pushes end with `)` instead of `,`, so match the open paren only
+      expect(readSource(senderFile)).toContain(`.send(${constName}.event.${key}`);
+    },
+  );
+
+  /**
+   * MENU events are dispatched data-driven: lib/menu/menu-template.js declares
+   * `electronChannel` string literals (the module is shared with the Next.js
+   * renderer, so it cannot depend on electron/lib). The drift test pins each
+   * constant value against the template literal instead.
+   *
+   * Known sender-less legacy channels (bridged for API-shape compatibility,
+   * no current main-process sender): onMenuNew / onMenuShowInFileManager.
+   */
+  const SENDERLESS_MENU_EVENTS = ["menu-new-triggered", "menu-show-in-file-manager"];
+
+  it("every menu event channel is subscribed in preload and (unless legacy sender-less) dispatched from menu-template.js", () => {
+    const menuTemplateSrc = readSource("../lib/menu/menu-template.js");
+    for (const [key, value] of Object.entries(MENU_CHANNELS.event)) {
+      expect(preloadSrc).toContain(`MENU_CHANNELS.event.${key}`);
+      if (!SENDERLESS_MENU_EVENTS.includes(value)) {
+        expect(menuTemplateSrc).toContain(`electronChannel: "${value}"`);
+      }
     }
   });
 
-  it("every dict event channel subscribed in preload has a main-process sender using the shared constant", () => {
-    expect(preloadSrc).toContain("DICT_CHANNELS.event.downloadProgress");
-    expect(dictIpcSrc).toContain("event.sender.send(DICT_CHANNELS.event.downloadProgress,");
-    expect(preloadSrc).toContain("DICT_CHANNELS.event.updateAvailable");
-    expect(mainSrc).toContain("webContents.send(DICT_CHANNELS.event.updateAvailable,");
-  });
-
-  it("preload no longer hard-codes storage/dict channel string literals", () => {
-    // "safe-storage:*" channels are a different (unmigrated) namespace and
-    // are not matched by these patterns.
-    expect(preloadSrc).not.toMatch(/["']storage:/);
-    expect(preloadSrc).not.toMatch(/["']dict:/);
+  it("preload no longer hard-codes ANY channel string literal", () => {
+    for (const group of Object.values(channels)) {
+      for (const record of [group.invoke, group.send ?? {}, group.event]) {
+        for (const value of Object.values(record)) {
+          expect(preloadSrc).not.toContain(`"${value}"`);
+        }
+      }
+    }
   });
 });
 
@@ -130,6 +413,7 @@ describe("ipc-bridge helpers: behavior parity with the hand-written wrappers", (
     const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
     return {
       invoke: vi.fn((..._args: unknown[]) => Promise.resolve("ok")),
+      send: vi.fn((..._args: unknown[]) => undefined),
       on: vi.fn((channel: string, handler: (...args: unknown[]) => void) => {
         listeners.set(channel, [...(listeners.get(channel) ?? []), handler]);
       }),
@@ -182,6 +466,29 @@ describe("ipc-bridge helpers: behavior parity with the hand-written wrappers", (
     expect(renderer.invoke).toHaveBeenCalledWith("dict:query", { term: "猫", limit: 5 });
   });
 
+  it("sendChannel uses fire-and-forget send (not invoke) with the same arity rules", () => {
+    const renderer = makeFakeRenderer();
+    const { sendChannel } = createIpcBridge(renderer);
+    const sendBufferClose = sendChannel("editor:buffer-close", { arity: 1 });
+    sendBufferClose("buffer-1", "unexpected-extra");
+    expect(renderer.send).toHaveBeenCalledWith("editor:buffer-close", "buffer-1");
+    expect(renderer.invoke).not.toHaveBeenCalled();
+  });
+
+  it("sendChannel with mapArgs reshapes positional args into the payload object", () => {
+    const renderer = makeFakeRenderer();
+    const { sendChannel } = createIpcBridge(renderer);
+    const sendBufferSync = sendChannel(
+      "editor:buffer-sync",
+      (bufferId: unknown, content: unknown) => ({ bufferId, content }) as unknown,
+    );
+    sendBufferSync("buffer-1", "本文");
+    expect(renderer.send).toHaveBeenCalledWith("editor:buffer-sync", {
+      bufferId: "buffer-1",
+      content: "本文",
+    });
+  });
+
   it("eventChannel strips the IpcRendererEvent and passes the payload to the callback", () => {
     const renderer = makeFakeRenderer();
     const { eventChannel } = createIpcBridge(renderer);
@@ -190,6 +497,30 @@ describe("ipc-bridge helpers: behavior parity with the hand-written wrappers", (
     onProgress((payload) => received.push(payload));
     renderer.emit("dict:download-progress", { progress: 42 });
     expect(received).toEqual([{ progress: 42 }]);
+  });
+
+  it("eventChannel with arity 0 invokes the callback with no arguments (signal-only events)", () => {
+    const renderer = makeFakeRenderer();
+    const { eventChannel } = createIpcBridge(renderer);
+    const onMenuSave = eventChannel("menu-save-triggered", { arity: 0 });
+    const calls: unknown[][] = [];
+    onMenuSave((...args: unknown[]) => calls.push(args));
+    renderer.emit("menu-save-triggered", "main-sent-junk");
+    expect(calls).toEqual([[]]);
+  });
+
+  it("eventChannel with arity 2 forwards exactly two payload args, padding with undefined", () => {
+    const renderer = makeFakeRenderer();
+    const { eventChannel } = createIpcBridge(renderer);
+    const onFormat = eventChannel("menu-format", { arity: 2 });
+    const calls: unknown[][] = [];
+    onFormat((...args: unknown[]) => calls.push(args));
+    renderer.emit("menu-format", "fontSize", "increase", "extra-dropped");
+    renderer.emit("menu-format", "verticalWriting");
+    expect(calls).toEqual([
+      ["fontSize", "increase"],
+      ["verticalWriting", undefined],
+    ]);
   });
 
   it("eventChannel unsubscribe removes only its own handler (no removeAllListeners)", () => {

--- a/electron/lib/ipc-bridge.js
+++ b/electron/lib/ipc-bridge.js
@@ -23,7 +23,7 @@ const { ipcRenderer } = require("electron");
  * Build the bridge helpers bound to a specific ipcRenderer.
  * The indirection exists so unit tests can inject a fake renderer;
  * production code uses the default-bound exports below.
- * @param {Pick<import("electron").IpcRenderer, "invoke" | "on" | "removeListener">} renderer
+ * @param {Pick<import("electron").IpcRenderer, "invoke" | "send" | "on" | "removeListener">} renderer
  */
 function createIpcBridge(renderer) {
   /**
@@ -50,24 +50,54 @@ function createIpcBridge(renderer) {
   }
 
   /**
-   * eventChannel(channel) -> (callback) => unsubscribe
-   * The callback receives the first IPC payload argument (the `_event` is
-   * stripped), matching the existing hand-written wrappers. The returned
-   * unsubscribe removes only this subscription.
+   * sendChannel(channel, { arity }) -> (...args) => send(channel, ...args.slice(0, arity))
+   * sendChannel(channel, mapArgs)   -> (...args) => send(channel, mapArgs(...args))
+   *
+   * Fire-and-forget variant of invokeChannel for ipcRenderer.send ↔ ipcMain.on
+   * channels. Same least-authority arity rules apply: extra renderer
+   * arguments never cross the IPC boundary.
    * @param {string} channel
-   * @returns {(callback: (payload: unknown) => void) => () => void}
+   * @param {((...args: unknown[]) => unknown) | { arity: number }} shape
+   * @returns {(...args: unknown[]) => void}
    */
-  function eventChannel(channel) {
+  function sendChannel(channel, shape) {
+    if (typeof shape === "function") {
+      return (...args) => renderer.send(channel, shape(...args));
+    }
+    const arity = shape?.arity ?? 0;
+    return (...args) => renderer.send(channel, ...args.slice(0, arity));
+  }
+
+  /**
+   * eventChannel(channel[, { arity }]) -> (callback) => unsubscribe
+   * The callback receives the first `arity` IPC payload arguments (the
+   * `_event` is always stripped), matching the existing hand-written
+   * wrappers:
+   * - arity 0: `() => callback()` (signal-only menu/lifecycle events)
+   * - arity 1 (default): `(_event, payload) => callback(payload)`
+   * - arity 2: `(_event, a, b) => callback(a, b)` (e.g. menu-format)
+   * The returned unsubscribe removes only this subscription.
+   * @param {string} channel
+   * @param {{ arity: number }} [shape]
+   * @returns {(callback: (...payload: unknown[]) => void) => () => void}
+   */
+  function eventChannel(channel, shape) {
+    const arity = shape?.arity ?? 1;
     return (callback) => {
-      const handler = (_event, payload) => callback(payload);
+      const handler = (_event, ...payload) => {
+        // Exactly `arity` args, padded with undefined — identical to the
+        // legacy `(_event, a, b) => callback(a, b)` destructuring wrappers.
+        payload.length = arity;
+        callback(...payload);
+      };
       renderer.on(channel, handler);
       return () => renderer.removeListener(channel, handler);
     };
   }
 
-  return { invokeChannel, eventChannel };
+  return { invokeChannel, sendChannel, eventChannel };
 }
 
-const { invokeChannel, eventChannel } = createIpcBridge(ipcRenderer);
+const { invokeChannel, sendChannel, eventChannel } = createIpcBridge(ipcRenderer);
 
-module.exports = { createIpcBridge, invokeChannel, eventChannel };
+module.exports = { createIpcBridge, invokeChannel, sendChannel, eventChannel };

--- a/electron/lib/ipc-channels.js
+++ b/electron/lib/ipc-channels.js
@@ -3,20 +3,25 @@
  *
  * Single source of truth for channel names, consumed by BOTH sides of the
  * bridge so the renderer/main contract cannot drift:
- * - preload (electron/preload.js) — ipcRenderer.invoke / ipcRenderer.on
- * - main (electron/ipc/*.js, electron/main.js) — ipcMain.handle / webContents.send
+ * - preload (electron/preload.js) — ipcRenderer.invoke / ipcRenderer.send / ipcRenderer.on
+ * - main (electron/ipc/*.js, electron/main.js, electron/window-manager.js)
+ *   — ipcMain.handle / ipcMain.on / webContents.send
  *
  * Structure per namespace:
  * - `invoke`: request/response channels (ipcRenderer.invoke ↔ ipcMain.handle)
+ * - `send`:   fire-and-forget renderer→main channels (ipcRenderer.send ↔ ipcMain.on)
  * - `event`:  push channels (webContents.send → ipcRenderer.on)
  *
  * IMPORTANT: these string values are the public IPC contract. Never rename
  * them; renderer payload semantics are pinned in types/electron.d.ts and the
  * drift test in electron/lib/__tests__/ipc-bridge.test.ts.
  *
- * Migration status (incremental, per issue #1434):
- * - storage, dict: migrated
- * - vfs / auth / menu / export / pty / editor popout / nlp / system: follow-up
+ * Special send sites:
+ * - MENU_CHANNELS.event values are dispatched data-driven from
+ *   lib/menu/menu-template.js (`electronChannel` fields) through the generic
+ *   dispatcher in electron/menu.js. menu-template.js stays literal-based
+ *   because it is shared with the Next.js renderer; the drift test pins the
+ *   literals against these constants instead.
  */
 
 const STORAGE_CHANNELS = Object.freeze({
@@ -57,4 +62,202 @@ const DICT_CHANNELS = Object.freeze({
   }),
 });
 
-module.exports = { STORAGE_CHANNELS, DICT_CHANNELS };
+// open/save/pending-file + system file-association pushes (electron/ipc/file-ipc.js)
+const FILE_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    openFile: "open-file",
+    saveFile: "save-file",
+    getPendingFile: "get-pending-file",
+  }),
+  event: Object.freeze({
+    openFileFromSystem: "open-file-from-system",
+    openAsProject: "open-as-project",
+  }),
+});
+
+// Document export / print (electron/ipc/file-ipc.js)
+const EXPORT_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    generatePdfPreview: "generate-pdf-preview",
+    exportPdf: "export-pdf",
+    exportEpub: "export-epub",
+    exportDocx: "export-docx",
+    printDocument: "print-document",
+  }),
+  event: Object.freeze({}),
+});
+
+// Shell / OS integration (electron/ipc/shell-ipc.js)
+const SHELL_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    showInFileManager: "show-in-file-manager",
+    revealInFileManager: "reveal-in-file-manager",
+    openWithDefaultApp: "open-with-default-app",
+    openExternal: "open-external",
+    openDictionaryPopup: "open-dictionary-popup",
+    showContextMenu: "show-context-menu",
+  }),
+  event: Object.freeze({}),
+});
+
+// System / window lifecycle (electron/ipc/system-ipc.js handles the invokes;
+// electron/window-manager.js pushes the close-handshake events)
+const SYSTEM_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    getChromeVersion: "get-chrome-version",
+    setDirty: "set-dirty",
+    saveBeforeCloseDone: "save-before-close-done",
+    newWindow: "new-window",
+  }),
+  event: Object.freeze({
+    requestSaveBeforeClose: "electron-request-save-before-close",
+    requestFlushStateBeforeClose: "electron-request-flush-state-before-close",
+  }),
+});
+
+// Native menu (invokes handled in electron/ipc/system-ipc.js; events are
+// dispatched data-driven from lib/menu/menu-template.js via electron/menu.js)
+const MENU_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    rebuild: "menu:rebuild",
+    syncUiState: "menu:sync-ui-state",
+    updateKeymapOverrides: "menu:update-keymap-overrides",
+  }),
+  event: Object.freeze({
+    newTriggered: "menu-new-triggered",
+    openTriggered: "menu-open-triggered",
+    saveTriggered: "menu-save-triggered",
+    saveAsTriggered: "menu-save-as-triggered",
+    closeTab: "menu-close-tab",
+    newTab: "menu-new-tab",
+    pasteAsPlaintext: "menu-paste-as-plaintext",
+    openProject: "menu-open-project",
+    openRecentProject: "menu-open-recent-project",
+    showInFileManager: "menu-show-in-file-manager",
+    toggleCompactMode: "menu-toggle-compact-mode",
+    format: "menu-format",
+    theme: "menu-theme",
+    print: "menu-print",
+    exportTxt: "menu-export-txt",
+    exportTxtRuby: "menu-export-txt-ruby",
+    exportPdf: "menu-export-pdf",
+    exportEpub: "menu-export-epub",
+    exportDocx: "menu-export-docx",
+  }),
+});
+
+// Virtual file system (electron/ipc/vfs-ipc.js)
+const VFS_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    openDirectory: "vfs:open-directory",
+    openFile: "vfs:open-file",
+    setRoot: "vfs:set-root",
+    readFile: "vfs:read-file",
+    writeFile: "vfs:write-file",
+    readDirectory: "vfs:read-directory",
+    stat: "vfs:stat",
+    exists: "vfs:exists",
+    mkdir: "vfs:mkdir",
+    delete: "vfs:delete",
+    rename: "vfs:rename",
+    indexLockAcquire: "vfs:index-lock:acquire",
+    indexLockRelease: "vfs:index-lock:release",
+  }),
+  event: Object.freeze({}),
+});
+
+// OAuth login (electron/ipc/auth-ipc.js)
+const AUTH_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    startLogin: "auth:start-login",
+    exchangeCode: "auth:exchange-code",
+    refreshToken: "auth:refresh-token",
+    getUserInfo: "auth:get-userinfo",
+    logout: "auth:logout",
+  }),
+  event: Object.freeze({
+    callback: "auth:callback",
+  }),
+});
+
+// safeStorage encryption (electron/ipc/system-ipc.js)
+const SAFE_STORAGE_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    encrypt: "safe-storage:encrypt",
+    decrypt: "safe-storage:decrypt",
+    isAvailable: "safe-storage:is-available",
+  }),
+  event: Object.freeze({}),
+});
+
+// Power monitoring (invoke in electron/ipc/system-ipc.js; event pushed from
+// electron/window-manager.js)
+const POWER_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    getState: "power:get-state",
+  }),
+  event: Object.freeze({
+    stateChanged: "power:state-changed",
+  }),
+});
+
+// Editor popout / multi-window buffer sync (electron/ipc/editor-ipc.js)
+const EDITOR_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    popoutPanel: "editor:popout-panel",
+  }),
+  send: Object.freeze({
+    bufferSync: "editor:buffer-sync",
+    bufferClose: "editor:buffer-close",
+  }),
+  event: Object.freeze({
+    bufferSyncBroadcast: "editor:buffer-sync-broadcast",
+    bufferCloseBroadcast: "editor:buffer-close-broadcast",
+  }),
+});
+
+// Morphological analysis (electron/ipc/nlp-ipc.js)
+const NLP_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    init: "nlp:init",
+    tokenizeParagraph: "nlp:tokenize-paragraph",
+    tokenizeDocument: "nlp:tokenize-document",
+    analyzeWordFrequency: "nlp:analyze-word-frequency",
+  }),
+  event: Object.freeze({
+    tokenizeProgress: "nlp:tokenize-progress",
+  }),
+});
+
+// Integrated terminal PTY sessions (electron/ipc/pty-ipc.js)
+const PTY_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    spawn: "pty:spawn",
+    attach: "pty:attach",
+    write: "pty:write",
+    resize: "pty:resize",
+    kill: "pty:kill",
+    status: "pty:status",
+  }),
+  event: Object.freeze({
+    data: "pty:data",
+    exit: "pty:exit",
+  }),
+});
+
+module.exports = {
+  STORAGE_CHANNELS,
+  DICT_CHANNELS,
+  FILE_CHANNELS,
+  EXPORT_CHANNELS,
+  SHELL_CHANNELS,
+  SYSTEM_CHANNELS,
+  MENU_CHANNELS,
+  VFS_CHANNELS,
+  AUTH_CHANNELS,
+  SAFE_STORAGE_CHANNELS,
+  POWER_CHANNELS,
+  EDITOR_CHANNELS,
+  NLP_CHANNELS,
+  PTY_CHANNELS,
+};

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,157 +1,88 @@
 // Electron の preload スクリプト
 // レンダラへ最小限かつ安全なAPIだけを公開する
+//
+// #1434: IPC ブリッジは electron/lib/ipc-bridge.js の宣言的ヘルパーで定義する。
+// channel 名は electron/lib/ipc-channels.js で main 側と共有され、契約の drift は
+// electron/lib/__tests__/ipc-bridge.test.ts が防止する。
+// 特殊な wrapper（nlp.tokenizeDocument の requestId フィルタ、
+// editor.removeAllListeners）のみ意図的に手書きのまま残す。
 
 const { contextBridge, ipcRenderer } = require("electron");
-const { invokeChannel, eventChannel } = require("./lib/ipc-bridge");
-const { STORAGE_CHANNELS, DICT_CHANNELS } = require("./lib/ipc-channels");
+const { invokeChannel, sendChannel, eventChannel } = require("./lib/ipc-bridge");
+const {
+  STORAGE_CHANNELS,
+  DICT_CHANNELS,
+  FILE_CHANNELS,
+  EXPORT_CHANNELS,
+  SHELL_CHANNELS,
+  SYSTEM_CHANNELS,
+  MENU_CHANNELS,
+  VFS_CHANNELS,
+  AUTH_CHANNELS,
+  SAFE_STORAGE_CHANNELS,
+  POWER_CHANNELS,
+  EDITOR_CHANNELS,
+  NLP_CHANNELS,
+  PTY_CHANNELS,
+} = require("./lib/ipc-channels");
 
 contextBridge.exposeInMainWorld("electronAPI", {
   isElectron: true,
-  openFile: () => ipcRenderer.invoke("open-file"),
-  saveFile: (filePath, content, fileType) =>
-    ipcRenderer.invoke("save-file", filePath, content, fileType),
-  getChromeVersion: () => ipcRenderer.invoke("get-chrome-version"),
-  setDirty: (dirty) => ipcRenderer.invoke("set-dirty", dirty),
+  openFile: invokeChannel(FILE_CHANNELS.invoke.openFile, { arity: 0 }),
+  saveFile: invokeChannel(FILE_CHANNELS.invoke.saveFile, { arity: 3 }),
+  getChromeVersion: invokeChannel(SYSTEM_CHANNELS.invoke.getChromeVersion, { arity: 0 }),
+  setDirty: invokeChannel(SYSTEM_CHANNELS.invoke.setDirty, { arity: 1 }),
   // 歴史的命名: flush 完了後にウィンドウを実際に閉じるためのシグナル。
   // Phase 2 で save 経路は消滅したが、close handshake の終端トリガとして引き続き利用する。
-  saveDoneAndClose: () => ipcRenderer.invoke("save-before-close-done"),
-  newWindow: () => ipcRenderer.invoke("new-window"),
-  openDictionaryPopup: (url, title) => ipcRenderer.invoke("open-dictionary-popup", url, title),
-  showContextMenu: (items) => ipcRenderer.invoke("show-context-menu", items),
-  onMenuNew: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-new-triggered", handler);
-    return () => ipcRenderer.removeListener("menu-new-triggered", handler);
-  },
-  onMenuOpen: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-open-triggered", handler);
-    return () => ipcRenderer.removeListener("menu-open-triggered", handler);
-  },
-  onMenuSave: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-save-triggered", handler);
-    return () => ipcRenderer.removeListener("menu-save-triggered", handler);
-  },
-  onMenuSaveAs: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-save-as-triggered", handler);
-    return () => ipcRenderer.removeListener("menu-save-as-triggered", handler);
-  },
-  onMenuCloseTab: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-close-tab", handler);
-    return () => ipcRenderer.removeListener("menu-close-tab", handler);
-  },
-  onMenuNewTab: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-new-tab", handler);
-    return () => ipcRenderer.removeListener("menu-new-tab", handler);
-  },
-  onSaveBeforeClose: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("electron-request-save-before-close", handler);
-    return () => ipcRenderer.removeListener("electron-request-save-before-close", handler);
-  },
-  onFlushStateBeforeClose: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("electron-request-flush-state-before-close", handler);
-    return () => ipcRenderer.removeListener("electron-request-flush-state-before-close", handler);
-  },
-  onOpenFileFromSystem: (callback) => {
-    const handler = (_event, payload) => callback(payload);
-    ipcRenderer.on("open-file-from-system", handler);
-    return () => ipcRenderer.removeListener("open-file-from-system", handler);
-  },
-  onOpenAsProject: (callback) => {
-    const handler = (_event, payload) => callback(payload);
-    ipcRenderer.on("open-as-project", handler);
-    return () => ipcRenderer.removeListener("open-as-project", handler);
-  },
-  getPendingFile: () => ipcRenderer.invoke("get-pending-file"),
-  onPasteAsPlaintext: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-paste-as-plaintext", handler);
-    return () => ipcRenderer.removeListener("menu-paste-as-plaintext", handler);
-  },
-  showInFileManager: (dirPath) => ipcRenderer.invoke("show-in-file-manager", dirPath),
-  revealInFileManager: (filePath) => ipcRenderer.invoke("reveal-in-file-manager", filePath),
-  openWithDefaultApp: (filePath) => ipcRenderer.invoke("open-with-default-app", filePath),
-  openExternal: (url) => ipcRenderer.invoke("open-external", url),
-  onMenuOpenProject: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-open-project", handler);
-    return () => ipcRenderer.removeListener("menu-open-project", handler);
-  },
-  onMenuOpenRecentProject: (callback) => {
-    const handler = (_event, projectId) => callback(projectId);
-    ipcRenderer.on("menu-open-recent-project", handler);
-    return () => ipcRenderer.removeListener("menu-open-recent-project", handler);
-  },
-  rebuildMenu: () => ipcRenderer.invoke("menu:rebuild"),
-  syncMenuUiState: (state) => ipcRenderer.invoke("menu:sync-ui-state", state),
-  updateKeymapOverrides: (overrides) =>
-    ipcRenderer.invoke("menu:update-keymap-overrides", overrides),
-  onMenuShowInFileManager: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-show-in-file-manager", handler);
-    return () => ipcRenderer.removeListener("menu-show-in-file-manager", handler);
-  },
-  onToggleCompactMode: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-toggle-compact-mode", handler);
-    return () => ipcRenderer.removeListener("menu-toggle-compact-mode", handler);
-  },
-  onFormatChange: (callback) => {
-    const handler = (_event, setting, action) => callback(setting, action);
-    ipcRenderer.on("menu-format", handler);
-    return () => ipcRenderer.removeListener("menu-format", handler);
-  },
-  onThemeChange: (callback) => {
-    const handler = (_event, mode) => callback(mode);
-    ipcRenderer.on("menu-theme", handler);
-    return () => ipcRenderer.removeListener("menu-theme", handler);
-  },
+  saveDoneAndClose: invokeChannel(SYSTEM_CHANNELS.invoke.saveBeforeCloseDone, { arity: 0 }),
+  newWindow: invokeChannel(SYSTEM_CHANNELS.invoke.newWindow, { arity: 0 }),
+  openDictionaryPopup: invokeChannel(SHELL_CHANNELS.invoke.openDictionaryPopup, { arity: 2 }),
+  showContextMenu: invokeChannel(SHELL_CHANNELS.invoke.showContextMenu, { arity: 1 }),
+  onMenuNew: eventChannel(MENU_CHANNELS.event.newTriggered, { arity: 0 }),
+  onMenuOpen: eventChannel(MENU_CHANNELS.event.openTriggered, { arity: 0 }),
+  onMenuSave: eventChannel(MENU_CHANNELS.event.saveTriggered, { arity: 0 }),
+  onMenuSaveAs: eventChannel(MENU_CHANNELS.event.saveAsTriggered, { arity: 0 }),
+  onMenuCloseTab: eventChannel(MENU_CHANNELS.event.closeTab, { arity: 0 }),
+  onMenuNewTab: eventChannel(MENU_CHANNELS.event.newTab, { arity: 0 }),
+  onSaveBeforeClose: eventChannel(SYSTEM_CHANNELS.event.requestSaveBeforeClose, { arity: 0 }),
+  onFlushStateBeforeClose: eventChannel(SYSTEM_CHANNELS.event.requestFlushStateBeforeClose, {
+    arity: 0,
+  }),
+  onOpenFileFromSystem: eventChannel(FILE_CHANNELS.event.openFileFromSystem),
+  onOpenAsProject: eventChannel(FILE_CHANNELS.event.openAsProject),
+  getPendingFile: invokeChannel(FILE_CHANNELS.invoke.getPendingFile, { arity: 0 }),
+  onPasteAsPlaintext: eventChannel(MENU_CHANNELS.event.pasteAsPlaintext, { arity: 0 }),
+  showInFileManager: invokeChannel(SHELL_CHANNELS.invoke.showInFileManager, { arity: 1 }),
+  revealInFileManager: invokeChannel(SHELL_CHANNELS.invoke.revealInFileManager, { arity: 1 }),
+  openWithDefaultApp: invokeChannel(SHELL_CHANNELS.invoke.openWithDefaultApp, { arity: 1 }),
+  openExternal: invokeChannel(SHELL_CHANNELS.invoke.openExternal, { arity: 1 }),
+  onMenuOpenProject: eventChannel(MENU_CHANNELS.event.openProject, { arity: 0 }),
+  onMenuOpenRecentProject: eventChannel(MENU_CHANNELS.event.openRecentProject),
+  rebuildMenu: invokeChannel(MENU_CHANNELS.invoke.rebuild, { arity: 0 }),
+  syncMenuUiState: invokeChannel(MENU_CHANNELS.invoke.syncUiState, { arity: 1 }),
+  updateKeymapOverrides: invokeChannel(MENU_CHANNELS.invoke.updateKeymapOverrides, { arity: 1 }),
+  onMenuShowInFileManager: eventChannel(MENU_CHANNELS.event.showInFileManager, { arity: 0 }),
+  onToggleCompactMode: eventChannel(MENU_CHANNELS.event.toggleCompactMode, { arity: 0 }),
+  onFormatChange: eventChannel(MENU_CHANNELS.event.format, { arity: 2 }),
+  onThemeChange: eventChannel(MENU_CHANNELS.event.theme),
   // Export
-  generatePdfPreview: (content, options) =>
-    ipcRenderer.invoke("generate-pdf-preview", content, options),
-  exportPDF: (content, options) => ipcRenderer.invoke("export-pdf", content, options),
-  exportEPUB: (content, options) => ipcRenderer.invoke("export-epub", content, options),
-  exportDOCX: (content, options) => ipcRenderer.invoke("export-docx", content, options),
-  printDocument: (content, options) => ipcRenderer.invoke("print-document", content, options),
-  onMenuPrint: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-print", handler);
-    return () => ipcRenderer.removeListener("menu-print", handler);
-  },
-  onMenuExportTxt: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-export-txt", handler);
-    return () => ipcRenderer.removeListener("menu-export-txt", handler);
-  },
-  onMenuExportTxtRuby: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-export-txt-ruby", handler);
-    return () => ipcRenderer.removeListener("menu-export-txt-ruby", handler);
-  },
-  onMenuExportPDF: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-export-pdf", handler);
-    return () => ipcRenderer.removeListener("menu-export-pdf", handler);
-  },
-  onMenuExportEPUB: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-export-epub", handler);
-    return () => ipcRenderer.removeListener("menu-export-epub", handler);
-  },
-  onMenuExportDOCX: (callback) => {
-    const handler = () => callback();
-    ipcRenderer.on("menu-export-docx", handler);
-    return () => ipcRenderer.removeListener("menu-export-docx", handler);
-  },
+  generatePdfPreview: invokeChannel(EXPORT_CHANNELS.invoke.generatePdfPreview, { arity: 2 }),
+  exportPDF: invokeChannel(EXPORT_CHANNELS.invoke.exportPdf, { arity: 2 }),
+  exportEPUB: invokeChannel(EXPORT_CHANNELS.invoke.exportEpub, { arity: 2 }),
+  exportDOCX: invokeChannel(EXPORT_CHANNELS.invoke.exportDocx, { arity: 2 }),
+  printDocument: invokeChannel(EXPORT_CHANNELS.invoke.printDocument, { arity: 2 }),
+  onMenuPrint: eventChannel(MENU_CHANNELS.event.print, { arity: 0 }),
+  onMenuExportTxt: eventChannel(MENU_CHANNELS.event.exportTxt, { arity: 0 }),
+  onMenuExportTxtRuby: eventChannel(MENU_CHANNELS.event.exportTxtRuby, { arity: 0 }),
+  onMenuExportPDF: eventChannel(MENU_CHANNELS.event.exportPdf, { arity: 0 }),
+  onMenuExportEPUB: eventChannel(MENU_CHANNELS.event.exportEpub, { arity: 0 }),
+  onMenuExportDOCX: eventChannel(MENU_CHANNELS.event.exportDocx, { arity: 0 }),
   nlp: {
-    init: (dicPath) => ipcRenderer.invoke("nlp:init", dicPath),
-    tokenizeParagraph: (text) => ipcRenderer.invoke("nlp:tokenize-paragraph", text),
+    init: invokeChannel(NLP_CHANNELS.invoke.init, { arity: 1 }),
+    tokenizeParagraph: invokeChannel(NLP_CHANNELS.invoke.tokenizeParagraph, { arity: 1 }),
+    // 意図的に手書き (#1434): requestId の生成と progress イベントの
+    // requestId フィルタリング + finally での listener 解除が必要なため、
+    // 宣言的ヘルパーでは表現できない。
     tokenizeDocument: (paragraphs, onProgress) => {
       // Generate a unique requestId so parallel calls don't interfere with each other
       const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
@@ -163,20 +94,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
             onProgress(progress);
           }
         };
-        ipcRenderer.on("nlp:tokenize-progress", handler);
+        ipcRenderer.on(NLP_CHANNELS.event.tokenizeProgress, handler);
 
         return ipcRenderer
-          .invoke("nlp:tokenize-document", { paragraphs, requestId })
+          .invoke(NLP_CHANNELS.invoke.tokenizeDocument, { paragraphs, requestId })
           .finally(() => {
-            ipcRenderer.removeListener("nlp:tokenize-progress", handler);
+            ipcRenderer.removeListener(NLP_CHANNELS.event.tokenizeProgress, handler);
           });
       }
 
-      return ipcRenderer.invoke("nlp:tokenize-document", { paragraphs, requestId });
+      return ipcRenderer.invoke(NLP_CHANNELS.invoke.tokenizeDocument, { paragraphs, requestId });
     },
-    analyzeWordFrequency: (text) => ipcRenderer.invoke("nlp:analyze-word-frequency", text),
+    analyzeWordFrequency: invokeChannel(NLP_CHANNELS.invoke.analyzeWordFrequency, { arity: 1 }),
   },
-  // #1434: declarative bridge — channel names shared with electron/ipc/storage-ipc.js
   storage: {
     saveSession: invokeChannel(STORAGE_CHANNELS.invoke.saveSession, { arity: 1 }),
     loadSession: invokeChannel(STORAGE_CHANNELS.invoke.loadSession, { arity: 0 }),
@@ -198,71 +128,60 @@ contextBridge.exposeInMainWorld("electronAPI", {
     removeItem: invokeChannel(STORAGE_CHANNELS.invoke.removeItem, { arity: 1 }),
   },
   vfs: {
-    openDirectory: () => ipcRenderer.invoke("vfs:open-directory"),
-    openFile: (opts) => ipcRenderer.invoke("vfs:open-file", opts),
+    openDirectory: invokeChannel(VFS_CHANNELS.invoke.openDirectory, { arity: 0 }),
+    openFile: invokeChannel(VFS_CHANNELS.invoke.openFile, { arity: 1 }),
     // #1476: rehydration — projectId added for project-scoped approval persistence
-    setRoot: (rootPath, projectId) => ipcRenderer.invoke("vfs:set-root", rootPath, projectId),
-    readFile: (filePath) => ipcRenderer.invoke("vfs:read-file", filePath),
-    writeFile: (filePath, content) => ipcRenderer.invoke("vfs:write-file", filePath, content),
-    readDirectory: (dirPath) => ipcRenderer.invoke("vfs:read-directory", dirPath),
-    stat: (filePath) => ipcRenderer.invoke("vfs:stat", filePath),
-    exists: (filePath) => ipcRenderer.invoke("vfs:exists", filePath),
-    mkdir: (dirPath) => ipcRenderer.invoke("vfs:mkdir", dirPath),
-    delete: (targetPath, options) => ipcRenderer.invoke("vfs:delete", targetPath, options),
-    rename: (oldPath, newPath) => ipcRenderer.invoke("vfs:rename", oldPath, newPath),
-    indexLockAcquire: (key) => ipcRenderer.invoke("vfs:index-lock:acquire", key),
-    indexLockRelease: (key) => ipcRenderer.invoke("vfs:index-lock:release", key),
+    setRoot: invokeChannel(VFS_CHANNELS.invoke.setRoot, { arity: 2 }),
+    readFile: invokeChannel(VFS_CHANNELS.invoke.readFile, { arity: 1 }),
+    writeFile: invokeChannel(VFS_CHANNELS.invoke.writeFile, { arity: 2 }),
+    readDirectory: invokeChannel(VFS_CHANNELS.invoke.readDirectory, { arity: 1 }),
+    stat: invokeChannel(VFS_CHANNELS.invoke.stat, { arity: 1 }),
+    exists: invokeChannel(VFS_CHANNELS.invoke.exists, { arity: 1 }),
+    mkdir: invokeChannel(VFS_CHANNELS.invoke.mkdir, { arity: 1 }),
+    delete: invokeChannel(VFS_CHANNELS.invoke.delete, { arity: 2 }),
+    rename: invokeChannel(VFS_CHANNELS.invoke.rename, { arity: 2 }),
+    indexLockAcquire: invokeChannel(VFS_CHANNELS.invoke.indexLockAcquire, { arity: 1 }),
+    indexLockRelease: invokeChannel(VFS_CHANNELS.invoke.indexLockRelease, { arity: 1 }),
   },
   auth: {
-    startLogin: () => ipcRenderer.invoke("auth:start-login"),
-    exchangeCode: (params) => ipcRenderer.invoke("auth:exchange-code", params),
-    refreshToken: (refreshToken) => ipcRenderer.invoke("auth:refresh-token", refreshToken),
-    getUserInfo: (accessToken) => ipcRenderer.invoke("auth:get-userinfo", accessToken),
-    logout: () => ipcRenderer.invoke("auth:logout"),
-    onCallback: (callback) => {
-      const handler = (_event, data) => callback(data);
-      ipcRenderer.on("auth:callback", handler);
-      return () => ipcRenderer.removeListener("auth:callback", handler);
-    },
+    startLogin: invokeChannel(AUTH_CHANNELS.invoke.startLogin, { arity: 0 }),
+    exchangeCode: invokeChannel(AUTH_CHANNELS.invoke.exchangeCode, { arity: 1 }),
+    refreshToken: invokeChannel(AUTH_CHANNELS.invoke.refreshToken, { arity: 1 }),
+    getUserInfo: invokeChannel(AUTH_CHANNELS.invoke.getUserInfo, { arity: 1 }),
+    logout: invokeChannel(AUTH_CHANNELS.invoke.logout, { arity: 0 }),
+    onCallback: eventChannel(AUTH_CHANNELS.event.callback),
   },
   safeStorage: {
-    encrypt: (plaintext) => ipcRenderer.invoke("safe-storage:encrypt", plaintext),
-    decrypt: (base64Cipher) => ipcRenderer.invoke("safe-storage:decrypt", base64Cipher),
-    isAvailable: () => ipcRenderer.invoke("safe-storage:is-available"),
+    encrypt: invokeChannel(SAFE_STORAGE_CHANNELS.invoke.encrypt, { arity: 1 }),
+    decrypt: invokeChannel(SAFE_STORAGE_CHANNELS.invoke.decrypt, { arity: 1 }),
+    isAvailable: invokeChannel(SAFE_STORAGE_CHANNELS.invoke.isAvailable, { arity: 0 }),
   },
   power: {
     // Returns an unsubscribe function that removes ONLY this wrapper.
     // (removeOnPowerStateChange was removed in #1567 S3: it used
     // removeAllListeners, which nuked other components' listeners.)
-    onPowerStateChange: (callback) => {
-      const handler = (_event, state) => callback(state);
-      ipcRenderer.on("power:state-changed", handler);
-      return () => ipcRenderer.removeListener("power:state-changed", handler);
-    },
-    getPowerState: () => ipcRenderer.invoke("power:get-state"),
+    onPowerStateChange: eventChannel(POWER_CHANNELS.event.stateChanged),
+    getPowerState: invokeChannel(POWER_CHANNELS.invoke.getState, { arity: 0 }),
   },
   editor: {
-    popoutPanel: (bufferId, content, fileName, fileType) =>
-      ipcRenderer.invoke("editor:popout-panel", { bufferId, content, fileName, fileType }),
-    sendBufferSync: (bufferId, content) =>
-      ipcRenderer.send("editor:buffer-sync", { bufferId, content }),
-    onBufferSync: (callback) => {
-      const handler = (_event, data) => callback(data);
-      ipcRenderer.on("editor:buffer-sync-broadcast", handler);
-      return () => ipcRenderer.removeListener("editor:buffer-sync-broadcast", handler);
-    },
-    sendBufferClose: (bufferId) => ipcRenderer.send("editor:buffer-close", bufferId),
-    onBufferClose: (callback) => {
-      const handler = (_event, bufferId) => callback(bufferId);
-      ipcRenderer.on("editor:buffer-close-broadcast", handler);
-      return () => ipcRenderer.removeListener("editor:buffer-close-broadcast", handler);
-    },
+    popoutPanel: invokeChannel(
+      EDITOR_CHANNELS.invoke.popoutPanel,
+      (bufferId, content, fileName, fileType) => ({ bufferId, content, fileName, fileType }),
+    ),
+    sendBufferSync: sendChannel(EDITOR_CHANNELS.send.bufferSync, (bufferId, content) => ({
+      bufferId,
+      content,
+    })),
+    onBufferSync: eventChannel(EDITOR_CHANNELS.event.bufferSyncBroadcast),
+    sendBufferClose: sendChannel(EDITOR_CHANNELS.send.bufferClose, { arity: 1 }),
+    onBufferClose: eventChannel(EDITOR_CHANNELS.event.bufferCloseBroadcast),
+    // 意図的に手書き (#1434): popout ウィンドウ破棄時に broadcast 系 listener を
+    // まとめて全解除する歴史的 API。eventChannel の unsubscribe とは意味が異なる。
     removeAllListeners: () => {
-      ipcRenderer.removeAllListeners("editor:buffer-sync-broadcast");
-      ipcRenderer.removeAllListeners("editor:buffer-close-broadcast");
+      ipcRenderer.removeAllListeners(EDITOR_CHANNELS.event.bufferSyncBroadcast);
+      ipcRenderer.removeAllListeners(EDITOR_CHANNELS.event.bufferCloseBroadcast);
     },
   },
-  // #1434: declarative bridge — channel names shared with electron/ipc/dict-ipc.js
   dict: {
     query: invokeChannel(DICT_CHANNELS.invoke.query, (term, limit) => ({ term, limit })),
     queryByReading: invokeChannel(DICT_CHANNELS.invoke.queryReading, (reading, limit) => ({
@@ -277,38 +196,34 @@ contextBridge.exposeInMainWorld("electronAPI", {
   },
   pty: {
     /** Spawn a new PTY session. Returns { sessionId } or { error }. */
-    spawn: (options) => ipcRenderer.invoke("pty:spawn", options),
+    spawn: invokeChannel(PTY_CHANNELS.invoke.spawn, { arity: 1 }),
     /** Re-attach to an existing session and retrieve buffered output. */
-    attach: (sessionId) => ipcRenderer.invoke("pty:attach", sessionId),
+    attach: invokeChannel(PTY_CHANNELS.invoke.attach, { arity: 1 }),
     /** Write keystroke data to a PTY session. */
-    write: (sessionId, data) => ipcRenderer.invoke("pty:write", { sessionId, data }),
+    write: invokeChannel(PTY_CHANNELS.invoke.write, (sessionId, data) => ({ sessionId, data })),
     /** Resize the terminal dimensions. */
-    resize: (sessionId, cols, rows) => ipcRenderer.invoke("pty:resize", { sessionId, cols, rows }),
+    resize: invokeChannel(PTY_CHANNELS.invoke.resize, (sessionId, cols, rows) => ({
+      sessionId,
+      cols,
+      rows,
+    })),
     /** Kill a PTY session (idempotent). */
-    kill: (sessionId) => ipcRenderer.invoke("pty:kill", sessionId),
+    kill: invokeChannel(PTY_CHANNELS.invoke.kill, { arity: 1 }),
     /** Query the state of a PTY session. */
-    status: (sessionId) => ipcRenderer.invoke("pty:status", sessionId),
+    status: invokeChannel(PTY_CHANNELS.invoke.status, { arity: 1 }),
     /**
      * Listen for PTY output data pushed from main process.
      * Returns a cleanup function that removes the listener.
      * @param {function({ sessionId: string, data: string }): void} callback
      * @returns {() => void}
      */
-    onData: (callback) => {
-      const handler = (_event, payload) => callback(payload);
-      ipcRenderer.on("pty:data", handler);
-      return () => ipcRenderer.removeListener("pty:data", handler);
-    },
+    onData: eventChannel(PTY_CHANNELS.event.data),
     /**
      * Listen for PTY process exit notification.
      * Returns a cleanup function that removes the listener.
      * @param {function({ sessionId: string, exitCode: number }): void} callback
      * @returns {() => void}
      */
-    onExit: (callback) => {
-      const handler = (_event, payload) => callback(payload);
-      ipcRenderer.on("pty:exit", handler);
-      return () => ipcRenderer.removeListener("pty:exit", handler);
-    },
+    onExit: eventChannel(PTY_CHANNELS.event.exit),
   },
 });

--- a/electron/window-manager.js
+++ b/electron/window-manager.js
@@ -5,6 +5,7 @@ const { app, BrowserWindow, dialog, shell } = require("electron");
 const path = require("path");
 const { isDev } = require("./app-constants");
 const { isSafeExternalUrl, normalizeExternalUrl } = require("./lib/url-policy");
+const { SYSTEM_CHANNELS, POWER_CHANNELS } = require("./lib/ipc-channels");
 
 let mainWindow = null;
 const allWindows = new Set();
@@ -17,7 +18,7 @@ const allWindows = new Set();
 function broadcastPowerState(state) {
   for (const win of allWindows) {
     if (!win.isDestroyed()) {
-      win.webContents.send("power:state-changed", state);
+      win.webContents.send(POWER_CHANNELS.event.stateChanged, state);
     }
   }
 }
@@ -123,10 +124,10 @@ async function createWindow({ showWelcome = false, hasPendingFile = false } = {}
         .then(({ response }) => {
           if (response === 0) {
             // "保存": flush state + save dirty files, then close
-            newWindow.webContents.send("electron-request-save-before-close");
+            newWindow.webContents.send(SYSTEM_CHANNELS.event.requestSaveBeforeClose);
           } else if (response === 1) {
             // "保存しない": flush state only (preserve tab/layout), then close
-            newWindow.webContents.send("electron-request-flush-state-before-close");
+            newWindow.webContents.send(SYSTEM_CHANNELS.event.requestFlushStateBeforeClose);
           } else {
             // "キャンセル": ウィンドウを開いたまま
             isHandlingClose = false;
@@ -137,7 +138,7 @@ async function createWindow({ showWelcome = false, hasPendingFile = false } = {}
         });
     } else {
       // 変更なし: タブ・レイアウト状態をフラッシュしてから閉じる
-      newWindow.webContents.send("electron-request-flush-state-before-close");
+      newWindow.webContents.send(SYSTEM_CHANNELS.event.requestFlushStateBeforeClose);
     }
   });
 


### PR DESCRIPTION
## 概要

Closes #1434（Phase 2 / 最終増分 — Phase 1 は #1593）

PR #1593 で確立した registry / helper パターンを、preload に残っていた **全 namespace** へ展開します。preload の channel 文字列リテラルは全廃され、channel 名は `electron/lib/ipc-channels.js` の定数として preload と main 側（`electron/ipc/*.js` / `electron/main.js` / `electron/window-manager.js`）の両方から参照されます。

## 変更内容

- **`electron/lib/ipc-channels.js`**: 全 14 namespace（111 channels）の定数を集約。editor 用に `send`（ipcRenderer.send ↔ ipcMain.on）カテゴリを追加
- **`electron/lib/ipc-bridge.js`**（最小限の拡張・テスト付き）:
  - `sendChannel(channel, { arity } | mapArgs)` — fire-and-forget 用。invokeChannel と同じ least-authority arity 規則（余剰引数は IPC を越えない）
  - `eventChannel(channel[, { arity }])` — callback へ渡す payload 引数の数を宣言（0 = シグナルのみ / 既定 1 / 2 = `menu-format`）。旧手書き wrapper と同一の「常にちょうど arity 個（undefined 埋め）」挙動
- **`electron/preload.js`**: 全 namespace を宣言的 one-liner へ移行。invoke wrapper は旧 wrapper のパラメータリストと同一の arity を宣言（arity 拡大なし）。payload を整形していた wrapper（`dict.query` / `editor.popoutPanel` / `editor.sendBufferSync` / `pty.write` / `pty.resize` 等）は mapArgs で同形を維持
- **main 側**: `ipcMain.handle` / `ipcMain.on` / `webContents.send` が同じ定数 module を参照（vfs / auth / system / shell / file / nlp / editor / pty の各 ipc module と window-manager.js）。**validation ロジック・入力検査は一切変更なし**。`contextIsolation: true` も無変更
- **drift 防止テスト**（`electron/lib/__tests__/ipc-bridge.test.ts`、53 tests）:
  1. 全 111 channel の文字列値を pin（後方互換契約）
  2. preload がブリッジする全 invoke/send/event channel に、main 側の同一定数参照（`ipcMain.handle` / `ipcMain.on` / `.send`）が存在することを検証
  3. preload に channel 文字列リテラルが 1 つも残っていないことを検証
  4. helper の挙動パリティ（invoke/send の arity・mapArgs、event の arity 0/1/2 と undefined 埋め、unsubscribe が自分の listener のみ解除）
- **`types/electron.d.ts`**: **diff ゼロ**（shape 変更なし）

## API shape 検証

旧 preload（origin/dev）と新 preload を electron stub 下で実行し、`window.electronAPI` の公開 shape（54 top-level keys、全 nested メソッド名と型）が **完全一致** することを確認済み。

## 意図的に手書きのまま（宣言的ヘルパーに乗らないもの）

| API | 理由 |
| --- | --- |
| `nlp.tokenizeDocument` | requestId の生成、progress イベントの requestId フィルタリング、`finally` での listener 解除という固有ロジックがあるため。channel 名は `NLP_CHANNELS` 定数参照に変更済み |
| `editor.removeAllListeners` | broadcast 系 2 channel を意図的に全解除する歴史的 API（eventChannel の per-handler unsubscribe とは意味が異なる）。channel 名は `EDITOR_CHANNELS` 定数参照に変更済み |
| `isElectron: true` | IPC ではない静的フラグ |

## 特記事項

- **MENU event channel の send 側**: `lib/menu/menu-template.js` の `electronChannel` リテラル（data-driven dispatch、electron/menu.js の generic dispatcher 経由）。この module は Next.js renderer と共有のため electron/lib への依存を持たせず、drift テストが定数値とテンプレートのリテラルを照合して pin
- **sender-less legacy channels**: `menu-new-triggered`（onMenuNew）と `menu-show-in-file-manager`（onMenuShowInFileManager）は現在 main 側に送信元が存在しない（API shape 互換のため購読は維持）。テストで明示リスト化
- bundle 検証: `npm run bundle:electron` 成功、`dist-main/preload.js` / `dist-main/main.js` 内に同一 channel 文字列が残ることを spot-check 済み

## Channel 同一性（before / after 全件、リネームゼロ）

全 111 channel。Before（移行前リテラル）と After（定数の値）は全件同一で、テストが文字列値を pin しています。

| API (`window.electronAPI.…`) | 種別 | Before (literal) | After (定数の値) | 同一 |
| --- | --- | --- | --- | --- |
| `storage.saveSession` | invoke | `storage:save-session` | `STORAGE_CHANNELS.invoke.saveSession` = `storage:save-session` | ✅ |
| `storage.loadSession` | invoke | `storage:load-session` | `STORAGE_CHANNELS.invoke.loadSession` = `storage:load-session` | ✅ |
| `storage.saveAppState` | invoke | `storage:save-app-state` | `STORAGE_CHANNELS.invoke.saveAppState` = `storage:save-app-state` | ✅ |
| `storage.loadAppState` | invoke | `storage:load-app-state` | `STORAGE_CHANNELS.invoke.loadAppState` = `storage:load-app-state` | ✅ |
| `storage.addToRecent` | invoke | `storage:add-to-recent` | `STORAGE_CHANNELS.invoke.addToRecent` = `storage:add-to-recent` | ✅ |
| `storage.getRecentFiles` | invoke | `storage:get-recent-files` | `STORAGE_CHANNELS.invoke.getRecentFiles` = `storage:get-recent-files` | ✅ |
| `storage.removeFromRecent` | invoke | `storage:remove-from-recent` | `STORAGE_CHANNELS.invoke.removeFromRecent` = `storage:remove-from-recent` | ✅ |
| `storage.clearRecent` | invoke | `storage:clear-recent` | `STORAGE_CHANNELS.invoke.clearRecent` = `storage:clear-recent` | ✅ |
| `storage.saveEditorBuffer` | invoke | `storage:save-editor-buffer` | `STORAGE_CHANNELS.invoke.saveEditorBuffer` = `storage:save-editor-buffer` | ✅ |
| `storage.loadEditorBuffer` | invoke | `storage:load-editor-buffer` | `STORAGE_CHANNELS.invoke.loadEditorBuffer` = `storage:load-editor-buffer` | ✅ |
| `storage.clearEditorBuffer` | invoke | `storage:clear-editor-buffer` | `STORAGE_CHANNELS.invoke.clearEditorBuffer` = `storage:clear-editor-buffer` | ✅ |
| `storage.clearAll` | invoke | `storage:clear-all` | `STORAGE_CHANNELS.invoke.clearAll` = `storage:clear-all` | ✅ |
| `storage.addRecentProject` | invoke | `storage:add-recent-project` | `STORAGE_CHANNELS.invoke.addRecentProject` = `storage:add-recent-project` | ✅ |
| `storage.getRecentProjects` | invoke | `storage:get-recent-projects` | `STORAGE_CHANNELS.invoke.getRecentProjects` = `storage:get-recent-projects` | ✅ |
| `storage.removeRecentProject` | invoke | `storage:remove-recent-project` | `STORAGE_CHANNELS.invoke.removeRecentProject` = `storage:remove-recent-project` | ✅ |
| `storage.setItem` | invoke | `storage:set-item` | `STORAGE_CHANNELS.invoke.setItem` = `storage:set-item` | ✅ |
| `storage.getItem` | invoke | `storage:get-item` | `STORAGE_CHANNELS.invoke.getItem` = `storage:get-item` | ✅ |
| `storage.removeItem` | invoke | `storage:remove-item` | `STORAGE_CHANNELS.invoke.removeItem` = `storage:remove-item` | ✅ |
| `dict.query` | invoke | `dict:query` | `DICT_CHANNELS.invoke.query` = `dict:query` | ✅ |
| `dict.queryByReading` | invoke | `dict:query-reading` | `DICT_CHANNELS.invoke.queryReading` = `dict:query-reading` | ✅ |
| `dict.getStatus` | invoke | `dict:get-status` | `DICT_CHANNELS.invoke.getStatus` = `dict:get-status` | ✅ |
| `dict.checkUpdate` | invoke | `dict:check-update` | `DICT_CHANNELS.invoke.checkUpdate` = `dict:check-update` | ✅ |
| `dict.download` | invoke | `dict:download` | `DICT_CHANNELS.invoke.download` = `dict:download` | ✅ |
| `dict.onDownloadProgress` | event | `dict:download-progress` | `DICT_CHANNELS.event.downloadProgress` = `dict:download-progress` | ✅ |
| `dict.onUpdateAvailable` | event | `dict:update-available` | `DICT_CHANNELS.event.updateAvailable` = `dict:update-available` | ✅ |
| `openFile` | invoke | `open-file` | `FILE_CHANNELS.invoke.openFile` = `open-file` | ✅ |
| `saveFile` | invoke | `save-file` | `FILE_CHANNELS.invoke.saveFile` = `save-file` | ✅ |
| `getPendingFile` | invoke | `get-pending-file` | `FILE_CHANNELS.invoke.getPendingFile` = `get-pending-file` | ✅ |
| `onOpenFileFromSystem` | event | `open-file-from-system` | `FILE_CHANNELS.event.openFileFromSystem` = `open-file-from-system` | ✅ |
| `onOpenAsProject` | event | `open-as-project` | `FILE_CHANNELS.event.openAsProject` = `open-as-project` | ✅ |
| `generatePdfPreview` | invoke | `generate-pdf-preview` | `EXPORT_CHANNELS.invoke.generatePdfPreview` = `generate-pdf-preview` | ✅ |
| `exportPDF` | invoke | `export-pdf` | `EXPORT_CHANNELS.invoke.exportPdf` = `export-pdf` | ✅ |
| `exportEPUB` | invoke | `export-epub` | `EXPORT_CHANNELS.invoke.exportEpub` = `export-epub` | ✅ |
| `exportDOCX` | invoke | `export-docx` | `EXPORT_CHANNELS.invoke.exportDocx` = `export-docx` | ✅ |
| `printDocument` | invoke | `print-document` | `EXPORT_CHANNELS.invoke.printDocument` = `print-document` | ✅ |
| `showInFileManager` | invoke | `show-in-file-manager` | `SHELL_CHANNELS.invoke.showInFileManager` = `show-in-file-manager` | ✅ |
| `revealInFileManager` | invoke | `reveal-in-file-manager` | `SHELL_CHANNELS.invoke.revealInFileManager` = `reveal-in-file-manager` | ✅ |
| `openWithDefaultApp` | invoke | `open-with-default-app` | `SHELL_CHANNELS.invoke.openWithDefaultApp` = `open-with-default-app` | ✅ |
| `openExternal` | invoke | `open-external` | `SHELL_CHANNELS.invoke.openExternal` = `open-external` | ✅ |
| `openDictionaryPopup` | invoke | `open-dictionary-popup` | `SHELL_CHANNELS.invoke.openDictionaryPopup` = `open-dictionary-popup` | ✅ |
| `showContextMenu` | invoke | `show-context-menu` | `SHELL_CHANNELS.invoke.showContextMenu` = `show-context-menu` | ✅ |
| `getChromeVersion` | invoke | `get-chrome-version` | `SYSTEM_CHANNELS.invoke.getChromeVersion` = `get-chrome-version` | ✅ |
| `setDirty` | invoke | `set-dirty` | `SYSTEM_CHANNELS.invoke.setDirty` = `set-dirty` | ✅ |
| `saveDoneAndClose` | invoke | `save-before-close-done` | `SYSTEM_CHANNELS.invoke.saveBeforeCloseDone` = `save-before-close-done` | ✅ |
| `newWindow` | invoke | `new-window` | `SYSTEM_CHANNELS.invoke.newWindow` = `new-window` | ✅ |
| `onSaveBeforeClose` | event | `electron-request-save-before-close` | `SYSTEM_CHANNELS.event.requestSaveBeforeClose` = `electron-request-save-before-close` | ✅ |
| `onFlushStateBeforeClose` | event | `electron-request-flush-state-before-close` | `SYSTEM_CHANNELS.event.requestFlushStateBeforeClose` = `electron-request-flush-state-before-close` | ✅ |
| `rebuildMenu` | invoke | `menu:rebuild` | `MENU_CHANNELS.invoke.rebuild` = `menu:rebuild` | ✅ |
| `syncMenuUiState` | invoke | `menu:sync-ui-state` | `MENU_CHANNELS.invoke.syncUiState` = `menu:sync-ui-state` | ✅ |
| `updateKeymapOverrides` | invoke | `menu:update-keymap-overrides` | `MENU_CHANNELS.invoke.updateKeymapOverrides` = `menu:update-keymap-overrides` | ✅ |
| `onMenuNew` | event | `menu-new-triggered` | `MENU_CHANNELS.event.newTriggered` = `menu-new-triggered` | ✅ |
| `onMenuOpen` | event | `menu-open-triggered` | `MENU_CHANNELS.event.openTriggered` = `menu-open-triggered` | ✅ |
| `onMenuSave` | event | `menu-save-triggered` | `MENU_CHANNELS.event.saveTriggered` = `menu-save-triggered` | ✅ |
| `onMenuSaveAs` | event | `menu-save-as-triggered` | `MENU_CHANNELS.event.saveAsTriggered` = `menu-save-as-triggered` | ✅ |
| `onMenuCloseTab` | event | `menu-close-tab` | `MENU_CHANNELS.event.closeTab` = `menu-close-tab` | ✅ |
| `onMenuNewTab` | event | `menu-new-tab` | `MENU_CHANNELS.event.newTab` = `menu-new-tab` | ✅ |
| `onPasteAsPlaintext` | event | `menu-paste-as-plaintext` | `MENU_CHANNELS.event.pasteAsPlaintext` = `menu-paste-as-plaintext` | ✅ |
| `onMenuOpenProject` | event | `menu-open-project` | `MENU_CHANNELS.event.openProject` = `menu-open-project` | ✅ |
| `onMenuOpenRecentProject` | event | `menu-open-recent-project` | `MENU_CHANNELS.event.openRecentProject` = `menu-open-recent-project` | ✅ |
| `onMenuShowInFileManager` | event | `menu-show-in-file-manager` | `MENU_CHANNELS.event.showInFileManager` = `menu-show-in-file-manager` | ✅ |
| `onToggleCompactMode` | event | `menu-toggle-compact-mode` | `MENU_CHANNELS.event.toggleCompactMode` = `menu-toggle-compact-mode` | ✅ |
| `onFormatChange` | event | `menu-format` | `MENU_CHANNELS.event.format` = `menu-format` | ✅ |
| `onThemeChange` | event | `menu-theme` | `MENU_CHANNELS.event.theme` = `menu-theme` | ✅ |
| `onMenuPrint` | event | `menu-print` | `MENU_CHANNELS.event.print` = `menu-print` | ✅ |
| `onMenuExportTxt` | event | `menu-export-txt` | `MENU_CHANNELS.event.exportTxt` = `menu-export-txt` | ✅ |
| `onMenuExportTxtRuby` | event | `menu-export-txt-ruby` | `MENU_CHANNELS.event.exportTxtRuby` = `menu-export-txt-ruby` | ✅ |
| `onMenuExportPDF` | event | `menu-export-pdf` | `MENU_CHANNELS.event.exportPdf` = `menu-export-pdf` | ✅ |
| `onMenuExportEPUB` | event | `menu-export-epub` | `MENU_CHANNELS.event.exportEpub` = `menu-export-epub` | ✅ |
| `onMenuExportDOCX` | event | `menu-export-docx` | `MENU_CHANNELS.event.exportDocx` = `menu-export-docx` | ✅ |
| `vfs.openDirectory` | invoke | `vfs:open-directory` | `VFS_CHANNELS.invoke.openDirectory` = `vfs:open-directory` | ✅ |
| `vfs.openFile` | invoke | `vfs:open-file` | `VFS_CHANNELS.invoke.openFile` = `vfs:open-file` | ✅ |
| `vfs.setRoot` | invoke | `vfs:set-root` | `VFS_CHANNELS.invoke.setRoot` = `vfs:set-root` | ✅ |
| `vfs.readFile` | invoke | `vfs:read-file` | `VFS_CHANNELS.invoke.readFile` = `vfs:read-file` | ✅ |
| `vfs.writeFile` | invoke | `vfs:write-file` | `VFS_CHANNELS.invoke.writeFile` = `vfs:write-file` | ✅ |
| `vfs.readDirectory` | invoke | `vfs:read-directory` | `VFS_CHANNELS.invoke.readDirectory` = `vfs:read-directory` | ✅ |
| `vfs.stat` | invoke | `vfs:stat` | `VFS_CHANNELS.invoke.stat` = `vfs:stat` | ✅ |
| `vfs.exists` | invoke | `vfs:exists` | `VFS_CHANNELS.invoke.exists` = `vfs:exists` | ✅ |
| `vfs.mkdir` | invoke | `vfs:mkdir` | `VFS_CHANNELS.invoke.mkdir` = `vfs:mkdir` | ✅ |
| `vfs.delete` | invoke | `vfs:delete` | `VFS_CHANNELS.invoke.delete` = `vfs:delete` | ✅ |
| `vfs.rename` | invoke | `vfs:rename` | `VFS_CHANNELS.invoke.rename` = `vfs:rename` | ✅ |
| `vfs.indexLockAcquire` | invoke | `vfs:index-lock:acquire` | `VFS_CHANNELS.invoke.indexLockAcquire` = `vfs:index-lock:acquire` | ✅ |
| `vfs.indexLockRelease` | invoke | `vfs:index-lock:release` | `VFS_CHANNELS.invoke.indexLockRelease` = `vfs:index-lock:release` | ✅ |
| `auth.startLogin` | invoke | `auth:start-login` | `AUTH_CHANNELS.invoke.startLogin` = `auth:start-login` | ✅ |
| `auth.exchangeCode` | invoke | `auth:exchange-code` | `AUTH_CHANNELS.invoke.exchangeCode` = `auth:exchange-code` | ✅ |
| `auth.refreshToken` | invoke | `auth:refresh-token` | `AUTH_CHANNELS.invoke.refreshToken` = `auth:refresh-token` | ✅ |
| `auth.getUserInfo` | invoke | `auth:get-userinfo` | `AUTH_CHANNELS.invoke.getUserInfo` = `auth:get-userinfo` | ✅ |
| `auth.logout` | invoke | `auth:logout` | `AUTH_CHANNELS.invoke.logout` = `auth:logout` | ✅ |
| `auth.onCallback` | event | `auth:callback` | `AUTH_CHANNELS.event.callback` = `auth:callback` | ✅ |
| `safeStorage.encrypt` | invoke | `safe-storage:encrypt` | `SAFE_STORAGE_CHANNELS.invoke.encrypt` = `safe-storage:encrypt` | ✅ |
| `safeStorage.decrypt` | invoke | `safe-storage:decrypt` | `SAFE_STORAGE_CHANNELS.invoke.decrypt` = `safe-storage:decrypt` | ✅ |
| `safeStorage.isAvailable` | invoke | `safe-storage:is-available` | `SAFE_STORAGE_CHANNELS.invoke.isAvailable` = `safe-storage:is-available` | ✅ |
| `power.getPowerState` | invoke | `power:get-state` | `POWER_CHANNELS.invoke.getState` = `power:get-state` | ✅ |
| `power.onPowerStateChange` | event | `power:state-changed` | `POWER_CHANNELS.event.stateChanged` = `power:state-changed` | ✅ |
| `editor.popoutPanel` | invoke | `editor:popout-panel` | `EDITOR_CHANNELS.invoke.popoutPanel` = `editor:popout-panel` | ✅ |
| `editor.sendBufferSync` | send | `editor:buffer-sync` | `EDITOR_CHANNELS.send.bufferSync` = `editor:buffer-sync` | ✅ |
| `editor.sendBufferClose` | send | `editor:buffer-close` | `EDITOR_CHANNELS.send.bufferClose` = `editor:buffer-close` | ✅ |
| `editor.onBufferSync` | event | `editor:buffer-sync-broadcast` | `EDITOR_CHANNELS.event.bufferSyncBroadcast` = `editor:buffer-sync-broadcast` | ✅ |
| `editor.onBufferClose` | event | `editor:buffer-close-broadcast` | `EDITOR_CHANNELS.event.bufferCloseBroadcast` = `editor:buffer-close-broadcast` | ✅ |
| `nlp.init` | invoke | `nlp:init` | `NLP_CHANNELS.invoke.init` = `nlp:init` | ✅ |
| `nlp.tokenizeParagraph` | invoke | `nlp:tokenize-paragraph` | `NLP_CHANNELS.invoke.tokenizeParagraph` = `nlp:tokenize-paragraph` | ✅ |
| `nlp.tokenizeDocument` | invoke | `nlp:tokenize-document` | `NLP_CHANNELS.invoke.tokenizeDocument` = `nlp:tokenize-document` | ✅ |
| `nlp.analyzeWordFrequency` | invoke | `nlp:analyze-word-frequency` | `NLP_CHANNELS.invoke.analyzeWordFrequency` = `nlp:analyze-word-frequency` | ✅ |
| `nlp.tokenizeDocument (onProgress)` | event | `nlp:tokenize-progress` | `NLP_CHANNELS.event.tokenizeProgress` = `nlp:tokenize-progress` | ✅ |
| `pty.spawn` | invoke | `pty:spawn` | `PTY_CHANNELS.invoke.spawn` = `pty:spawn` | ✅ |
| `pty.attach` | invoke | `pty:attach` | `PTY_CHANNELS.invoke.attach` = `pty:attach` | ✅ |
| `pty.write` | invoke | `pty:write` | `PTY_CHANNELS.invoke.write` = `pty:write` | ✅ |
| `pty.resize` | invoke | `pty:resize` | `PTY_CHANNELS.invoke.resize` = `pty:resize` | ✅ |
| `pty.kill` | invoke | `pty:kill` | `PTY_CHANNELS.invoke.kill` = `pty:kill` | ✅ |
| `pty.status` | invoke | `pty:status` | `PTY_CHANNELS.invoke.status` = `pty:status` | ✅ |
| `pty.onData` | event | `pty:data` | `PTY_CHANNELS.event.data` = `pty:data` | ✅ |
| `pty.onExit` | event | `pty:exit` | `PTY_CHANNELS.event.exit` = `pty:exit` | ✅ |

## テスト

- `npx tsc --noEmit` ✅
- `npm run lint` ✅（0 errors、warnings は既存と同数）
- `npx vitest run electron lib` ✅ 82 files / 1254 tests passed（drift テスト 53 件含む）
- `npm run bundle:electron` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
