### PR TITLE
fix(editor): コピー時に生MDIではなく純テキストを出力

### DIFF
--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -243,6 +243,9 @@ export default function MilkdownEditor({
           enableRuby: mdiExtensionsEnabled,
           enableTcy: mdiExtensionsEnabled,
           enableMdiBreak: mdiExtensionsEnabled,
+          // .txt: characters like *, #, ** are literal — copy must bypass
+          // markdown stripping / MDI conversion (P2-A).
+          plainText: isPlainText,
         }),
       );
 

--- a/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
@@ -6,8 +6,10 @@ import { describe, it, expect, afterEach } from "vitest";
 import { Editor, rootCtx, defaultValueCtx, editorViewCtx } from "@milkdown/core";
 import { commonmark } from "@milkdown/preset-commonmark";
 import { clipboard } from "@milkdown/plugin-clipboard";
+import { $remark } from "@milkdown/utils";
 import type { EditorView } from "@milkdown/prose/view";
 import { japaneseNovel } from "../index";
+import { remarkPlainTextPlugin } from "../syntax/remark-plain-text";
 
 const mountedRoots: HTMLElement[] = [];
 afterEach(() => {
@@ -97,6 +99,43 @@ async function makeViewRubyOnly(markdown: string): Promise<{ editor: Editor; vie
         enableNoBreak: false,
         enableKern: false,
         enableMdiBreak: false,
+      }),
+    )
+    .create();
+  let view!: EditorView;
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx);
+  });
+  return { editor, view };
+}
+
+/**
+ * Plain-text (.txt) mode: mirrors MilkdownEditor for `.txt` documents — all MDI
+ * features disabled, `remarkPlainTextPlugin` installed so `*` / `#` / `**` are
+ * LITERAL characters, and `plainText: true` so the clipboard serializer bypasses
+ * markdown stripping / MDI conversion entirely (P2-A).
+ */
+async function makeViewPlainText(source: string): Promise<{ editor: Editor; view: EditorView }> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  mountedRoots.push(root);
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, source);
+    })
+    .use(commonmark)
+    .use($remark("plainText", () => remarkPlainTextPlugin))
+    .use(
+      japaneseNovel({
+        isVertical: false,
+        showManuscriptLine: false,
+        enableRuby: false,
+        enableTcy: false,
+        enableNoBreak: false,
+        enableKern: false,
+        enableMdiBreak: false,
+        plainText: true,
       }),
     )
     .create();
@@ -304,5 +343,70 @@ describe("clipboard text serializer — P2-2: CommonMark escape leak", () => {
     await editor.destroy();
     expect(text).not.toContain("\\\\");
     expect(text).toContain("C:\\Users\\name");
+  });
+});
+
+describe("clipboard text serializer — P2-A: plain-text (.txt) mode bypass", () => {
+  it("**literal** is copied verbatim (markdown stripping bypassed)", async () => {
+    const { editor, view } = await makeViewPlainText("**literal**");
+    const text = copyAll(view);
+    await editor.destroy();
+    // In .txt mode `**` is a literal character, NOT bold markup. It must NOT be
+    // stripped (the old bug produced `\literal\`).
+    expect(text).toBe("**literal**");
+    expect(text).not.toContain("\\");
+  });
+
+  it("# heading is copied verbatim (heading marker not stripped)", async () => {
+    const { editor, view } = await makeViewPlainText("# heading");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toBe("# heading");
+  });
+
+  it("a line of asterisks and a bullet-looking line stay literal", async () => {
+    const { editor, view } = await makeViewPlainText("* not a bullet\n- also literal\n*it*");
+    const text = copyAll(view);
+    await editor.destroy();
+    // None of these are markdown in .txt — every character survives.
+    expect(text).toContain("* not a bullet");
+    expect(text).toContain("- also literal");
+    expect(text).toContain("*it*");
+  });
+
+  it("literal MDI macros are copied verbatim in plain-text mode", async () => {
+    const { editor, view } = await makeViewPlainText("{花|か} ^2024^ [[br]]");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("{花|か}");
+    expect(text).toContain("^2024^");
+    expect(text).toContain("[[br]]");
+    expect(text).not.toContain("花（か）");
+  });
+});
+
+describe("clipboard text serializer — P2-B: list bullets not consumed as emphasis", () => {
+  it("unordered list with emphasis keeps content, no dangling * and no lost bullet text", async () => {
+    const { editor, view } = await makeView("- item with **bold** and *it*\n- second");
+    const text = copyAll(view);
+    await editor.destroy();
+    // The leading bullet must NOT be treated as an opening emphasis delimiter.
+    // Result: clean plain text, bullet stripped, emphasis stripped, no dangling `*`.
+    expect(text).toContain("item with bold and it");
+    expect(text).toContain("second");
+    expect(text).not.toContain("*");
+    // No content was eaten: the first item's leading word survives.
+    expect(text).toMatch(/^item with bold and it$/m);
+  });
+
+  it("ordered list copies as clean text without numbering markers leaking emphasis", async () => {
+    const { editor, view } = await makeView("1. one **bold**\n2. two *it*");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("one bold");
+    expect(text).toContain("two it");
+    expect(text).not.toContain("*");
+    // Ordered markers (`1.` / `2.`) are stripped to clean text.
+    expect(text).not.toMatch(/^\d+\.\s/m);
   });
 });

--- a/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
@@ -45,7 +45,9 @@ async function makeView(markdown: string): Promise<{ editor: Editor; view: Edito
 // Mirror the real app's plugin order: japaneseNovel(...) is .use()d BEFORE
 // @milkdown/plugin-clipboard (MilkdownEditor.tsx). ProseMirror's someProp uses
 // the first non-null clipboardTextSerializer, so ours must win.
-async function makeViewWithClipboard(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
+async function makeViewWithClipboard(
+  markdown: string,
+): Promise<{ editor: Editor; view: EditorView }> {
   const root = document.createElement("div");
   document.body.appendChild(root);
   mountedRoots.push(root);

--- a/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
@@ -15,6 +15,7 @@ afterEach(() => {
   mountedRoots.length = 0;
 });
 
+/** MDI mode: ruby/tcy/mdi-break all enabled (.mdi documents). */
 async function makeView(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
   const root = document.createElement("div");
   document.body.appendChild(root);
@@ -32,6 +33,37 @@ async function makeView(markdown: string): Promise<{ editor: Editor; view: Edito
         enableRuby: true,
         enableTcy: true,
         enableMdiBreak: true,
+      }),
+    )
+    .create();
+  let view!: EditorView;
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx);
+  });
+  return { editor, view };
+}
+
+/**
+ * Non-MDI mode: all MDI macro features disabled (.md / .txt documents).
+ * Literal `{花|か}`, `^2024^`, `[[br]]` must survive verbatim on the clipboard.
+ */
+async function makeViewNonMdi(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  mountedRoots.push(root);
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, markdown);
+    })
+    .use(commonmark)
+    .use(
+      japaneseNovel({
+        isVertical: false,
+        showManuscriptLine: false,
+        enableRuby: false,
+        enableTcy: false,
+        enableMdiBreak: false,
       }),
     )
     .create();
@@ -121,5 +153,78 @@ describe("clipboard text serializer (Bug D)", () => {
     expect(text).not.toContain("{花|");
     expect(text).not.toMatch(/^#\s/m);
     expect(text).toContain("花（か）");
+  });
+});
+
+describe("clipboard text serializer — P2-1: mode blindness (non-MDI mode)", () => {
+  it("literal ruby {花|か} is copied verbatim in non-MDI mode", async () => {
+    const { editor, view } = await makeViewNonMdi("本文に{花|か}と書いた。");
+    const text = copyAll(view);
+    await editor.destroy();
+    // In .md/.txt mode the brace-pipe syntax is literal text, NOT ruby — must not convert.
+    expect(text).toContain("{花|か}");
+    expect(text).not.toContain("花（か）");
+  });
+
+  it("literal TCY ^2024^ is copied verbatim in non-MDI mode", async () => {
+    const { editor, view } = await makeViewNonMdi("西暦^2024^年の出来事。");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("^2024^");
+  });
+
+  it("literal [[br]] is copied verbatim in non-MDI mode", async () => {
+    const { editor, view } = await makeViewNonMdi("行A[[br]]行B");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("[[br]]");
+    // Must NOT be converted to a newline (which would make the marker disappear)
+    expect(text).not.toMatch(/行A\n行B/);
+  });
+
+  it("fenced code block content is copied verbatim in non-MDI mode", async () => {
+    const { editor, view } = await makeViewNonMdi(
+      "説明文\n\n```\n{花|か} ^2024^ [[br]]\n```\n\n後続テキスト",
+    );
+    const text = copyAll(view);
+    await editor.destroy();
+    // Code block content must not be MDI-transformed
+    expect(text).toContain("{花|か}");
+    expect(text).toContain("^2024^");
+    expect(text).toContain("[[br]]");
+    expect(text).not.toContain("花（か）");
+  });
+});
+
+describe("clipboard text serializer — P2-2: CommonMark escape leak", () => {
+  it("escaped markdown punctuation \\# copies without the backslash", async () => {
+    // \# in CommonMark means a literal `#` character (not a heading).
+    // The Milkdown serializer emits `\# title` for a paragraph starting with `# title`.
+    // After stripping, the user should get `# title` on the clipboard, not `\# title`.
+    const { editor, view } = await makeView("\\# タイトル行\n\n本文。");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).not.toContain("\\#");
+    expect(text).toContain("# タイトル行");
+  });
+
+  it("escaped backslash \\\\ copies as single backslash", async () => {
+    // CommonMark: \\ → literal backslash.
+    // Milkdown serializer emits \\ for a paragraph containing a single `\`.
+    // Our unescaper must reduce \\ → \ so the user gets one backslash, not two.
+    const { editor, view } = await makeView("パス: C:\\\\Users\\\\name");
+    const text = copyAll(view);
+    await editor.destroy();
+    // The double backslash must be collapsed to single
+    expect(text).not.toContain("\\\\");
+    expect(text).toContain("C:\\Users\\name");
+  });
+
+  it("escaped backslash in non-MDI mode also resolves correctly", async () => {
+    const { editor, view } = await makeViewNonMdi("パス: C:\\\\Users\\\\name");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).not.toContain("\\\\");
+    expect(text).toContain("C:\\Users\\name");
   });
 });

--- a/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Bug D: copying from the editor must produce clean plain text on text/plain,
+ * not raw MDI markup (# {花|か}, \[\[blank]], etc).
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { Editor, rootCtx, defaultValueCtx, editorViewCtx } from "@milkdown/core";
+import { commonmark } from "@milkdown/preset-commonmark";
+import { clipboard } from "@milkdown/plugin-clipboard";
+import type { EditorView } from "@milkdown/prose/view";
+import { japaneseNovel } from "../index";
+
+const mountedRoots: HTMLElement[] = [];
+afterEach(() => {
+  mountedRoots.forEach((r) => r.remove());
+  mountedRoots.length = 0;
+});
+
+async function makeView(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  mountedRoots.push(root);
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, markdown);
+    })
+    .use(commonmark)
+    .use(
+      japaneseNovel({
+        isVertical: false,
+        showManuscriptLine: false,
+        enableRuby: true,
+        enableTcy: true,
+        enableMdiBreak: true,
+      }),
+    )
+    .create();
+  let view!: EditorView;
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx);
+  });
+  return { editor, view };
+}
+
+// Mirror the real app's plugin order: japaneseNovel(...) is .use()d BEFORE
+// @milkdown/plugin-clipboard (MilkdownEditor.tsx). ProseMirror's someProp uses
+// the first non-null clipboardTextSerializer, so ours must win.
+async function makeViewWithClipboard(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  mountedRoots.push(root);
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, markdown);
+    })
+    .use(commonmark)
+    .use(
+      japaneseNovel({
+        isVertical: false,
+        showManuscriptLine: false,
+        enableRuby: true,
+        enableTcy: true,
+        enableMdiBreak: true,
+      }),
+    )
+    .use(clipboard)
+    .create();
+  let view!: EditorView;
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx);
+  });
+  return { editor, view };
+}
+
+function copyAll(view: EditorView): string {
+  const slice = view.state.doc.slice(0, view.state.doc.content.size);
+  const fn = view.someProp("clipboardTextSerializer");
+  if (!fn) throw new Error("no clipboardTextSerializer registered");
+  return fn(slice, view);
+}
+
+describe("clipboard text serializer (Bug D)", () => {
+  it("ruby heading becomes clean text with fullwidth-paren ruby, no markup", async () => {
+    const { editor, view } = await makeView("# {花|か}{様|よう}{年|ねん}{華|か}\n\n本文テスト。");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).not.toContain("{花|");
+    expect(text).not.toContain("|");
+    expect(text).not.toMatch(/^#\s/m); // heading marker stripped
+    expect(text).toContain("花（か）");
+    expect(text).toContain("本文テスト");
+  });
+
+  it("[[blank]] markers do not leak (no literal marker, no escaped \\[)", async () => {
+    const { editor, view } = await makeView("A段落\n\n[[blank]]\n\nB段落");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).not.toContain("[[blank]]");
+    expect(text).not.toContain("\\[");
+    expect(text).toContain("A段落");
+    expect(text).toContain("B段落");
+  });
+
+  it("dialogue paragraphs survive as plain text", async () => {
+    const { editor, view } = await makeView("「ほんとに、いたんですか。」\n\n「さあ。」");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("「ほんとに、いたんですか。」");
+    expect(text).toContain("「さあ。」");
+  });
+
+  it("wins over @milkdown/plugin-clipboard in real plugin order", async () => {
+    const { editor, view } = await makeViewWithClipboard("# {花|か}{様|よう}\n\n本文。");
+    const text = copyAll(view);
+    await editor.destroy();
+    // The default clipboard plugin would emit raw markdown (`# {花|か}`);
+    // our serializer must take precedence and produce clean text.
+    expect(text).not.toContain("{花|");
+    expect(text).not.toMatch(/^#\s/m);
+    expect(text).toContain("花（か）");
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
@@ -74,6 +74,39 @@ async function makeViewNonMdi(markdown: string): Promise<{ editor: Editor; view:
   return { editor, view };
 }
 
+/**
+ * Only-ruby mode: ruby enabled, every other macro family disabled. Ruby still
+ * converts, but literal `^2024^` / `[[br]]` must be copied verbatim (P2-A).
+ */
+async function makeViewRubyOnly(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  mountedRoots.push(root);
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, markdown);
+    })
+    .use(commonmark)
+    .use(
+      japaneseNovel({
+        isVertical: false,
+        showManuscriptLine: false,
+        enableRuby: true,
+        enableTcy: false,
+        enableNoBreak: false,
+        enableKern: false,
+        enableMdiBreak: false,
+      }),
+    )
+    .create();
+  let view!: EditorView;
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx);
+  });
+  return { editor, view };
+}
+
 // Mirror the real app's plugin order: japaneseNovel(...) is .use()d BEFORE
 // @milkdown/plugin-clipboard (MilkdownEditor.tsx). ProseMirror's someProp uses
 // the first non-null clipboardTextSerializer, so ours must win.
@@ -193,6 +226,51 @@ describe("clipboard text serializer — P2-1: mode blindness (non-MDI mode)", ()
     expect(text).toContain("^2024^");
     expect(text).toContain("[[br]]");
     expect(text).not.toContain("花（か）");
+  });
+});
+
+describe("clipboard text serializer — P2-A: per-feature gating (only ruby enabled)", () => {
+  it("ruby converts but literal ^2024^ / [[br]] are copied verbatim", async () => {
+    const { editor, view } = await makeViewRubyOnly("{花|か}は西暦^2024^年[[br]]に咲く。");
+    const text = copyAll(view);
+    await editor.destroy();
+    // Ruby feature is ON → converts.
+    expect(text).toContain("花（か）");
+    // TCY / mdi-break features are OFF → literal text must survive verbatim.
+    expect(text).toContain("^2024^");
+    expect(text).toContain("[[br]]");
+    expect(text).not.toMatch(/年\nに/); // [[br]] not turned into a newline
+  });
+});
+
+describe("clipboard text serializer — P2-B: code context", () => {
+  it("fenced code block content is copied literally even in MDI mode", async () => {
+    const { editor, view } = await makeView(
+      "説明文\n\n```\n{花|か} ^2024^ [[br]]\n```\n\n後続テキスト",
+    );
+    const text = copyAll(view);
+    await editor.destroy();
+    // Code content must bypass MDI/markdown transformation entirely.
+    expect(text).toContain("{花|か}");
+    expect(text).toContain("^2024^");
+    expect(text).toContain("[[br]]");
+    expect(text).not.toContain("花（か）");
+    // Surrounding prose still copies as plain text.
+    expect(text).toContain("説明文");
+    expect(text).toContain("後続テキスト");
+  });
+
+  it("inline code span content is copied literally even in MDI mode", async () => {
+    const { editor, view } = await makeView("コードは `{花|か} ^2024^ [[br]]` と書く。");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("{花|か}");
+    expect(text).toContain("^2024^");
+    expect(text).toContain("[[br]]");
+    expect(text).not.toContain("花（か）");
+    // The non-code prose around the span survives.
+    expect(text).toContain("コードは");
+    expect(text).toContain("と書く。");
   });
 });
 

--- a/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/clipboard-serializer.test.ts
@@ -410,3 +410,77 @@ describe("clipboard text serializer — P2-B: list bullets not consumed as empha
     expect(text).not.toMatch(/^\d+\.\s/m);
   });
 });
+
+describe("clipboard text serializer — AST walk: emphasis / link marks drop to text", () => {
+  it("normal emphasis **bold** *it* → bold it (no markers, no dangling)", async () => {
+    const { editor, view } = await makeView("これは **bold** と *it* です。");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toBe("これは bold と it です。");
+    expect(text).not.toContain("*");
+    expect(text).not.toContain("\\");
+  });
+
+  it("link mark emits the link text, not the URL", async () => {
+    const { editor, view } = await makeView("詳細は [公式サイト](https://example.com) を参照。");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("公式サイト");
+    expect(text).not.toContain("https://example.com");
+    expect(text).not.toContain("](");
+    expect(text).not.toContain("[");
+  });
+});
+
+describe("clipboard text serializer — AST walk: literal text is verbatim (no escape un-parsing)", () => {
+  it("escaped-looking literal \\*not italic\\* copies as *not italic* verbatim", async () => {
+    // The source `\*not italic\*` is literal `*not italic*` text in the editor —
+    // the AST text node already holds the bare characters, so the walk emits them
+    // verbatim. The previous regex pipeline turned `\*x\*` into `\x\` (escape leak).
+    const { editor, view } = await makeView("文中に \\*not italic\\* と書く。");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("*not italic*");
+    expect(text).not.toContain("\\");
+  });
+
+  it("inline code {花|か} ^2024^ [[br]] is verbatim, prose around it is plain", async () => {
+    const { editor, view } = await makeView("コードは `{花|か} ^2024^ [[br]]` と書く。");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("{花|か} ^2024^ [[br]]");
+    expect(text).not.toContain("花（か）");
+    expect(text).not.toContain("`");
+    expect(text).toContain("コードは");
+    expect(text).toContain("と書く。");
+  });
+
+  it("code block content {花|か} ^2024^ [[br]] survives verbatim with no fences", async () => {
+    const { editor, view } = await makeView("説明\n\n```\n{花|か} ^2024^ [[br]]\n```\n\n後続");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("{花|か} ^2024^ [[br]]");
+    expect(text).not.toContain("```");
+    expect(text).not.toContain("花（か）");
+    expect(text).toContain("説明");
+    expect(text).toContain("後続");
+  });
+});
+
+describe("clipboard text serializer — AST walk: plain-text (.txt) structure", () => {
+  it("a\\n\\nb preserves paragraph structure without extra blank lines", async () => {
+    const { editor, view } = await makeViewPlainText("a\n\nb");
+    const text = copyAll(view);
+    await editor.destroy();
+    // Two paragraphs joined by exactly one blank line — no spurious blanks.
+    expect(text).toBe("a\n\nb");
+  });
+
+  it("<br /> is copied verbatim in .txt mode (not converted to newline)", async () => {
+    const { editor, view } = await makeViewPlainText("行A<br />行B");
+    const text = copyAll(view);
+    await editor.destroy();
+    expect(text).toContain("<br />");
+    expect(text).not.toMatch(/行A\n行B/);
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/config.ts
+++ b/packages/milkdown-plugin-japanese-novel/config.ts
@@ -17,6 +17,13 @@ export interface JapaneseNovelOptions {
   enableKern?: boolean;
   /** 明示改行を有効化する（[[br]] 記法） */
   enableMdiBreak?: boolean;
+  /**
+   * プレーンテキスト（.txt）モード。`MilkdownEditor` が `remarkPlainTextPlugin`
+   * を導入し、`*` `#` `**` 等を Markdown ではなくリテラル文字として扱う場合に
+   * `true`。クリップボード書き出し時は Markdown 除去・MDI 変換を一切行わず、
+   * 選択範囲のテキストをそのままコピーする。
+   */
+  plainText?: boolean;
 }
 
 export const defaultJapaneseNovelOptions: Required<JapaneseNovelOptions> = {
@@ -27,4 +34,5 @@ export const defaultJapaneseNovelOptions: Required<JapaneseNovelOptions> = {
   enableNoBreak: true,
   enableKern: true,
   enableMdiBreak: true,
+  plainText: false,
 };

--- a/packages/milkdown-plugin-japanese-novel/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/index.ts
@@ -25,6 +25,7 @@ import {
 import { createHeadingIdFixerPlugin } from "./plugins/heading-id-fixer";
 import { createHardbreakIndentPlugin } from "./plugins/hardbreak-indent";
 import { createDialogueIndentPlugin } from "./plugins/dialogue-indent";
+import { createClipboardSerializerPlugin } from "./plugins/clipboard-serializer";
 import { defaultJapaneseNovelOptions, type JapaneseNovelOptions } from "./config";
 
 export type { JapaneseNovelOptions } from "./config";
@@ -116,6 +117,10 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     return createDialogueIndentPlugin();
   });
 
+  const clipboardSerializerPlugin = $prose((ctx) => {
+    return createClipboardSerializerPlugin(ctx);
+  });
+
   const plugins: MilkdownPlugin[] = [
     ...(enableRuby ? [remarkRuby, rubySchema] : []),
     ...(enableTcy ? [remarkTcy, tcySchema] : []),
@@ -129,6 +134,7 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     headingIdFixerPlugin,
     hardbreakIndentPlugin,
     dialogueIndentPlugin,
+    clipboardSerializerPlugin,
     stylePlugin,
   ].flat();
 

--- a/packages/milkdown-plugin-japanese-novel/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/index.ts
@@ -44,6 +44,7 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     enableNoBreak,
     enableKern,
     enableMdiBreak,
+    plainText,
   } = opts;
 
   const classes: string[] = ["milkdown-japanese-base"];
@@ -124,6 +125,7 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
   const clipboardSerializerPlugin = $prose((ctx) => {
     return createClipboardSerializerPlugin(ctx, {
       features: { enableRuby, enableTcy, enableNoBreak, enableKern, enableMdiBreak },
+      plainText,
     });
   });
 

--- a/packages/milkdown-plugin-japanese-novel/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/index.ts
@@ -117,8 +117,12 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     return createDialogueIndentPlugin();
   });
 
+  // MDI macros are active when at least one macro-parsing feature is enabled.
+  // Gate clipboard conversion on this so that .md/.txt documents that happen
+  // to contain literal `{花|か}` or `^2024^` are not silently transformed.
+  const enableMdiMacros = Boolean(enableRuby || enableTcy || enableMdiBreak);
   const clipboardSerializerPlugin = $prose((ctx) => {
-    return createClipboardSerializerPlugin(ctx);
+    return createClipboardSerializerPlugin(ctx, { enableMdiMacros });
   });
 
   const plugins: MilkdownPlugin[] = [

--- a/packages/milkdown-plugin-japanese-novel/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/index.ts
@@ -117,12 +117,14 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     return createDialogueIndentPlugin();
   });
 
-  // MDI macros are active when at least one macro-parsing feature is enabled.
-  // Gate clipboard conversion on this so that .md/.txt documents that happen
-  // to contain literal `{花|か}` or `^2024^` are not silently transformed.
-  const enableMdiMacros = Boolean(enableRuby || enableTcy || enableMdiBreak);
+  // Gate clipboard MDI conversion per feature so each macro family is only
+  // transformed when its own parser is active. A consumer that enables ONLY
+  // ruby still copies literal `^2024^` / `[[br]]` verbatim, and `.md` / `.txt`
+  // documents (no feature enabled) keep `{花|か}` / `^2024^` as literal text.
   const clipboardSerializerPlugin = $prose((ctx) => {
-    return createClipboardSerializerPlugin(ctx, { enableMdiMacros });
+    return createClipboardSerializerPlugin(ctx, {
+      features: { enableRuby, enableTcy, enableNoBreak, enableKern, enableMdiBreak },
+    });
   });
 
   const plugins: MilkdownPlugin[] = [

--- a/packages/milkdown-plugin-japanese-novel/mdi-document.ts
+++ b/packages/milkdown-plugin-japanese-novel/mdi-document.ts
@@ -266,6 +266,19 @@ function restoreCodePlaceholders(text: string, segments?: readonly string[]): st
 }
 
 /**
+ * Resolve CommonMark backslash-escapes (`\#` → `#`, `\*` → `*`, `\\` → `\`).
+ * Covers every ASCII punctuation char CommonMark allows to be escaped,
+ * including MDI-specific chars (`\{` `\^` `\[`) as a superset.
+ *
+ * Used both inside {@link stripMarkdown} and by the plain-text clipboard bypass,
+ * where markup stripping must NOT run but serializer-added escapes still need to
+ * be undone so the user gets verbatim characters.
+ */
+function unescapeCommonMark(text: string): string {
+  return text.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "$1");
+}
+
+/**
  * Strip markdown formatting while preserving text structure.
  * Handles headings, bold, italic, horizontal rules, etc.
  */
@@ -291,6 +304,16 @@ function stripMarkdown(text: string): string {
       continue;
     }
 
+    // List bullets: strip a line-leading list marker (`* `, `- `, `+ `, `N. `)
+    // to its bare text BEFORE emphasis processing. The Milkdown serializer emits
+    // unordered lists as `* item …`; if the leading `* ` reached the italic
+    // regex below it would be consumed as an opening emphasis delimiter, eating
+    // the bullet and leaving a dangling `*` (e.g. `* a *it*` → ` a it*`). A
+    // horizontal-rule line (`***` / `---`) has no space after the marker, so it
+    // is handled above and never matches here. Indentation before the marker is
+    // tolerated for nested lists.
+    processed = processed.replace(/^\s*(?:[*+-]\s+|\d+\.\s+)/, "");
+
     // Bold italic: ***text*** → text
     processed = processed.replace(/\*\*\*(.+?)\*\*\*/g, "$1");
 
@@ -301,9 +324,7 @@ function stripMarkdown(text: string): string {
     processed = processed.replace(/\*(.+?)\*/g, "$1");
 
     // CommonMark escapable punctuation: \# \* \_ \- \+ \. \! \\ etc. → literal
-    // Covers all ASCII punctuation that CommonMark allows backslash-escape,
-    // including MDI-specific chars (\{ \^ \[) as a superset.
-    processed = processed.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "$1");
+    processed = unescapeCommonMark(processed);
 
     result.push(processed);
   }
@@ -605,12 +626,25 @@ export class MdiDocument {
    * pipeline untouched and are restored verbatim at the end, so `{花|か}`,
    * `^2024^`, `[[br]]` inside code never get transformed or markdown-stripped.
    *
+   * Plain-text mode (`options.plainText === true`, i.e. `.txt` documents where
+   * MilkdownEditor installs `remarkPlainTextPlugin` and `*` / `#` / `**` are
+   * LITERAL characters, not markdown) bypasses both MDI conversion and markdown
+   * stripping entirely: a `.txt` line `**literal**` or `# heading` must copy
+   * verbatim, not as `literal` / `heading`. Only structural paragraph blank
+   * lines are collapsed and serializer-added CommonMark escapes are resolved.
+   *
    * In all modes the result has collapsed blank lines for clean pasting.
    */
   toClipboardText(options: {
     features: MdiFeatureFlags;
     codeSegments?: readonly string[];
+    plainText?: boolean;
   }): string {
+    if (options.plainText) {
+      // No MDI conversion, no markdown stripping — characters are literal.
+      const literal = collapseBlankLines(unescapeCommonMark(this.raw));
+      return restoreCodePlaceholders(literal, options.codeSegments);
+    }
     const converted = replaceMdiWithRubyTextGated(this.raw, options.features);
     const stripped = collapseBlankLines(stripMarkdown(converted));
     return restoreCodePlaceholders(stripped, options.codeSegments);

--- a/packages/milkdown-plugin-japanese-novel/mdi-document.ts
+++ b/packages/milkdown-plugin-japanese-novel/mdi-document.ts
@@ -218,8 +218,10 @@ function stripMarkdown(text: string): string {
     // Italic: *text* → text
     processed = processed.replace(/\*(.+?)\*/g, "$1");
 
-    // Escaped characters: \{ \^ \[ → literal
-    processed = processed.replace(/\\([{^[\]])/g, "$1");
+    // CommonMark escapable punctuation: \# \* \_ \- \+ \. \! \\ etc. → literal
+    // Covers all ASCII punctuation that CommonMark allows backslash-escape,
+    // including MDI-specific chars (\{ \^ \[) as a superset.
+    processed = processed.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "$1");
 
     result.push(processed);
   }
@@ -504,6 +506,29 @@ export class MdiDocument {
     const flattened =
       format === "txt-ruby" ? replaceMdiWithRubyText(this.raw) : stripMdiInlineSyntax(this.raw);
     return collapseBlankLines(stripMarkdown(flattened));
+  }
+
+  /**
+   * Plain text for the clipboard (`text/plain`).
+   *
+   * - `enableMdiMacros: true` (.mdi mode): runs the full MDI export pipeline
+   *   (same as `toExportText("txt-ruby")` — ruby → fullwidth-paren, [[blank]]
+   *   → empty line, [[br]] → newline, markdown markup stripped, CommonMark
+   *   backslash-escapes resolved).
+   * - `enableMdiMacros: false` (.md / .txt mode): MDI macros are literal text
+   *   and must NOT be transformed.  Only markdown markup is stripped and
+   *   CommonMark backslash-escapes are resolved (e.g. `\# title` → `# title`).
+   *
+   * In both modes the result has collapsed blank lines for clean pasting.
+   */
+  toClipboardText(options: { enableMdiMacros: boolean }): string {
+    if (options.enableMdiMacros) {
+      // Full MDI pipeline: convert macros then strip markdown.
+      return collapseBlankLines(stripMarkdown(replaceMdiWithRubyText(this.raw)));
+    }
+    // Non-MDI pipeline: preserve macro text verbatim; only strip markdown
+    // formatting and resolve CommonMark escapes.
+    return collapseBlankLines(stripMarkdown(this.raw));
   }
 
   /**

--- a/packages/milkdown-plugin-japanese-novel/mdi-document.ts
+++ b/packages/milkdown-plugin-japanese-novel/mdi-document.ts
@@ -230,49 +230,13 @@ export function replaceMdiWithRubyTextGated(text: string, flags: MdiFeatureFlags
 /** Sentinel to distinguish scene breaks from paragraph-separation blank lines */
 const SCENE_BREAK_MARKER = "\x00SCENE_BREAK\x00";
 
-// ---------------------------------------------------------------------------
-// Code-context placeholders
-// ---------------------------------------------------------------------------
-//
-// To keep inline-code and fenced-code text out of the MDI/markdown rewriting
-// pipeline, the clipboard serializer replaces each code segment's text with a
-// NUL-wrapped placeholder before building the markdown string. NUL bytes never
-// appear in user text and are not matched by any MDI / markdown regex, so the
-// placeholder survives `replaceMdiWithRubyTextGated`, `stripMarkdown`, and
-// `collapseBlankLines` untouched and is restored verbatim afterwards.
-
-/** Prefix/suffix for code placeholders (NUL-wrapped, regex-inert). */
-const CODE_PLACEHOLDER_PREFIX = "\x00MDI_CODE_";
-const CODE_PLACEHOLDER_SUFFIX = "\x00";
-
-/** Build the placeholder token for the code segment at `index`. */
-export function codePlaceholder(index: number): string {
-  return `${CODE_PLACEHOLDER_PREFIX}${index}${CODE_PLACEHOLDER_SUFFIX}`;
-}
-
-/**
- * Restore code placeholders with their verbatim segment text.
- * No-op when `segments` is undefined/empty.
- */
-function restoreCodePlaceholders(text: string, segments?: readonly string[]): string {
-  if (!segments || segments.length === 0) return text;
-  return text.replace(
-    new RegExp(`${CODE_PLACEHOLDER_PREFIX}(\\d+)${CODE_PLACEHOLDER_SUFFIX}`, "g"),
-    (_match, idx: string) => {
-      const segment = segments[Number(idx)];
-      return segment ?? _match;
-    },
-  );
-}
-
 /**
  * Resolve CommonMark backslash-escapes (`\#` → `#`, `\*` → `*`, `\\` → `\`).
  * Covers every ASCII punctuation char CommonMark allows to be escaped,
  * including MDI-specific chars (`\{` `\^` `\[`) as a superset.
  *
- * Used both inside {@link stripMarkdown} and by the plain-text clipboard bypass,
- * where markup stripping must NOT run but serializer-added escapes still need to
- * be undone so the user gets verbatim characters.
+ * Used inside {@link stripMarkdown} to undo serializer-added escapes after
+ * markup stripping so plain-text export gets verbatim characters.
  */
 function unescapeCommonMark(text: string): string {
   return text.replace(/\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "$1");
@@ -609,45 +573,6 @@ export class MdiDocument {
     const flattened =
       format === "txt-ruby" ? replaceMdiWithRubyText(this.raw) : stripMdiInlineSyntax(this.raw);
     return collapseBlankLines(stripMarkdown(flattened));
-  }
-
-  /**
-   * Plain text for the clipboard (`text/plain`).
-   *
-   * MDI macro conversion is gated **per feature** (`options.features`): a macro
-   * family whose flag is `false` is preserved verbatim, so a session with only
-   * ruby enabled still copies literal `^2024^` / `[[br]]` unchanged. When every
-   * flag is `false` this collapses to the non-MDI behavior (markdown markup
-   * stripped, CommonMark backslash-escapes resolved, macros verbatim).
-   *
-   * Code context is honored via `options.codeSegments`: the serializer replaces
-   * inline-code and fenced-code text with NUL-wrapped placeholders before
-   * calling this method; the placeholders pass through the MDI / markdown
-   * pipeline untouched and are restored verbatim at the end, so `{花|か}`,
-   * `^2024^`, `[[br]]` inside code never get transformed or markdown-stripped.
-   *
-   * Plain-text mode (`options.plainText === true`, i.e. `.txt` documents where
-   * MilkdownEditor installs `remarkPlainTextPlugin` and `*` / `#` / `**` are
-   * LITERAL characters, not markdown) bypasses both MDI conversion and markdown
-   * stripping entirely: a `.txt` line `**literal**` or `# heading` must copy
-   * verbatim, not as `literal` / `heading`. Only structural paragraph blank
-   * lines are collapsed and serializer-added CommonMark escapes are resolved.
-   *
-   * In all modes the result has collapsed blank lines for clean pasting.
-   */
-  toClipboardText(options: {
-    features: MdiFeatureFlags;
-    codeSegments?: readonly string[];
-    plainText?: boolean;
-  }): string {
-    if (options.plainText) {
-      // No MDI conversion, no markdown stripping — characters are literal.
-      const literal = collapseBlankLines(unescapeCommonMark(this.raw));
-      return restoreCodePlaceholders(literal, options.codeSegments);
-    }
-    const converted = replaceMdiWithRubyTextGated(this.raw, options.features);
-    const stripped = collapseBlankLines(stripMarkdown(converted));
-    return restoreCodePlaceholders(stripped, options.codeSegments);
   }
 
   /**

--- a/packages/milkdown-plugin-japanese-novel/mdi-document.ts
+++ b/packages/milkdown-plugin-japanese-novel/mdi-document.ts
@@ -153,25 +153,72 @@ export function stripMdiInlineSyntax(text: string): string {
  * Example: {漢字|かんじ} → 漢字（かんじ）
  */
 export function replaceMdiWithRubyText(text: string): string {
+  return replaceMdiWithRubyTextGated(text, ALL_MDI_FEATURES_ENABLED);
+}
+
+/**
+ * Per-feature MDI macro flags. Each flag gates exactly one macro family so a
+ * consumer that enables only ruby (for example) still copies literal `^2024^`
+ * and `[[br]]` verbatim. Mirrors the parsing flags passed to
+ * `japaneseNovel(options)` (see `config.ts`).
+ */
+export interface MdiFeatureFlags {
+  /** `{base|ruby}` → `base（ruby）` */
+  enableRuby: boolean;
+  /** `^text^` → `text` */
+  enableTcy: boolean;
+  /** `[[no-break:text]]` → `text` */
+  enableNoBreak: boolean;
+  /** `[[kern:amount:text]]` → `text` */
+  enableKern: boolean;
+  /** `[[br]]` → newline */
+  enableMdiBreak: boolean;
+}
+
+/** All macro families enabled — used by the legacy whole-string export helpers. */
+const ALL_MDI_FEATURES_ENABLED: MdiFeatureFlags = {
+  enableRuby: true,
+  enableTcy: true,
+  enableNoBreak: true,
+  enableKern: true,
+  enableMdiBreak: true,
+};
+
+/**
+ * Replace MDI inline syntax with per-feature gating. A macro family whose flag
+ * is `false` is left as literal text verbatim — only enabled families are
+ * transformed. Ruby renders as fullwidth parentheses (txt-ruby semantics).
+ */
+export function replaceMdiWithRubyTextGated(text: string, flags: MdiFeatureFlags): string {
   let result = text;
 
   // Ruby: base（ruby）  — strip dots from split ruby
-  result = result.replace(MDI_RUBY_RE, (_match, base: string, ruby: string) => {
-    const cleanRuby = ruby.replace(/\./g, "");
-    return `${base}（${cleanRuby}）`;
-  });
+  if (flags.enableRuby) {
+    result = result.replace(MDI_RUBY_RE, (_match, base: string, ruby: string) => {
+      const cleanRuby = ruby.replace(/\./g, "");
+      return `${base}（${cleanRuby}）`;
+    });
+  }
 
   // Tate-chu-yoko: keep text
-  result = result.replace(MDI_TCY_RE, "$1");
+  if (flags.enableTcy) {
+    result = result.replace(MDI_TCY_RE, "$1");
+  }
 
   // No-break: keep text
-  result = result.replace(MDI_NOBR_RE, "$1");
+  if (flags.enableNoBreak) {
+    result = result.replace(MDI_NOBR_RE, "$1");
+  }
 
   // Kerning: keep text
-  result = result.replace(MDI_KERN_RE, "$2");
+  if (flags.enableKern) {
+    result = result.replace(MDI_KERN_RE, "$2");
+  }
 
   // Explicit line break: newline
-  result = result.replace(MDI_BREAK_RE, "\n");
+  if (flags.enableMdiBreak) {
+    result = result.replace(MDI_BREAK_RE, "\n");
+  }
 
   return result;
 }
@@ -182,6 +229,41 @@ export function replaceMdiWithRubyText(text: string): string {
 
 /** Sentinel to distinguish scene breaks from paragraph-separation blank lines */
 const SCENE_BREAK_MARKER = "\x00SCENE_BREAK\x00";
+
+// ---------------------------------------------------------------------------
+// Code-context placeholders
+// ---------------------------------------------------------------------------
+//
+// To keep inline-code and fenced-code text out of the MDI/markdown rewriting
+// pipeline, the clipboard serializer replaces each code segment's text with a
+// NUL-wrapped placeholder before building the markdown string. NUL bytes never
+// appear in user text and are not matched by any MDI / markdown regex, so the
+// placeholder survives `replaceMdiWithRubyTextGated`, `stripMarkdown`, and
+// `collapseBlankLines` untouched and is restored verbatim afterwards.
+
+/** Prefix/suffix for code placeholders (NUL-wrapped, regex-inert). */
+const CODE_PLACEHOLDER_PREFIX = "\x00MDI_CODE_";
+const CODE_PLACEHOLDER_SUFFIX = "\x00";
+
+/** Build the placeholder token for the code segment at `index`. */
+export function codePlaceholder(index: number): string {
+  return `${CODE_PLACEHOLDER_PREFIX}${index}${CODE_PLACEHOLDER_SUFFIX}`;
+}
+
+/**
+ * Restore code placeholders with their verbatim segment text.
+ * No-op when `segments` is undefined/empty.
+ */
+function restoreCodePlaceholders(text: string, segments?: readonly string[]): string {
+  if (!segments || segments.length === 0) return text;
+  return text.replace(
+    new RegExp(`${CODE_PLACEHOLDER_PREFIX}(\\d+)${CODE_PLACEHOLDER_SUFFIX}`, "g"),
+    (_match, idx: string) => {
+      const segment = segments[Number(idx)];
+      return segment ?? _match;
+    },
+  );
+}
 
 /**
  * Strip markdown formatting while preserving text structure.
@@ -511,24 +593,27 @@ export class MdiDocument {
   /**
    * Plain text for the clipboard (`text/plain`).
    *
-   * - `enableMdiMacros: true` (.mdi mode): runs the full MDI export pipeline
-   *   (same as `toExportText("txt-ruby")` — ruby → fullwidth-paren, [[blank]]
-   *   → empty line, [[br]] → newline, markdown markup stripped, CommonMark
-   *   backslash-escapes resolved).
-   * - `enableMdiMacros: false` (.md / .txt mode): MDI macros are literal text
-   *   and must NOT be transformed.  Only markdown markup is stripped and
-   *   CommonMark backslash-escapes are resolved (e.g. `\# title` → `# title`).
+   * MDI macro conversion is gated **per feature** (`options.features`): a macro
+   * family whose flag is `false` is preserved verbatim, so a session with only
+   * ruby enabled still copies literal `^2024^` / `[[br]]` unchanged. When every
+   * flag is `false` this collapses to the non-MDI behavior (markdown markup
+   * stripped, CommonMark backslash-escapes resolved, macros verbatim).
    *
-   * In both modes the result has collapsed blank lines for clean pasting.
+   * Code context is honored via `options.codeSegments`: the serializer replaces
+   * inline-code and fenced-code text with NUL-wrapped placeholders before
+   * calling this method; the placeholders pass through the MDI / markdown
+   * pipeline untouched and are restored verbatim at the end, so `{花|か}`,
+   * `^2024^`, `[[br]]` inside code never get transformed or markdown-stripped.
+   *
+   * In all modes the result has collapsed blank lines for clean pasting.
    */
-  toClipboardText(options: { enableMdiMacros: boolean }): string {
-    if (options.enableMdiMacros) {
-      // Full MDI pipeline: convert macros then strip markdown.
-      return collapseBlankLines(stripMarkdown(replaceMdiWithRubyText(this.raw)));
-    }
-    // Non-MDI pipeline: preserve macro text verbatim; only strip markdown
-    // formatting and resolve CommonMark escapes.
-    return collapseBlankLines(stripMarkdown(this.raw));
+  toClipboardText(options: {
+    features: MdiFeatureFlags;
+    codeSegments?: readonly string[];
+  }): string {
+    const converted = replaceMdiWithRubyTextGated(this.raw, options.features);
+    const stripped = collapseBlankLines(stripMarkdown(converted));
+    return restoreCodePlaceholders(stripped, options.codeSegments);
   }
 
   /**

--- a/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
+++ b/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
@@ -1,0 +1,39 @@
+import { Plugin, PluginKey } from "@milkdown/prose/state";
+import { serializerCtx, schemaCtx } from "@milkdown/core";
+import type { Ctx } from "@milkdown/ctx";
+import { MdiDocument } from "../mdi-document";
+
+/**
+ * Clipboard *text* serializer.
+ *
+ * Copying from the editor must put **clean plain text** on `text/plain`, not the
+ * raw MDI/markdown that the default `@milkdown/plugin-clipboard` emits (e.g.
+ * `# {花|か}{様|よう}`, escaped `\[\[blank]]`). We serialize the copied slice to
+ * markdown, then run it through the MDI export pipeline so that:
+ *   - ruby `{親|ルビ}` → `親（ルビ）`
+ *   - `[[blank]]` / `\[\[blank]]` / `<br>` → blank lines
+ *   - heading `#`, emphasis `*` … markdown markup is stripped
+ *
+ * `text/html` is intentionally left to the default serializer so rich paste into
+ * Word/Pages keeps headings, ruby (`<ruby>`), and structure.
+ *
+ * This plugin is registered as part of `japaneseNovel(...)`, which is `.use()`d
+ * before `@milkdown/plugin-clipboard`; ProseMirror's `someProp` walks plugins in
+ * order and uses the first non-null `clipboardTextSerializer`, so ours wins.
+ */
+export function createClipboardSerializerPlugin(ctx: Ctx): Plugin {
+  return new Plugin({
+    key: new PluginKey("mdiClipboardSerializer"),
+    props: {
+      clipboardTextSerializer: (slice) => {
+        const serializer = ctx.get(serializerCtx);
+        const schema = ctx.get(schemaCtx);
+        const doc = schema.topNodeType.createAndFill(undefined, slice.content);
+        // Fallback to ProseMirror's bare text if the slice can't form a doc.
+        if (!doc) return slice.content.textBetween(0, slice.content.size, "\n\n");
+        const markdown = serializer(doc);
+        return MdiDocument.fromEditorOutput(markdown, { fileType: ".mdi" }).toExportText("txt-ruby");
+      },
+    },
+  });
+}

--- a/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
+++ b/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
@@ -1,15 +1,8 @@
-import { serializerCtx, schemaCtx } from "@milkdown/core";
 import { Plugin, PluginKey } from "@milkdown/prose/state";
-import { Fragment } from "@milkdown/prose/model";
 import type { Ctx } from "@milkdown/ctx";
-import type { Node as ProseNode, Schema } from "@milkdown/prose/model";
-import { MdiDocument, codePlaceholder } from "../mdi-document";
+import type { Fragment, Node as ProseNode } from "@milkdown/prose/model";
+import { replaceMdiWithRubyTextGated } from "../mdi-document";
 import type { MdiFeatureFlags } from "../mdi-document";
-
-/** ProseMirror node type name for fenced/indented code blocks (commonmark). */
-const CODE_BLOCK_NODE = "code_block";
-/** ProseMirror inline mark name for `` `code` `` spans (commonmark). */
-const INLINE_CODE_MARK = "inlineCode";
 
 /**
  * Options controlling which MDI features are active in the current editor
@@ -19,116 +12,205 @@ const INLINE_CODE_MARK = "inlineCode";
  * `[[br]]` verbatim.
  */
 export interface ClipboardSerializerOptions {
-  /** Per-feature MDI macro flags, forwarded to `toClipboardText`. */
+  /** Per-feature MDI macro flags governing inline-macro rendering. */
   features: MdiFeatureFlags;
   /**
    * Plain-text (`.txt`) mode. When `true`, the editor installs
    * `remarkPlainTextPlugin` (see `MilkdownEditor.tsx`) so `*`, `#`, `**` are
-   * LITERAL characters, not markdown. The clipboard serializer must then bypass
-   * markdown stripping / MDI conversion entirely and copy the selection's text
-   * verbatim (only undoing serializer-added CommonMark escapes). Defaults to
-   * `false` for `.md` / `.mdi` documents.
+   * LITERAL characters, not markdown. The clipboard serializer must then copy
+   * the selection's text verbatim — every character is already literal in the
+   * ProseMirror text nodes, so the AST walk needs no special casing beyond
+   * joining blocks with newlines. Defaults to `false` for `.md` / `.mdi`.
    */
   plainText?: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// ProseMirror schema type names (commonmark preset + MDI nodes)
+// ---------------------------------------------------------------------------
+
 /**
- * Whether any MDI macro family is enabled. When none are, the serialized text
- * is treated as `.md` / `.txt` content (macros are literal, no bracket-macro
- * recovery on the editor output).
+ * Fenced/indented code block: content is copied verbatim, never MDI-converted.
+ *
+ * Inline `` `code` `` spans need no special case: they are plain text carrying
+ * the `inlineCode` mark, and the walk emits `node.text` verbatim — the mark
+ * (like em/strong/link) carries no markup text, so backticks never appear and
+ * MDI conversion never runs on text inside an inline-code span.
  */
-function anyMdiFeatureEnabled(features: MdiFeatureFlags): boolean {
-  return (
-    features.enableRuby ||
-    features.enableTcy ||
-    features.enableNoBreak ||
-    features.enableKern ||
-    features.enableMdiBreak
-  );
+const CODE_BLOCK_NODE = "code_block";
+/** CommonMark hard line break (Shift+Enter / trailing two spaces) → newline. */
+const HARDBREAK_NODE = "hardbreak";
+/** MDI explicit line break `[[br]]`. */
+const MDI_BREAK_NODE = "mdibreak";
+/** MDI forced empty paragraph `[[blank]]`. */
+const BLANK_PARAGRAPH_NODE = "blankParagraph";
+/** Ruby annotation node: attrs `base` / `text`. */
+const RUBY_NODE = "ruby";
+/** Tate-chu-yoko node: attr `value`. */
+const TCY_NODE = "tcy";
+/** No-break span node: attr `text`. */
+const NOBREAK_NODE = "nobreak";
+/** Kerning span node: attrs `amount` / `text`. */
+const KERN_NODE = "kern";
+
+/** Block container nodes whose children are themselves block-level. */
+const LIST_CONTAINER_NODES = new Set(["bullet_list", "ordered_list"]);
+const LIST_ITEM_NODE = "list_item";
+const BLOCKQUOTE_NODE = "blockquote";
+
+/**
+ * Render the literal `.mdi` source string that an MDI inline node round-trips
+ * to (matching each node's `toMarkdown` runner). Used when the node's feature
+ * flag is OFF so the macro is copied verbatim.
+ */
+function mdiNodeLiteral(node: ProseNode): string {
+  switch (node.type.name) {
+    case RUBY_NODE:
+      return `{${node.attrs.base as string}|${node.attrs.text as string}}`;
+    case TCY_NODE:
+      return `^${node.attrs.value as string}^`;
+    case NOBREAK_NODE:
+      return `[[no-break:${node.attrs.text as string}]]`;
+    case KERN_NODE:
+      return `[[kern:${node.attrs.amount as string}:${node.attrs.text as string}]]`;
+    case MDI_BREAK_NODE:
+      return "[[br]]";
+    default:
+      return "";
+  }
 }
 
 /**
- * Replace every code region in `doc` with a regex-inert placeholder so the
- * MDI/markdown rewriting pipeline never touches code content:
+ * Render a single inline node to clipboard text.
  *
- * - `code_block` nodes are swapped for a paragraph whose only child is a
- *   placeholder text node (keeps the block on its own line, separated by blank
- *   lines, but drops the ``` fences so the restored text is verbatim).
- * - text carrying the `inlineCode` mark is swapped for a placeholder text node
- *   WITHOUT the mark (drops the surrounding backticks).
- *
- * Captured verbatim code text is returned in `segments`, indexed by the number
- * embedded in each placeholder; `MdiDocument.toClipboardText` restores them
- * after the pipeline runs.
+ * - Text nodes (incl. inline-code-marked text) emit `node.text` VERBATIM. The
+ *   text is already literal in the ProseMirror model — there is no markdown
+ *   escaping to undo and no emphasis/link markup to strip (marks carry no text).
+ * - MDI macro nodes render per their feature flag: enabled → converted
+ *   (ruby `base（text）`, tcy/no-break/kern → inner text, `[[br]]` → newline);
+ *   disabled → the literal `.mdi` source verbatim.
+ * - `hardbreak` → newline.
  */
-function extractCodeSegments(
-  doc: ProseNode,
-  schema: Schema,
-): { doc: ProseNode; segments: string[] } {
+function inlineNodeToText(node: ProseNode, features: MdiFeatureFlags): string {
+  if (node.isText) return node.text ?? "";
+
+  switch (node.type.name) {
+    case RUBY_NODE:
+      // Reuse the shared ruby renderer so split-ruby dot handling stays in one place.
+      return features.enableRuby
+        ? replaceMdiWithRubyTextGated(mdiNodeLiteral(node), features)
+        : mdiNodeLiteral(node);
+    case TCY_NODE:
+      return features.enableTcy ? (node.attrs.value as string) : mdiNodeLiteral(node);
+    case NOBREAK_NODE:
+      return features.enableNoBreak ? (node.attrs.text as string) : mdiNodeLiteral(node);
+    case KERN_NODE:
+      return features.enableKern ? (node.attrs.text as string) : mdiNodeLiteral(node);
+    case MDI_BREAK_NODE:
+      return features.enableMdiBreak ? "\n" : mdiNodeLiteral(node);
+    case HARDBREAK_NODE:
+      return "\n";
+    default:
+      // Any other inline leaf (e.g. image) contributes only its text content.
+      return node.textContent;
+  }
+}
+
+/** Concatenate the inline children of a block node into a single text line. */
+function inlineFragmentToText(fragment: Fragment, features: MdiFeatureFlags): string {
+  let out = "";
+  fragment.forEach((child) => {
+    out += inlineNodeToText(child, features);
+  });
+  return out;
+}
+
+/**
+ * Walk a block-level fragment, producing an array of block text segments.
+ * Each entry is one logical block (paragraph, heading, list item, code block);
+ * the caller joins them with a single blank line so author-intended paragraph
+ * separation is preserved without spurious markdown blank-line artifacts.
+ *
+ * A `blankParagraph` ([[blank]]) yields an empty segment, which the blank-line
+ * join renders as an intentional extra blank line between its neighbours.
+ */
+function blocksToSegments(fragment: Fragment, features: MdiFeatureFlags): string[] {
   const segments: string[] = [];
-  const codeBlockType = schema.nodes[CODE_BLOCK_NODE];
-  const paragraphType = schema.nodes.paragraph;
-  const inlineCodeMark = schema.marks[INLINE_CODE_MARK];
 
-  const placeholderTextNode = (text: string): ProseNode => {
-    const index = segments.length;
-    segments.push(text);
-    return schema.text(codePlaceholder(index));
-  };
+  fragment.forEach((node) => {
+    const name = node.type.name;
 
-  const mapInline = (fragment: Fragment): Fragment => {
-    const out: ProseNode[] = [];
-    fragment.forEach((child) => {
-      if (inlineCodeMark && child.isText && child.marks.some((m) => m.type === inlineCodeMark)) {
-        out.push(placeholderTextNode(child.text ?? ""));
-        return;
+    if (name === CODE_BLOCK_NODE) {
+      // Code content is literal: never MDI-converted, never markdown-stripped.
+      segments.push(node.textContent);
+      return;
+    }
+
+    if (name === BLANK_PARAGRAPH_NODE) {
+      // Empty [[blank]] → intentional blank line; non-empty behaves like a paragraph.
+      segments.push(node.content.size === 0 ? "" : inlineFragmentToText(node.content, features));
+      return;
+    }
+
+    if (LIST_CONTAINER_NODES.has(name) || name === LIST_ITEM_NODE || name === BLOCKQUOTE_NODE) {
+      // Recurse into block containers; their block children become their own
+      // segments (no list markers / blockquote markers in plain text).
+      for (const seg of blocksToSegments(node.content, features)) {
+        segments.push(seg);
       }
-      out.push(child);
-    });
-    return Fragment.fromArray(out);
-  };
-
-  const mapNode = (node: ProseNode): ProseNode => {
-    if (codeBlockType && node.type === codeBlockType) {
-      const placeholder = placeholderTextNode(node.textContent);
-      // Wrap in a paragraph when available so block separation is preserved;
-      // fall back to a bare text node otherwise.
-      return paragraphType ? paragraphType.create(null, placeholder) : placeholder;
+      return;
     }
-    if (node.isText) return node;
+
     if (node.inlineContent) {
-      return node.copy(mapInline(node.content));
+      // paragraph / heading: emit the inline text with no markdown markers.
+      // An EMPTY regular paragraph is a markdown blank-line artifact (the
+      // round-trip form of a single author-typed blank line) — skip it so two
+      // real paragraphs are separated by exactly one blank line, not two.
+      // Author-intended empty blocks use `blankParagraph` ([[blank]]), handled
+      // above, which DOES emit an empty segment.
+      const text = inlineFragmentToText(node.content, features);
+      if (text.length > 0) segments.push(text);
+      return;
     }
-    if (node.childCount > 0) {
-      const mapped: ProseNode[] = [];
-      node.content.forEach((child) => mapped.push(mapNode(child)));
-      return node.copy(Fragment.fromArray(mapped));
-    }
-    return node;
-  };
 
-  const mappedChildren: ProseNode[] = [];
-  doc.content.forEach((child) => mappedChildren.push(mapNode(child)));
-  return { doc: doc.copy(Fragment.fromArray(mappedChildren)), segments };
+    if (node.childCount > 0) {
+      // Unknown block wrapper: recurse so nested content is not dropped.
+      for (const seg of blocksToSegments(node.content, features)) {
+        segments.push(seg);
+      }
+      return;
+    }
+
+    // Leaf block (e.g. hr / image): contribute its text content, if any.
+    const text = node.textContent;
+    if (text.length > 0) segments.push(text);
+  });
+
+  return segments;
 }
 
 /**
- * Clipboard *text* serializer.
+ * Clipboard *text* serializer (AST-walk).
  *
  * Copying from the editor must put **clean plain text** on `text/plain`, not
  * the raw MDI/markdown that the default `@milkdown/plugin-clipboard` emits
- * (e.g. `# {花|か}`, escaped `\[\[blank]]`). We serialize the copied slice to
- * markdown, then run `MdiDocument.toClipboardText` which:
+ * (e.g. `# {花|か}`, escaped `\[\[blank]]`). Rather than serialize the slice to
+ * markdown and then un-parse it with regexes (whack-a-mole on escapes, code
+ * fences, list bullets, `.txt` literals), we walk the ProseMirror slice
+ * directly. Text nodes are already LITERAL — no markdown to undo — and
+ * structure (code / list / emphasis / MDI) is explicit in the node tree:
  *
- * - converts each MDI macro family **only when its feature flag is enabled**
- *   (ruby `{親|ルビ}` → `親（ルビ）`, `^2024^` → `2024`, `[[br]]` → newline …);
- *   a disabled family is preserved verbatim;
- * - strips markdown markup (heading `#`, emphasis `*`, …) and resolves
- *   CommonMark backslash-escapes (`\# title` → `# title`).
- *
- * Before serializing, code regions (`code_block` nodes and `inlineCode`-marked
- * text) are replaced with regex-inert placeholders and restored verbatim after
- * the pipeline, so MDI macros and markdown inside code are copied literally.
+ * - block nodes (paragraph, heading, list item, code block) are joined by a
+ *   single blank line; an empty `blankParagraph` ([[blank]]) yields an extra
+ *   intentional blank line;
+ * - text nodes emit `node.text` verbatim (em/strong/link marks carry no text,
+ *   so their markup simply never appears);
+ * - inline-code marked text and `code_block` content are emitted verbatim,
+ *   never MDI-converted;
+ * - MDI nodes are gated per feature flag: enabled → converted, disabled →
+ *   literal `.mdi` source. In non-MDI / `.txt` mode the MDI plugins are not
+ *   installed, so these appear as literal text nodes and are emitted verbatim
+ *   automatically.
  *
  * `text/html` is intentionally left to the default serializer so rich paste
  * into Word/Pages keeps headings, ruby (`<ruby>`), and structure.
@@ -138,33 +220,20 @@ function extractCodeSegments(
  * in order and uses the first non-null `clipboardTextSerializer`, so ours wins.
  */
 export function createClipboardSerializerPlugin(
-  ctx: Ctx,
+  _ctx: Ctx,
   options: ClipboardSerializerOptions,
 ): Plugin {
-  const { features, plainText = false } = options;
+  // `plainText` needs no special casing in the AST walk: in `.txt` mode the MDI
+  // plugins are not installed and `remarkPlainTextPlugin` keeps `*` / `#` / `**`
+  // as literal text nodes, which the walk already emits verbatim.
+  const { features } = options;
 
   return new Plugin({
     key: new PluginKey("mdiClipboardSerializer"),
     props: {
       clipboardTextSerializer: (slice) => {
-        const serializer = ctx.get(serializerCtx);
-        const schema = ctx.get(schemaCtx);
-        const rawDoc = schema.topNodeType.createAndFill(undefined, slice.content);
-        // Fallback to ProseMirror's bare text if the slice can't form a doc.
-        if (!rawDoc) return slice.content.textBetween(0, slice.content.size, "\n\n");
-
-        const { doc, segments } = extractCodeSegments(rawDoc, schema);
-        const markdown = serializer(doc);
-
-        // In MDI mode the editor parses `\[\[blank]]` back to `[[blank]]`, so we
-        // use `.mdi` normalisation to recover the bracket macros before export.
-        // In non-MDI / plain-text mode (no macro family enabled) that step is skipped.
-        const fileType = anyMdiFeatureEnabled(features) ? ".mdi" : undefined;
-        return MdiDocument.fromEditorOutput(markdown, { fileType }).toClipboardText({
-          features,
-          codeSegments: segments,
-          plainText,
-        });
+        const segments = blocksToSegments(slice.content, features);
+        return segments.join("\n\n");
       },
     },
   });

--- a/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
+++ b/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
@@ -1,25 +1,106 @@
-import { Plugin, PluginKey } from "@milkdown/prose/state";
 import { serializerCtx, schemaCtx } from "@milkdown/core";
+import { Plugin, PluginKey } from "@milkdown/prose/state";
+import { Fragment } from "@milkdown/prose/model";
 import type { Ctx } from "@milkdown/ctx";
-import { MdiDocument } from "../mdi-document";
+import type { Node as ProseNode, Schema } from "@milkdown/prose/model";
+import { MdiDocument, codePlaceholder } from "../mdi-document";
+import type { MdiFeatureFlags } from "../mdi-document";
+
+/** ProseMirror node type name for fenced/indented code blocks (commonmark). */
+const CODE_BLOCK_NODE = "code_block";
+/** ProseMirror inline mark name for `` `code` `` spans (commonmark). */
+const INLINE_CODE_MARK = "inlineCode";
 
 /**
  * Options controlling which MDI features are active in the current editor
- * session. These mirror the flags passed to `japaneseNovel(options)` so the
- * clipboard serializer can gate MDI macro conversion to the modes that
- * actually parse those macros (i.e. `.mdi` documents).
+ * session. These mirror the per-feature flags passed to `japaneseNovel(options)`
+ * so the clipboard serializer can gate each MDI macro family independently:
+ * a session that enables ONLY ruby must still copy literal `^2024^` and
+ * `[[br]]` verbatim.
  */
 export interface ClipboardSerializerOptions {
-  /**
-   * When true at least one MDI inline feature (ruby / tcy / mdi-break) is
-   * active and the editor parses the corresponding macros.  The clipboard
-   * serializer will then run the full MDI-aware export pipeline so that
-   * `{花|か}` copies as `花（か）`, `^2024^` copies as `2024`, etc.
-   *
-   * When false (`.md` / `.txt` mode) those macros are literal text and must
-   * be preserved verbatim on the clipboard.
-   */
-  enableMdiMacros: boolean;
+  /** Per-feature MDI macro flags, forwarded to `toClipboardText`. */
+  features: MdiFeatureFlags;
+}
+
+/**
+ * Whether any MDI macro family is enabled. When none are, the serialized text
+ * is treated as `.md` / `.txt` content (macros are literal, no bracket-macro
+ * recovery on the editor output).
+ */
+function anyMdiFeatureEnabled(features: MdiFeatureFlags): boolean {
+  return (
+    features.enableRuby ||
+    features.enableTcy ||
+    features.enableNoBreak ||
+    features.enableKern ||
+    features.enableMdiBreak
+  );
+}
+
+/**
+ * Replace every code region in `doc` with a regex-inert placeholder so the
+ * MDI/markdown rewriting pipeline never touches code content:
+ *
+ * - `code_block` nodes are swapped for a paragraph whose only child is a
+ *   placeholder text node (keeps the block on its own line, separated by blank
+ *   lines, but drops the ``` fences so the restored text is verbatim).
+ * - text carrying the `inlineCode` mark is swapped for a placeholder text node
+ *   WITHOUT the mark (drops the surrounding backticks).
+ *
+ * Captured verbatim code text is returned in `segments`, indexed by the number
+ * embedded in each placeholder; `MdiDocument.toClipboardText` restores them
+ * after the pipeline runs.
+ */
+function extractCodeSegments(
+  doc: ProseNode,
+  schema: Schema,
+): { doc: ProseNode; segments: string[] } {
+  const segments: string[] = [];
+  const codeBlockType = schema.nodes[CODE_BLOCK_NODE];
+  const paragraphType = schema.nodes.paragraph;
+  const inlineCodeMark = schema.marks[INLINE_CODE_MARK];
+
+  const placeholderTextNode = (text: string): ProseNode => {
+    const index = segments.length;
+    segments.push(text);
+    return schema.text(codePlaceholder(index));
+  };
+
+  const mapInline = (fragment: Fragment): Fragment => {
+    const out: ProseNode[] = [];
+    fragment.forEach((child) => {
+      if (inlineCodeMark && child.isText && child.marks.some((m) => m.type === inlineCodeMark)) {
+        out.push(placeholderTextNode(child.text ?? ""));
+        return;
+      }
+      out.push(child);
+    });
+    return Fragment.fromArray(out);
+  };
+
+  const mapNode = (node: ProseNode): ProseNode => {
+    if (codeBlockType && node.type === codeBlockType) {
+      const placeholder = placeholderTextNode(node.textContent);
+      // Wrap in a paragraph when available so block separation is preserved;
+      // fall back to a bare text node otherwise.
+      return paragraphType ? paragraphType.create(null, placeholder) : placeholder;
+    }
+    if (node.isText) return node;
+    if (node.inlineContent) {
+      return node.copy(mapInline(node.content));
+    }
+    if (node.childCount > 0) {
+      const mapped: ProseNode[] = [];
+      node.content.forEach((child) => mapped.push(mapNode(child)));
+      return node.copy(Fragment.fromArray(mapped));
+    }
+    return node;
+  };
+
+  const mappedChildren: ProseNode[] = [];
+  doc.content.forEach((child) => mappedChildren.push(mapNode(child)));
+  return { doc: doc.copy(Fragment.fromArray(mappedChildren)), segments };
 }
 
 /**
@@ -28,15 +109,17 @@ export interface ClipboardSerializerOptions {
  * Copying from the editor must put **clean plain text** on `text/plain`, not
  * the raw MDI/markdown that the default `@milkdown/plugin-clipboard` emits
  * (e.g. `# {花|か}`, escaped `\[\[blank]]`). We serialize the copied slice to
- * markdown, then:
+ * markdown, then run `MdiDocument.toClipboardText` which:
  *
- * - In **MDI mode** (`enableMdiMacros: true`): run the MDI export pipeline so
- *   ruby `{親|ルビ}` → `親（ルビ）`, `[[blank]]` / `\[\[blank]]` / `<br>` →
- *   blank lines, heading `#`, emphasis `*` … markdown markup is stripped.
- * - In **non-MDI mode** (`enableMdiMacros: false`): the macros are literal
- *   text and must be preserved verbatim.  Only markdown formatting is stripped
- *   and CommonMark backslash-escapes are resolved (e.g. `\# title` →
- *   `# title`).
+ * - converts each MDI macro family **only when its feature flag is enabled**
+ *   (ruby `{親|ルビ}` → `親（ルビ）`, `^2024^` → `2024`, `[[br]]` → newline …);
+ *   a disabled family is preserved verbatim;
+ * - strips markdown markup (heading `#`, emphasis `*`, …) and resolves
+ *   CommonMark backslash-escapes (`\# title` → `# title`).
+ *
+ * Before serializing, code regions (`code_block` nodes and `inlineCode`-marked
+ * text) are replaced with regex-inert placeholders and restored verbatim after
+ * the pipeline, so MDI macros and markdown inside code are copied literally.
  *
  * `text/html` is intentionally left to the default serializer so rich paste
  * into Word/Pages keeps headings, ruby (`<ruby>`), and structure.
@@ -49,7 +132,7 @@ export function createClipboardSerializerPlugin(
   ctx: Ctx,
   options: ClipboardSerializerOptions,
 ): Plugin {
-  const { enableMdiMacros } = options;
+  const { features } = options;
 
   return new Plugin({
     key: new PluginKey("mdiClipboardSerializer"),
@@ -57,17 +140,20 @@ export function createClipboardSerializerPlugin(
       clipboardTextSerializer: (slice) => {
         const serializer = ctx.get(serializerCtx);
         const schema = ctx.get(schemaCtx);
-        const doc = schema.topNodeType.createAndFill(undefined, slice.content);
+        const rawDoc = schema.topNodeType.createAndFill(undefined, slice.content);
         // Fallback to ProseMirror's bare text if the slice can't form a doc.
-        if (!doc) return slice.content.textBetween(0, slice.content.size, "\n\n");
+        if (!rawDoc) return slice.content.textBetween(0, slice.content.size, "\n\n");
+
+        const { doc, segments } = extractCodeSegments(rawDoc, schema);
         const markdown = serializer(doc);
 
-        // In MDI mode the editor actually parses `\[\[blank]]` back to
-        // `[[blank]]` markers, so we use `.mdi` normalisation to recover them
-        // before export.  In non-MDI mode the bracket-macro step is skipped.
-        const fileType = enableMdiMacros ? ".mdi" : undefined;
+        // In MDI mode the editor parses `\[\[blank]]` back to `[[blank]]`, so we
+        // use `.mdi` normalisation to recover the bracket macros before export.
+        // In non-MDI mode (no macro family enabled) that step is skipped.
+        const fileType = anyMdiFeatureEnabled(features) ? ".mdi" : undefined;
         return MdiDocument.fromEditorOutput(markdown, { fileType }).toClipboardText({
-          enableMdiMacros,
+          features,
+          codeSegments: segments,
         });
       },
     },

--- a/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
+++ b/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
@@ -21,6 +21,15 @@ const INLINE_CODE_MARK = "inlineCode";
 export interface ClipboardSerializerOptions {
   /** Per-feature MDI macro flags, forwarded to `toClipboardText`. */
   features: MdiFeatureFlags;
+  /**
+   * Plain-text (`.txt`) mode. When `true`, the editor installs
+   * `remarkPlainTextPlugin` (see `MilkdownEditor.tsx`) so `*`, `#`, `**` are
+   * LITERAL characters, not markdown. The clipboard serializer must then bypass
+   * markdown stripping / MDI conversion entirely and copy the selection's text
+   * verbatim (only undoing serializer-added CommonMark escapes). Defaults to
+   * `false` for `.md` / `.mdi` documents.
+   */
+  plainText?: boolean;
 }
 
 /**
@@ -132,7 +141,7 @@ export function createClipboardSerializerPlugin(
   ctx: Ctx,
   options: ClipboardSerializerOptions,
 ): Plugin {
-  const { features } = options;
+  const { features, plainText = false } = options;
 
   return new Plugin({
     key: new PluginKey("mdiClipboardSerializer"),
@@ -149,11 +158,12 @@ export function createClipboardSerializerPlugin(
 
         // In MDI mode the editor parses `\[\[blank]]` back to `[[blank]]`, so we
         // use `.mdi` normalisation to recover the bracket macros before export.
-        // In non-MDI mode (no macro family enabled) that step is skipped.
+        // In non-MDI / plain-text mode (no macro family enabled) that step is skipped.
         const fileType = anyMdiFeatureEnabled(features) ? ".mdi" : undefined;
         return MdiDocument.fromEditorOutput(markdown, { fileType }).toClipboardText({
           features,
           codeSegments: segments,
+          plainText,
         });
       },
     },

--- a/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
+++ b/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
@@ -4,24 +4,53 @@ import type { Ctx } from "@milkdown/ctx";
 import { MdiDocument } from "../mdi-document";
 
 /**
+ * Options controlling which MDI features are active in the current editor
+ * session. These mirror the flags passed to `japaneseNovel(options)` so the
+ * clipboard serializer can gate MDI macro conversion to the modes that
+ * actually parse those macros (i.e. `.mdi` documents).
+ */
+export interface ClipboardSerializerOptions {
+  /**
+   * When true at least one MDI inline feature (ruby / tcy / mdi-break) is
+   * active and the editor parses the corresponding macros.  The clipboard
+   * serializer will then run the full MDI-aware export pipeline so that
+   * `{花|か}` copies as `花（か）`, `^2024^` copies as `2024`, etc.
+   *
+   * When false (`.md` / `.txt` mode) those macros are literal text and must
+   * be preserved verbatim on the clipboard.
+   */
+  enableMdiMacros: boolean;
+}
+
+/**
  * Clipboard *text* serializer.
  *
- * Copying from the editor must put **clean plain text** on `text/plain`, not the
- * raw MDI/markdown that the default `@milkdown/plugin-clipboard` emits (e.g.
- * `# {花|か}{様|よう}`, escaped `\[\[blank]]`). We serialize the copied slice to
- * markdown, then run it through the MDI export pipeline so that:
- *   - ruby `{親|ルビ}` → `親（ルビ）`
- *   - `[[blank]]` / `\[\[blank]]` / `<br>` → blank lines
- *   - heading `#`, emphasis `*` … markdown markup is stripped
+ * Copying from the editor must put **clean plain text** on `text/plain`, not
+ * the raw MDI/markdown that the default `@milkdown/plugin-clipboard` emits
+ * (e.g. `# {花|か}`, escaped `\[\[blank]]`). We serialize the copied slice to
+ * markdown, then:
  *
- * `text/html` is intentionally left to the default serializer so rich paste into
- * Word/Pages keeps headings, ruby (`<ruby>`), and structure.
+ * - In **MDI mode** (`enableMdiMacros: true`): run the MDI export pipeline so
+ *   ruby `{親|ルビ}` → `親（ルビ）`, `[[blank]]` / `\[\[blank]]` / `<br>` →
+ *   blank lines, heading `#`, emphasis `*` … markdown markup is stripped.
+ * - In **non-MDI mode** (`enableMdiMacros: false`): the macros are literal
+ *   text and must be preserved verbatim.  Only markdown formatting is stripped
+ *   and CommonMark backslash-escapes are resolved (e.g. `\# title` →
+ *   `# title`).
+ *
+ * `text/html` is intentionally left to the default serializer so rich paste
+ * into Word/Pages keeps headings, ruby (`<ruby>`), and structure.
  *
  * This plugin is registered as part of `japaneseNovel(...)`, which is `.use()`d
- * before `@milkdown/plugin-clipboard`; ProseMirror's `someProp` walks plugins in
- * order and uses the first non-null `clipboardTextSerializer`, so ours wins.
+ * before `@milkdown/plugin-clipboard`; ProseMirror's `someProp` walks plugins
+ * in order and uses the first non-null `clipboardTextSerializer`, so ours wins.
  */
-export function createClipboardSerializerPlugin(ctx: Ctx): Plugin {
+export function createClipboardSerializerPlugin(
+  ctx: Ctx,
+  options: ClipboardSerializerOptions,
+): Plugin {
+  const { enableMdiMacros } = options;
+
   return new Plugin({
     key: new PluginKey("mdiClipboardSerializer"),
     props: {
@@ -32,9 +61,14 @@ export function createClipboardSerializerPlugin(ctx: Ctx): Plugin {
         // Fallback to ProseMirror's bare text if the slice can't form a doc.
         if (!doc) return slice.content.textBetween(0, slice.content.size, "\n\n");
         const markdown = serializer(doc);
-        return MdiDocument.fromEditorOutput(markdown, { fileType: ".mdi" }).toExportText(
-          "txt-ruby",
-        );
+
+        // In MDI mode the editor actually parses `\[\[blank]]` back to
+        // `[[blank]]` markers, so we use `.mdi` normalisation to recover them
+        // before export.  In non-MDI mode the bracket-macro step is skipped.
+        const fileType = enableMdiMacros ? ".mdi" : undefined;
+        return MdiDocument.fromEditorOutput(markdown, { fileType }).toClipboardText({
+          enableMdiMacros,
+        });
       },
     },
   });

--- a/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
+++ b/packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts
@@ -32,7 +32,9 @@ export function createClipboardSerializerPlugin(ctx: Ctx): Plugin {
         // Fallback to ProseMirror's bare text if the slice can't form a doc.
         if (!doc) return slice.content.textBetween(0, slice.content.size, "\n\n");
         const markdown = serializer(doc);
-        return MdiDocument.fromEditorOutput(markdown, { fileType: ".mdi" }).toExportText("txt-ruby");
+        return MdiDocument.fromEditorOutput(markdown, { fileType: ".mdi" }).toExportText(
+          "txt-ruby",
+        );
       },
     },
   });


### PR DESCRIPTION
## 背景

エディタ本文をコピーすると、`text/plain` に **生の MDI マークアップ**がそのまま載っていた：

```
# {花|か}{様|よう}{年|ねん}{華|か}

…

\[\[blank]]
```

他アプリ（チャット・メモ等）に貼ると読みづらく「不潔」な状態。純テキストを出すべき。

## 原因

`@milkdown/plugin-clipboard` の `clipboardTextSerializer` は、コピーした slice を markdown serializer に通した結果を `text/plain` に載せる。serializer は MDI bracket macro の `[` をエスケープし（`\[\[blank]]`）、ルビは `{親|ルビ}`、見出しは `# ` のまま出力するため、生 MDI が貼り付けられていた（Bug B と同根）。

## 修正

`japaneseNovel(...)` に clipboard-serializer prose plugin を追加：

- コピー slice → markdown 化 → `MdiDocument.fromEditorOutput(...).toExportText("txt-ruby")` でクリーン化
  - ルビ `{親|ルビ}` → `親（ルビ）`
  - `[[blank]]` / `\[\[blank]]` / `<br>` → 空行
  - 見出し `#`・強調 `*` 等の markdown 記号を除去
- `japaneseNovel` は `@milkdown/plugin-clipboard` より先に `.use()` されるため、ProseMirror の `someProp` が本 serializer を優先（**テストで実証**）

`text/html` はデフォルト serializer のまま → **Word/Pages へのリッチ貼り付けは見出し・ルビ(`<ruby>`)・構造を保持**（ユーザー要望の「Word に書式保持」を満たす）。

- `packages/milkdown-plugin-japanese-novel/plugins/clipboard-serializer.ts`（新規）
- `packages/milkdown-plugin-japanese-novel/index.ts`

## テスト

`__tests__/clipboard-serializer.test.ts`（新規 4 件）:
- ルビ見出し → `花（か）…`、markup なし
- `[[blank]]` リーク無し（`[[blank]]` も `\[` も出ない）
- 台詞段落（「…」）が純テキストで保持
- **plugin-clipboard を含む実プラグイン順で本 serializer が優先される**

package テスト **65 件 all green** / `tsc --noEmit` クリーン。

## 関連 issue
関連 issue なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)