### PR TITLE
feat(readability): 読みやすさの幻辞連携 — 語彙難易度を freq_rank ベースに (#1627)

### DIFF
--- a/components/inspector/StatsPanel.tsx
+++ b/components/inspector/StatsPanel.tsx
@@ -44,6 +44,7 @@ interface StatsPanelProps {
       paragraphDensity: number;
     };
     hasMorphologicalAnalysis?: boolean;
+    hasDictAnalysis?: boolean;
   };
   previousDayStats?: PreviousDayStats | null;
 }
@@ -293,6 +294,12 @@ export default function StatsPanel({
                   {readabilityAnalysis.hasMorphologicalAnalysis === false && (
                     <span className="opacity-50 normal-case font-normal">(基本分析)</span>
                   )}
+                  {readabilityAnalysis.hasMorphologicalAnalysis === true &&
+                    readabilityAnalysis.hasDictAnalysis === false && (
+                      <span className="opacity-50 normal-case font-normal">
+                        (辞書未導入のため簡易判定)
+                      </span>
+                    )}
                 </p>
                 {(
                   [

--- a/lib/editor-page/use-text-statistics.ts
+++ b/lib/editor-page/use-text-statistics.ts
@@ -7,6 +7,7 @@ import {
   cleanMarkdown,
   analyzeReadability,
   enrichReadabilityWithMorphology,
+  enrichReadabilityWithDict,
 } from "@/lib/utils";
 
 import type {
@@ -16,6 +17,8 @@ import type {
 } from "@/lib/utils";
 
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
+import { getDictAccess } from "@/lib/dict/dict-access";
+import type { Token } from "@/lib/nlp-client/types";
 import { computeTextStatistics } from "./text-statistics";
 import type { TextStatistics } from "./text-statistics";
 
@@ -37,10 +40,12 @@ export interface TextStatisticsResult extends TextStatistics {
  * All values are memoized and only recomputed when content changes.
  *
  * 原稿用紙換算統計を含む統合統計を返す。
- * Readability is computed in two phases:
+ * Readability is computed in three phases:
  *   Phase 1 (sync):  surface-level analysis via analyzeReadability()
  *   Phase 2 (async): morphological enrichment via enrichReadabilityWithMorphology()
  *                    using kuromoji through INlpClient
+ *   Phase 3 (async): dictionary enrichment via enrichReadabilityWithDict()
+ *                    using Genji freq_rank via DictAccess — only when state === "ready"
  */
 export function useTextStatistics(content: string): TextStatisticsResult {
   const manuscriptStats = useMemo(() => computeTextStatistics(content), [content]);
@@ -57,7 +62,7 @@ export function useTextStatistics(content: string): TextStatisticsResult {
   // Phase 1: synchronous surface analysis（即時）
   const surfaceAnalysis = useMemo(() => analyzeReadability(cleanedContent), [cleanedContent]);
 
-  // Phase 2: async morphological enrichment（NLP完了後に更新）
+  // Phase 2 + 3: async enrichment（NLP完了後 → 辞書補強）
   const [readabilityAnalysis, setReadabilityAnalysis] =
     useState<EnhancedReadabilityAnalysis>(surfaceAnalysis);
 
@@ -69,15 +74,52 @@ export function useTextStatistics(content: string): TextStatisticsResult {
     if (cleanedContent.length < 50) return;
 
     let cancelled = false;
-    getNlpClient()
-      .tokenizeParagraph(cleanedContent)
-      .then((tokens) => {
+
+    const run = async (): Promise<void> => {
+      // Phase 2: kuromoji 形態素解析
+      let morphResult = surfaceAnalysis;
+      let tokens: Token[] = [];
+      try {
+        tokens = await getNlpClient().tokenizeParagraph(cleanedContent);
         if (cancelled) return;
-        setReadabilityAnalysis(enrichReadabilityWithMorphology(surfaceAnalysis, tokens));
-      })
-      .catch(() => {
+        morphResult = enrichReadabilityWithMorphology(surfaceAnalysis, tokens);
+        setReadabilityAnalysis(morphResult);
+      } catch {
         // NLP失敗時は表層結果のまま維持（silent fallback）
-      });
+        if (cancelled) return;
+      }
+
+      // Phase 3: 幻辞辞書補強（state === "ready" のときのみ実行）
+      // Web では重い一括照合をしないためヘルスチェックで必ず確認する
+      try {
+        const access = getDictAccess();
+        const health = await access.getHealth();
+        if (cancelled) return;
+        if (health.state !== "ready") return; // graceful degradation
+
+        // 内容語（名詞/動詞/形容詞/副詞）の basic_form を収集してバッチ照合
+        const contentForms = [
+          ...new Set(
+            tokens
+              .filter((t) => ["名詞", "動詞", "形容詞", "副詞"].includes(t.pos))
+              .map((t) => t.basic_form ?? t.surface)
+              .filter((f): f is string => typeof f === "string" && f.length > 0),
+          ),
+        ];
+
+        if (contentForms.length === 0) return;
+
+        const lookupMap = await access.lookupBatch(contentForms);
+        if (cancelled) return;
+
+        const dictResult = enrichReadabilityWithDict(morphResult, tokens, lookupMap);
+        setReadabilityAnalysis(dictResult);
+      } catch {
+        // 辞書補強失敗時は Tier 2 結果のまま維持（silent fallback）
+      }
+    };
+
+    void run();
 
     return () => {
       cancelled = true;

--- a/lib/utils/__tests__/readability-genji.test.ts
+++ b/lib/utils/__tests__/readability-genji.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { analyzeReadability, enrichReadabilityWithDict } from "../readability";
+import type { DictLookup } from "@/lib/dict/dict-types";
+import type { Token } from "@/lib/nlp-client/types";
+
+/**
+ * Tests for Tier 3 (幻辞 freq_rank) readability enrichment, #1627.
+ * Pure-function level — the health gating / DictAccess wiring lives in
+ * use-text-statistics.ts and is exercised there.
+ */
+
+const BASE_TEXT = "吾輩は猫である。名前はまだ無いが、彼は静かに庭を眺めていた。";
+
+function noun(basicForm: string): Token {
+  return {
+    surface: basicForm,
+    pos: "名詞",
+    basic_form: basicForm,
+    reading: "",
+    start: 0,
+    end: basicForm.length,
+  } as Token;
+}
+
+function lookup(map: Record<string, number | null>): Map<string, DictLookup> {
+  const out = new Map<string, DictLookup>();
+  for (const [word, freqRank] of Object.entries(map)) {
+    out.set(word, freqRank === null ? { found: false } : { found: true, freqRank });
+  }
+  return out;
+}
+
+describe("enrichReadabilityWithDict (Tier 3, #1627)", () => {
+  it("sets hasDictAnalysis=true and leaves scores untouched for an empty lookup map", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const result = enrichReadabilityWithDict(base, [], new Map());
+    expect(result.hasDictAnalysis).toBe(true);
+    expect(result.subScores.vocabulary).toBe(base.subScores.vocabulary);
+  });
+
+  it("sets hasDictAnalysis=true but does not change vocabulary when no content word is found", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const tokens = [noun("造語A"), noun("造語B")];
+    const result = enrichReadabilityWithDict(base, tokens, lookup({ 造語A: null, 造語B: null }));
+    expect(result.hasDictAnalysis).toBe(true);
+    expect(result.subScores.vocabulary).toBe(base.subScores.vocabulary);
+    expect(result.detail.vocabulary.avgFreqRank).toBeUndefined();
+  });
+
+  it("lowers the vocabulary subscore when rare words dominate", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const tokens = [noun("顰蹙"), noun("邂逅"), noun("瀟洒")];
+    // All rare (freq_rank > 50,000): rareWordRate = 1.0, avgFreqRank > 30,000.
+    const result = enrichReadabilityWithDict(
+      base,
+      tokens,
+      lookup({ 顰蹙: 62000, 邂逅: 58000, 瀟洒: 71000 }),
+    );
+    expect(result.hasDictAnalysis).toBe(true);
+    expect(result.subScores.vocabulary).toBeLessThan(base.subScores.vocabulary);
+    expect(result.detail.vocabulary.rareWordRate).toBe(1);
+    expect(result.detail.vocabulary.avgFreqRank).toBeGreaterThan(30_000);
+  });
+
+  it("gives a small bonus when common words dominate", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const tokens = [noun("猫"), noun("名前"), noun("庭")];
+    // All common (avg freq_rank < 3,000), no rare words.
+    const result = enrichReadabilityWithDict(
+      base,
+      tokens,
+      lookup({ 猫: 800, 名前: 400, 庭: 1500 }),
+    );
+    expect(result.hasDictAnalysis).toBe(true);
+    expect(result.subScores.vocabulary).toBeGreaterThanOrEqual(base.subScores.vocabulary);
+    expect(result.detail.vocabulary.rareWordRate).toBe(0);
+  });
+
+  it("recomputes the composite score and level from the adjusted subscores", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const tokens = [noun("顰蹙"), noun("邂逅")];
+    const result = enrichReadabilityWithDict(base, tokens, lookup({ 顰蹙: 62000, 邂逅: 70000 }));
+    // Lower vocabulary → composite score should not exceed the base score.
+    expect(result.score).toBeLessThanOrEqual(base.score);
+    expect(["easy", "normal", "difficult"]).toContain(result.level);
+  });
+});

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -5,7 +5,12 @@
 import { stripMdiInlineSyntax } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import { analyzeReadability, cleanMarkdown } from "./readability";
 export type { EnhancedReadabilityAnalysis, ReadabilitySubScores } from "./readability-types";
-export { analyzeReadability, enrichReadabilityWithMorphology, cleanMarkdown } from "./readability";
+export {
+  analyzeReadability,
+  enrichReadabilityWithMorphology,
+  enrichReadabilityWithDict,
+  cleanMarkdown,
+} from "./readability";
 
 /**
  * 文字数から原稿用紙枚数を算出する

--- a/lib/utils/readability-types.ts
+++ b/lib/utils/readability-types.ts
@@ -36,6 +36,10 @@ export interface VocabularyMetrics {
   properNounRate?: number;
   /** kuromoji使用時のみ有効: type-token ratio（内容語） */
   ttr?: number;
+  /** 幻辞使用時のみ有効: ヒット語の freq_rank 平均（小さいほど一般語） */
+  avgFreqRank?: number;
+  /** 幻辞使用時のみ有効: 稀少語（freq_rank > RARE_THRESHOLD）の割合 */
+  rareWordRate?: number;
 }
 
 /** 構文に関する指標 */
@@ -102,4 +106,6 @@ export interface EnhancedReadabilityAnalysis {
   avgPunctuationSpacing: number;
   /** kuromoji形態素分析が反映されているか */
   hasMorphologicalAnalysis: boolean;
+  /** 幻辞（Genji）辞書による語彙補強が反映されているか */
+  hasDictAnalysis: boolean;
 }

--- a/lib/utils/readability.ts
+++ b/lib/utils/readability.ts
@@ -14,6 +14,7 @@
 
 import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import type { Token } from "@/lib/nlp-client/types";
+import type { DictLookup } from "@/lib/dict/dict-types";
 import type {
   EnhancedReadabilityAnalysis,
   ParagraphMetrics,
@@ -375,6 +376,7 @@ export function analyzeReadability(rawText: string): EnhancedReadabilityAnalysis
     avgSentenceLength,
     avgPunctuationSpacing: syntaxMetrics.avgPunctuationSpacing,
     hasMorphologicalAnalysis: false,
+    hasDictAnalysis: false,
   };
 }
 
@@ -458,5 +460,116 @@ export function enrichReadabilityWithMorphology(
       syntax: enrichedSyntax,
     },
     hasMorphologicalAnalysis: true,
+    hasDictAnalysis: base.hasDictAnalysis,
+  };
+}
+
+// ── Tier 3: Dictionary-based enrichment ───────────────────────────────────
+
+/**
+ * 幻辞 freq_rank を利用した語彙難易度算出の閾値・重み定数。
+ *
+ * 根拠:
+ *   Genji corpus は約 50 万語収録（推定）。freq_rank 1〜10,000 が一般語（常用〜準常用）、
+ *   10,001〜50,000 が準稀少語、50,001 以上が稀少語と大雑把に分類できる。
+ *   「稀少語率」は小説における語彙の難度に直接影響する指標（JIS X 4051 準拠評価や
+ *   文化庁「公用文作成の考え方」（2022）が「平易な語の選択」を求める背景から妥当）。
+ *
+ *   スコア補正: 平均 freq_rank が高いほど（稀少語が多いほど）語彙スコアを下げる。
+ *   - 稀少語率 > 0.3 → -15 pt（明らかに難語が多い）
+ *   - 稀少語率 0.2〜0.3 → -8 pt
+ *   - 稀少語率 0.1〜0.2 → -4 pt
+ *   - 平均 freq_rank > 30,000 → 追加 -10 pt
+ *   - 平均 freq_rank 10,000〜30,000 → 追加 -5 pt
+ *   - 平均 freq_rank < 3,000（平易語が多い）→ +5 pt ボーナス
+ */
+const RARE_THRESHOLD = 50_000;
+
+/**
+ * 幻辞（Genji）の freq_rank バッチ照合結果で語彙難易度サブスコアを補強する（Tier 3）。
+ *
+ * 純関数: 副作用なし。`getDictAccess()` の呼び出し・グレースフル劣化判断は呼び出し元が行う。
+ * `hasMorphologicalAnalysis` 付きの結果にも重ねがけ可能。
+ *
+ * @param base      - Tier 1 または Tier 2 の分析結果
+ * @param tokens    - kuromoji トークン配列（内容語の basic_form 抽出に使用）。
+ *                    Tier 1 のみの場合は空配列を渡すと基本形フォールバック動作。
+ * @param lookupMap - `DictAccess.lookupBatch()` が返す Map<headword, DictLookup>
+ * @returns 語彙サブスコアと detail.vocabulary を幻辞情報で補正した新しい分析結果
+ */
+export function enrichReadabilityWithDict(
+  base: EnhancedReadabilityAnalysis,
+  tokens: Token[],
+  lookupMap: Map<string, DictLookup>,
+): EnhancedReadabilityAnalysis {
+  if (lookupMap.size === 0) {
+    // 照合結果が空: hasDictAnalysis=true にして返す（呼び出し元が "ready" を確認済み）
+    return { ...base, hasDictAnalysis: true };
+  }
+
+  // 内容語の basic_form を収集（kuromoji トークン有り優先、なければ lookupMap のキーを使用）
+  const contentForms: string[] =
+    tokens.length > 0
+      ? tokens
+          .filter((t) => ["名詞", "動詞", "形容詞", "副詞"].includes(t.pos))
+          .map((t) => t.basic_form ?? t.surface)
+      : [...lookupMap.keys()];
+
+  // ヒットした内容語の freq_rank を収集
+  const freqRanks: number[] = [];
+  let rareCount = 0;
+
+  for (const form of contentForms) {
+    const lookup = lookupMap.get(form);
+    if (lookup?.found && lookup.freqRank !== undefined) {
+      freqRanks.push(lookup.freqRank);
+      if (lookup.freqRank > RARE_THRESHOLD) rareCount++;
+    }
+  }
+
+  if (freqRanks.length === 0) {
+    // 内容語が1件もヒットしない（辞書外文章等）: フラグだけ立てて返す
+    return { ...base, hasDictAnalysis: true };
+  }
+
+  const avgFreqRank = Math.round(freqRanks.reduce((a, b) => a + b, 0) / freqRanks.length);
+  const rareWordRate = rareCount / freqRanks.length;
+
+  // 語彙スコア補正: 稀少語率・平均 freq_rank に基づいてペナルティ/ボーナスを加算
+  let vocabDelta = 0;
+
+  if (rareWordRate > 0.3) vocabDelta -= 15;
+  else if (rareWordRate > 0.2) vocabDelta -= 8;
+  else if (rareWordRate > 0.1) vocabDelta -= 4;
+
+  if (avgFreqRank > 30_000) vocabDelta -= 10;
+  else if (avgFreqRank > 10_000) vocabDelta -= 5;
+  else if (avgFreqRank < 3_000) vocabDelta += 5;
+
+  const newVocabScore = Math.max(0, Math.min(100, base.subScores.vocabulary + vocabDelta));
+
+  const enrichedVocab: VocabularyMetrics = {
+    ...base.detail.vocabulary,
+    avgFreqRank,
+    rareWordRate,
+  };
+
+  const newSubScores: ReadabilitySubScores = {
+    ...base.subScores,
+    vocabulary: newVocabScore,
+  };
+
+  const score = Math.max(0, Math.min(100, compositeScore(newSubScores)));
+
+  return {
+    ...base,
+    score,
+    level: scoreToLevel(score),
+    subScores: newSubScores,
+    detail: {
+      ...base.detail,
+      vocabulary: enrichedVocab,
+    },
+    hasDictAnalysis: true,
   };
 }


### PR DESCRIPTION
エピック #1623 / 共有アクセス層 #1624（dev にマージ済み）の上に実装。

## 変更
- `lib/utils/readability.ts`: `enrichReadabilityWithDict(base, tokens, lookupMap)`（Tier3・純関数）。内容語の freq_rank から稀少語率・平均ランクを算出し語彙サブスコアを補正、score/level を再計算。閾値は定数化・根拠コメント
- 型: `EnhancedReadabilityAnalysis.hasDictAnalysis`、`VocabularyMetrics.avgFreqRank / rareWordRate`
- `lib/editor-page/use-text-statistics.ts`: Phase3 を追加（`health.state === "ready"` のときのみ実行）
- `components/inspector/StatsPanel.tsx`: 「辞書未導入のため簡易判定」注記

## グレースフル劣化
Tier2（kuromoji）の `hasMorphologicalAnalysis` と同思想。幻辞が ready でない/失敗時は Tier1/Tier2 結果へ silent fallback。Web では一括照合しない。

## テスト
`lib/utils/__tests__/readability-genji.test.ts` 5 件（空・未ヒット・稀少語難化・平易語ボーナス・score/level 再計算）。type-check green。

## 注意
`StatsPanel.tsx` は #1625 とも重なるため、先にマージされた側に合わせて rebase 済み/する。

Refs #1623
Closes #1627