### PR TITLE
feat(dict): 幻辞分析アクセス層 dict-access (#1624)

### DIFF
--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -20,7 +20,7 @@ import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
 import { getUserDictionaryService } from "@/lib/services/user-dictionary-service";
 import DictionaryEntryDialog from "./Dictionary/DictionaryEntryDialog";
 import { getDictService } from "@/lib/dict/dict-service";
-import type { DictEntry, DictExample } from "@/lib/dict/dict-types";
+import type { DictEntry, DictExample, DictDownloadStatus } from "@/lib/dict/dict-types";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
 
 // Web dictionary sources
@@ -76,9 +76,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   // Master dict state
   const [masterResults, setMasterResults] = useState<DictEntry[]>([]);
   const [masterLoading, setMasterLoading] = useState(false);
-  const [localInstallStatus, setLocalInstallStatus] = useState<
-    "not-installed" | "downloading" | "installing" | "installed" | "error"
-  >("not-installed");
+  const [localInstallStatus, setLocalInstallStatus] = useState<DictDownloadStatus>("not-installed");
   const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
   const [expandedMasterId, setExpandedMasterId] = useState<string | null>(null);
 

--- a/components/settings/DictSettingsTab.tsx
+++ b/components/settings/DictSettingsTab.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Download, RefreshCw, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
 import { useDictSettingsContext } from "@/contexts/EditorSettingsContext";
 import type { DictDownloadStatus } from "@/lib/dict/dict-types";
+import { getDictAccess } from "@/lib/dict/dict-access";
 import { SettingsField, SettingsSection, SettingsToggle } from "./primitives";
 
 interface UpdateInfo {
@@ -104,6 +105,8 @@ export default function DictSettingsTab() {
           onDictInstalledVersionChange(result.version);
         }
         setCheckResult(null);
+        // Drop cached "corrupt" health + negative lookups now the DB is fresh.
+        getDictAccess().invalidate();
       } else {
         setError(result.error ?? "ダウンロードに失敗しました");
         setDbStatus("error");
@@ -134,6 +137,7 @@ export default function DictSettingsTab() {
   };
 
   const isInstalled = dbStatus === "installed";
+  const isCorrupt = dbStatus === "corrupt";
   const updateAvailable = checkResult?.updateAvailable ?? false;
 
   return (
@@ -148,12 +152,21 @@ export default function DictSettingsTab() {
           {isInstalled ? (
             <CheckCircle2 className="w-4 h-4 text-success flex-shrink-0" />
           ) : (
-            <AlertCircle className="w-4 h-4 text-foreground-tertiary flex-shrink-0" />
+            <AlertCircle
+              className={`w-4 h-4 flex-shrink-0 ${isCorrupt ? "text-danger" : "text-foreground-tertiary"}`}
+            />
           )}
           <span className="text-sm text-foreground">
-            {isInstalled ? "インストール済み" : "未インストール"}
+            {isInstalled ? "インストール済み" : isCorrupt ? "破損（再ダウンロードが必要）" : "未インストール"}
           </span>
         </div>
+
+        {/* Corrupt notice */}
+        {isCorrupt && (
+          <div className="text-xs text-danger">
+            辞書データが破損しています。「再ダウンロード」で修復してください。
+          </div>
+        )}
 
         {/* Version */}
         {dictInstalledVersion && (
@@ -226,7 +239,7 @@ export default function DictSettingsTab() {
                 ) : (
                   <Download className="w-3 h-3" />
                 )}
-                {isInstalled ? "更新" : "ダウンロード"}
+                {isCorrupt ? "再ダウンロード" : isInstalled ? "更新" : "ダウンロード"}
               </button>
             )}
           </div>

--- a/components/settings/DictSettingsTab.tsx
+++ b/components/settings/DictSettingsTab.tsx
@@ -157,7 +157,11 @@ export default function DictSettingsTab() {
             />
           )}
           <span className="text-sm text-foreground">
-            {isInstalled ? "インストール済み" : isCorrupt ? "破損（再ダウンロードが必要）" : "未インストール"}
+            {isInstalled
+              ? "インストール済み"
+              : isCorrupt
+                ? "破損（再ダウンロードが必要）"
+                : "未インストール"}
           </span>
         </div>
 

--- a/electron/__tests__/dict-manager-access.test.ts
+++ b/electron/__tests__/dict-manager-access.test.ts
@@ -1,0 +1,194 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Backend tests for the analysis-access additions to DictManager (#1624):
+ *   - verify()      — fast integrity check (ok / not-installed / schema / malformed)
+ *   - lookupBatch() — exact-match lightweight projection
+ *   - getStatus()   — reports "corrupt" once the flag is tripped
+ *
+ * The real better-sqlite3 can't open here (the local copy is rebuilt for
+ * Electron's ABI) and vitest externalizes the native module so it can't be
+ * vi.mock'd. Instead we inject a fake DB through the manager's `_createDatabase`
+ * seam — the same override style as `_getDictDir` in dict-manager.test.ts —
+ * which still exercises the manager's projection / grouping / corruption logic.
+ */
+
+const { appGetPathMock } = vi.hoisted(() => ({
+  appGetPathMock: vi.fn(() => "/tmp/illusions-dict-access-test"),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: appGetPathMock },
+}));
+
+type DbMode = "healthy" | "no-table" | "malformed";
+
+class FakeStatement {
+  constructor(
+    private readonly sql: string,
+    private readonly rows: Array<{ entry: string; raw_json: string }>,
+    private readonly mode: DbMode,
+  ) {}
+  get(): unknown {
+    if (this.sql.includes("sqlite_master")) {
+      return this.mode === "no-table" ? undefined : { name: "entries" };
+    }
+    if (this.sql.includes("LIMIT 1")) {
+      return this.rows[0] ? { raw_json: this.rows[0].raw_json } : undefined;
+    }
+    return undefined;
+  }
+  all(...args: unknown[]): unknown[] {
+    if (this.sql.includes("WHERE entry IN")) {
+      const wanted = new Set(args as string[]);
+      return this.rows.filter((r) => wanted.has(r.entry)).map((r) => ({ ...r }));
+    }
+    return [];
+  }
+  run(): void {}
+}
+
+class FakeDatabase {
+  constructor(
+    private readonly rows: Array<{ entry: string; raw_json: string }>,
+    private readonly mode: DbMode,
+  ) {
+    if (mode === "malformed") throw new Error("file is not a database");
+  }
+  prepare(sql: string): FakeStatement {
+    return new FakeStatement(sql, this.rows, this.mode);
+  }
+  pragma(): void {}
+  exec(): void {}
+  close(): void {}
+}
+
+interface RawJsonInput {
+  entry: string;
+  reading: string;
+  pos?: string[];
+  register?: string;
+  freqRank?: number;
+}
+
+function rawJson(input: RawJsonInput): string {
+  return JSON.stringify({
+    uuid: `uuid-${input.entry}`,
+    entry: input.entry,
+    reading: { primary: input.reading, alternatives: [] },
+    grammar: { pos: input.pos ?? null },
+    definitions: input.register
+      ? [{ index: 0, gloss: "x", register: input.register }]
+      : [{ index: 0, gloss: "x" }],
+    relations: { homophones: [], synonyms: [], antonyms: [], related: [] },
+    meta: input.freqRank !== undefined ? { freq_rank: input.freqRank } : {},
+  });
+}
+
+interface TestableManager {
+  _getDictDir: () => string;
+  _createDatabase: (dbPath: string, opts?: unknown) => unknown;
+  verify: () => { ok: boolean; reason?: string };
+  lookupBatch: (
+    terms: string[],
+  ) => Array<{ entry: string; found: boolean; reading?: string; pos?: string; register?: string; freqRank?: number }>;
+  getStatus: () => { status: string; installedVersion?: string };
+}
+
+interface ManagerOptions {
+  rows?: RawJsonInput[];
+  mode?: DbMode;
+}
+
+async function freshManager(dictDir: string, opts: ManagerOptions = {}): Promise<TestableManager> {
+  const { rows = [], mode = "healthy" } = opts;
+  const fakeRows = rows.map((r) => ({ entry: r.entry, raw_json: rawJson(r) }));
+  const { getDictManager } = await import("../dict-manager.js");
+  const mgr = getDictManager() as unknown as TestableManager;
+  mgr._getDictDir = () => dictDir;
+  mgr._createDatabase = () => new FakeDatabase(fakeRows, mode);
+  return mgr;
+}
+
+describe("DictManager analysis access (#1624)", () => {
+  let tempDir: string;
+  let dictDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "illusions-dict-access-"));
+    dictDir = path.join(tempDir, "dict");
+    fs.mkdirSync(dictDir, { recursive: true });
+    dbPath = path.join(dictDir, "genji.db");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const LOOKUP_ROWS: RawJsonInput[] = [
+    { entry: "雪", reading: "ゆき", pos: ["名詞"], register: "文章語", freqRank: 1200 },
+    { entry: "走る", reading: "はしる", pos: ["動詞"], freqRank: 800 },
+  ];
+
+  describe("verify()", () => {
+    it("returns ok for a healthy DB with an entries table", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: [{ entry: "雪", reading: "ゆき" }] });
+      expect(mgr.verify()).toEqual({ ok: true });
+    });
+
+    it("returns not-installed when the DB file is absent", async () => {
+      const mgr = await freshManager(dictDir);
+      expect(mgr.verify()).toEqual({ ok: false, reason: "not-installed" });
+    });
+
+    it("returns schema when the entries table is missing", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { mode: "no-table" });
+      expect(mgr.verify()).toEqual({ ok: false, reason: "schema" });
+    });
+
+    it("returns malformed for a truncated / non-SQLite file", async () => {
+      fs.writeFileSync(dbPath, "this is not a sqlite database");
+      const mgr = await freshManager(dictDir, { mode: "malformed" });
+      expect(mgr.verify()).toEqual({ ok: false, reason: "malformed" });
+    });
+
+    it("flips getStatus() to corrupt after a malformed verify", async () => {
+      fs.writeFileSync(dbPath, "garbage");
+      const mgr = await freshManager(dictDir, { mode: "malformed" });
+      mgr.verify();
+      expect(mgr.getStatus().status).toBe("corrupt");
+    });
+  });
+
+  describe("lookupBatch()", () => {
+    it("projects reading / pos / register / freqRank for hits", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: LOOKUP_ROWS });
+      expect(mgr.lookupBatch(["雪"])).toEqual([
+        { entry: "雪", found: true, reading: "ゆき", pos: "名詞", register: "文章語", freqRank: 1200 },
+      ]);
+    });
+
+    it("omits terms with no match and dedupes input", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: LOOKUP_ROWS });
+      const entries = mgr.lookupBatch(["雪", "存在しない語", "走る", "雪"]).map((r) => r.entry).sort();
+      expect(entries).toEqual(["走る", "雪"]);
+    });
+
+    it("returns [] for an empty request", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: LOOKUP_ROWS });
+      expect(mgr.lookupBatch([])).toEqual([]);
+      expect(mgr.lookupBatch(["", "  "].map((s) => s.trim()))).toEqual([]);
+    });
+  });
+});

--- a/electron/__tests__/dict-manager-access.test.ts
+++ b/electron/__tests__/dict-manager-access.test.ts
@@ -92,9 +92,14 @@ interface TestableManager {
   _getDictDir: () => string;
   _createDatabase: (dbPath: string, opts?: unknown) => unknown;
   verify: () => { ok: boolean; reason?: string };
-  lookupBatch: (
-    terms: string[],
-  ) => Array<{ entry: string; found: boolean; reading?: string; pos?: string; register?: string; freqRank?: number }>;
+  lookupBatch: (terms: string[]) => Array<{
+    entry: string;
+    found: boolean;
+    reading?: string;
+    pos?: string;
+    register?: string;
+    freqRank?: number;
+  }>;
   getStatus: () => { status: string; installedVersion?: string };
 }
 
@@ -173,14 +178,24 @@ describe("DictManager analysis access (#1624)", () => {
       fs.writeFileSync(dbPath, "sqlite");
       const mgr = await freshManager(dictDir, { rows: LOOKUP_ROWS });
       expect(mgr.lookupBatch(["雪"])).toEqual([
-        { entry: "雪", found: true, reading: "ゆき", pos: "名詞", register: "文章語", freqRank: 1200 },
+        {
+          entry: "雪",
+          found: true,
+          reading: "ゆき",
+          pos: "名詞",
+          register: "文章語",
+          freqRank: 1200,
+        },
       ]);
     });
 
     it("omits terms with no match and dedupes input", async () => {
       fs.writeFileSync(dbPath, "sqlite");
       const mgr = await freshManager(dictDir, { rows: LOOKUP_ROWS });
-      const entries = mgr.lookupBatch(["雪", "存在しない語", "走る", "雪"]).map((r) => r.entry).sort();
+      const entries = mgr
+        .lookupBatch(["雪", "存在しない語", "走る", "雪"])
+        .map((r) => r.entry)
+        .sort();
       expect(entries).toEqual(["走る", "雪"]);
     });
 

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -310,9 +310,7 @@ class DictManager {
   lookupBatch(terms) {
     if (this._downloadMutex.locked) return [];
     if (!Array.isArray(terms)) return [];
-    const unique = [
-      ...new Set(terms.filter((t) => typeof t === "string" && t.length > 0)),
-    ];
+    const unique = [...new Set(terms.filter((t) => typeof t === "string" && t.length > 0))];
     if (unique.length === 0) return [];
 
     const db = this._openDb();

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -76,6 +76,27 @@ class DictManager {
     this._latestAssetUrl = null;
     this._latestAssetDigest = null;
     this._latestVersion = null;
+    // Set when a DB open/query fails with a corruption-class error, so getStatus
+    // can report "corrupt" without re-running an integrity scan on every call.
+    this._corrupt = false;
+  }
+
+  /**
+   * Does this error look like SQLite database corruption (truncated download,
+   * bad header, encrypted/foreign file)? Used to flip the corrupt flag so the
+   * UI can prompt a re-download.
+   * @private
+   * @param {unknown} err
+   * @returns {boolean}
+   */
+  _isCorruptionError(err) {
+    const msg = String(err?.message ?? err ?? "").toLowerCase();
+    return (
+      msg.includes("malformed") ||
+      msg.includes("not a database") ||
+      msg.includes("file is encrypted") ||
+      msg.includes("disk image is malformed")
+    );
   }
 
   /**
@@ -127,6 +148,19 @@ class DictManager {
   // Database access
   // ---------------------------------------------------------------------------
 
+  /**
+   * Open a better-sqlite3 connection. Single seam for all three open sites
+   * (read handle, index writer, integrity probe) so tests can inject a fake DB
+   * without mocking the native module (which vitest externalizes).
+   * @private
+   * @param {string} dbPath
+   * @param {{ readonly?: boolean }} [opts]
+   */
+  _createDatabase(dbPath, opts) {
+    const Database = require("better-sqlite3");
+    return new Database(dbPath, opts);
+  }
+
   _openDb() {
     if (this._db) return this._db;
 
@@ -143,13 +177,14 @@ class DictManager {
     }
 
     try {
-      const Database = require("better-sqlite3");
-      const db = new Database(dbPath, { readonly: true });
+      const db = this._createDatabase(dbPath, { readonly: true });
       this._db = db;
+      this._corrupt = false;
       console.log("[DictManager] Database opened:", dbPath);
       return db;
     } catch (err) {
       console.error("[DictManager] Failed to open database:", err);
+      if (this._isCorruptionError(err)) this._corrupt = true;
       return null;
     }
   }
@@ -162,8 +197,7 @@ class DictManager {
   _ensureIndexes(dbPath) {
     let rwDb = null;
     try {
-      const Database = require("better-sqlite3");
-      rwDb = new Database(dbPath);
+      rwDb = this._createDatabase(dbPath);
 
       // Check if the entries table exists at all
       const tableCheck = rwDb
@@ -229,6 +263,7 @@ class DictManager {
       return rows.map((row) => this._rawJsonToEntry(row.raw_json)).filter(Boolean);
     } catch (err) {
       console.error("[DictManager] query error:", err);
+      if (this._isCorruptionError(err)) this._corrupt = true;
       return [];
     }
   }
@@ -258,7 +293,115 @@ class DictManager {
       return rows.map((row) => this._rawJsonToEntry(row.raw_json)).filter(Boolean);
     } catch (err) {
       console.error("[DictManager] queryByReading error:", err);
+      if (this._isCorruptionError(err)) this._corrupt = true;
       return [];
+    }
+  }
+
+  /**
+   * Exact-match batch lookup for analysis features (vocabulary stats,
+   * readability, ruby, lint rules). Returns a lightweight projection per term —
+   * never the full DictEntry — so hundreds of words cost one query + one small
+   * IPC payload. Terms with no match are simply absent from the result.
+   *
+   * @param {string[]} terms
+   * @returns {Array<{ entry: string } & import("../lib/dict/dict-types").DictLookup>}
+   */
+  lookupBatch(terms) {
+    if (this._downloadMutex.locked) return [];
+    if (!Array.isArray(terms)) return [];
+    const unique = [
+      ...new Set(terms.filter((t) => typeof t === "string" && t.length > 0)),
+    ];
+    if (unique.length === 0) return [];
+
+    const db = this._openDb();
+    if (!db) return [];
+
+    try {
+      const placeholders = unique.map(() => "?").join(",");
+      const rows = db
+        .prepare(`SELECT entry, raw_json FROM entries WHERE entry IN (${placeholders})`)
+        .all(...unique);
+
+      const byEntry = new Map();
+      for (const row of rows) {
+        if (byEntry.has(row.entry)) continue; // first row wins for a given headword
+        const proj = this._rawJsonToLookup(row.raw_json);
+        if (proj) byEntry.set(row.entry, { entry: row.entry, ...proj });
+      }
+      return [...byEntry.values()];
+    } catch (err) {
+      console.error("[DictManager] lookupBatch error:", err);
+      if (this._isCorruptionError(err)) this._corrupt = true;
+      return [];
+    }
+  }
+
+  /**
+   * Project a raw_json string into the lightweight {@link DictLookup} shape
+   * (reading / pos / register / freqRank). Mirrors the analysis projection in
+   * lib/dict/providers/genji-api-backend.ts.
+   * @private
+   */
+  _rawJsonToLookup(rawJson) {
+    if (!rawJson) return null;
+    let raw;
+    try {
+      raw = typeof rawJson === "string" ? JSON.parse(rawJson) : rawJson;
+    } catch {
+      return null;
+    }
+    if (!raw) return null;
+
+    const register = (raw.definitions ?? []).find((d) => d?.register)?.register;
+    return {
+      found: true,
+      reading: raw.reading?.primary || undefined,
+      pos: raw.grammar?.pos?.join("・") || undefined,
+      register: register || undefined,
+      freqRank: typeof raw.meta?.freq_rank === "number" ? raw.meta.freq_rank : undefined,
+    };
+  }
+
+  /**
+   * Fast integrity check used to decide whether the installed DB is usable or
+   * needs re-downloading. Opens a short-lived read-only connection and runs a
+   * sentinel (schema + one row) rather than a full `PRAGMA integrity_check`,
+   * which would scan the whole ~500 MB file. Catches the realistic corruption
+   * modes: truncated download, bad header, missing `entries` table.
+   *
+   * @returns {{ ok: boolean, reason?: "not-installed" | "schema" | "malformed" }}
+   */
+  verify() {
+    const dbPath = this._getDbPath();
+    if (!fs.existsSync(dbPath)) return { ok: false, reason: "not-installed" };
+    // Mid-install: the file may be momentarily inconsistent; don't flag it.
+    if (this._downloadMutex.locked) return { ok: true };
+
+    let probe = null;
+    try {
+      probe = this._createDatabase(dbPath, { readonly: true });
+      const tbl = probe
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='entries'")
+        .get();
+      if (!tbl) {
+        this._corrupt = true;
+        return { ok: false, reason: "schema" };
+      }
+      probe.prepare("SELECT raw_json FROM entries LIMIT 1").get();
+      this._corrupt = false;
+      return { ok: true };
+    } catch (err) {
+      console.error("[DictManager] verify failed:", err);
+      this._corrupt = true;
+      return { ok: false, reason: "malformed" };
+    } finally {
+      if (probe) {
+        try {
+          probe.close();
+        } catch {}
+      }
     }
   }
 
@@ -340,6 +483,12 @@ class DictManager {
     try {
       installedVersion = fs.readFileSync(this._getVersionPath(), "utf8").trim();
     } catch {}
+
+    // A prior open/query tripped the corruption flag — surface it so the UI can
+    // prompt a re-download instead of silently returning empty results forever.
+    if (this._corrupt) {
+      return { status: "corrupt", installedVersion };
+    }
 
     return { status: "installed", installedVersion };
   }
@@ -519,6 +668,8 @@ class DictManager {
 
       onProgress?.(100);
       const version = this._latestVersion;
+      // Fresh install replaces any corrupt file — clear the flag.
+      this._corrupt = false;
       console.log("[DictManager] Download complete:", version);
 
       // Clear cached release info so next download fetches fresh data

--- a/electron/ipc/dict-ipc.js
+++ b/electron/ipc/dict-ipc.js
@@ -38,6 +38,35 @@ function registerDictHandlers() {
     }
   });
 
+  // Max headwords accepted in a single batch lookup. The renderer-side facade
+  // chunks larger sets; this is a defensive cap so a malformed payload can't
+  // build an unbounded SQL statement.
+  const MAX_BATCH_TERMS = 1000;
+
+  // Exact-match batch lookup (lightweight projection) for analysis features
+  ipcMain.handle(DICT_CHANNELS.invoke.lookupBatch, async (_event, { terms } = {}) => {
+    try {
+      if (!Array.isArray(terms)) return [];
+      const safe = terms
+        .filter((t) => typeof t === "string" && t.length > 0)
+        .slice(0, MAX_BATCH_TERMS);
+      return mgr.lookupBatch(safe);
+    } catch (err) {
+      console.error("[Dict IPC] dict:lookup-batch failed:", err);
+      return [];
+    }
+  });
+
+  // Fast integrity check (used to detect a corrupt DB and prompt re-download)
+  ipcMain.handle(DICT_CHANNELS.invoke.verify, async () => {
+    try {
+      return mgr.verify();
+    } catch (err) {
+      console.error("[Dict IPC] dict:verify failed:", err);
+      return { ok: false, reason: "malformed" };
+    }
+  });
+
   // Get installation status and installed version
   ipcMain.handle(DICT_CHANNELS.invoke.getStatus, async () => {
     try {

--- a/electron/lib/__tests__/ipc-bridge.test.ts
+++ b/electron/lib/__tests__/ipc-bridge.test.ts
@@ -101,6 +101,8 @@ describe("ipc-channels: pinned channel names (public IPC contract)", () => {
     expect(DICT_CHANNELS.invoke).toEqual({
       query: "dict:query",
       queryReading: "dict:query-reading",
+      lookupBatch: "dict:lookup-batch",
+      verify: "dict:verify",
       getStatus: "dict:get-status",
       checkUpdate: "dict:check-update",
       download: "dict:download",

--- a/electron/lib/ipc-channels.js
+++ b/electron/lib/ipc-channels.js
@@ -52,6 +52,8 @@ const DICT_CHANNELS = Object.freeze({
   invoke: Object.freeze({
     query: "dict:query",
     queryReading: "dict:query-reading",
+    lookupBatch: "dict:lookup-batch",
+    verify: "dict:verify",
     getStatus: "dict:get-status",
     checkUpdate: "dict:check-update",
     download: "dict:download",

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -188,6 +188,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       reading,
       limit,
     })),
+    lookupBatch: invokeChannel(DICT_CHANNELS.invoke.lookupBatch, (terms) => ({ terms })),
+    verify: invokeChannel(DICT_CHANNELS.invoke.verify, { arity: 0 }),
     getStatus: invokeChannel(DICT_CHANNELS.invoke.getStatus, { arity: 0 }),
     checkUpdate: invokeChannel(DICT_CHANNELS.invoke.checkUpdate, { arity: 0 }),
     download: invokeChannel(DICT_CHANNELS.invoke.download, { arity: 0 }),

--- a/lib/dict/__tests__/dict-access.test.ts
+++ b/lib/dict/__tests__/dict-access.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DictLookup } from "../dict-types";
+
+/**
+ * Tests for the DictAccess facade (#1624): health resolution, batch lookup with
+ * caching + negative caching, membership, web fallback, and invalidate().
+ */
+
+const mockLookupBatchRemote = vi.fn<(terms: string[]) => Promise<Map<string, DictLookup>>>();
+
+vi.mock("../providers/genji-api-backend", () => ({
+  lookupBatchRemote: (terms: string[]) => mockLookupBatchRemote(terms),
+}));
+
+interface DictApiMock {
+  lookupBatch: ReturnType<typeof vi.fn>;
+  verify: ReturnType<typeof vi.fn>;
+  getStatus: ReturnType<typeof vi.fn>;
+}
+
+function setElectronDict(dict: DictApiMock | null): void {
+  const w = window as unknown as { electronAPI?: unknown };
+  if (dict) {
+    w.electronAPI = { dict };
+  } else {
+    delete w.electronAPI;
+  }
+}
+
+async function importFresh() {
+  const mod = await import("../dict-access");
+  return mod.getDictAccess();
+}
+
+describe("DictAccess (#1624)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setElectronDict(null);
+  });
+
+  afterEach(() => {
+    setElectronDict(null);
+  });
+
+  describe("getHealth()", () => {
+    it("reports web-fallback when there is no Electron dict API", async () => {
+      const access = await importFresh();
+      const health = await access.getHealth();
+      expect(health.state).toBe("web-fallback");
+    });
+
+    it("reports not-installed", async () => {
+      setElectronDict({
+        getStatus: vi.fn().mockResolvedValue({ status: "not-installed" }),
+        verify: vi.fn(),
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      expect((await access.getHealth()).state).toBe("not-installed");
+    });
+
+    it("reports corrupt when getStatus is corrupt", async () => {
+      setElectronDict({
+        getStatus: vi.fn().mockResolvedValue({ status: "corrupt", installedVersion: "v1" }),
+        verify: vi.fn(),
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      const health = await access.getHealth();
+      expect(health.state).toBe("corrupt");
+      expect(health.installedVersion).toBe("v1");
+    });
+
+    it("reports ready when installed and verify passes", async () => {
+      const verify = vi.fn().mockResolvedValue({ ok: true });
+      setElectronDict({
+        getStatus: vi.fn().mockResolvedValue({ status: "installed", installedVersion: "v2" }),
+        verify,
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      const health = await access.getHealth();
+      expect(health.state).toBe("ready");
+      expect(verify).toHaveBeenCalledOnce();
+    });
+
+    it("reports corrupt when installed but verify fails", async () => {
+      setElectronDict({
+        getStatus: vi.fn().mockResolvedValue({ status: "installed", installedVersion: "v2" }),
+        verify: vi.fn().mockResolvedValue({ ok: false, reason: "malformed" }),
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      expect((await access.getHealth()).state).toBe("corrupt");
+    });
+
+    it("caches health within the TTL (one getStatus call across two reads)", async () => {
+      const getStatus = vi.fn().mockResolvedValue({ status: "installed" });
+      setElectronDict({
+        getStatus,
+        verify: vi.fn().mockResolvedValue({ ok: true }),
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      await access.getHealth();
+      await access.getHealth();
+      expect(getStatus).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("lookupBatch() — local Electron path", () => {
+    it("projects hits, caches negatives, and returns an entry for every term", async () => {
+      const lookupBatch = vi
+        .fn()
+        .mockResolvedValue([{ entry: "雪", found: true, reading: "ゆき", freqRank: 1200 }]);
+      setElectronDict({
+        lookupBatch,
+        verify: vi.fn(),
+        getStatus: vi.fn(),
+      });
+      const access = await importFresh();
+
+      const result = await access.lookupBatch(["雪", "存在しない語"]);
+      expect(result.get("雪")).toEqual({ found: true, reading: "ゆき", freqRank: 1200 });
+      expect(result.get("存在しない語")).toEqual({ found: false });
+
+      // Second call for the same terms is fully cache-served (no extra IPC).
+      await access.lookupBatch(["雪", "存在しない語"]);
+      expect(lookupBatch).toHaveBeenCalledOnce();
+    });
+
+    it("dedupes and ignores empty terms", async () => {
+      const lookupBatch = vi.fn().mockResolvedValue([{ entry: "雪", found: true }]);
+      setElectronDict({ lookupBatch, verify: vi.fn(), getStatus: vi.fn() });
+      const access = await importFresh();
+
+      await access.lookupBatch(["雪", "雪", ""]);
+      expect(lookupBatch).toHaveBeenCalledWith(["雪"]);
+    });
+  });
+
+  describe("has()", () => {
+    it("returns true for a known headword and false for an unknown one", async () => {
+      setElectronDict({
+        lookupBatch: vi.fn().mockResolvedValue([{ entry: "雪", found: true }]),
+        verify: vi.fn(),
+        getStatus: vi.fn(),
+      });
+      const access = await importFresh();
+      expect(await access.has("雪")).toBe(true);
+      expect(await access.has("存在しない語")).toBe(false);
+      expect(await access.has("")).toBe(false);
+    });
+  });
+
+  describe("lookupBatch() — web fallback", () => {
+    it("uses the remote backend when there is no Electron dict", async () => {
+      mockLookupBatchRemote.mockResolvedValue(
+        new Map<string, DictLookup>([["雪", { found: true, reading: "ゆき" }]]),
+      );
+      const access = await importFresh();
+      const result = await access.lookupBatch(["雪"]);
+      expect(mockLookupBatchRemote).toHaveBeenCalledWith(["雪"]);
+      expect(result.get("雪")).toEqual({ found: true, reading: "ゆき" });
+    });
+  });
+
+  describe("invalidate()", () => {
+    it("clears cached lookups so the next call re-queries", async () => {
+      const lookupBatch = vi.fn().mockResolvedValue([{ entry: "雪", found: true }]);
+      setElectronDict({ lookupBatch, verify: vi.fn(), getStatus: vi.fn() });
+      const access = await importFresh();
+
+      await access.lookupBatch(["雪"]);
+      access.invalidate();
+      await access.lookupBatch(["雪"]);
+      expect(lookupBatch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/lib/dict/dict-access.ts
+++ b/lib/dict/dict-access.ts
@@ -1,0 +1,229 @@
+/**
+ * DictAccess — consumer-facing facade over the Genji dictionary for analysis
+ * features (型態分析 / 語彙統計 / 読みやすさ / ルビ) and lint rules.
+ *
+ * Why this exists separately from {@link getDictService}:
+ *   `DictService.query()` returns full {@link DictEntry} objects by prefix match
+ *   — right for the lookup panel, wrong for bulk analysis (heavy payloads, one
+ *   round-trip per word, no freq_rank/register exposed). DictAccess adds the
+ *   three primitives analysis needs:
+ *     - getHealth()    — single source of truth for download presence + corruption
+ *     - has()          — exact-match membership (lint "辞書外語" rule)
+ *     - lookupBatch()  — many headwords in one IPC, lightweight projection, cached
+ *
+ * Graceful degradation: consumers should call getHealth() and only enrich when
+ * `state === "ready"` (local Electron DB). On web the remote API still answers
+ * single-word lookups (ruby), but bulk lookups are capped.
+ *
+ * Usage:
+ *   import { getDictAccess } from "@/lib/dict/dict-access";
+ *   const health = await getDictAccess().getHealth();
+ *   if (health.state === "ready") {
+ *     const map = await getDictAccess().lookupBatch(words);
+ *   }
+ */
+import type { DictLookup } from "./dict-types";
+import { LRUCache } from "@/lib/utils/lru-cache";
+import * as GenjiApiBackend from "./providers/genji-api-backend";
+
+export type GenjiHealthState = "ready" | "web-fallback" | "not-installed" | "corrupt" | "unknown";
+
+export interface GenjiHealth {
+  state: GenjiHealthState;
+  installedVersion?: string;
+  /** Japanese UI hint; populated for not-installed / corrupt / web-fallback. */
+  message?: string;
+}
+
+interface ElectronDictApi {
+  lookupBatch: (terms: string[]) => Promise<Array<{ entry: string } & DictLookup>>;
+  verify: () => Promise<{ ok: boolean; reason?: string }>;
+  getStatus: () => Promise<{ status: string; installedVersion?: string }>;
+}
+
+function getElectronDict(): ElectronDictApi | null {
+  if (typeof window === "undefined") return null;
+  return (
+    (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict ?? null
+  );
+}
+
+const CORRUPT_MESSAGE = "辞書データが破損しています。設定から再ダウンロードしてください。";
+
+const HEALTH_TTL_MS = 5000;
+const LOOKUP_CACHE_SIZE = 8000;
+/** SQLite bind-variable limit is 999; stay comfortably under it per query. */
+const LOCAL_BATCH_CHUNK = 400;
+/** Cap web bulk lookups so analysis can't fan out into hundreds of requests. */
+const REMOTE_MAX_TERMS = 300;
+
+const MISS: DictLookup = Object.freeze({ found: false });
+
+class DictAccess {
+  private readonly cache = new LRUCache<string, DictLookup>(LOOKUP_CACHE_SIZE);
+  private health: { value: GenjiHealth; at: number } | null = null;
+
+  /**
+   * Clear cached health + lookups. Call after a (re)download so newly installed
+   * data and previously-cached negatives are re-evaluated.
+   */
+  invalidate(): void {
+    this.health = null;
+    this.cache.clear();
+  }
+
+  /** Resolve dictionary availability/health, cached for a few seconds. */
+  async getHealth(): Promise<GenjiHealth> {
+    const now = Date.now();
+    if (this.health && now - this.health.at < HEALTH_TTL_MS) {
+      return this.health.value;
+    }
+    const value = await this.computeHealth();
+    this.health = { value, at: now };
+    return value;
+  }
+
+  private async computeHealth(): Promise<GenjiHealth> {
+    const dict = getElectronDict();
+    if (!dict) {
+      return {
+        state: "web-fallback",
+        message: "Web版ではオンライン辞典（幻辞API）を使用します。",
+      };
+    }
+    try {
+      const status = await dict.getStatus();
+      if (status.status === "not-installed") {
+        return { state: "not-installed", message: "辞書が未ダウンロードです。" };
+      }
+      if (status.status === "corrupt") {
+        return { state: "corrupt", installedVersion: status.installedVersion, message: CORRUPT_MESSAGE };
+      }
+      if (status.status === "installed") {
+        // Proactively confirm integrity — catches a bad DB before the first query.
+        const v = await dict.verify();
+        if (!v.ok) {
+          return {
+            state: "corrupt",
+            installedVersion: status.installedVersion,
+            message: CORRUPT_MESSAGE,
+          };
+        }
+        return { state: "ready", installedVersion: status.installedVersion };
+      }
+      return { state: "unknown" };
+    } catch (err) {
+      console.warn("[dict-access] health check failed:", err);
+      return { state: "unknown" };
+    }
+  }
+
+  /** Exact-match membership check (for the future 辞書外語 lint rule). */
+  async has(term: string): Promise<boolean> {
+    if (!term) return false;
+    const result = await this.lookupBatch([term]);
+    return result.get(term)?.found ?? false;
+  }
+
+  /**
+   * Batch exact-match lookup. Returns a map keyed by every requested (deduped,
+   * non-empty) term; misses map to `{ found: false }`. Cached per-term.
+   */
+  async lookupBatch(terms: string[]): Promise<Map<string, DictLookup>> {
+    const out = new Map<string, DictLookup>();
+    const misses: string[] = [];
+    const seen = new Set<string>();
+
+    for (const t of terms) {
+      if (typeof t !== "string" || t.length === 0 || seen.has(t)) continue;
+      seen.add(t);
+      const cached = this.cache.get(t);
+      if (cached !== undefined) {
+        out.set(t, cached);
+      } else {
+        misses.push(t);
+      }
+    }
+    if (misses.length === 0) return out;
+
+    const dict = getElectronDict();
+    if (dict) {
+      await this.lookupLocal(dict, misses, out);
+    } else {
+      await this.lookupRemote(misses, out);
+    }
+    return out;
+  }
+
+  private async lookupLocal(
+    dict: ElectronDictApi,
+    misses: string[],
+    out: Map<string, DictLookup>,
+  ): Promise<void> {
+    for (let i = 0; i < misses.length; i += LOCAL_BATCH_CHUNK) {
+      const chunk = misses.slice(i, i + LOCAL_BATCH_CHUNK);
+      let rows: Array<{ entry: string } & DictLookup> = [];
+      try {
+        rows = await dict.lookupBatch(chunk);
+      } catch (err) {
+        console.warn("[dict-access] local lookupBatch failed:", err);
+        rows = [];
+      }
+
+      const found = new Set<string>();
+      for (const row of rows) {
+        const { entry, ...rest } = row;
+        const lookup: DictLookup = { ...rest, found: true };
+        this.cache.set(entry, lookup);
+        out.set(entry, lookup);
+        found.add(entry);
+      }
+      // Cache negatives so repeated analysis doesn't re-query absent words.
+      for (const t of chunk) {
+        if (!found.has(t)) {
+          this.cache.set(t, MISS);
+          out.set(t, MISS);
+        }
+      }
+    }
+  }
+
+  private async lookupRemote(misses: string[], out: Map<string, DictLookup>): Promise<void> {
+    const capped = misses.slice(0, REMOTE_MAX_TERMS);
+    if (capped.length < misses.length) {
+      console.warn(
+        `[dict-access] remote lookup capped at ${REMOTE_MAX_TERMS}/${misses.length} terms`,
+      );
+    }
+
+    let map: Map<string, DictLookup>;
+    try {
+      map = await GenjiApiBackend.lookupBatchRemote(capped);
+    } catch (err) {
+      console.warn("[dict-access] remote lookupBatch failed:", err);
+      map = new Map();
+    }
+
+    for (const t of capped) {
+      const lookup = map.get(t) ?? MISS;
+      this.cache.set(t, lookup);
+      out.set(t, lookup);
+    }
+    // Terms beyond the cap: report as not-found WITHOUT caching, so a later
+    // smaller request can still resolve them.
+    for (const t of misses.slice(REMOTE_MAX_TERMS)) {
+      if (!out.has(t)) out.set(t, MISS);
+    }
+  }
+}
+
+let _instance: DictAccess | null = null;
+
+export function getDictAccess(): DictAccess {
+  if (!_instance) {
+    _instance = new DictAccess();
+  }
+  return _instance;
+}
+
+export type { DictAccess };

--- a/lib/dict/dict-access.ts
+++ b/lib/dict/dict-access.ts
@@ -97,7 +97,11 @@ class DictAccess {
         return { state: "not-installed", message: "辞書が未ダウンロードです。" };
       }
       if (status.status === "corrupt") {
-        return { state: "corrupt", installedVersion: status.installedVersion, message: CORRUPT_MESSAGE };
+        return {
+          state: "corrupt",
+          installedVersion: status.installedVersion,
+          message: CORRUPT_MESSAGE,
+        };
       }
       if (status.status === "installed") {
         // Proactively confirm integrity — catches a bad DB before the first query.

--- a/lib/dict/dict-types.ts
+++ b/lib/dict/dict-types.ts
@@ -88,6 +88,9 @@ export type DictDownloadStatus =
   | "downloading"
   | "installing"
   | "installed"
+  /** DB file exists but failed an integrity check (truncated download, bad
+   * header, missing table). The user should re-download. */
+  | "corrupt"
   | "error";
 
 export interface DictDownloadState {
@@ -121,4 +124,27 @@ export interface DictQueryResult {
   noResults: boolean;
   /** True when the provider is not installed / not available */
   providerUnavailable: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight analysis projection
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal per-term projection returned by batch lookups for analysis features
+ * (vocabulary stats, readability, ruby, lint rules). Deliberately small so it
+ * is cheap to ship across IPC for hundreds of words at once — never the full
+ * {@link DictEntry} (definitions/examples/relations) which the lookup panel uses.
+ */
+export interface DictLookup {
+  /** Whether the headword exists in the dictionary (exact match). */
+  found: boolean;
+  /** Primary kana reading (読み) — used for ruby suggestions. */
+  reading?: string;
+  /** Part(s) of speech, joined with "・". */
+  pos?: string;
+  /** Register label (口語/文章語/雅語 …) from the first definition that has one. */
+  register?: string;
+  /** Frequency rank (smaller = more common) — used for vocabulary difficulty. */
+  freqRank?: number;
 }

--- a/lib/dict/providers/genji-api-backend.ts
+++ b/lib/dict/providers/genji-api-backend.ts
@@ -11,6 +11,7 @@ import type {
   DictExample,
   DictRelationships,
   DictReading,
+  DictLookup,
 } from "../dict-types";
 
 const GENJI_API_BASE = "https://api.dict.illusions.app";
@@ -185,6 +186,52 @@ export async function queryByEntry(term: string, limit: number): Promise<DictEnt
     limit: String(limit),
   });
   return raws.map(mapRawJsonToDictEntry);
+}
+
+/** Project a raw_json row into the lightweight analysis shape. */
+function rawJsonToLookup(raw: RawJson): DictLookup {
+  const register = raw.definitions?.find((d) => d.register)?.register;
+  return {
+    found: true,
+    reading: raw.reading?.primary || undefined,
+    pos: raw.grammar?.pos?.join("・") || undefined,
+    register: register || undefined,
+    freqRank: typeof raw.meta?.freq_rank === "number" ? raw.meta.freq_rank : undefined,
+  };
+}
+
+/** Headwords per remote chunk — keeps each Datasette URL well under length limits. */
+const REMOTE_BATCH_CHUNK = 50;
+
+/**
+ * Exact-match batch lookup over the remote Genji API (web fallback). Issues one
+ * parameterized `entry IN (...)` query per chunk. Returns a map keyed by the
+ * requested term; misses map to `{ found: false }`. Slower than the local
+ * Electron path, so callers doing bulk analysis should gate on dictionary
+ * health and prefer the local DB.
+ */
+export async function lookupBatchRemote(terms: string[]): Promise<Map<string, DictLookup>> {
+  const result = new Map<string, DictLookup>();
+  const unique = [...new Set(terms.filter((t) => typeof t === "string" && t.length > 0))];
+
+  for (let i = 0; i < unique.length; i += REMOTE_BATCH_CHUNK) {
+    const chunk = unique.slice(i, i + REMOTE_BATCH_CHUNK);
+    const params: Record<string, string> = {};
+    const names = chunk.map((t, j) => {
+      params[`p${j}`] = t;
+      return `:p${j}`;
+    });
+    const sql = `SELECT raw_json FROM entries WHERE entry IN (${names.join(",")})`;
+    const raws = await executeSql(sql, params);
+    for (const raw of raws) {
+      if (!result.has(raw.entry)) result.set(raw.entry, rawJsonToLookup(raw));
+    }
+  }
+
+  for (const t of unique) {
+    if (!result.has(t)) result.set(t, { found: false });
+  }
+  return result;
 }
 
 /**

--- a/lib/editor-page/use-startup-checks.ts
+++ b/lib/editor-page/use-startup-checks.ts
@@ -5,8 +5,11 @@
 import { useEffect, useRef } from "react";
 import { startupCheckQueue } from "@/lib/services/startup-check-queue";
 import { dictUpdateCheck } from "@/lib/services/startup-checks/dict-update-check";
+import { dictCorruptCheck } from "@/lib/services/startup-checks/dict-corrupt-check";
 
 // Register built-in checks once at module load. register() is idempotent per id.
+// Corrupt is checked before update: a corrupt DB needs re-download regardless of version.
+startupCheckQueue.register(dictCorruptCheck);
 startupCheckQueue.register(dictUpdateCheck);
 
 export function useStartupChecks(): void {

--- a/lib/services/startup-checks/dict-corrupt-check.ts
+++ b/lib/services/startup-checks/dict-corrupt-check.ts
@@ -1,0 +1,70 @@
+/**
+ * Startup check: installed Japanese dictionary (Genji) is corrupt.
+ *
+ * Electron-only (no local DB on web). When {@link getDictAccess}'s health
+ * resolves to "corrupt" — the DB file exists but failed a fast integrity check
+ * (truncated download, bad header, missing table) — surface a warning that
+ * offers to re-download. This runs alongside {@link dictUpdateCheck}; the
+ * corrupt state takes precedence conceptually (a corrupt DB answers no queries).
+ */
+import { getDictAccess } from "@/lib/dict/dict-access";
+import { notificationManager } from "../notification-manager";
+import type { StartupCheck, StartupNotice } from "../startup-check-queue";
+
+interface DictDownloadResult {
+  success: boolean;
+  version?: string;
+  error?: string;
+}
+
+interface ElectronDictApi {
+  download?: () => Promise<DictDownloadResult | undefined>;
+}
+
+function getElectronDict(): ElectronDictApi | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict;
+}
+
+function startRedownload(): void {
+  const dict = getElectronDict();
+  if (!dict?.download) return;
+  notificationManager.info("辞書の再ダウンロードを開始しました。");
+  dict
+    .download()
+    .then((result) => {
+      if (result?.success === false) {
+        notificationManager.error(
+          `辞書の再ダウンロードに失敗しました：${result.error ?? "不明なエラー"}`,
+        );
+      } else {
+        // Clear cached "corrupt" health + negative lookups now that the DB is fresh.
+        getDictAccess().invalidate();
+      }
+    })
+    .catch((e: unknown) => {
+      console.warn("[dict] re-download failed:", e);
+      notificationManager.error(
+        `辞書の再ダウンロードに失敗しました：${e instanceof Error ? e.message : String(e)}`,
+      );
+    });
+}
+
+export const dictCorruptCheck: StartupCheck = {
+  id: "dict-corrupt",
+  async evaluate(): Promise<StartupNotice | null> {
+    // Electron-only feature; the browser has no local dictionary file.
+    if (!getElectronDict()) return null;
+
+    const health = await getDictAccess().getHealth();
+    if (health.state !== "corrupt") return null;
+
+    return {
+      id: "dict-corrupt",
+      type: "warning",
+      message: health.message ?? "辞書データが破損しています。再ダウンロードしてください。",
+      duration: 0, // keep until dismissed
+      actions: [{ label: "再ダウンロード", onClick: startRedownload }],
+    };
+  },
+};

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -9,7 +9,7 @@ import type {
 import type { Token, WordEntry, TokenizeProgress } from "@/lib/nlp-client/types";
 import type { VFSWatchEvent } from "@/lib/vfs/types";
 import type { KeymapOverrides } from "@/lib/keymap/keymap-types";
-import type { DictEntry, DictDownloadStatus } from "@/lib/dict/dict-types";
+import type { DictEntry, DictDownloadStatus, DictLookup } from "@/lib/dict/dict-types";
 import type { PdfGenerationOptions } from "@/lib/export/types";
 
 export {};
@@ -289,6 +289,16 @@ declare global {
       query: (term: string, limit?: number) => Promise<DictEntry[]>;
       /** Query entries by kana reading (homophone lookup) */
       queryByReading: (reading: string, limit?: number) => Promise<DictEntry[]>;
+      /**
+       * Exact-match batch lookup (lightweight projection) for analysis features.
+       * Terms with no match are omitted from the result array.
+       */
+      lookupBatch: (terms: string[]) => Promise<Array<{ entry: string } & DictLookup>>;
+      /** Fast integrity check; `ok: false` means the DB should be re-downloaded. */
+      verify: () => Promise<{
+        ok: boolean;
+        reason?: "not-installed" | "schema" | "malformed";
+      }>;
       /** Get current installation status */
       getStatus: () => Promise<{
         status: DictDownloadStatus;


### PR DESCRIPTION
## 概要

型態分析 / 語彙統計 / 読みやすさ / ルビ / 校正ルールが共有する**幻辞アクセス層**を新設（エピック #1623 のフェーズ0、全件のブロッカー）。

`DictService.query()` は全 `DictEntry` を前方一致で返すため一括分析に不向きで、`corrupt` 状態も `has()` も無かった。本層がダウンロード有無・破損検出・一括照合・メンバーシップを一手に引き受ける。

## API（`lib/dict/dict-access.ts`）

```ts
getHealth(): Promise<GenjiHealth>   // ready | web-fallback | not-installed | corrupt | unknown
has(term): Promise<boolean>         // 完全一致メンバーシップ（将来の辞書外語ルール用）
lookupBatch(terms): Promise<Map<string, DictLookup>>  // 多数語を1 IPC・軽量射影・LRU
```

## 変更点

- **DictManager**: `verify()`（高速整合性チェック=schema+1行 sentinel、500MB 全走査はしない）/ `lookupBatch()`（完全一致・軽量射影）/ corruption 検出（malformed/not-a-database で `_corrupt` フラグ→`getStatus` が `corrupt` を返す）。`_createDatabase` シームで native module を mock せずテスト可能化
- **IPC**: `dict:lookup-batch` / `dict:verify` 追加（preload・handler・`types/electron.d.ts`・drift テスト更新）
- **型**: `DictDownloadStatus` に `"corrupt"`、新 `DictLookup`
- **破損 UX**: 起動時トースト `dict-corrupt-check`（再ダウンロード導線）+ 設定タブの破損バナー。再DL 成功で `getDictAccess().invalidate()`
- **Web フォールバック**: `genji-api-backend.lookupBatchRemote`（チャンク50・上限300、`no silent cap` ログ）
- **劣化**: `state !== "ready"` で重い一括照合をスキップ可能（各機能が幻辞無しでも従来動作）

## テスト

- `electron/__tests__/dict-manager-access.test.ts` … verify 4状態 / lookupBatch 射影・dedup・空 = 8 件
- `lib/dict/__tests__/dict-access.test.ts` … health 各状態 / lookupBatch キャッシュ・負キャッシュ / has / web fallback / invalidate = 11 件
- type-check green、全 1545+ テストパス、lint 0 error

## 注意

- 本 PR はアクセス層のみ。型態分析/語彙統計/読みやすさ/ルビの実機連携は後続 PR（#1625 #1626 #1627 #1629）で本層に乗せる
- 校正ルール（#1628）は今回スコープ外（issue は open のまま）

Refs #1623
Closes #1624