### PR TITLE
feat(editor): バブルメニューに書式解除ボタンを追加

### DIFF
--- a/components/BubbleMenu.tsx
+++ b/components/BubbleMenu.tsx
@@ -14,6 +14,7 @@ import {
   Heading2,
   Heading3,
   Code,
+  RemoveFormatting,
 } from "lucide-react";
 import clsx from "clsx";
 
@@ -34,7 +35,8 @@ export type FormatType =
   | "bulletList"
   | "orderedList"
   | "blockquote"
-  | "code";
+  | "code"
+  | "clearFormatting";
 
 export default function BubbleMenu({
   selectionState,
@@ -126,6 +128,11 @@ export default function BubbleMenu({
     { icon: List, label: "箇条書き", format: "bulletList" },
     { icon: ListOrdered, label: "番号付き", format: "orderedList" },
     { icon: Code, label: "コード", format: "code" },
+    {
+      icon: RemoveFormatting,
+      label: "標準本文に戻す（書式をすべて解除）",
+      format: "clearFormatting",
+    },
   ];
 
   const menu = (

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -14,6 +14,7 @@ import {
   wrapInOrderedListCommand,
 } from "@milkdown/preset-commonmark";
 import { gfm, toggleStrikethroughCommand } from "@milkdown/preset-gfm";
+import { clearFormatting } from "@/lib/editor-page/clear-formatting";
 import { listener, listenerCtx } from "@milkdown/plugin-listener";
 import { history } from "@milkdown/plugin-history";
 import { clipboard } from "@milkdown/plugin-clipboard";
@@ -619,6 +620,12 @@ export default function MilkdownEditor({
           break;
         case "code":
           execute(toggleInlineCodeCommand.key);
+          break;
+        case "clearFormatting":
+          // 選択範囲を標準本文（段落・装飾なし）に戻す
+          editor.action((ctx) => {
+            clearFormatting(ctx.get(editorViewCtx));
+          });
           break;
         default:
           break;

--- a/lib/editor-page/__tests__/clear-formatting.test.ts
+++ b/lib/editor-page/__tests__/clear-formatting.test.ts
@@ -1,0 +1,91 @@
+/**
+ * clearFormatting: 選択範囲を標準本文（段落・装飾なし）へ戻す。
+ * 見出し・太字・取り消し線・引用・リスト・コードブロックが
+ * すべて素の段落テキストになることを検証する。
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { Editor, rootCtx, defaultValueCtx, editorViewCtx } from "@milkdown/core";
+import { commonmark } from "@milkdown/preset-commonmark";
+import { gfm } from "@milkdown/preset-gfm";
+import { TextSelection } from "@milkdown/prose/state";
+import type { EditorView } from "@milkdown/prose/view";
+import { clearFormatting } from "../clear-formatting";
+
+const mountedRoots: HTMLElement[] = [];
+afterEach(() => {
+  mountedRoots.forEach((r) => r.remove());
+  mountedRoots.length = 0;
+});
+
+async function makeView(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  mountedRoots.push(root);
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, markdown);
+    })
+    .use(commonmark)
+    .use(gfm)
+    .create();
+  let view!: EditorView;
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx);
+  });
+  return { editor, view };
+}
+
+/** 文書全体を選択して書式解除を実行する。 */
+function selectAllAndClear(view: EditorView): void {
+  const { doc } = view.state;
+  const sel = TextSelection.create(doc, 1, doc.content.size - 1);
+  view.dispatch(view.state.tr.setSelection(sel));
+  clearFormatting(view);
+}
+
+describe("clearFormatting", () => {
+  it("見出しを標準段落に戻す", async () => {
+    const { view } = await makeView("# 花様年華");
+    selectAllAndClear(view);
+    const top = view.state.doc.firstChild;
+    expect(top?.type.name).toBe("paragraph");
+    expect(view.state.doc.textContent).toBe("花様年華");
+  });
+
+  it("太字・斜体・取り消し線などのインラインマークを除去する", async () => {
+    const { view } = await makeView("**太字** *斜体* ~~取り消し~~");
+    selectAllAndClear(view);
+    let markCount = 0;
+    view.state.doc.descendants((node) => {
+      markCount += node.marks.length;
+    });
+    expect(markCount).toBe(0);
+    expect(view.state.doc.firstChild?.type.name).toBe("paragraph");
+  });
+
+  it("引用ブロックを解除して段落に戻す", async () => {
+    const { view } = await makeView("> 引用文です");
+    selectAllAndClear(view);
+    expect(view.state.doc.firstChild?.type.name).toBe("paragraph");
+    expect(view.state.doc.textContent).toBe("引用文です");
+  });
+
+  it("リスト項目を解除して段落に戻す", async () => {
+    const { view } = await makeView("- 項目一\n- 項目二");
+    selectAllAndClear(view);
+    view.state.doc.forEach((node) => {
+      expect(node.type.name).toBe("paragraph");
+    });
+  });
+
+  it("選択が空のときは何も変更しない", async () => {
+    const { view } = await makeView("# 見出し");
+    const before = view.state.doc.toJSON();
+    // カーソルのみ（空選択）
+    const sel = TextSelection.create(view.state.doc, 1, 1);
+    view.dispatch(view.state.tr.setSelection(sel));
+    clearFormatting(view);
+    expect(view.state.doc.toJSON()).toEqual(before);
+  });
+});

--- a/lib/editor-page/clear-formatting.ts
+++ b/lib/editor-page/clear-formatting.ts
@@ -1,0 +1,49 @@
+import { setBlockType, lift } from "@milkdown/prose/commands";
+import { liftListItem } from "@milkdown/prose/schema-list";
+import type { EditorView } from "@milkdown/prose/view";
+
+/** lift 系コマンドを変化が無くなるまで反復実行する（多重ネスト対策）。上限付き。 */
+function repeat(
+  view: EditorView,
+  command: (state: EditorView["state"], dispatch: EditorView["dispatch"]) => boolean,
+): void {
+  for (let i = 0; i < 16; i += 1) {
+    if (!command(view.state, view.dispatch)) break;
+  }
+}
+
+/**
+ * 選択範囲を標準本文（段落・装飾なし）に戻す。
+ *
+ * Milkdown には単一の「書式解除」コマンドが無いため、ProseMirror を直接操作する。
+ * 1) インラインマーク（太字・斜体・取り消し線・コード等）をすべて除去
+ * 2) 見出し・コードブロック等のテキストブロックを標準段落へ変換
+ * 3) リスト項目を段落へ引き上げ（list_item は generic lift では解除できないため専用コマンド）
+ * 4) 引用などの残りのラッパーから段落を引き上げる
+ *
+ * 選択が空の場合は何もしない。
+ */
+export function clearFormatting(view: EditorView): void {
+  if (view.state.selection.empty) return;
+
+  // 1) インラインマークをすべて除去
+  const { from, to } = view.state.selection;
+  view.dispatch(view.state.tr.removeMark(from, to));
+
+  // 2) テキストブロックを標準段落へ変換
+  const paragraph = view.state.schema.nodes.paragraph;
+  if (paragraph) {
+    setBlockType(paragraph)(view.state, view.dispatch);
+  }
+
+  // 3) リスト項目を引き上げてリストから抜ける
+  const listItem = view.state.schema.nodes.list_item;
+  if (listItem) {
+    repeat(view, liftListItem(listItem));
+  }
+
+  // 4) 引用などの残りのラッパーを解除
+  repeat(view, lift);
+
+  view.focus();
+}


### PR DESCRIPTION
## 概要
選択範囲のスタイルをすべて解除して**標準本文（段落・装飾なし）に戻す**ボタンを、選択時に表示されるバブルメニュー（BubbleMenu）に追加しました。アイコンは「A」字の `RemoveFormatting`（書式解除の慣用アイコン）です。

要望: ツールバーに「上がったスタイルを標準本文に戻す」ボタンが無く不便、というユーザー報告。

## 挙動
- インラインマーク（太字・斜体・取り消し線・コード）を全除去
- 見出し・コードブロックを標準段落へ変換
- 引用・リストのラッパーを解除（`liftListItem` + `lift` を反復）
- 選択が空のときは何もしない

## 実装
- `lib/editor-page/clear-formatting.ts` — ロジックを純関数 `clearFormatting(view)` として切り出し
- `components/BubbleMenu.tsx` — `FormatType` に `clearFormatting` を追加、ボタンを末尾に配置
- `components/editor/MilkdownEditor.tsx` — `handleFormat` で呼び出し

## テスト
`lib/editor-page/__tests__/clear-formatting.test.ts` — 実エディタをマウントして 5 ケース検証（見出し / インラインマーク / 引用 / リスト / 空選択）。全 green。`tsc --noEmit` も pass。

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)