### PR TITLE
fix(export): TXT/DOCX で \[\[blank]] / <br> が空行にならない問題を修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -681,6 +681,11 @@ export default function EditorPage() {
         const result = await window.electronAPI.exportDOCX(dialogState.content, {
           metadata: dialogState.metadata,
           settings,
+          // Thread the active tab's snapshotted file type so the main-process
+          // generateDocx un-escapes macros only for ".mdi". Without this, the
+          // handler defaults to ".mdi" and silently drops author-written
+          // \[\[blank]] literals in ".md"/".txt" on the installed desktop app.
+          fileType: dialogState.fileType,
         });
 
         notificationManager.dismiss(progressId);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -331,6 +331,10 @@ export default function EditorPage() {
   // Stable ref so export / shortcut callbacks can read the current value without re-creating
   const isEditorTabActiveRef = useRef<boolean>(!!activeEditorTab);
   isEditorTabActiveRef.current = !!activeEditorTab;
+  // Stable ref to the active tab's file type, so dialog-request callbacks (deps:
+  // []) can snapshot the true file type for export normalization.
+  const activeFileTypeRef = useRef<SupportedFileExtension>(activeFileType);
+  activeFileTypeRef.current = activeFileType;
 
   // Auto-collapse right panel when all tabs are closed, restore when a tab opens
   const rightPanelUserPrefRef = useRef(isRightPanelCollapsed);
@@ -499,12 +503,21 @@ export default function EditorPage() {
     const name = (tab && isEditorTab(tab) ? tab.file?.name : undefined) ?? "untitled";
     return name.replace(/\.[^.]+$/, "");
   }, [tabs, activeTabId]);
+  // Source of truth for export normalization: the active tab's actual file
+  // type. Read freshly (like getExportTitle) rather than inferred from the
+  // extension-stripped display title.
+  const getExportFileType = useCallback((): SupportedFileExtension => {
+    const tab = tabs.find((t) => t.id === activeTabId);
+    return (tab && isEditorTab(tab) ? tab.fileType : undefined) ?? ".mdi";
+  }, [tabs, activeTabId]);
 
   // Export dialog state (PDF / DOCX share a single state slot)
   interface ExportDialogState {
     format: "pdf" | "docx" | "epub";
     content: string;
     metadata: ExportMetadata;
+    /** Snapshot of the active tab's file type at the moment the dialog opened. */
+    fileType: SupportedFileExtension;
   }
   const [exportDialogState, setExportDialogState] = useState<ExportDialogState | null>(null);
   const exportDialogStateRef = useRef<ExportDialogState | null>(null);
@@ -522,7 +535,12 @@ export default function EditorPage() {
 
   const handleExportDialogRequest = useCallback(
     (format: "pdf" | "docx" | "epub", content: string, metadata: ExportMetadata) => {
-      const state: ExportDialogState = { format, content, metadata };
+      const state: ExportDialogState = {
+        format,
+        content,
+        metadata,
+        fileType: activeFileTypeRef.current,
+      };
       exportDialogStateRef.current = state;
       setExportDialogState(state);
     },
@@ -692,16 +710,14 @@ export default function EditorPage() {
 
     try {
       const { generateDocxBlob } = await import("@/lib/export/docx-exporter");
-      // Derive file type from the document title so macro un-escaping only
-      // applies to ".mdi" documents (DATA-LOSS guard for ".md"/".txt" authors).
-      const docTitle = dialogState.metadata.title ?? "";
-      const docExtMatch = /\.([^.]+)$/.exec(docTitle);
-      const docTitleExt = docExtMatch ? `.${docExtMatch[1].toLowerCase()}` : ".mdi";
-      const docFileType = [".mdi", ".md", ".txt"].includes(docTitleExt) ? docTitleExt : ".mdi";
+      // Use the active tab's actual file type (snapshotted when the dialog
+      // opened) so macro un-escaping only applies to ".mdi" documents. Inferring
+      // from the title is wrong — the display title is extension-stripped, which
+      // would silently drop author-written \[\[blank]] literals in ".md"/".txt".
       const blob = await generateDocxBlob(dialogState.content, {
         metadata: dialogState.metadata,
         settings,
-        fileType: docFileType,
+        fileType: dialogState.fileType,
       });
       const baseName = (dialogState.metadata.title || "untitled").replace(/\.[^.]+$/, "");
       const { saveBlobFile } = await import("@/lib/export/save-blob-file");
@@ -786,6 +802,7 @@ export default function EditorPage() {
   const { exportAs, printDocument } = useExport({
     getContent: getExportContent,
     getTitle: getExportTitle,
+    getFileType: getExportFileType,
     getIsEditorTabActive: useCallback(() => isEditorTabActiveRef.current, []),
     onExportDialogRequest: handleExportDialogRequest,
     onPrintDialogRequest: handlePrintDialogRequest,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -692,9 +692,16 @@ export default function EditorPage() {
 
     try {
       const { generateDocxBlob } = await import("@/lib/export/docx-exporter");
+      // Derive file type from the document title so macro un-escaping only
+      // applies to ".mdi" documents (DATA-LOSS guard for ".md"/".txt" authors).
+      const docTitle = dialogState.metadata.title ?? "";
+      const docExtMatch = /\.([^.]+)$/.exec(docTitle);
+      const docTitleExt = docExtMatch ? `.${docExtMatch[1].toLowerCase()}` : ".mdi";
+      const docFileType = [".mdi", ".md", ".txt"].includes(docTitleExt) ? docTitleExt : ".mdi";
       const blob = await generateDocxBlob(dialogState.content, {
         metadata: dialogState.metadata,
         settings,
+        fileType: docFileType,
       });
       const baseName = (dialogState.metadata.title || "untitled").replace(/\.[^.]+$/, "");
       const { saveBlobFile } = await import("@/lib/export/save-blob-file");

--- a/lib/export/__tests__/blank-paragraph-export.test.ts
+++ b/lib/export/__tests__/blank-paragraph-export.test.ts
@@ -197,3 +197,75 @@ describe("export — fileType preservation guard (.md/.txt)", () => {
     });
   });
 });
+
+// Regression for Codex P3: `fromEditorOutput` normalizes editor-injected HTML
+// (rewrites standalone/inline `<br>` and strips paired HTML tags like `<p>`)
+// regardless of fileType — only MDI macro un-escaping was gated on ".mdi".
+// For non-".mdi" exports the content is raw authored text, so this normalization
+// is a regression: a literal `<br />` became a newline and `<p>x</p>` lost its
+// tags. Non-".mdi" exports must go through `fromRawText` and preserve literals.
+describe("export — non-.mdi preserves literal editor HTML (Codex P3)", () => {
+  describe("txt exporter", () => {
+    it(".txt: literal <br /> is PRESERVED (not turned into a newline)", () => {
+      const txt = mdiToPlainText("行1<br />行2", ".txt");
+      // The literal tag must survive verbatim; it must NOT be rewritten to a
+      // line break that splits 行1 / 行2 onto separate lines.
+      expect(txt).toContain("<br />");
+      expect(txt).toContain("行1<br />行2");
+    });
+
+    it(".md: literal <p>x</p> is PRESERVED (tags not stripped)", () => {
+      const txt = mdiToPlainText("前<p>中</p>後", ".md");
+      expect(txt).toContain("<p>中</p>");
+    });
+
+    it(".mdi: standalone <br /> still normalizes to a blank line (unchanged)", () => {
+      const txt = mdiToPlainText("A段落\n\n<br />\n\nB段落", ".mdi");
+      expect(txt).not.toContain("<br");
+    });
+
+    it(".mdi: <p>x</p> tags are still stripped (unchanged)", () => {
+      const txt = mdiToPlainText("<p>本文</p>", ".mdi");
+      expect(txt).not.toContain("<p>");
+      expect(txt).not.toContain("</p>");
+      expect(txt).toContain("本文");
+    });
+  });
+
+  describe("docx exporter", () => {
+    it(".txt: literal <br /> survives into the docx text run (not a <w:br/>)", async () => {
+      const blob = await generateDocxBlob("行1<br />行2", {
+        metadata: { title: "story.txt", language: "ja" },
+        fileType: ".txt",
+      });
+      const unzipped = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+      const documentXml = strFromU8(unzipped["word/document.xml"]!);
+      // The literal angle-bracket tag is preserved as text (XML-escaped).
+      expect(documentXml).toContain("&lt;br /&gt;");
+      // No explicit line break should have been emitted from the literal tag.
+      expect(documentXml).not.toContain("<w:br/>");
+    });
+
+    it(".md: literal <p>x</p> tags are preserved as text (not stripped)", async () => {
+      const blob = await generateDocxBlob("前<p>中</p>後", {
+        metadata: { title: "note.md", language: "ja" },
+        fileType: ".md",
+      });
+      const unzipped = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+      const documentXml = strFromU8(unzipped["word/document.xml"]!);
+      expect(documentXml).toContain("&lt;p&gt;");
+      expect(documentXml).toContain("&lt;/p&gt;");
+    });
+
+    it(".mdi: <p>x</p> tags are still stripped (unchanged)", async () => {
+      const blob = await generateDocxBlob("<p>本文</p>", {
+        metadata: { title: "novel.mdi", language: "ja" },
+        fileType: ".mdi",
+      });
+      const unzipped = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+      const documentXml = strFromU8(unzipped["word/document.xml"]!);
+      expect(documentXml).not.toContain("&lt;p&gt;");
+      expect(documentXml).toContain("本文");
+    });
+  });
+});

--- a/lib/export/__tests__/blank-paragraph-export.test.ts
+++ b/lib/export/__tests__/blank-paragraph-export.test.ts
@@ -64,3 +64,38 @@ describe("docx exporter — [[blank]] paragraph handling", () => {
     expect(documentXml).toContain("B");
   });
 });
+
+// Regression for Bug B: the Milkdown serializer escapes MDI bracket macros
+// (`[[blank]]` → `\[\[blank]]`) and may emit standalone `<br />`. Export takes
+// the live serializer output, so it must normalize these before the
+// marker-aware pipeline runs — otherwise they leak into the output verbatim.
+describe("export — serializer-escaped blank markers (Bug B)", () => {
+  it("txt: \\[\\[blank]] (escaped) → forced blank line, no leak", () => {
+    const txt = mdiToPlainText("A段落\n\n\\[\\[blank]]\n\nB段落");
+    expect(txt).not.toContain("[[blank]]");
+    expect(txt).not.toContain("\\[");
+    const lines = txt.split("\n");
+    const aIdx = lines.findIndex((l) => l.includes("A段落"));
+    const bIdx = lines.findIndex((l) => l.includes("B段落"));
+    expect(aIdx).toBeGreaterThanOrEqual(0);
+    expect(bIdx).toBeGreaterThan(aIdx);
+    expect(lines.slice(aIdx + 1, bIdx).some((l) => l.trim() === "")).toBe(true);
+  });
+
+  it("txt: standalone <br /> → blank line, no leak", () => {
+    const txt = mdiToPlainText("A段落\n\n<br />\n\nB段落");
+    expect(txt).not.toContain("<br");
+  });
+
+  it("docx: \\[\\[blank]] (escaped) → empty <w:p>, no leak", async () => {
+    const blob = await generateDocxBlob("A\n\n\\[\\[blank]]\n\nB", {
+      metadata: { title: "テスト", language: "ja" },
+    });
+    const unzipped = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+    const documentXml = strFromU8(unzipped["word/document.xml"]!);
+    expect(documentXml).not.toContain("[[blank]]");
+    expect(documentXml).not.toContain("\\[");
+    expect(documentXml).toContain("A");
+    expect(documentXml).toContain("B");
+  });
+});

--- a/lib/export/__tests__/blank-paragraph-export.test.ts
+++ b/lib/export/__tests__/blank-paragraph-export.test.ts
@@ -99,3 +99,101 @@ describe("export — serializer-escaped blank markers (Bug B)", () => {
     expect(documentXml).toContain("B");
   });
 });
+
+// Regression for DATA-LOSS guard (Codex P2): for ".md"/".txt" documents, an
+// author's intentionally-escaped literal `\[\[blank]]` must NOT be promoted to
+// a blank line by the exporter. Only ".mdi" documents apply macro un-escaping.
+describe("export — fileType preservation guard (.md/.txt)", () => {
+  describe("txt exporter", () => {
+    it(".md: \\[\\[blank]] (serializer-escaped) → literal [[blank]] in output, NOT a blank line", () => {
+      // Simulates a .md author who literally typed \[\[blank]] — it should
+      // survive export as the text "[[blank]]", not be silently blanked.
+      const txt = mdiToPlainText("A段落\n\n\\[\\[blank]]\n\nB段落", ".md");
+      // The escaped bracket becomes literal [[blank]] text (backslash stripped
+      // by stripMarkdown's escape handler) — it must not vanish as a blank line.
+      expect(txt).toContain("[[blank]]");
+      // No forced blank line should have been inserted between A and B
+      const lines = txt.split("\n");
+      const aIdx = lines.findIndex((l) => l.includes("A段落"));
+      const bIdx = lines.findIndex((l) => l.includes("B段落"));
+      expect(aIdx).toBeGreaterThanOrEqual(0);
+      expect(bIdx).toBeGreaterThan(aIdx);
+      // There must be no blank line between them (the [[blank]] line is text, not a separator)
+      const between = lines.slice(aIdx + 1, bIdx);
+      expect(between.every((l) => l.trim() !== "")).toBe(true);
+    });
+
+    it(".txt: \\[\\[blank]] (serializer-escaped) → literal [[blank]] in output, NOT a blank line", () => {
+      const txt = mdiToPlainText("段落1\n\n\\[\\[blank]]\n\n段落2", ".txt");
+      expect(txt).toContain("[[blank]]");
+      const lines = txt.split("\n");
+      const idx1 = lines.findIndex((l) => l.includes("段落1"));
+      const idx2 = lines.findIndex((l) => l.includes("段落2"));
+      expect(idx1).toBeGreaterThanOrEqual(0);
+      expect(idx2).toBeGreaterThan(idx1);
+      const between = lines.slice(idx1 + 1, idx2);
+      expect(between.every((l) => l.trim() !== "")).toBe(true);
+    });
+
+    it(".mdi: \\[\\[blank]] (serializer-escaped) → still becomes blank line (existing behavior unchanged)", () => {
+      const txt = mdiToPlainText("A段落\n\n\\[\\[blank]]\n\nB段落", ".mdi");
+      expect(txt).not.toContain("[[blank]]");
+      expect(txt).not.toContain("\\[");
+      const lines = txt.split("\n");
+      const aIdx = lines.findIndex((l) => l.includes("A段落"));
+      const bIdx = lines.findIndex((l) => l.includes("B段落"));
+      expect(aIdx).toBeGreaterThanOrEqual(0);
+      expect(bIdx).toBeGreaterThan(aIdx);
+      expect(lines.slice(aIdx + 1, bIdx).some((l) => l.trim() === "")).toBe(true);
+    });
+  });
+
+  describe("docx exporter", () => {
+    it(".md: \\[\\[blank]] → preserved as text paragraph, no blank <w:p> inserted", async () => {
+      // For a .md document the author typed \[\[blank]] as a literal escape.
+      // fromEditorOutput skips Step 0 (macro un-escaping), so the raw text
+      // stays as \[\[blank]]. parseMarkdownToDocxParagraphs does not strip
+      // backslash escapes, so the text appears verbatim in the DOCX paragraph —
+      // crucially as a *text* run, not as an empty blank paragraph.
+      const blob = await generateDocxBlob("A\n\n\\[\\[blank]]\n\nB", {
+        metadata: { title: "test.md", language: "ja" },
+        fileType: ".md",
+      });
+      const unzipped = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+      const documentXml = strFromU8(unzipped["word/document.xml"]!);
+      // The escaped text appears as a text run in a paragraph (DATA-LOSS guard:
+      // the content must NOT silently become an empty blank <w:p>).
+      // The docx XML will contain the literal backslash-bracket sequence.
+      expect(documentXml).toContain("\\[\\[blank]]");
+      // Exactly 3 content paragraphs: A, \[\[blank]] text, B
+      // (NOT 4, which would indicate an extra blank paragraph was inserted).
+      const pCount = (documentXml.match(/<w:p[\s>]/g) ?? []).length;
+      expect(pCount).toBe(3);
+    });
+
+    it(".txt: \\[\\[blank]] → preserved as text paragraph, no blank <w:p> inserted", async () => {
+      const blob = await generateDocxBlob("段落1\n\n\\[\\[blank]]\n\n段落2", {
+        metadata: { title: "story.txt", language: "ja" },
+        fileType: ".txt",
+      });
+      const unzipped = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+      const documentXml = strFromU8(unzipped["word/document.xml"]!);
+      expect(documentXml).toContain("\\[\\[blank]]");
+      const pCount = (documentXml.match(/<w:p[\s>]/g) ?? []).length;
+      expect(pCount).toBe(3);
+    });
+
+    it(".mdi: \\[\\[blank]] → empty <w:p> (existing behavior unchanged)", async () => {
+      const blob = await generateDocxBlob("A\n\n\\[\\[blank]]\n\nB", {
+        metadata: { title: "novel.mdi", language: "ja" },
+        fileType: ".mdi",
+      });
+      const unzipped = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+      const documentXml = strFromU8(unzipped["word/document.xml"]!);
+      expect(documentXml).not.toContain("[[blank]]");
+      expect(documentXml).not.toContain("\\[");
+      const pCount = (documentXml.match(/<w:p[\s>]/g) ?? []).length;
+      expect(pCount).toBeGreaterThanOrEqual(3);
+    });
+  });
+});

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -40,6 +40,13 @@ import type { DocxExportSettings, DocxFontConfig } from "./docx-export-settings"
 export interface DocxExportOptions {
   metadata: ExportMetadata;
   settings?: DocxExportSettings;
+  /**
+   * Active document file extension (".mdi" | ".md" | ".txt").
+   * Defaults to ".mdi". Non-MDI types skip macro un-escaping in
+   * `fromEditorOutput` so that an author's intentional literal
+   * `\[\[blank]]` is not silently promoted to a blank line (DATA-LOSS guard).
+   */
+  fileType?: string;
 }
 
 /**
@@ -53,7 +60,12 @@ function buildDocxDocument(content: string, options: DocxExportOptions): Documen
   // Normalize editor serializer output (un-escape `\[\[blank]]` macros and
   // `<br />`) so blank paragraphs become real empty paragraphs instead of
   // leaking the literal marker into the .docx. Idempotent on clean raw text.
-  const normalized = MdiDocument.fromEditorOutput(content, { fileType: ".mdi" }).toRawText();
+  // fileType controls whether macro un-escaping runs: ".mdi" → normalize;
+  // ".md"/".txt" → preserve escaped literals to prevent DATA-LOSS for authors
+  // who literally typed `\[\[blank]]` in a non-MDI document.
+  const normalized = MdiDocument.fromEditorOutput(content, {
+    fileType: options.fileType ?? ".mdi",
+  }).toRawText();
   const paragraphs = parseMarkdownToDocxParagraphs(normalized, settings, fontConfig);
 
   // Page dimensions (swap for landscape)

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -57,15 +57,19 @@ function buildDocxDocument(content: string, options: DocxExportOptions): Documen
   const { metadata } = options;
   const settings = options.settings ? sanitizeSettings(options.settings) : DEFAULT_DOCX_SETTINGS;
   const fontConfig = toDocxFont(settings.fontFamily);
-  // Normalize editor serializer output (un-escape `\[\[blank]]` macros and
-  // `<br />`) so blank paragraphs become real empty paragraphs instead of
-  // leaking the literal marker into the .docx. Idempotent on clean raw text.
-  // fileType controls whether macro un-escaping runs: ".mdi" → normalize;
-  // ".md"/".txt" → preserve escaped literals to prevent DATA-LOSS for authors
-  // who literally typed `\[\[blank]]` in a non-MDI document.
-  const normalized = MdiDocument.fromEditorOutput(content, {
-    fileType: options.fileType ?? ".mdi",
-  }).toRawText();
+  // Branch on fileType to pick the source pipeline:
+  // - ".mdi": `content` is the live editor serializer output, so normalize it
+  //   via `fromEditorOutput` (un-escape `\[\[blank]]` macros, rewrite `<br />`,
+  //   strip editor-injected HTML) so blank paragraphs become real empty
+  //   paragraphs instead of leaking the literal marker into the .docx.
+  // - non-".mdi" (".md"/".txt"/...): `content` is raw authored text. Use
+  //   `fromRawText` so NO editor-HTML normalization runs — literal `<br />`,
+  //   `<p>x</p>`, `\[\[blank]]` are preserved verbatim (DATA-LOSS guard).
+  const fileType = options.fileType ?? ".mdi";
+  const normalized =
+    fileType === ".mdi"
+      ? MdiDocument.fromEditorOutput(content, { fileType: ".mdi" }).toRawText()
+      : MdiDocument.fromRawText(content).toRawText();
   const paragraphs = parseMarkdownToDocxParagraphs(normalized, settings, fontConfig);
 
   // Page dimensions (swap for landscape)

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -18,6 +18,7 @@ import {
   TextDirection,
 } from "docx";
 import {
+  MdiDocument,
   replaceMdiWithRubyText,
   MDI_BREAK_RE,
   isMdiBlankParagraphLine,
@@ -49,7 +50,11 @@ function buildDocxDocument(content: string, options: DocxExportOptions): Documen
   const { metadata } = options;
   const settings = options.settings ? sanitizeSettings(options.settings) : DEFAULT_DOCX_SETTINGS;
   const fontConfig = toDocxFont(settings.fontFamily);
-  const paragraphs = parseMarkdownToDocxParagraphs(content, settings, fontConfig);
+  // Normalize editor serializer output (un-escape `\[\[blank]]` macros and
+  // `<br />`) so blank paragraphs become real empty paragraphs instead of
+  // leaking the literal marker into the .docx. Idempotent on clean raw text.
+  const normalized = MdiDocument.fromEditorOutput(content, { fileType: ".mdi" }).toRawText();
+  const paragraphs = parseMarkdownToDocxParagraphs(normalized, settings, fontConfig);
 
   // Page dimensions (swap for landscape)
   const baseDims = PAGE_DIMENSIONS[settings.pageSize] ?? PAGE_DIMENSIONS["A5"];

--- a/lib/export/txt-exporter.ts
+++ b/lib/export/txt-exporter.ts
@@ -22,15 +22,24 @@ import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-docum
  * the macros and normalizes `<br />` before the marker-aware export pipeline
  * runs (otherwise `[[blank]]` / `<br />` leak into the .txt). `fromEditorOutput`
  * is idempotent on already-clean raw text, so on-disk content is unaffected.
+ *
+ * @param content - Milkdown/ProseMirror serializer output
+ * @param fileType - Active document file extension (".mdi" | ".md" | ".txt").
+ *   Defaults to ".mdi". Non-MDI types skip macro un-escaping so that an
+ *   author's intentional literal `\[\[blank]]` is not silently promoted to a
+ *   blank line (DATA-LOSS guard).
  */
-export function mdiToPlainText(content: string): string {
-  return MdiDocument.fromEditorOutput(content, { fileType: ".mdi" }).toExportText("txt");
+export function mdiToPlainText(content: string, fileType: string = ".mdi"): string {
+  return MdiDocument.fromEditorOutput(content, { fileType }).toExportText("txt");
 }
 
 /**
  * Convert MDI markdown to text with ruby in fullwidth parentheses.
  * Example: {漢字|かんじ} → 漢字（かんじ）
+ *
+ * @param content - Milkdown/ProseMirror serializer output
+ * @param fileType - Active document file extension. See {@link mdiToPlainText}.
  */
-export function mdiToRubyText(content: string): string {
-  return MdiDocument.fromEditorOutput(content, { fileType: ".mdi" }).toExportText("txt-ruby");
+export function mdiToRubyText(content: string, fileType: string = ".mdi"): string {
+  return MdiDocument.fromEditorOutput(content, { fileType }).toExportText("txt-ruby");
 }

--- a/lib/export/txt-exporter.ts
+++ b/lib/export/txt-exporter.ts
@@ -15,9 +15,16 @@ import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-docum
 /**
  * Convert MDI markdown to plain text without ruby annotations.
  * Strips all MDI syntax and markdown formatting.
+ *
+ * `content` is the live editor serializer output, where the Milkdown markdown
+ * serializer escapes MDI bracket macros (`[[blank]]` → `\[\[blank]]`) and may
+ * emit `<br />`. We therefore go through `fromEditorOutput`, which un-escapes
+ * the macros and normalizes `<br />` before the marker-aware export pipeline
+ * runs (otherwise `[[blank]]` / `<br />` leak into the .txt). `fromEditorOutput`
+ * is idempotent on already-clean raw text, so on-disk content is unaffected.
  */
 export function mdiToPlainText(content: string): string {
-  return MdiDocument.fromRawText(content).toExportText("txt");
+  return MdiDocument.fromEditorOutput(content, { fileType: ".mdi" }).toExportText("txt");
 }
 
 /**
@@ -25,5 +32,5 @@ export function mdiToPlainText(content: string): string {
  * Example: {漢字|かんじ} → 漢字（かんじ）
  */
 export function mdiToRubyText(content: string): string {
-  return MdiDocument.fromRawText(content).toExportText("txt-ruby");
+  return MdiDocument.fromEditorOutput(content, { fileType: ".mdi" }).toExportText("txt-ruby");
 }

--- a/lib/export/txt-exporter.ts
+++ b/lib/export/txt-exporter.ts
@@ -13,33 +13,46 @@
 import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 
 /**
+ * Build the source MDI document for an export, branching on file type.
+ *
+ * - `.mdi`: `content` is the live editor serializer output. The Milkdown
+ *   markdown serializer escapes MDI bracket macros (`[[blank]]` → `\[\[blank]]`)
+ *   and may emit `<br />` / wrap content in HTML tags. We therefore go through
+ *   `fromEditorOutput({ fileType: ".mdi" })`, which un-escapes the macros and
+ *   normalizes editor-injected HTML before the marker-aware pipeline runs
+ *   (otherwise `[[blank]]` / `<br />` leak into the export).
+ * - Non-`.mdi` (`.md` / `.txt` / anything else): `content` is plain authored
+ *   text. We use `fromRawText`, which applies NO normalization — literal
+ *   `<br />`, `<p>x</p>`, `\[\[blank]]` are preserved verbatim (DATA-LOSS guard:
+ *   the editor-HTML rewrites in `fromEditorOutput` are MDI-only).
+ */
+function buildExportDocument(content: string, fileType: string): MdiDocument {
+  return fileType === ".mdi"
+    ? MdiDocument.fromEditorOutput(content, { fileType: ".mdi" })
+    : MdiDocument.fromRawText(content);
+}
+
+/**
  * Convert MDI markdown to plain text without ruby annotations.
  * Strips all MDI syntax and markdown formatting.
  *
- * `content` is the live editor serializer output, where the Milkdown markdown
- * serializer escapes MDI bracket macros (`[[blank]]` → `\[\[blank]]`) and may
- * emit `<br />`. We therefore go through `fromEditorOutput`, which un-escapes
- * the macros and normalizes `<br />` before the marker-aware export pipeline
- * runs (otherwise `[[blank]]` / `<br />` leak into the .txt). `fromEditorOutput`
- * is idempotent on already-clean raw text, so on-disk content is unaffected.
- *
- * @param content - Milkdown/ProseMirror serializer output
+ * @param content - Milkdown/ProseMirror serializer output (`.mdi`) or raw
+ *   authored text (non-`.mdi`)
  * @param fileType - Active document file extension (".mdi" | ".md" | ".txt").
- *   Defaults to ".mdi". Non-MDI types skip macro un-escaping so that an
- *   author's intentional literal `\[\[blank]]` is not silently promoted to a
- *   blank line (DATA-LOSS guard).
+ *   Defaults to ".mdi". See {@link buildExportDocument} for the branch rationale.
  */
 export function mdiToPlainText(content: string, fileType: string = ".mdi"): string {
-  return MdiDocument.fromEditorOutput(content, { fileType }).toExportText("txt");
+  return buildExportDocument(content, fileType).toExportText("txt");
 }
 
 /**
  * Convert MDI markdown to text with ruby in fullwidth parentheses.
  * Example: {漢字|かんじ} → 漢字（かんじ）
  *
- * @param content - Milkdown/ProseMirror serializer output
+ * @param content - Milkdown/ProseMirror serializer output (`.mdi`) or raw
+ *   authored text (non-`.mdi`)
  * @param fileType - Active document file extension. See {@link mdiToPlainText}.
  */
 export function mdiToRubyText(content: string, fileType: string = ".mdi"): string {
-  return MdiDocument.fromEditorOutput(content, { fileType }).toExportText("txt-ruby");
+  return buildExportDocument(content, fileType).toExportText("txt-ruby");
 }

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -7,6 +7,7 @@ import { saveBlobFile } from "./save-blob-file";
 import { mdiToPlainText, mdiToRubyText } from "./txt-exporter";
 import { openWebPrintPreview } from "./web-print-preview";
 import { loadExportSettings, toPdfExportSettings } from "./export-settings";
+import type { SupportedFileExtension } from "@/lib/project/project-types";
 import type { ExportFormat, ExportMetadata } from "./types";
 
 interface UseExportParams {
@@ -14,6 +15,13 @@ interface UseExportParams {
   getContent: () => string;
   /** Returns the document title (file name or fallback) */
   getTitle: () => string;
+  /**
+   * Returns the active editor tab's file type (".mdi" | ".md" | ".txt").
+   * This is the source of truth for export normalization — it must NOT be
+   * inferred from the display title, which is extension-stripped. Defaults
+   * to ".mdi" when no editor tab is active.
+   */
+  getFileType: () => SupportedFileExtension;
   /** Returns true when the active tab is an editor tab.
    *  Export operations no-op when false (e.g. terminal or diff tab is active). */
   getIsEditorTabActive: () => boolean;
@@ -38,6 +46,7 @@ interface UseExportParams {
 export function useExport({
   getContent,
   getTitle,
+  getFileType,
   getIsEditorTabActive,
   onExportDialogRequest,
   onPrintDialogRequest,
@@ -61,12 +70,11 @@ export function useExport({
       const title = getTitle();
       const metadata = { title, language: "ja" };
 
-      // Derive the active document's file type from the title extension.
-      // Default to ".mdi" (novel document) when the extension is absent or
-      // unrecognised — this preserves existing behaviour for MDI documents.
-      const extMatch = /\.([^.]+)$/.exec(title);
-      const titleExt = extMatch ? `.${extMatch[1].toLowerCase()}` : ".mdi";
-      const fileType = [".mdi", ".md", ".txt"].includes(titleExt) ? titleExt : ".mdi";
+      // Source of truth for export normalization: the active tab's actual file
+      // type. Must NOT be inferred from the display title, which is
+      // extension-stripped (would always fall back to ".mdi" and silently drop
+      // author-written \[\[blank]] / <br> literals in ".md" / ".txt" docs).
+      const fileType = getFileType();
 
       const formatLabels: Record<ExportFormat, string> = {
         pdf: "PDF",
@@ -161,7 +169,7 @@ export function useExport({
         notificationManager.error(`${label}のエクスポートに失敗しました: ${message}`);
       }
     },
-    [getContent, getTitle, getIsEditorTabActive, isElectron, onExportDialogRequest],
+    [getContent, getTitle, getFileType, getIsEditorTabActive, isElectron, onExportDialogRequest],
   );
 
   const printDocument = useCallback(() => {

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -61,6 +61,13 @@ export function useExport({
       const title = getTitle();
       const metadata = { title, language: "ja" };
 
+      // Derive the active document's file type from the title extension.
+      // Default to ".mdi" (novel document) when the extension is absent or
+      // unrecognised — this preserves existing behaviour for MDI documents.
+      const extMatch = /\.([^.]+)$/.exec(title);
+      const titleExt = extMatch ? `.${extMatch[1].toLowerCase()}` : ".mdi";
+      const fileType = [".mdi", ".md", ".txt"].includes(titleExt) ? titleExt : ".mdi";
+
       const formatLabels: Record<ExportFormat, string> = {
         pdf: "PDF",
         epub: "EPUB",
@@ -77,7 +84,8 @@ export function useExport({
         });
 
         try {
-          const converted = format === "txt" ? mdiToPlainText(content) : mdiToRubyText(content);
+          const converted =
+            format === "txt" ? mdiToPlainText(content, fileType) : mdiToRubyText(content, fileType);
 
           const baseName = title.replace(/\.(mdi|md|txt)$/i, "");
           const suffix = format === "txt-ruby" ? "_ruby" : "";
@@ -106,7 +114,7 @@ export function useExport({
 
       // --- Web mode: browser-side export ---
       if (!isElectron || !window.electronAPI) {
-        await exportAsWeb(format, content, title, metadata, label);
+        await exportAsWeb(format, content, title, metadata, label, fileType);
         return;
       }
 
@@ -218,6 +226,7 @@ async function exportAsWeb(
   title: string,
   metadata: ExportMetadata,
   label: string,
+  fileType: string = ".mdi",
 ): Promise<void> {
   const baseName = title.replace(/\.(mdi|md|txt)$/i, "");
 
@@ -247,7 +256,7 @@ async function exportAsWeb(
     switch (format) {
       case "docx": {
         const { generateDocxBlob } = await import("./docx-exporter");
-        blob = await generateDocxBlob(content, { metadata });
+        blob = await generateDocxBlob(content, { metadata, fileType });
         suggestedName = `${baseName}.docx`;
         break;
       }

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -146,7 +146,10 @@ export function useExport({
             result = await window.electronAPI.exportEPUB?.(content, { metadata });
             break;
           case "docx":
-            result = await window.electronAPI.exportDOCX?.(content, { metadata });
+            // Thread the active tab's file type so the main-process generateDocx
+            // un-escapes macros only for ".mdi" and preserves \[\[blank]] literals
+            // authored in ".md"/".txt". Otherwise the handler defaults to ".mdi".
+            result = await window.electronAPI.exportDOCX?.(content, { metadata, fileType });
             break;
         }
 

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -101,6 +101,9 @@ declare global {
           textIndent?: number;
           showPageNumbers?: boolean;
         };
+        // Active tab's file type. The main-process generateDocx un-escapes MDI
+        // macros only for ".mdi"; absent/unknown falls back to ".mdi".
+        fileType?: import("@/lib/project/project-types").SupportedFileExtension;
       },
     ) => Promise<string | { success: false; error: string } | null>;
     printDocument?: (


### PR DESCRIPTION
## 背景

実作品 `花様年華` を TXT 書き出しすると、`[[blank]]`（空白段落マーカー）が空行に変換されず **文字列のまま 18 個残留**し、単独 `<br />` も素通りしていた（仕様 `docs/MDI/spec.md` §6.2「TXT → 空行」違反）。DOCX も同様。

## 根本原因

TXT/DOCX エクスポートは `getContent()`（**エディタの Milkdown serializer 出力**）を `MdiDocument.fromRawText()` で処理していた。ところが serializer は CommonMark のリンク記法と衝突しないよう MDI bracket macro の先頭 `[` を **エスケープ**して出力する：

- `[[blank]]` → `\[\[blank]]`
- 単独空白段落 → `<br />` になる場合もある

`fromRawText` は正規化を行わないため、`isMdiBlankParagraphLine` の正規表現 `/^\[\[blank\]\].../ ` が先頭の `\` にマッチせず、空行化されずに残っていた。

（実バイト確認: serializer 出力で `\[\[blank]]`、現行 TXT で `[[blank]]` 18 個）

## 修正

`fromRawText` → `fromEditorOutput(content, { fileType: ".mdi" })` に変更。`normalizeEditorOutput` の Step 0/1 がエスケープ解除（`\[\[blank]]` → `[[blank]]`）と `<br />` 正規化を行ってから marker-aware パイプラインに渡す。**clean な raw text には冪等**なので既存挙動は不変（既存テスト全 pass）。

- `lib/export/txt-exporter.ts` — `mdiToPlainText` / `mdiToRubyText`
- `lib/export/docx-exporter.ts` — `buildDocxDocument` 入口で正規化

## テスト

回帰テスト 3 件追加（`lib/export/__tests__/blank-paragraph-export.test.ts`）：
- txt: escaped `\[\[blank]]` → 強制空行・リーク無し
- txt: standalone `<br />` → 空行・リーク無し
- docx: escaped `\[\[blank]]` → 空 `<w:p>`・リーク無し

export 関連テスト **88 件 all green** / `tsc --noEmit` クリーン。

## 関連 issue
関連 issue なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)