### PR TITLE
fix(export): PDF/DOCX/EPUB で [[blank]] が文字列リークする問題を根本修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -574,6 +574,10 @@ export default function EditorPage() {
           pageNumberPosition: settings.pageNumberPosition,
           textIndent: settings.textIndent,
           googleFontFamily: settings.googleFontFamily,
+          // Thread the active tab's snapshotted file type so the HTML pipeline
+          // un-escapes MDI macros only for ".mdi" and preserves \[\[blank]]
+          // literals authored in ".md"/".txt".
+          fileType: dialogState.fileType,
         });
 
         notificationManager.dismiss(progressId);
@@ -598,7 +602,12 @@ export default function EditorPage() {
 
     // Web path: browser print preview (static import — no await before window.open)
     try {
-      const opened = await openWebPrintPreview(dialogState.content, dialogState.metadata, settings);
+      const opened = await openWebPrintPreview(
+        dialogState.content,
+        dialogState.metadata,
+        settings,
+        dialogState.fileType,
+      );
       if (!opened) {
         notificationManager.warning(
           "ポップアップがブロックされました。ブラウザの設定を確認してください。",
@@ -745,6 +754,11 @@ export default function EditorPage() {
     const dialogState = exportDialogStateRef.current;
     if (!dialogState) return;
 
+    // Thread the active tab's snapshotted file type so the HTML pipeline
+    // un-escapes MDI macros only for ".mdi" and preserves \[\[blank]] literals
+    // authored in ".md"/".txt".
+    const epubOptions: EpubExportOptions = { ...options, fileType: dialogState.fileType };
+
     // Electron path: use IPC
     if (window.electronAPI?.exportEPUB) {
       setExportDialogState(null);
@@ -755,7 +769,7 @@ export default function EditorPage() {
 
       try {
         // Electron IPC serializes Uint8Array automatically
-        const result = await window.electronAPI.exportEPUB(dialogState.content, options);
+        const result = await window.electronAPI.exportEPUB(dialogState.content, epubOptions);
 
         notificationManager.dismiss(progressId);
 
@@ -784,7 +798,7 @@ export default function EditorPage() {
 
     try {
       const { generateEpubBlob } = await import("@/lib/export/epub-web");
-      const blob = await generateEpubBlob(dialogState.content, options);
+      const blob = await generateEpubBlob(dialogState.content, epubOptions);
       const baseName = (options.metadata.title || "untitled")
         .replace(/[<>:"/\\|?*]/g, "_")
         .replace(/\.[^.]+$/, "");
@@ -1201,6 +1215,7 @@ export default function EditorPage() {
           onEpubExport: handleEpubExportConfirm,
           content: exportDialogState?.content ?? "",
           metadata: exportDialogState?.metadata ?? { title: "" },
+          fileType: exportDialogState?.fileType,
         },
         printDialog: {
           state: printDialogState,

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -105,6 +105,7 @@ interface EditorLayoutProps {
       onEpubExport: (options: EpubExportOptions) => void;
       content: string;
       metadata: ExportMetadata;
+      fileType?: string;
     };
     printDialog: {
       state: { content: string; metadata: ExportMetadata } | null;
@@ -112,6 +113,7 @@ interface EditorLayoutProps {
       onPrint: (settings: PdfExportSettings) => void;
       content: string;
       metadata: ExportMetadata;
+      fileType?: string;
     };
   };
   recovery: {
@@ -289,6 +291,7 @@ export default function EditorLayout({
               onExportEpub={dialogs.exportDialog.onEpubExport}
               content={dialogs.exportDialog.content}
               metadata={dialogs.exportDialog.metadata}
+              fileType={dialogs.exportDialog.fileType}
             />
 
             <ExportDialog
@@ -300,6 +303,7 @@ export default function EditorLayout({
               onExportDocx={() => {}}
               content={dialogs.printDialog.content}
               metadata={dialogs.printDialog.metadata}
+              fileType={dialogs.printDialog.fileType}
             />
 
             {!chrome.isElectron && recovery.wasAutoRecovered && !recovery.dismissedRecovery && (

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -46,6 +46,12 @@ interface ExportDialogProps {
   onExportEpub?: (options: EpubExportOptions) => void;
   content: string;
   metadata: ExportMetadata;
+  /**
+   * Active document file type. Forwarded to the PDF preview IPC so the HTML
+   * pipeline un-escapes MDI macros only for ".mdi" and preserves \[\[blank]]
+   * literals in ".md"/".txt". Absent → ".mdi".
+   */
+  fileType?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -114,6 +120,7 @@ export default function ExportDialog({
   onExportEpub,
   content,
   metadata,
+  fileType,
 }: ExportDialogProps): React.ReactNode {
   if (!isOpen) return null;
   return (
@@ -126,6 +133,7 @@ export default function ExportDialog({
       onExportEpub={onExportEpub}
       content={content}
       metadata={metadata}
+      fileType={fileType}
     />
   );
 }
@@ -139,6 +147,7 @@ function ExportDialogInner({
   onExportEpub,
   content,
   metadata,
+  fileType,
 }: Omit<ExportDialogProps, "isOpen">) {
   const [selectedFormat, setSelectedFormat] = useState<ExportDialogFormat>(initialFormat);
   const [settings, setSettings] = useState<UnifiedExportSettings>(() => ({
@@ -314,6 +323,7 @@ function ExportDialogInner({
           pageNumberPosition: previewSettings.pageNumberPosition,
           textIndent: previewSettings.textIndent,
           googleFontFamily: previewSettings.googleFontFamily,
+          fileType,
         });
 
         if (id !== generationIdRef.current) return;
@@ -343,7 +353,7 @@ function ExportDialogInner({
       if (previewTimeoutRef.current) clearTimeout(previewTimeoutRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasPreviewApi, settings, selectedFormat, content, metadata]);
+  }, [hasPreviewApi, settings, selectedFormat, content, metadata, fileType]);
 
   // Cleanup blob URLs on unmount (refs always hold the latest values)
   useEffect(() => {

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -453,6 +453,7 @@ function registerFileHandlers() {
         verticalWriting,
         typesetting,
         googleFontFamily: opts.googleFontFamily,
+        fileType: opts.fileType,
       });
 
       const partition = `print-${Date.now()}`;

--- a/lib/export/__tests__/blank-paragraph-export.test.ts
+++ b/lib/export/__tests__/blank-paragraph-export.test.ts
@@ -3,6 +3,7 @@ import { unzipSync, strFromU8 } from "fflate";
 import { mdiToHtml } from "@/lib/export/mdi-to-html";
 import { mdiToPlainText } from "@/lib/export/txt-exporter";
 import { generateDocxBlob } from "@/lib/export/docx-exporter";
+import { buildEpubFiles } from "@/lib/export/epub-shared";
 
 describe("html exporter — [[blank]] paragraph handling", () => {
   it("[[blank]] → <p></p>", () => {
@@ -26,6 +27,38 @@ describe("html exporter — [[blank]] paragraph handling", () => {
     const html = mdiToHtml("文章\n\n```\n[[blank]]\n```\n\n続き", { bodyOnly: true });
     expect(html).not.toContain("");
     expect(html).not.toContain("[[blank]]");
+  });
+});
+
+// Regression for the PDF/EPUB leak (花様年華): the HTML pipeline (mdiToHtml) is
+// fed the *live Milkdown serializer output*, where MDI macros are escaped to
+// `\[\[blank]]`. Before the fix, mdiToHtml never normalized this, so MDI_BLANK_RE
+// (which matches the unescaped marker) missed it and `[[blank]]` leaked verbatim
+// into PDF / EPUB / print output. TXT/DOCX already normalized via MdiDocument;
+// these tests lock the HTML path to the same behavior.
+describe("html exporter — serializer-escaped [[blank]] (PDF/EPUB leak regression)", () => {
+  it("default (.mdi): \\[\\[blank]] (escaped) → <p></p>, no [[blank]] leak", () => {
+    const html = mdiToHtml("A\n\n\\[\\[blank]]\n\nB", { bodyOnly: true });
+    expect(html).toContain("<p></p>");
+    expect(html).not.toContain("[[blank]]");
+    expect(html).not.toContain("\\[");
+    // U+E000 sentinel must not leak
+    expect(html).not.toContain(String.fromCharCode(0xe000));
+  });
+
+  it(".mdi (explicit): \\[\\[blank]] (escaped) → <p></p>, no leak", () => {
+    const html = mdiToHtml("A\n\n\\[\\[blank]]\n\nB", { bodyOnly: true, fileType: ".mdi" });
+    expect(html).toContain("<p></p>");
+    expect(html).not.toContain("[[blank]]");
+    expect(html).not.toContain("\\[");
+  });
+
+  it(".md: \\[\\[blank]] (escaped) → preserved as literal text, NOT an empty <p> (DATA-LOSS guard)", () => {
+    const html = mdiToHtml("A\n\n\\[\\[blank]]\n\nB", { bodyOnly: true, fileType: ".md" });
+    // For non-.mdi the authored literal must survive — markdown-it un-escapes the
+    // backslash so the visible text is "[[blank]]" inside a real paragraph.
+    expect(html).toContain("[[blank]]");
+    expect(html).not.toContain("<p></p>");
   });
 });
 
@@ -62,6 +95,42 @@ describe("docx exporter — [[blank]] paragraph handling", () => {
     expect(pCount).toBeGreaterThanOrEqual(3);
     expect(documentXml).toContain("A");
     expect(documentXml).toContain("B");
+  });
+});
+
+// End-to-end EPUB regression: buildEpubFiles → splitIntoChapters → mdiToHtml.
+// The chapter xhtml is where [[blank]] previously leaked in the exported book
+// (3rd screenshot of #花様年華). Confirms fileType threads all the way through.
+describe("epub exporter — serializer-escaped [[blank]] in chapter xhtml", () => {
+  it("default (.mdi): \\[\\[blank]] → empty <p>, no [[blank]] leak in chapter-1.xhtml", () => {
+    const files = buildEpubFiles("# 第一章\n\nA\n\n\\[\\[blank]]\n\nB", {
+      metadata: { title: "テスト", language: "ja" },
+    });
+    const chapter = files.get("OEBPS/chapter-1.xhtml") as string;
+    expect(chapter).toBeTruthy();
+    expect(chapter).toContain("<p></p>");
+    expect(chapter).not.toContain("[[blank]]");
+    expect(chapter).not.toContain("\\[");
+  });
+
+  it(".mdi (explicit): unescaped [[blank]] → empty <p>, no leak", () => {
+    const files = buildEpubFiles("# 第一章\n\nA\n\n[[blank]]\n\nB", {
+      metadata: { title: "テスト", language: "ja" },
+      fileType: ".mdi",
+    });
+    const chapter = files.get("OEBPS/chapter-1.xhtml") as string;
+    expect(chapter).toContain("<p></p>");
+    expect(chapter).not.toContain("[[blank]]");
+  });
+
+  it(".md: \\[\\[blank]] → preserved as literal text, no empty <p> (DATA-LOSS guard)", () => {
+    const files = buildEpubFiles("# 第一章\n\nA\n\n\\[\\[blank]]\n\nB", {
+      metadata: { title: "note.md", language: "ja" },
+      fileType: ".md",
+    });
+    const chapter = files.get("OEBPS/chapter-1.xhtml") as string;
+    expect(chapter).toContain("[[blank]]");
+    expect(chapter).not.toContain("<p></p>");
   });
 });
 

--- a/lib/export/__tests__/mdi-to-html.test.ts
+++ b/lib/export/__tests__/mdi-to-html.test.ts
@@ -42,12 +42,30 @@ describe("mdiToHtml", () => {
     expect(html).toContain('外では<br class="mdi-break">変換する');
   });
 
-  it("preserves escaped MDI syntax as literal text", () => {
-    const html = mdiToHtml("\\{東京|とうきょう} \\^12^ \\[[br]]", { bodyOnly: true });
+  it(".md/.txt: preserves escaped MDI syntax as literal text (DATA-LOSS guard)", () => {
+    // Non-.mdi documents are raw authored text — the HTML pipeline must NOT
+    // recover serializer escapes, so author-written literals survive verbatim.
+    for (const fileType of [".md", ".txt"]) {
+      const html = mdiToHtml("\\{東京|とうきょう} \\^12^ \\[[br]]", { bodyOnly: true, fileType });
+      expect(html).toContain("{東京|とうきょう} ^12^ [[br]]");
+      expect(html).not.toContain("<ruby>");
+      expect(html).not.toContain('class="mdi-break"');
+      expect(html).not.toContain('class="mdi-tcy"');
+    }
+  });
 
-    expect(html).toContain("{東京|とうきょう} ^12^ [[br]]");
+  it(".mdi: recovers serializer-escaped bracket macros so they render (PDF/EPUB parity)", () => {
+    // The Milkdown serializer escapes the leading `[` of MDI bracket macros to
+    // `\[`. For ".mdi" the HTML pipeline un-escapes them (Step 0) — matching the
+    // save path and TXT/DOCX — so e.g. `\[[br]]` becomes a real <br> instead of
+    // leaking `[[br]]` as literal text. (Ruby `{…}` / tcy `^…^` are outside
+    // Step 0's recovery scope and intentionally stay literal.)
+    const html = mdiToHtml("\\{東京|とうきょう} \\^12^ \\[[br]]", { bodyOnly: true, fileType: ".mdi" });
+    expect(html).toContain('<br class="mdi-break">');
+    expect(html).not.toContain("[[br]]");
+    // Ruby / tcy escapes are not in Step 0's scope → remain literal text.
+    expect(html).toContain("{東京|とうきょう} ^12^");
     expect(html).not.toContain("<ruby>");
-    expect(html).not.toContain('class="mdi-break"');
     expect(html).not.toContain('class="mdi-tcy"');
   });
 });

--- a/lib/export/__tests__/mdi-to-html.test.ts
+++ b/lib/export/__tests__/mdi-to-html.test.ts
@@ -60,7 +60,10 @@ describe("mdiToHtml", () => {
     // save path and TXT/DOCX — so e.g. `\[[br]]` becomes a real <br> instead of
     // leaking `[[br]]` as literal text. (Ruby `{…}` / tcy `^…^` are outside
     // Step 0's recovery scope and intentionally stay literal.)
-    const html = mdiToHtml("\\{東京|とうきょう} \\^12^ \\[[br]]", { bodyOnly: true, fileType: ".mdi" });
+    const html = mdiToHtml("\\{東京|とうきょう} \\^12^ \\[[br]]", {
+      bodyOnly: true,
+      fileType: ".mdi",
+    });
     expect(html).toContain('<br class="mdi-break">');
     expect(html).not.toContain("[[br]]");
     // Ruby / tcy escapes are not in Step 0's scope → remain literal text.

--- a/lib/export/epub-shared.ts
+++ b/lib/export/epub-shared.ts
@@ -21,6 +21,12 @@ export interface EpubExportOptions {
   chapterSplitLevel?: ChapterSplitLevel;
   coverImage?: Uint8Array;
   coverMediaType?: string;
+  /**
+   * Active document file type. Forwarded to mdiToHtml so editor-escaped MDI
+   * macros (e.g. `\[\[blank]]`) are un-escaped for ".mdi" and preserved as
+   * literals for ".md"/".txt". Absent → ".mdi".
+   */
+  fileType?: string;
 }
 
 /** Map chapter split level string to numeric value for splitIntoChapters() */
@@ -87,9 +93,9 @@ export function buildEpubFiles(
   const coverMediaType = validCoverType;
 
   const splitLevel = splitLevelToNumber(options.chapterSplitLevel);
-  const chapters = splitIntoChapters(content, splitLevel);
+  const chapters = splitIntoChapters(content, splitLevel, options.fileType);
   if (chapters.length === 0) {
-    const html = mdiToHtml(content, { bodyOnly: true });
+    const html = mdiToHtml(content, { bodyOnly: true, fileType: options.fileType });
     chapters.push({ title, htmlContent: html, level: 1 });
   }
   // When no splitting or single untitled chapter, use the book title

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -16,6 +16,7 @@ import {
   MDI_BREAK_RE,
   MDI_KERN_AMOUNT_RE,
   MDI_BLANK_RE,
+  MdiDocument,
 } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import { PAGE_DIMENSIONS } from "./pdf-export-settings";
 
@@ -245,13 +246,30 @@ export function mdiToHtml(
     typesetting?: Omit<MdiStylesheetOptions, "verticalWriting">;
     /** Google Font family name to inject as <link> tag (e.g. "Noto Serif JP") */
     googleFontFamily?: string;
+    /**
+     * Active document file type. Editor-serialized input escapes the leading `[`
+     * of MDI bracket macros (e.g. `\[\[blank]]`); ".mdi" un-escapes them back to
+     * markers so [[blank]] etc. convert correctly, while ".md"/".txt" preserve the
+     * authored literal (DATA-LOSS guard, see #1608). Absent → ".mdi".
+     */
+    fileType?: string;
   },
 ): string {
   const md = createMarkdownIt();
+  // Normalize editor-serialized output into canonical MDI text before rendering.
+  // The Milkdown serializer escapes the leading `[` of MDI macros to `\[`; without
+  // this, MDI_BLANK_RE (and the inline macro rules) never match and `[[blank]]`
+  // leaks as literal text into PDF/EPUB/print output. TXT/DOCX already normalize
+  // this way via MdiDocument — this brings the HTML pipeline to parity.
+  const fileType = options?.fileType ?? ".mdi";
+  const normalized =
+    fileType === ".mdi"
+      ? MdiDocument.fromEditorOutput(markdown, { fileType: ".mdi" }).toRawText()
+      : MdiDocument.fromRawText(markdown).toRawText();
   // Pre-process: replace [[blank]] paragraph markers with a U+E000 PUA sentinel.
   // markdown-it will wrap the sentinel in <p>…</p>; we swap it for an empty <p></p> after rendering.
   const BLANK_SENTINEL = "";
-  const preprocessed = markdown.replace(new RegExp(MDI_BLANK_RE.source, "gm"), BLANK_SENTINEL);
+  const preprocessed = normalized.replace(new RegExp(MDI_BLANK_RE.source, "gm"), BLANK_SENTINEL);
   const rawHtml = md.render(preprocessed);
   // Replace the sentinel paragraph with a true empty paragraph. Then final-sweep any
   // remaining sentinel that escaped the <p>…</p> wrap (e.g. inside fenced code blocks
@@ -326,10 +344,14 @@ export function mdiToHtml(
  * @param splitLevel - Max heading level to split on (1=H1, 2=H1+H2, 3=H1+H2+H3, 0=no split)
  * @returns Array of Chapter objects
  */
-export function splitIntoChapters(markdown: string, splitLevel: number = 1): Chapter[] {
+export function splitIntoChapters(
+  markdown: string,
+  splitLevel: number = 1,
+  fileType?: string,
+): Chapter[] {
   // No splitting — entire document is one chapter
   if (splitLevel <= 0) {
-    const html = mdiToHtml(markdown, { bodyOnly: true });
+    const html = mdiToHtml(markdown, { bodyOnly: true, fileType });
     return [{ title: "", htmlContent: html, level: 1 }];
   }
 
@@ -350,7 +372,7 @@ export function splitIntoChapters(markdown: string, splitLevel: number = 1): Cha
         const content = currentLines.join("\n").trim();
         chapters.push({
           title: currentTitle,
-          htmlContent: content ? mdiToHtml(content, { bodyOnly: true }) : "",
+          htmlContent: content ? mdiToHtml(content, { bodyOnly: true, fileType }) : "",
           level: currentLevel,
         });
       }
@@ -372,7 +394,7 @@ export function splitIntoChapters(markdown: string, splitLevel: number = 1): Cha
     const content = currentLines.join("\n").trim();
     chapters.push({
       title: currentTitle,
-      htmlContent: content ? mdiToHtml(content, { bodyOnly: true }) : "",
+      htmlContent: content ? mdiToHtml(content, { bodyOnly: true, fileType }) : "",
       level: currentLevel,
     });
   }

--- a/lib/export/pdf-exporter.ts
+++ b/lib/export/pdf-exporter.ts
@@ -31,6 +31,12 @@ export interface PdfExportOptions {
   textIndent?: number;
   /** Google Font family name — triggers <link> injection and CSP relaxation */
   googleFontFamily?: string;
+  /**
+   * Active document file type. Forwarded to mdiToHtml so editor-escaped MDI
+   * macros (e.g. `\[\[blank]]`) are un-escaped for ".mdi" and preserved as
+   * literals for ".md"/".txt". Absent → ".mdi".
+   */
+  fileType?: string;
 }
 
 /**
@@ -83,6 +89,7 @@ export async function generatePdf(content: string, options: PdfExportOptions): P
       margins: options.margins,
     },
     googleFontFamily: options.googleFontFamily,
+    fileType: options.fileType,
   });
 
   // Use a unique in-memory partition (no "persist:" prefix) per export so

--- a/lib/export/types.ts
+++ b/lib/export/types.ts
@@ -37,6 +37,11 @@ export interface PdfGenerationOptions {
   textIndent?: number;
   /** Google Font family name for PDF export (triggers <link> injection and CSP relaxation) */
   googleFontFamily?: string;
+  /**
+   * Active document file type. The HTML pipeline un-escapes MDI macros only for
+   * ".mdi"; ".md"/".txt" preserve authored `\[\[blank]]` literals. Absent → ".mdi".
+   */
+  fileType?: string;
 }
 
 export type ExportFormat = "pdf" | "epub" | "docx" | "txt" | "txt-ruby";

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -136,14 +136,17 @@ export function useExport({
 
         switch (format) {
           case "pdf":
+            // Thread fileType so the HTML pipeline un-escapes MDI macros for
+            // ".mdi" and preserves \[\[blank]] literals in ".md"/".txt".
             result = await window.electronAPI.exportPDF?.(content, {
               metadata,
               verticalWriting: false,
               pageSize: "A5",
+              fileType,
             });
             break;
           case "epub":
-            result = await window.electronAPI.exportEPUB?.(content, { metadata });
+            result = await window.electronAPI.exportEPUB?.(content, { metadata, fileType });
             break;
           case "docx":
             // Thread the active tab's file type so the main-process generateDocx
@@ -245,7 +248,7 @@ async function exportAsWeb(
     // Defensive fallback: normally PDF goes through dialog (line 103),
     // but if no dialog callback is wired, use default export settings.
     const defaults = toPdfExportSettings(await loadExportSettings());
-    const opened = await openWebPrintPreview(content, metadata, defaults);
+    const opened = await openWebPrintPreview(content, metadata, defaults, fileType);
     if (!opened) {
       notificationManager.warning(
         "ポップアップがブロックされました。ブラウザの設定を確認してください。",
@@ -273,7 +276,7 @@ async function exportAsWeb(
       }
       case "epub": {
         const { generateEpubBlob } = await import("./epub-web");
-        blob = await generateEpubBlob(content, { metadata });
+        blob = await generateEpubBlob(content, { metadata, fileType });
         suggestedName = `${baseName}.epub`;
         break;
       }

--- a/lib/export/web-print-preview.ts
+++ b/lib/export/web-print-preview.ts
@@ -21,6 +21,7 @@ export async function openWebPrintPreview(
   content: string,
   metadata: ExportMetadata,
   settings: PdfExportSettings,
+  fileType?: string,
 ): Promise<boolean> {
   // MUST be the first statement — synchronous, within user gesture
   const printWindow = window.open("", "_blank");
@@ -51,6 +52,7 @@ export async function openWebPrintPreview(
         pageSize: settings.pageSize,
         landscape: settings.landscape,
       },
+      fileType,
     });
 
     printWindow.document.open();


### PR DESCRIPTION
## 問題

`[[blank]]`（MDI 空行マクロ）を含む小説をエクスポートすると、**PDF / DOCX / EPUB** のプレビュー・出力に `[[blank]]` という文字列がそのまま表示される。**TXT** では正しく空行になる（#花様年華 のスクリーンショット）。

## 根本原因（治標不治本だった点）

エディタ（Milkdown serializer）は MDI macro を `\[\[blank]]` に**エスケープ**して出力する。

- **TXT / DOCX**: `MdiDocument.fromEditorOutput(content, { fileType })` で正規化（Step 0 でアンエスケープ）してから処理 → ✅
- **HTML 系（PDF / EPUB / 印刷）**: `mdiToHtml()` が**生のエディタ出力を直接受け取り正規化していなかった** → `MDI_BLANK_RE`（エスケープ無しパターン）が `\[\[blank]]` にマッチせず literal リーク → ❌

PR #1608 / #1609 は TXT/DOCX 経路だけを正規化し、HTML 系を正規化パイプラインの外に残していたため未修正だった。

## 修正

`mdiToHtml()` を**正規化の単一チョークポイント**にし、描画前に `fileType` に応じて `MdiDocument.fromEditorOutput(".mdi")` / `fromRawText` を通す。これで **PDF・EPUB・Web 印刷・Electron 印刷**の全 HTML 経路が TXT/DOCX と同一挙動になる。`[[blank]]` 以外の MDI macro（`[[br]]` 等）も同時に解消。

`fileType` を **UI → IPC → exporter** まで貫通させ、#1608 の **.md/.txt DATA-LOSS ガード**（作者が書いたエスケープ literal の保持）も維持。

### 変更ファイル
- `lib/export/mdi-to-html.ts`: `mdiToHtml` / `splitIntoChapters` に `fileType` を追加し、描画前に `MdiDocument` で正規化
- `lib/export/{pdf-exporter,epub-shared,types,web-print-preview}.ts`: `fileType` 伝播
- `electron/ipc/file-ipc.js`: `printDocument` ハンドラで `fileType` 転送
- `app/page.tsx` / `components/{EditorLayout,ExportDialog}.tsx`: UI から `fileType` 貫通
- tests: HTML/EPUB 経路でエスケープ済み `\[\[blank]]` が空段落になる回帰テスト、`.md`/`.txt` の literal 保持ガードを追加。既存 `mdi-to-html` の escaped テストを新挙動（`.mdi` は recover / `.md`・`.txt` は literal）に更新

## 検証
- `npm run type-check` ✅
- `npx vitest run`（全 1533 tests）✅
- `npm run bundle:electron` ✅

関連 issue なし（新規バグ報告）。