### PR TITLE
fix(editor): 縦書き初期表示でタイトルが右枠に密着する問題を修正

### DIFF
--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -351,9 +351,23 @@ export default function NovelEditor({
     if (isVertical && !hasVerticalInitialScrollRef.current) {
       if (setScrollProgress({ container, isVertical: true }, 0)) {
         hasVerticalInitialScrollRef.current = true;
+        // onLayoutReady fires before the web font (Noto Serif JP) finishes
+        // loading. When the font swaps in, the content width (scrollWidth)
+        // grows but scrollLeft stays put, so the document start (right edge)
+        // drifts out of view and the title sticks to the right frame.
+        // Re-pin to the start once fonts are ready (first vertical entry only).
+        if (typeof document !== "undefined" && document.fonts?.ready) {
+          document.fonts.ready.then(() => {
+            const c = scrollContainerRef.current;
+            if (!c) return;
+            requestAnimationFrame(() => {
+              setScrollProgress({ container: c, isVertical: true }, 0);
+            });
+          });
+        }
       }
     }
-  }, [isVertical]);
+  }, [isVertical, scrollContainerRef]);
 
   // 縦書き: コンテンツ幅の変化（Web フォント読込・行字数再計算など）後も読書位置を維持する。
   // scrollLeft は数値のまま据え置かれるため、コンテンツが伸びると文書先頭（右端）が


### PR DESCRIPTION
## 背景

縦書きでファイルを開いた直後、文書先頭（右端）の**タイトルが右枠に密着**し、余白が見えない。手動で少しスクロールすると正しい位置（余白あり）に戻る（ユーザー確認済み）。

## 原因（実機 DevTools で切り分け）

- タイトル右の余白は scrollContainer の `padding-right: 64px` が担っており、要素自体には存在する（DevTools で確認）。
- つまり padding 不足ではなく **初期スクロール位置のドリフト**。
- `onLayoutReady`（初回先頭固定 `setScrollProgress(0)` を呼ぶ）は **Web フォント（Noto Serif JP）読込前**に発火する。フォントが swap-in すると `scrollWidth` が伸びるが `scrollLeft` は据え置かれ、縦書きの先頭（右端）がビューポート外へドリフト → タイトルが枠際に密着。
- 既存の `ResizeObserver` 再固定（#1568）は observe 開始タイミング次第でフォント読込を取りこぼすことがある。

## 修正

`components/Editor.tsx` の初回縦書き入場処理で、`document.fonts.ready` 後に `requestAnimationFrame` で先頭（progress 0）へ固定し直す（**初回のみ・タイミング非依存**）。既存の `ResizeObserver` 経路はそのまま温存し、その隙間を埋める形。

## テスト / 検証

スクロール位置・`scrollWidth`・Web フォント読込は jsdom で再現できないため自動テストは付けていません（既存の縦書きスクロール処理も同様に実機目視前提）。**実機での確認をお願いします**: 縦書きで `花様年華.mdi` を開いた直後にタイトル右へ余白が出ること／横書きに影響がないこと。

`tsc --noEmit` クリーン。

## 関連 issue
関連 issue なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)