### PR TITLE
feat(stats): 語彙統計の幻辞連携 — 頻度ランク/レジスター/辞書外語数 (#1626)

### DIFF
--- a/components/WordFrequency.tsx
+++ b/components/WordFrequency.tsx
@@ -9,7 +9,14 @@ import { useContextMenu } from "@/lib/hooks/use-context-menu";
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
 import { getProjectFileService } from "@/lib/services/project-file-service";
 import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
+import { getDictAccess } from "@/lib/dict/dict-access";
+import {
+  summarizeGenjiVocabulary,
+  freqRankDistributionToRows,
+  registerDistributionToRows,
+} from "@/lib/utils/vocabulary-genji";
 import type { WordEntry } from "@/lib/nlp-client/types";
+import type { GenjiVocabularySummary } from "@/lib/utils/vocabulary-genji";
 
 /** Cache file schema for word frequency results */
 interface WordFrequencyCache {
@@ -76,6 +83,12 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
   const [error, setError] = useState<string | null>(null);
   const [lastAnalyzedContent, setLastAnalyzedContent] = useState<string>("");
   const [cacheTimestamp, setCacheTimestamp] = useState<number>(0);
+
+  // Genji vocabulary enrichment state
+  const [genjiSummary, setGenjiSummary] = useState<GenjiVocabularySummary | null>(null);
+  const [genjiLoading, setGenjiLoading] = useState(false);
+  /** Set to true when the Genji DB is ready (health.state === "ready"). False means graceful hide. */
+  const [genjiReady, setGenjiReady] = useState(false);
 
   /** Generation counter — incremented on each analysis start; stale async results are discarded (#1078) */
   const genRef = useRef(0);
@@ -224,6 +237,54 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
     }
   }, [content, lastAnalyzedContent]);
 
+  // Genji vocabulary enrichment — run after words list changes
+  useEffect(() => {
+    if (words.length === 0) {
+      setGenjiSummary(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const runGenji = async (): Promise<void> => {
+      const access = getDictAccess();
+      const health = await access.getHealth();
+
+      if (cancelled) return;
+
+      // Graceful degradation: only enrich when the local Electron DB is ready.
+      // Web-fallback and not-installed states skip bulk lookup.
+      if (health.state !== "ready") {
+        setGenjiReady(false);
+        setGenjiSummary(null);
+        return;
+      }
+
+      setGenjiReady(true);
+      setGenjiLoading(true);
+
+      try {
+        const wordStrings = words.map((w) => w.word);
+        const lookupMap = await access.lookupBatch(wordStrings);
+        if (cancelled) return;
+        const summary = summarizeGenjiVocabulary(wordStrings, lookupMap);
+        setGenjiSummary(summary);
+      } catch (err) {
+        console.warn("[WordFrequency] Genji enrichment failed:", err);
+        // Non-critical — swallow and hide the section
+        setGenjiSummary(null);
+      } finally {
+        if (!cancelled) setGenjiLoading(false);
+      }
+    };
+
+    void runGenji();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [words]);
+
   const stats = useMemo(() => {
     const totalWords = words.reduce((sum, w) => sum + w.count, 0);
     const uniqueWords = words.length;
@@ -343,6 +404,72 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
           </div>
         )}
       </div>
+
+      {/* 幻辞メトリクスセクション — Genji DB が ready のときのみ表示 */}
+      {genjiReady && (
+        <div className="flex-shrink-0 border-t border-border">
+          <div className="px-3 py-2">
+            <div className="flex items-center justify-between mb-1.5">
+              <h3 className="text-xs font-medium text-foreground-secondary">幻辞分析</h3>
+              {genjiLoading && (
+                <LoaderCircle className="w-3 h-3 text-foreground-tertiary animate-spin" />
+              )}
+            </div>
+
+            {genjiSummary !== null && !genjiLoading && (
+              <>
+                {/* 頻度ランク分布 */}
+                <div className="mb-2">
+                  <p className="text-xs text-foreground-tertiary mb-1">頻度ランク分布</p>
+                  <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+                    {freqRankDistributionToRows(genjiSummary.freqRankDistribution).map((row) => (
+                      <span key={row.label} className="text-xs text-foreground-tertiary">
+                        {row.label}:{" "}
+                        <span className="text-foreground font-medium">{row.count}</span>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                {/* レジスター分布（文体ラベルが1種類以上あるときのみ） */}
+                {Object.keys(genjiSummary.registerDistribution).length > 0 && (
+                  <div className="mb-2">
+                    <p className="text-xs text-foreground-tertiary mb-1">文体</p>
+                    <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+                      {registerDistributionToRows(genjiSummary.registerDistribution).map((row) => (
+                        <span key={row.label} className="text-xs text-foreground-tertiary">
+                          {row.label}:{" "}
+                          <span className="text-foreground font-medium">{row.count}</span>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* 辞書外語数 */}
+                <p className="text-xs text-foreground-tertiary">
+                  辞書外語:{" "}
+                  <span className="text-foreground font-medium">
+                    {genjiSummary.unknownWordCount}
+                  </span>
+                  <span className="ml-1 text-foreground-tertiary">
+                    （固有名詞・造語・誤記の候補）
+                  </span>
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* 幻辞未導入時の案内（Electron のみ、web では非表示） */}
+      {!genjiReady && typeof window !== "undefined" && window.electronAPI !== undefined && (
+        <div className="flex-shrink-0 border-t border-border px-3 py-2">
+          <p className="text-xs text-foreground-tertiary">
+            幻辞辞書をダウンロードすると、頻度ランク・文体・辞書外語分析が使えます。
+          </p>
+        </div>
+      )}
 
       {/* Web context menu */}
       {contextMenu.menu && (

--- a/lib/utils/__tests__/vocabulary-genji.test.ts
+++ b/lib/utils/__tests__/vocabulary-genji.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  summarizeGenjiVocabulary,
+  freqRankDistributionToRows,
+  registerDistributionToRows,
+  FREQ_RANK_EVERYDAY,
+  FREQ_RANK_GENERAL,
+} from "@/lib/utils/vocabulary-genji";
+import type { DictLookup } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMap(entries: Array<[string, DictLookup]>): Map<string, DictLookup> {
+  return new Map(entries);
+}
+
+// ---------------------------------------------------------------------------
+// summarizeGenjiVocabulary — basic counts
+// ---------------------------------------------------------------------------
+
+describe("summarizeGenjiVocabulary", () => {
+  it("returns all-zero summary for empty word list", () => {
+    const summary = summarizeGenjiVocabulary([], makeMap([]));
+    expect(summary.freqRankDistribution.everyday).toBe(0);
+    expect(summary.freqRankDistribution.general).toBe(0);
+    expect(summary.freqRankDistribution.rare).toBe(0);
+    expect(summary.freqRankDistribution.unknown).toBe(0);
+    expect(summary.unknownWordCount).toBe(0);
+    expect(summary.totalLookedUp).toBe(0);
+    expect(summary.registerDistribution).toEqual({});
+  });
+
+  it("counts not-found words as unknown (辞書外)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["新語", "造語"],
+      makeMap([
+        ["新語", { found: false }],
+        ["造語", { found: false }],
+      ]),
+    );
+    expect(summary.freqRankDistribution.unknown).toBe(2);
+    expect(summary.unknownWordCount).toBe(2);
+    expect(summary.freqRankDistribution.everyday).toBe(0);
+  });
+
+  it("treats word absent from lookupMap as not-found", () => {
+    // "幽霊語" is not in the map at all — should count as unknown
+    const summary = summarizeGenjiVocabulary(["幽霊語"], makeMap([]));
+    expect(summary.freqRankDistribution.unknown).toBe(1);
+    expect(summary.unknownWordCount).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Bucket boundary tests
+  // -------------------------------------------------------------------------
+
+  it("places rank === FREQ_RANK_EVERYDAY in everyday bucket (boundary)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["境界語"],
+      makeMap([["境界語", { found: true, freqRank: FREQ_RANK_EVERYDAY }]]),
+    );
+    expect(summary.freqRankDistribution.everyday).toBe(1);
+    expect(summary.freqRankDistribution.general).toBe(0);
+  });
+
+  it("places rank === FREQ_RANK_EVERYDAY + 1 in general bucket (boundary)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["境界語"],
+      makeMap([["境界語", { found: true, freqRank: FREQ_RANK_EVERYDAY + 1 }]]),
+    );
+    expect(summary.freqRankDistribution.everyday).toBe(0);
+    expect(summary.freqRankDistribution.general).toBe(1);
+  });
+
+  it("places rank === FREQ_RANK_GENERAL in general bucket (boundary)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["境界語"],
+      makeMap([["境界語", { found: true, freqRank: FREQ_RANK_GENERAL }]]),
+    );
+    expect(summary.freqRankDistribution.general).toBe(1);
+    expect(summary.freqRankDistribution.rare).toBe(0);
+  });
+
+  it("places rank === FREQ_RANK_GENERAL + 1 in rare bucket (boundary)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["境界語"],
+      makeMap([["境界語", { found: true, freqRank: FREQ_RANK_GENERAL + 1 }]]),
+    );
+    expect(summary.freqRankDistribution.rare).toBe(1);
+    expect(summary.freqRankDistribution.general).toBe(0);
+  });
+
+  it("places found word with undefined freqRank in general bucket", () => {
+    const summary = summarizeGenjiVocabulary(["読み"], makeMap([["読み", { found: true }]]));
+    expect(summary.freqRankDistribution.general).toBe(1);
+    expect(summary.freqRankDistribution.everyday).toBe(0);
+    expect(summary.freqRankDistribution.rare).toBe(0);
+    expect(summary.freqRankDistribution.unknown).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Mixed bucket distribution
+  // -------------------------------------------------------------------------
+
+  it("correctly distributes a mixed word list across all four buckets", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["猫", "走る", "碧落", "新語"],
+      makeMap([
+        ["猫", { found: true, freqRank: 500 }], // everyday
+        ["走る", { found: true, freqRank: 4_000 }], // general
+        ["碧落", { found: true, freqRank: 15_000 }], // rare
+        ["新語", { found: false }], // unknown
+      ]),
+    );
+    expect(summary.freqRankDistribution.everyday).toBe(1);
+    expect(summary.freqRankDistribution.general).toBe(1);
+    expect(summary.freqRankDistribution.rare).toBe(1);
+    expect(summary.freqRankDistribution.unknown).toBe(1);
+    expect(summary.totalLookedUp).toBe(4);
+  });
+
+  // -------------------------------------------------------------------------
+  // Register distribution
+  // -------------------------------------------------------------------------
+
+  it("accumulates register counts correctly", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["言う", "申す", "おっしゃる"],
+      makeMap([
+        ["言う", { found: true, freqRank: 100, register: "口語" }],
+        ["申す", { found: true, freqRank: 2_000, register: "文章語" }],
+        ["おっしゃる", { found: true, freqRank: 800, register: "口語" }],
+      ]),
+    );
+    expect(summary.registerDistribution["口語"]).toBe(2);
+    expect(summary.registerDistribution["文章語"]).toBe(1);
+  });
+
+  it("uses 'なし' key for found words with no register label", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["猫", "犬"],
+      makeMap([
+        ["猫", { found: true, freqRank: 500 }], // no register
+        ["犬", { found: true, freqRank: 600 }], // no register
+      ]),
+    );
+    expect(summary.registerDistribution["なし"]).toBe(2);
+  });
+
+  it("does not add register entry for not-found words", () => {
+    const summary = summarizeGenjiVocabulary(["造語"], makeMap([["造語", { found: false }]]));
+    // No register key should exist because the word wasn't found
+    expect(Object.keys(summary.registerDistribution)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// freqRankDistributionToRows
+// ---------------------------------------------------------------------------
+
+describe("freqRankDistributionToRows", () => {
+  it("returns four rows in fixed order: 常用 → 一般 → 稀少 → 辞書外", () => {
+    const rows = freqRankDistributionToRows({
+      everyday: 10,
+      general: 20,
+      rare: 5,
+      unknown: 3,
+    });
+    expect(rows.map((r) => r.label)).toEqual(["常用", "一般", "稀少", "辞書外"]);
+    expect(rows.map((r) => r.count)).toEqual([10, 20, 5, 3]);
+  });
+
+  it("returns all-zero rows for empty distribution", () => {
+    const rows = freqRankDistributionToRows({
+      everyday: 0,
+      general: 0,
+      rare: 0,
+      unknown: 0,
+    });
+    expect(rows.every((r) => r.count === 0)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerDistributionToRows
+// ---------------------------------------------------------------------------
+
+describe("registerDistributionToRows", () => {
+  it("sorts by count descending", () => {
+    const rows = registerDistributionToRows({
+      文章語: 1,
+      口語: 5,
+      雅語: 3,
+    });
+    expect(rows[0].label).toBe("口語");
+    expect(rows[1].label).toBe("雅語");
+    expect(rows[2].label).toBe("文章語");
+  });
+
+  it("places 'なし' last regardless of count", () => {
+    const rows = registerDistributionToRows({
+      なし: 100,
+      口語: 2,
+    });
+    expect(rows[rows.length - 1].label).toBe("なし");
+  });
+
+  it("returns empty array for empty distribution", () => {
+    expect(registerDistributionToRows({})).toEqual([]);
+  });
+});

--- a/lib/utils/vocabulary-genji.ts
+++ b/lib/utils/vocabulary-genji.ts
@@ -1,0 +1,161 @@
+/**
+ * Genji vocabulary enrichment utilities for the word-frequency panel.
+ *
+ * All functions in this module are pure (no side-effects, no async) so they
+ * can be unit-tested without mocking IPC / window / React.
+ *
+ * Bucket thresholds for frequency rank (freqRank):
+ *   常用 (everyday)  : rank ≤ 3 000  — roughly the top-3000 headwords in contemporary
+ *                       Japanese corpora; covers the bulk of newspaper/novel text.
+ *   一般 (general)   : 3 001–10 000  — standard vocabulary found in mid-range prose.
+ *   稀少 (rare)      : rank > 10 000  — low-frequency, archaic, or highly specialised terms.
+ *   辞書外 (unknown) : found === false — not in the dictionary at all (proper nouns,
+ *                       neologisms, typos, MDI meta-words, …).
+ *
+ * The boundaries are based on:
+ *   • 国語研究所「現代雑誌90誌の語彙調査」(1994) — top ~3500 types cover 90% of tokens.
+ *   • 日本語能力試験(JLPT)語彙リスト — N1 vocabulary ends around 10 000 items.
+ */
+
+import type { DictLookup } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Constants — bucket boundaries
+// ---------------------------------------------------------------------------
+
+/** Upper inclusive boundary for 常用 (everyday) frequency bucket. */
+export const FREQ_RANK_EVERYDAY = 3_000;
+
+/** Upper inclusive boundary for 一般 (general) frequency bucket. */
+export const FREQ_RANK_GENERAL = 10_000;
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/** Frequency rank distribution across the four buckets. */
+export interface FreqRankDistribution {
+  /** Words with freqRank ≤ FREQ_RANK_EVERYDAY */
+  everyday: number;
+  /** Words with freqRank in (FREQ_RANK_EVERYDAY, FREQ_RANK_GENERAL] */
+  general: number;
+  /** Words with freqRank > FREQ_RANK_GENERAL */
+  rare: number;
+  /** Words with found === false (no dictionary entry) */
+  unknown: number;
+}
+
+/** Register (文体) distribution keyed by register label. */
+export type RegisterDistribution = Record<string, number>;
+
+/** Aggregated Genji metrics for the vocabulary panel. */
+export interface GenjiVocabularySummary {
+  /** Frequency rank distribution. */
+  freqRankDistribution: FreqRankDistribution;
+  /**
+   * Register distribution.
+   * Keys are the register strings from DictLookup.register (e.g. "口語", "文章語", "雅語").
+   * The special key "なし" counts words that were found but carry no register label.
+   */
+  registerDistribution: RegisterDistribution;
+  /** Number of words not found in the dictionary (found === false). */
+  unknownWordCount: number;
+  /** Total number of unique words that were looked up. */
+  totalLookedUp: number;
+}
+
+// ---------------------------------------------------------------------------
+// Core aggregation function
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate Genji dictionary lookup results into panel-ready metrics.
+ *
+ * @param words      - Unique word strings to summarise (typically WordEntry.word list).
+ * @param lookupMap  - Map returned by DictAccess.lookupBatch(); words absent from the
+ *                     map are treated as not-found.
+ * @returns          - Aggregated summary (pure, no I/O).
+ */
+export function summarizeGenjiVocabulary(
+  words: readonly string[],
+  lookupMap: ReadonlyMap<string, DictLookup>,
+): GenjiVocabularySummary {
+  const freqRankDistribution: FreqRankDistribution = {
+    everyday: 0,
+    general: 0,
+    rare: 0,
+    unknown: 0,
+  };
+  const registerDistribution: RegisterDistribution = {};
+  let unknownWordCount = 0;
+
+  for (const word of words) {
+    const lookup = lookupMap.get(word) ?? { found: false };
+
+    if (!lookup.found) {
+      freqRankDistribution.unknown++;
+      unknownWordCount++;
+      continue;
+    }
+
+    // Frequency rank bucketing
+    const rank = lookup.freqRank;
+    if (rank === undefined) {
+      // Found in dictionary but rank not available — count as 一般 as a safe fallback.
+      freqRankDistribution.general++;
+    } else if (rank <= FREQ_RANK_EVERYDAY) {
+      freqRankDistribution.everyday++;
+    } else if (rank <= FREQ_RANK_GENERAL) {
+      freqRankDistribution.general++;
+    } else {
+      freqRankDistribution.rare++;
+    }
+
+    // Register distribution
+    const register = lookup.register ?? "なし";
+    registerDistribution[register] = (registerDistribution[register] ?? 0) + 1;
+  }
+
+  return {
+    freqRankDistribution,
+    registerDistribution,
+    unknownWordCount,
+    totalLookedUp: words.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a FreqRankDistribution to a sorted array of label/count pairs
+ * suitable for rendering. Order: 常用 → 一般 → 稀少 → 辞書外.
+ */
+export function freqRankDistributionToRows(
+  dist: FreqRankDistribution,
+): Array<{ label: string; count: number }> {
+  return [
+    { label: "常用", count: dist.everyday },
+    { label: "一般", count: dist.general },
+    { label: "稀少", count: dist.rare },
+    { label: "辞書外", count: dist.unknown },
+  ];
+}
+
+/**
+ * Convert a RegisterDistribution to a sorted array of label/count pairs,
+ * descending by count, with "なし" last.
+ */
+export function registerDistributionToRows(
+  dist: RegisterDistribution,
+): Array<{ label: string; count: number }> {
+  const rows = Object.entries(dist).map(([label, count]) => ({ label, count }));
+  rows.sort((a, b) => {
+    // Push "なし" to the end
+    if (a.label === "なし") return 1;
+    if (b.label === "なし") return -1;
+    return b.count - a.count;
+  });
+  return rows;
+}


### PR DESCRIPTION
エピック #1623 / 共有アクセス層 #1624（dev にマージ済み）の上に実装。

## 変更
- `lib/utils/vocabulary-genji.ts`（新規・純関数）: `summarizeGenjiVocabulary(words, lookupMap)` ＋ 頻度ランク/レジスター分布の行変換。閾値（常用 ~3000 / 一般 ~10000）は定数化・根拠コメント付き
- `components/WordFrequency.tsx`: 頻度ランク分布・レジスター分布・**辞書外語数**を表示

## グレースフル劣化
`getDictAccess().getHealth()` が `ready` のときのみ幻辞メトリクスを表示。Web/未導入/破損/失敗時は既存の語彙統計のみで従来動作（幻辞セクション非表示）。

## テスト
`lib/utils/__tests__/vocabulary-genji.test.ts` 17 件（バケット境界・辞書外カウント・空入力・分布変換）。type-check green / eslint 0 error。

Refs #1623
Closes #1626