### PR TITLE
fix(editor): 段落番号を会話文/通常段落で一直線に揃える

### DIFF
--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -899,7 +899,16 @@ export default function MilkdownEditor({
             ? `
               content: counter(paragraph);
               position: absolute;
-              left: -2em;
+              /* Anchor the number's edge nearest the text at a fixed distance
+                 from the paragraph's inline start, so every number lines up
+                 regardless of digit count. */
+              right: 100%;
+              margin-right: 0.6em;
+              /* abspos blockifies ::before, which would otherwise inherit the
+                 paragraph's text-indent and offset dialogue (indent 0) vs
+                 normal (indent N) numbers. Pin it so all numbers align. */
+              text-indent: 0;
+              text-align: right;
               font-size: 0.7em;
               opacity: 0.5;
               color: currentColor;
@@ -913,6 +922,11 @@ export default function MilkdownEditor({
             ? `
               content: counter(paragraph);
               position: absolute;
+              /* In vertical-rl the inline axis is vertical, so the paragraph's
+                 text-indent shifts the number downward. abspos blockifies
+                 ::before and it inherits that indent, offsetting dialogue
+                 (indent 0) vs normal numbers. Pin it to 0 so all numbers align. */
+              text-indent: 0;
               top: -2em;
               right: 0;
               font-size: 0.7em;


### PR DESCRIPTION
## Summary

- 段落番号 (`::before` カウンタ) が会話文段落と通常段落で横位置がズレ、番号列が一直線にならない問題を修正
- 横書き・縦書き両方で、番号が桁数や段落種別に関係なく一直線に揃うようになる

## 原因

段落番号は `p::before { content: counter(paragraph) }` で描画している。`position: absolute` を付けると CSS 仕様で `::before` が **block 化 (blockification)** され、親 `<p>` の `text-indent` を**継承**する。

- 通常段落: `text-indent: N em` → 番号が本文側にズレる
- 会話文段落 (`.mdi-dialogue`, `text-indent: 0`) → 番号がズレない

この差で会話文の番号だけ位置が変わり、番号列が揃わなかった。

## Changes

| 箇所 | 内容 |
| --- | --- |
| `components/editor/MilkdownEditor.tsx` 横書き `::before` | `text-indent: 0` を明示して継承を遮断。`right: 100%` + `margin-right` + `text-align: right` で本文側の端を固定基準にし、1/2/3 桁が混在しても番号列が揃うようにする |
| `components/editor/MilkdownEditor.tsx` 縦書き `::before` | `text-indent: 0` を明示して継承を遮断（位置指定は従来どおり `top: -2em; right: 0`） |

## Test plan

- [ ] 横書きで会話文 (`「…」` 始まり) と通常段落が混在する文書を開き、段落番号が縦一直線に揃うことを確認
- [ ] 番号が 1 桁→2 桁→3 桁に跨る長い文書でも番号列が揃うことを確認
- [ ] 縦書きに切り替え、会話文と通常段落で番号位置が揃うことを確認
- [ ] 空行段落 (`.mdi-blank`) が番号付与・カウントされないことを確認（既存挙動の非回帰）

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)