### PR TITLE
fix: prevent cloud stale save echoes from restoring deleted content

### DIFF
--- a/lib/tab-manager/__tests__/save-executor.test.ts
+++ b/lib/tab-manager/__tests__/save-executor.test.ts
@@ -461,6 +461,32 @@ describe("executeTabSave: conflict re-check", () => {
 // ---------------------------------------------------------------------------
 
 describe("executeTabSave: standalone (saveMdiFile)", () => {
+  it("suppresses the file watcher before saving an existing standalone path", async () => {
+    const tab = makeTab({ content: "<div>本文</div>" });
+    const h = makeHarness([tab]);
+    const descriptor = tab.file as MdiFileDescriptor;
+    saveMdiFileMock.mockResolvedValue({ descriptor, content: "本文" });
+
+    const outcome = await executeTabSave({
+      tab,
+      isProject: false,
+      tabsRef: h.tabsRef,
+      setTabs: h.setTabs,
+      tryCreateSnapshot: vi.fn(),
+    });
+
+    expect(outcome.status).toBe("saved");
+    expect(suppressFileWatchMock).toHaveBeenCalledWith("/p/main.mdi", "本文");
+    expect(saveMdiFileMock).toHaveBeenCalledWith({
+      descriptor,
+      content: "本文",
+      fileType: ".mdi",
+    });
+    expect(suppressFileWatchMock.mock.invocationCallOrder[0]).toBeLessThan(
+      saveMdiFileMock.mock.invocationCallOrder[0],
+    );
+  });
+
   it("returns 'cancelled' and clears isSaving when the dialog is cancelled", async () => {
     const tab = makeTab({ file: null });
     const h = makeHarness([tab]);

--- a/lib/tab-manager/__tests__/save-lock.test.ts
+++ b/lib/tab-manager/__tests__/save-lock.test.ts
@@ -14,9 +14,13 @@
  *     the conflicted transition into tabsRef before React re-renders.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { acquireSaveLock, releaseSaveLock, isSaveLocked, clearSaveLocks } from "../save-lock";
-import { buildOnChanged } from "../use-file-watch-integration";
+import {
+  buildOnChanged,
+  RECENT_SAVE_EXTERNAL_RELOAD_GRACE_MS,
+  RECENT_SAVE_RECHECK_DELAY_MS,
+} from "../use-file-watch-integration";
 import { isEditorTab } from "../tab-types";
 import type { Dispatch, SetStateAction } from "react";
 import type { EditorTabState, TabState } from "../tab-types";
@@ -115,6 +119,10 @@ describe("buildOnChanged: eagerly mirrors conflicted into tabsRef (#1562 b)", ()
     openDiffTab = vi.fn<OpenDiffTab>();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("dirty tab: tabsRef shows conflicted before React re-renders", () => {
     const tab = makeEditorTab({ fileSyncStatus: "dirty", isDirty: true });
     tabsRef = { current: [tab] };
@@ -187,6 +195,97 @@ describe("buildOnChanged: eagerly mirrors conflicted into tabsRef (#1562 b)", ()
     const latest = tabsRef.current.find((t) => t.id === tab.id);
     if (latest && isEditorTab(latest)) {
       expect(latest.fileSyncStatus).toBe("clean");
+    }
+  });
+
+  it("clean tab: recent stale disk echo is quarantined while the file is re-read", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000_000);
+
+    const tab = makeEditorTab({
+      fileSyncStatus: "clean",
+      isDirty: false,
+      content: "saved after delete",
+      lastSavedContent: "saved after delete",
+      lastSavedTime: Date.now() - Math.floor(RECENT_SAVE_EXTERNAL_RELOAD_GRACE_MS / 2),
+    });
+    tabsRef = { current: [tab] };
+    const pendingVerifications = new Map<string, ReturnType<typeof setTimeout>>();
+    const readDiskContent = vi.fn(async () => "saved after delete");
+    const onChanged = buildOnChanged(tab.id, setTabs, tabsRef, openDiffTab, undefined, undefined, {
+      filePath: "/p/main.mdi",
+      pendingVerifications,
+      readDiskContent,
+    });
+
+    onChanged("stale cloud copy before delete", 2_000_000);
+
+    const latest = tabsRef.current.find((t) => t.id === tab.id);
+    expect(latest && isEditorTab(latest)).toBe(true);
+    if (latest && isEditorTab(latest)) {
+      expect(latest.content).toBe("saved after delete");
+      expect(latest.lastSavedContent).toBe("saved after delete");
+      expect(latest.pendingExternalContent ?? null).toBeNull();
+      expect(latest.fileSyncStatus).toBe("clean");
+      expect(latest.conflictDiskContent).toBeNull();
+    }
+    expect(setTabs).not.toHaveBeenCalled();
+    expect(pendingVerifications.size).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(RECENT_SAVE_RECHECK_DELAY_MS);
+
+    expect(readDiskContent).toHaveBeenCalledWith("/p/main.mdi");
+    const afterRecheck = tabsRef.current.find((t) => t.id === tab.id);
+    expect(afterRecheck && isEditorTab(afterRecheck)).toBe(true);
+    if (afterRecheck && isEditorTab(afterRecheck)) {
+      expect(afterRecheck.content).toBe("saved after delete");
+      expect(afterRecheck.fileSyncStatus).toBe("clean");
+      expect(afterRecheck.conflictDiskContent).toBeNull();
+      expect(afterRecheck.pendingExternalContent ?? null).toBeNull();
+    }
+  });
+
+  it("clean tab: recent disk mismatch becomes a conflict only when the re-read still differs", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000_000);
+
+    const tab = makeEditorTab({
+      fileSyncStatus: "clean",
+      isDirty: false,
+      content: "saved after delete",
+      lastSavedContent: "saved after delete",
+      lastSavedTime: Date.now() - Math.floor(RECENT_SAVE_EXTERNAL_RELOAD_GRACE_MS / 2),
+    });
+    tabsRef = { current: [tab] };
+    const pendingVerifications = new Map<string, ReturnType<typeof setTimeout>>();
+    const readDiskContent = vi.fn(async () => "stale cloud copy before delete");
+    const onChanged = buildOnChanged(tab.id, setTabs, tabsRef, openDiffTab, undefined, undefined, {
+      filePath: "/p/main.mdi",
+      pendingVerifications,
+      readDiskContent,
+    });
+
+    onChanged("stale cloud copy before delete", 2_000_000);
+
+    let latest = tabsRef.current.find((t) => t.id === tab.id);
+    expect(latest && isEditorTab(latest)).toBe(true);
+    if (latest && isEditorTab(latest)) {
+      expect(latest.content).toBe("saved after delete");
+      expect(latest.pendingExternalContent ?? null).toBeNull();
+      expect(latest.fileSyncStatus).toBe("clean");
+      expect(latest.conflictDiskContent).toBeNull();
+    }
+
+    await vi.advanceTimersByTimeAsync(RECENT_SAVE_RECHECK_DELAY_MS);
+
+    latest = tabsRef.current.find((t) => t.id === tab.id);
+    expect(latest && isEditorTab(latest)).toBe(true);
+    if (latest && isEditorTab(latest)) {
+      expect(latest.content).toBe("saved after delete");
+      expect(latest.lastSavedContent).toBe("saved after delete");
+      expect(latest.pendingExternalContent ?? null).toBeNull();
+      expect(latest.fileSyncStatus).toBe("conflicted");
+      expect(latest.conflictDiskContent).toBe("stale cloud copy before delete");
     }
   });
 });

--- a/lib/tab-manager/save-executor.ts
+++ b/lib/tab-manager/save-executor.ts
@@ -285,6 +285,10 @@ export async function executeTabSave(params: ExecuteTabSaveParams): Promise<Save
         : null
       : tab.file;
 
+    if (descriptor?.path) {
+      suppressFileWatch(descriptor.path, sanitized);
+    }
+
     const result = await saveMdiFile({ descriptor, content: sanitized, fileType: tab.fileType });
     if (!result) {
       // User cancelled the save dialog

--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -5,10 +5,11 @@ import { shouldPauseFileWatchers } from "../editor-page/power-policy";
 import { getWindowActivitySnapshot, subscribeWindowActivity } from "../editor-page/window-activity";
 import { createFileWatcher } from "../services/file-watcher";
 import { notificationManager } from "../services/notification-manager";
+import { getProjectFileService } from "../services/project-file-service";
 import { isEditorTab } from "./tab-types";
 import type { WindowActivityState } from "../editor-page/window-activity";
 import type { FileWatcher } from "../services/file-watcher";
-import type { TabId, TabState, EditorTabState, DiffTabState } from "./tab-types";
+import type { TabId, EditorTabState } from "./tab-types";
 import type { TabManagerCore } from "./types";
 import type { SnapshotType } from "../services/history-policy";
 
@@ -64,6 +65,28 @@ export interface UseFileWatchIntegrationParams extends TabManagerCore {
 // ---------------------------------------------------------------------------
 
 /**
+ * Cloud sync clients can briefly echo stale contents immediately after a save.
+ * During this window, a clean tab must not auto-reload differing disk bytes
+ * because that can resurrect content the user just deleted. Quarantine the
+ * first mismatch and re-read the file after a short delay; only persistent
+ * divergence becomes a conflict.
+ */
+export const RECENT_SAVE_EXTERNAL_RELOAD_GRACE_MS = 30_000;
+export const RECENT_SAVE_RECHECK_DELAY_MS = 2_000;
+
+function isWithinRecentSaveGrace(tab: EditorTabState, now: number = Date.now()): boolean {
+  if (!tab.lastSavedTime) return false;
+  const elapsed = now - tab.lastSavedTime;
+  return elapsed >= 0 && elapsed <= RECENT_SAVE_EXTERNAL_RELOAD_GRACE_MS;
+}
+
+interface RecentSaveVerificationOptions {
+  filePath: string;
+  pendingVerifications: Map<TabId, ReturnType<typeof setTimeout>>;
+  readDiskContent: (path: string) => Promise<string>;
+}
+
+/**
  * Build the onChanged callback for an editor tab.
  * Implements the state-transition logic described in issue #825.
  *
@@ -79,6 +102,7 @@ export function buildOnChanged(
   openDiffTab: UseFileWatchIntegrationParams["openDiffTab"],
   onEditorRemountNeeded?: () => void,
   tryCreateSnapshot?: UseFileWatchIntegrationParams["tryCreateSnapshot"],
+  recentSaveVerification?: RecentSaveVerificationOptions,
 ): (diskContent: string, lastModified: number) => void {
   return (diskContent: string, lastModified: number) => {
     const currentTabs = tabsRef.current;
@@ -87,6 +111,13 @@ export function buildOnChanged(
 
     const fileName = tab.file?.name ?? "ファイル";
 
+    const clearPendingRecentSaveVerification = (): void => {
+      const pending = recentSaveVerification?.pendingVerifications.get(tabId);
+      if (!pending) return;
+      clearTimeout(pending);
+      recentSaveVerification?.pendingVerifications.delete(tabId);
+    };
+
     // Self-write echo guard (#1448 Codex review): a save performed while the
     // watchers were paused can outlive the time-boxed suppressFileWatch entry
     // (~poll interval + 3s). When the watcher resumes and reports a "change"
@@ -94,30 +125,16 @@ export function buildOnChanged(
     // echoing back — never a real external change. Reloading it would reset
     // the cursor (clean tab) or raise a phantom conflict (dirty tab).
     if (diskContent === tab.lastSavedContent) {
+      clearPendingRecentSaveVerification();
       return;
     }
 
-    if (tab.fileSyncStatus === "clean") {
-      // Clean tab: auto-reload with disk content via pendingExternalContent
-      // (preserves scroll position instead of remounting the editor)
-      setTabs((prev) =>
-        prev.map((t) => {
-          if (t.id !== tabId || !isEditorTab(t)) return t;
-          return {
-            ...t,
-            content: diskContent,
-            lastSavedContent: diskContent,
-            isDirty: false,
-            fileSyncStatus: "clean",
-            conflictDiskContent: null,
-            pendingExternalContent: diskContent,
-          } satisfies EditorTabState;
-        }),
-      );
-      notificationManager.info(`「${fileName}」が更新されました`, 3000);
-    } else if (tab.fileSyncStatus === "dirty") {
-      // Dirty tab: do NOT touch buffer; enter conflicted state
-      const localContent = tab.content;
+    const enterConflictedState = (
+      localContent: string,
+      conflictDiskContent: string,
+      conflictLastModified: number,
+    ): void => {
+      clearPendingRecentSaveVerification();
 
       // Fix #1562 (b): eagerly mirror the conflicted transition into tabsRef.
       // tabsRef is only reassigned from React state on the next render, so
@@ -128,8 +145,9 @@ export function buildOnChanged(
         if (t.id !== tabId || !isEditorTab(t)) return t;
         return {
           ...t,
+          isDirty: true,
           fileSyncStatus: "conflicted",
-          conflictDiskContent: diskContent,
+          conflictDiskContent,
         } satisfies EditorTabState;
       });
 
@@ -138,8 +156,9 @@ export function buildOnChanged(
           if (t.id !== tabId || !isEditorTab(t)) return t;
           return {
             ...t,
+            isDirty: true,
             fileSyncStatus: "conflicted",
-            conflictDiskContent: diskContent,
+            conflictDiskContent,
           } satisfies EditorTabState;
         }),
       );
@@ -152,7 +171,7 @@ export function buildOnChanged(
           {
             label: "差分を表示",
             onClick: () => {
-              openDiffTab(tabId, fileName, localContent, diskContent, lastModified);
+              openDiffTab(tabId, fileName, localContent, conflictDiskContent, conflictLastModified);
               // Do not clear conflict state; user must explicitly resolve
             },
           },
@@ -181,8 +200,8 @@ export function buildOnChanged(
                   if (t.id !== tabId || !isEditorTab(t)) return t;
                   return {
                     ...t,
-                    content: diskContent,
-                    lastSavedContent: diskContent,
+                    content: conflictDiskContent,
+                    lastSavedContent: conflictDiskContent,
                     isDirty: false,
                     fileSyncStatus: "clean",
                     conflictDiskContent: null,
@@ -200,6 +219,7 @@ export function buildOnChanged(
                   if (t.id !== tabId || !isEditorTab(t)) return t;
                   return {
                     ...t,
+                    isDirty: true,
                     fileSyncStatus: "dirty",
                     conflictDiskContent: null,
                   } satisfies EditorTabState;
@@ -209,6 +229,80 @@ export function buildOnChanged(
           },
         ],
       });
+    };
+
+    const applyCleanExternalReload = (newDiskContent: string): void => {
+      clearPendingRecentSaveVerification();
+
+      // Clean tab: auto-reload with disk content via pendingExternalContent
+      // (preserves scroll position instead of remounting the editor)
+      setTabs((prev) =>
+        prev.map((t) => {
+          if (t.id !== tabId || !isEditorTab(t)) return t;
+          return {
+            ...t,
+            content: newDiskContent,
+            lastSavedContent: newDiskContent,
+            isDirty: false,
+            fileSyncStatus: "clean",
+            conflictDiskContent: null,
+            pendingExternalContent: newDiskContent,
+          } satisfies EditorTabState;
+        }),
+      );
+      notificationManager.info(`「${fileName}」が更新されました`, 3000);
+    };
+
+    const scheduleRecentSaveVerification = (): void => {
+      if (!recentSaveVerification) {
+        enterConflictedState(tab.content, diskContent, lastModified);
+        return;
+      }
+
+      clearPendingRecentSaveVerification();
+
+      const { filePath, pendingVerifications, readDiskContent } = recentSaveVerification;
+      const timer = setTimeout(() => {
+        pendingVerifications.delete(tabId);
+        void (async () => {
+          let confirmedDiskContent = diskContent;
+
+          try {
+            confirmedDiskContent = await readDiskContent(filePath);
+          } catch (error) {
+            console.warn("Failed to re-read file after recent-save watcher mismatch:", error);
+          }
+
+          const latest = tabsRef.current.find((t) => t.id === tabId);
+          if (!latest || !isEditorTab(latest)) return;
+          if (latest.file?.path !== filePath) return;
+          if (latest.fileSyncStatus === "conflicted") return;
+
+          // The cloud client settled back to the bytes we saved. Treat the first
+          // watcher event as transient sync noise and keep the UI quiet.
+          if (confirmedDiskContent === latest.lastSavedContent) {
+            return;
+          }
+
+          if (latest.fileSyncStatus === "clean" || latest.fileSyncStatus === "dirty") {
+            enterConflictedState(latest.content, confirmedDiskContent, lastModified);
+          }
+        })();
+      }, RECENT_SAVE_RECHECK_DELAY_MS);
+
+      pendingVerifications.set(tabId, timer);
+    };
+
+    if (tab.fileSyncStatus === "clean") {
+      if (isWithinRecentSaveGrace(tab)) {
+        scheduleRecentSaveVerification();
+        return;
+      }
+
+      applyCleanExternalReload(diskContent);
+    } else if (tab.fileSyncStatus === "dirty") {
+      // Dirty tab: do NOT touch buffer; enter conflicted state
+      enterConflictedState(tab.content, diskContent, lastModified);
     }
     // If already "conflicted", ignore further disk changes (user must resolve first)
   };
@@ -281,6 +375,9 @@ export function useFileWatchIntegration(params: UseFileWatchIntegrationParams): 
    * Save As 後の path 変更を検出するために使用する。
    */
   const watcherPathsRef = useRef<Map<TabId, string>>(new Map());
+  const pendingRecentSaveVerificationsRef = useRef<Map<TabId, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
 
   /**
    * Whether watchers are currently paused by the window-activity policy
@@ -313,6 +410,11 @@ export function useFileWatchIntegration(params: UseFileWatchIntegrationParams): 
         watcher.stop();
         watchers.delete(tabId);
         watcherPaths.delete(tabId);
+        const pending = pendingRecentSaveVerificationsRef.current.get(tabId);
+        if (pending) {
+          clearTimeout(pending);
+          pendingRecentSaveVerificationsRef.current.delete(tabId);
+        }
       }
     }
 
@@ -332,6 +434,11 @@ export function useFileWatchIntegration(params: UseFileWatchIntegrationParams): 
         existing.stop();
         watchers.delete(tab.id);
         watcherPaths.delete(tab.id);
+        const pending = pendingRecentSaveVerificationsRef.current.get(tab.id);
+        if (pending) {
+          clearTimeout(pending);
+          pendingRecentSaveVerificationsRef.current.delete(tab.id);
+        }
       }
 
       if (!watchers.has(tab.id)) {
@@ -343,6 +450,11 @@ export function useFileWatchIntegration(params: UseFileWatchIntegrationParams): 
           openDiffTab,
           onEditorRemountNeeded,
           tryCreateSnapshot,
+          {
+            filePath,
+            pendingVerifications: pendingRecentSaveVerificationsRef.current,
+            readDiskContent: (path) => getProjectFileService().readFile(path),
+          },
         );
         const watcher = createFileWatcher({ path: filePath, onChanged });
 
@@ -442,12 +554,20 @@ export function useFileWatchIntegration(params: UseFileWatchIntegrationParams): 
   // ---------------------------------------------------------------------------
 
   useEffect(() => {
+    const watchers = watchersRef.current;
+    const watcherPaths = watcherPathsRef.current;
+    const pendingRecentSaveVerifications = pendingRecentSaveVerificationsRef.current;
+
     return () => {
-      for (const watcher of watchersRef.current.values()) {
+      for (const watcher of watchers.values()) {
         watcher.stop();
       }
-      watchersRef.current.clear();
-      watcherPathsRef.current.clear();
+      watchers.clear();
+      watcherPaths.clear();
+      for (const pending of pendingRecentSaveVerifications.values()) {
+        clearTimeout(pending);
+      }
+      pendingRecentSaveVerifications.clear();
     };
   }, []);
 }


### PR DESCRIPTION
## Summary
- suppress file watcher notifications for standalone path saves, matching the project-mode save path
- quarantine differing disk content detected shortly after a save, then re-read the file after 2s before deciding whether it is a real conflict
- quietly ignore Google Drive-style transient stale echoes when the re-read has settled back to the saved content
- add regression coverage for transient stale echoes, persistent mismatches, and standalone suppression ordering

## Verification
- npm run type-check
- npm test -- lib/tab-manager/__tests__/save-lock.test.ts lib/tab-manager/__tests__/save-executor.test.ts lib/tab-manager/__tests__/file-watch-activity-pause.test.tsx lib/tab-manager/__tests__/pre-external-reload-snapshot.test.ts lib/tab-manager/__tests__/auto-save-activity-throttle.test.tsx lib/tab-manager/__tests__/auto-save-sync-status.test.ts lib/tab-manager/__tests__/close-dialog-conflict-guard.test.ts
- npm test
- npm run lint (passes with existing warnings)
- npx prettier --check lib/tab-manager/use-file-watch-integration.ts lib/tab-manager/save-executor.ts lib/tab-manager/__tests__/save-lock.test.ts lib/tab-manager/__tests__/save-executor.test.ts
- git diff --check
