### PR TITLE
fix(menu): CMD+P で印刷ダイアログを開けるようにする

### DIFF
--- a/lib/menu/menu-template.js
+++ b/lib/menu/menu-template.js
@@ -77,9 +77,11 @@ const MENU_TEMPLATE = [
       {
         id: "print",
         label: "印刷...",
-        // Electron resolves user overrides for file.print but has no default
-        // native accelerator; the Web menu shows a static platform string.
+        // CmdOrCtrl+P は印刷の直感的な既定キー。他の File 操作と同様に Electron へ既定
+        // accelerator を与える（user override も commandId 経由で解決される）。Web は
+        // 静的な platform 文字列を表示する。
         commandId: "file.print",
+        nativeAccelerator: "CmdOrCtrl+P",
         webCommandLookup: false,
         webAccelerator: { mac: "Cmd+P", other: "Ctrl+P" },
         electronChannel: "menu-print",


### PR DESCRIPTION
## 背景
デスクトップ版（Electron）で **CMD+P を押しても印刷ダイアログが開かない**。

## 原因
`lib/menu/menu-template.js` の `print` 項目だけ **Electron 用の既定 accelerator（`nativeAccelerator`）が欠落**していた（コメントにも "has no default native accelerator"）。印刷実行のハンドラ（`menu-print` → `onMenuPrint` → `printDocument`）自体は存在するが、キーが割り当たっていなかった。Web 版は `webAccelerator` で動作。

## 修正
他の File 操作（開く `CmdOrCtrl+O` / 保存 `CmdOrCtrl+S` 等）と同形式で `nativeAccelerator: "CmdOrCtrl+P"` を付与。CMD+P＝印刷という直感的な既定キーを Electron でも有効化（user override も `commandId: file.print` 経由で解決）。

## 類似ショートカットの点検（ユーザー要望）
- `undo`/`redo`/`cut`/`copy`/`paste`/`select-all`/`zoom` はすべて `electronRole` を持ち、OS 既定キー（CMD+Z, CMD+Shift+Z, CMD+A, CMD+±0 等）が自動付与される → **問題なし・直感的**
- 既定 accelerator が欠落していたのは **`print` のみ**

## テスト
`menu-template-drift.test.ts` 15 件 green。実機（Electron）での CMD+P 動作確認を推奨。

## 関連 issue
関連 issue なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)