### PR TITLE
feat(ruby): ルビ機能の幻辞連携 — 自動ふりがな候補 (#1629)

### DIFF
--- a/components/RubyDialog.tsx
+++ b/components/RubyDialog.tsx
@@ -4,8 +4,12 @@ import { useState, useEffect, useCallback } from "react";
 import { Loader2 } from "lucide-react";
 import GlassDialog from "./GlassDialog";
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
+import { getDictAccess } from "@/lib/dict/dict-access";
+import { getDictService } from "@/lib/dict/dict-service";
+import { buildBatchReadingCandidates } from "@/lib/utils/ruby-readings";
 
 import type { Token } from "@/lib/nlp-client/types";
+import type { DictLookup, DictEntry } from "@/lib/dict/dict-types";
 
 /** A segment of text with its editable reading */
 interface RubySegment {
@@ -23,11 +27,11 @@ interface RubyDialogProps {
 }
 
 /** Regex to detect kanji characters */
-const KANJI_REGEX = /[\u4e00-\u9faf\u3400-\u4dbf]/;
+const KANJI_REGEX = /[一-龯㐀-䶿]/;
 
 /** Convert katakana to hiragana */
 function katakanaToHiragana(str: string): string {
-  return str.replace(/[\u30a1-\u30f6]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0x60));
+  return str.replace(/[ァ-ヶ]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0x60));
 }
 
 /** Group consecutive tokens into Ruby segments */
@@ -60,10 +64,75 @@ function buildRubyMarkup(segments: RubySegment[]): string {
     .join("");
 }
 
+/**
+ * Fetch Genji reading candidates for kanji segments.
+ * Returns a map from surface → ordered candidate list.
+ * Silently swallows all errors to avoid breaking the dialog.
+ */
+async function fetchGenjiCandidates(segments: RubySegment[]): Promise<Map<string, string[]>> {
+  const result = new Map<string, string[]>();
+
+  const kanjiSegments = segments.filter((s) => s.hasKanji);
+  if (kanjiSegments.length === 0) return result;
+
+  try {
+    const access = getDictAccess();
+    const health = await access.getHealth();
+    // Proceed for both "ready" (local DB) and "web-fallback" (remote API)
+    if (health.state !== "ready" && health.state !== "web-fallback") {
+      return result;
+    }
+
+    const surfaces = kanjiSegments.map((s) => s.surface);
+    const lookupMap = await access.lookupBatch(surfaces);
+
+    // For richer alternatives, query DictService per kanji segment.
+    // ルビ選択語は少数なので個別クエリで OK。
+    const entriesMap = new Map<string, DictEntry[]>();
+    await Promise.all(
+      kanjiSegments.map(async (seg) => {
+        try {
+          const queryResult = await getDictService().query(seg.surface, 5);
+          // Keep only entries that are exact-match headwords
+          const exact = queryResult.entries.filter((e) => e.entry === seg.surface);
+          entriesMap.set(seg.surface, exact);
+        } catch {
+          // Silently ignore per-term failures
+          entriesMap.set(seg.surface, []);
+        }
+      }),
+    );
+
+    const inputs = kanjiSegments.map((seg) => ({
+      surface: seg.surface,
+      kuromojiReading: seg.reading,
+      dictLookup: lookupMap.get(seg.surface) as DictLookup | undefined,
+      dictEntries: entriesMap.get(seg.surface) ?? [],
+    }));
+
+    const batchResult = buildBatchReadingCandidates(inputs);
+    for (const item of batchResult) {
+      // Only populate map when Genji adds extra candidates beyond kuromoji
+      if (item.candidates.length > 1) {
+        result.set(item.surface, item.candidates);
+      } else if (item.candidates.length === 1 && item.candidates[0] !== "") {
+        // Even a single candidate is useful for confirmation
+        result.set(item.surface, item.candidates);
+      }
+    }
+  } catch {
+    // Swallow all Genji errors; dialog must remain functional
+  }
+
+  return result;
+}
+
 export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: RubyDialogProps) {
   const [segments, setSegments] = useState<RubySegment[]>([]);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** surface → ordered reading candidates from Genji (empty map = Genji unavailable) */
+  const [candidatesMap, setCandidatesMap] = useState<Map<string, string[]>>(new Map());
 
   // Analyze text when dialog opens
   useEffect(() => {
@@ -74,6 +143,7 @@ export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: R
     const analyze = async () => {
       setIsAnalyzing(true);
       setError(null);
+      setCandidatesMap(new Map());
 
       try {
         let nlpClient;
@@ -90,7 +160,14 @@ export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: R
 
         if (cancelled) return;
 
-        setSegments(tokensToSegments(tokens));
+        const segs = tokensToSegments(tokens);
+        setSegments(segs);
+
+        // Fetch Genji candidates in the background; do not block dialog display
+        const genjiMap = await fetchGenjiCandidates(segs);
+        if (!cancelled) {
+          setCandidatesMap(genjiMap);
+        }
       } catch (err) {
         if (cancelled) return;
         setError(`形態素解析に失敗しました: ${err instanceof Error ? err.message : String(err)}`);
@@ -156,29 +233,54 @@ export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: R
       {!isAnalyzing && !error && segments.length > 0 && (
         <>
           <div className="space-y-2 max-h-64 overflow-y-auto mb-4">
-            {segments.map((seg, i) => (
-              <div
-                key={`${seg.surface}-${i}`}
-                className="flex items-center gap-3 p-2 bg-background-secondary rounded-lg border border-border"
-              >
-                <span className="text-sm font-medium text-foreground min-w-[3rem] text-center">
-                  {seg.surface}
-                </span>
-                {seg.hasKanji ? (
-                  <input
-                    type="text"
-                    value={seg.reading}
-                    onChange={(e) => handleReadingChange(i, e.target.value)}
-                    className="flex-1 text-sm px-2 py-1 border border-border-secondary rounded bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
-                    placeholder="読み"
-                  />
-                ) : (
-                  <span className="flex-1 text-sm text-foreground-tertiary px-2 py-1">
-                    {seg.reading}
-                  </span>
-                )}
-              </div>
-            ))}
+            {segments.map((seg, i) => {
+              const candidates = candidatesMap.get(seg.surface) ?? [];
+              return (
+                <div
+                  key={`${seg.surface}-${i}`}
+                  className="flex flex-col gap-1 p-2 bg-background-secondary rounded-lg border border-border"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-medium text-foreground min-w-[3rem] text-center">
+                      {seg.surface}
+                    </span>
+                    {seg.hasKanji ? (
+                      <input
+                        type="text"
+                        value={seg.reading}
+                        onChange={(e) => handleReadingChange(i, e.target.value)}
+                        className="flex-1 text-sm px-2 py-1 border border-border-secondary rounded bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+                        placeholder="読み"
+                      />
+                    ) : (
+                      <span className="flex-1 text-sm text-foreground-tertiary px-2 py-1">
+                        {seg.reading}
+                      </span>
+                    )}
+                  </div>
+                  {/* 幻辞の読み候補チップ */}
+                  {seg.hasKanji && candidates.length > 1 && (
+                    <div className="flex flex-wrap gap-1 pl-[calc(3rem+0.75rem)]">
+                      {candidates.map((candidate) => (
+                        <button
+                          key={candidate}
+                          type="button"
+                          onClick={() => handleReadingChange(i, candidate)}
+                          className={[
+                            "text-xs px-2 py-0.5 rounded-full border transition-colors",
+                            seg.reading === candidate
+                              ? "border-accent bg-accent/10 text-accent font-medium"
+                              : "border-border text-foreground-tertiary hover:border-accent hover:text-accent",
+                          ].join(" ")}
+                        >
+                          {candidate}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
 
           {/* Preview */}

--- a/lib/utils/__tests__/ruby-readings.test.ts
+++ b/lib/utils/__tests__/ruby-readings.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for lib/utils/ruby-readings.ts
+ *
+ * Covers:
+ *   - katakana→hiragana normalisation
+ *   - deduplication (order-preserving, case-insensitive normalised)
+ *   - buildReadingCandidates: Genji primary+alternatives + kuromoji merge
+ *   - buildReadingCandidates: Genji hit absent → kuromoji only
+ *   - buildReadingCandidates: empty inputs
+ *   - buildBatchReadingCandidates: multiple segments
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  katakanaToHiragana,
+  deduplicateReadings,
+  buildReadingCandidates,
+  buildBatchReadingCandidates,
+} from "../ruby-readings";
+import type { DictLookup, DictEntry } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDictEntry(primary: string, alternatives: string[] = []): DictEntry {
+  return {
+    id: `test-${primary}`,
+    entry: "雪女",
+    reading: { primary, alternatives },
+    definitions: [],
+    relationships: { homophones: [], synonyms: [], antonyms: [], related: [] },
+    source: "test",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// katakanaToHiragana
+// ---------------------------------------------------------------------------
+
+describe("katakanaToHiragana", () => {
+  it("converts full-width katakana to hiragana", () => {
+    expect(katakanaToHiragana("ユキオンナ")).toBe("ゆきおんな");
+  });
+
+  it("leaves hiragana unchanged", () => {
+    expect(katakanaToHiragana("ゆき")).toBe("ゆき");
+  });
+
+  it("leaves kanji and ASCII unchanged", () => {
+    expect(katakanaToHiragana("ABC漢字")).toBe("ABC漢字");
+  });
+
+  it("handles empty string", () => {
+    expect(katakanaToHiragana("")).toBe("");
+  });
+
+  it("converts mixed katakana/hiragana string", () => {
+    expect(katakanaToHiragana("ユキゆきオンナおんな")).toBe("ゆきゆきおんなおんな");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deduplicateReadings
+// ---------------------------------------------------------------------------
+
+describe("deduplicateReadings", () => {
+  it("removes exact duplicates", () => {
+    expect(deduplicateReadings(["ゆき", "ゆき", "おんな"])).toEqual(["ゆき", "おんな"]);
+  });
+
+  it("normalises katakana before deduplication", () => {
+    // katakana ユキ and hiragana ゆき should collapse to one entry
+    expect(deduplicateReadings(["ユキ", "ゆき"])).toEqual(["ゆき"]);
+  });
+
+  it("preserves first occurrence order", () => {
+    expect(deduplicateReadings(["おんな", "ゆき", "おんな"])).toEqual(["おんな", "ゆき"]);
+  });
+
+  it("removes empty strings and whitespace-only entries", () => {
+    expect(deduplicateReadings(["", "  ", "ゆき"])).toEqual(["ゆき"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(deduplicateReadings([])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReadingCandidates
+// ---------------------------------------------------------------------------
+
+describe("buildReadingCandidates", () => {
+  it("returns only kuromoji reading when Genji has no match", () => {
+    const lookup: DictLookup = { found: false };
+    const result = buildReadingCandidates("ゆきおんな", lookup, []);
+    expect(result).toEqual(["ゆきおんな"]);
+  });
+
+  it("returns Genji primary first, then kuromoji (if different)", () => {
+    const lookup: DictLookup = { found: true, reading: "せつじょ" };
+    // kuromoji gives a different reading
+    const result = buildReadingCandidates("ゆきおんな", lookup, []);
+    expect(result[0]).toBe("せつじょ");
+    expect(result).toContain("ゆきおんな");
+  });
+
+  it("deduplicates Genji primary when kuromoji gives the same reading", () => {
+    const lookup: DictLookup = { found: true, reading: "ゆきおんな" };
+    const result = buildReadingCandidates("ゆきおんな", lookup, []);
+    // Should not repeat
+    expect(result).toEqual(["ゆきおんな"]);
+  });
+
+  it("includes DictEntry alternatives", () => {
+    const lookup: DictLookup = { found: true, reading: "ゆきおんな" };
+    const entry = makeDictEntry("ゆきおんな", ["せつじょ", "ゆきにょうぼう"]);
+    const result = buildReadingCandidates("ゆきおんな", lookup, [entry]);
+    // primary from DictLookup first, then entry alternatives
+    expect(result).toContain("せつじょ");
+    expect(result).toContain("ゆきにょうぼう");
+    // No duplicates: ゆきおんな appears once even though it's in DictLookup + entry primary
+    expect(result.filter((r) => r === "ゆきおんな").length).toBe(1);
+  });
+
+  it("handles undefined dictLookup gracefully", () => {
+    const result = buildReadingCandidates("ゆき", undefined, []);
+    expect(result).toEqual(["ゆき"]);
+  });
+
+  it("handles empty kuromojiReading and no Genji data", () => {
+    const result = buildReadingCandidates("", undefined, []);
+    expect(result).toEqual([]);
+  });
+
+  it("handles katakana kuromoji reading by normalising to hiragana", () => {
+    const lookup: DictLookup = { found: false };
+    const result = buildReadingCandidates("ユキ", lookup, []);
+    expect(result).toEqual(["ゆき"]);
+  });
+
+  it("merges multiple DictEntries with overlapping alternatives", () => {
+    const entry1 = makeDictEntry("とうきょう", ["とうけい"]);
+    const entry2 = makeDictEntry("とうきょう", ["とうけい", "もとのなまえ"]);
+    const result = buildReadingCandidates("とうきょう", undefined, [entry1, entry2]);
+    // Deduplicated: とうきょう, とうけい, もとのなまえ
+    expect(result).toEqual(["とうきょう", "とうけい", "もとのなまえ"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBatchReadingCandidates
+// ---------------------------------------------------------------------------
+
+describe("buildBatchReadingCandidates", () => {
+  it("processes multiple segments independently", () => {
+    const inputs = [
+      { surface: "雪", kuromojiReading: "ゆき" },
+      {
+        surface: "女",
+        kuromojiReading: "おんな",
+        dictLookup: { found: true, reading: "じょ" } satisfies DictLookup,
+      },
+    ];
+    const results = buildBatchReadingCandidates(inputs);
+    expect(results).toHaveLength(2);
+    expect(results[0].candidates).toEqual(["ゆき"]);
+    // Genji reading first for 女
+    expect(results[1].candidates[0]).toBe("じょ");
+    expect(results[1].candidates).toContain("おんな");
+  });
+
+  it("returns empty candidates for segment with no reading data", () => {
+    const results = buildBatchReadingCandidates([{ surface: "　", kuromojiReading: "" }]);
+    expect(results[0].candidates).toEqual([]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(buildBatchReadingCandidates([])).toEqual([]);
+  });
+});

--- a/lib/utils/ruby-readings.ts
+++ b/lib/utils/ruby-readings.ts
@@ -1,0 +1,125 @@
+/**
+ * ruby-readings — pure helpers to build per-segment reading candidate lists
+ * for the RubyDialog, merging kuromoji readings with Genji dictionary readings.
+ *
+ * Design goals:
+ *   - Pure functions: no side effects, fully testable without mocking
+ *   - Graceful degradation: Genji results are optional; kuromoji-only always works
+ *   - Deduplication + normalisation: katakana→hiragana, unique order-preserving
+ */
+
+import type { DictLookup } from "@/lib/dict/dict-types";
+import type { DictEntry } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Normalisation
+// ---------------------------------------------------------------------------
+
+/** Convert katakana to hiragana (full-width only). */
+export function katakanaToHiragana(str: string): string {
+  return str.replace(/[ァ-ヶ]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0x60));
+}
+
+// ---------------------------------------------------------------------------
+// Core pure functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Deduplicate an array of readings, normalising each to hiragana first.
+ * The first occurrence of each normalised form is preserved; order kept stable.
+ */
+export function deduplicateReadings(readings: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of readings) {
+    const normalised = katakanaToHiragana(r.trim());
+    if (normalised.length === 0) continue;
+    if (!seen.has(normalised)) {
+      seen.add(normalised);
+      out.push(normalised);
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a candidate reading list for a single segment from:
+ *   - `kuromojiReading`: reading from kuromoji tokenizer (may be empty string)
+ *   - `dictLookup`: lightweight {@link DictLookup} from `getDictAccess().lookupBatch()`
+ *   - `dictEntries`: richer {@link DictEntry}[] from `getDictService().query()` (optional)
+ *
+ * Returns a deduplicated, hiragana-normalised array.  The first element is the
+ * "best" reading — kuromoji if Genji has nothing; Genji primary otherwise.
+ * If both match, kuromoji is still listed so the user can confirm it.
+ *
+ * Genji readings take precedence in ordering because the dictionary is more
+ * reliable for proper nouns and archaic words that kuromoji mislabels.
+ */
+export function buildReadingCandidates(
+  kuromojiReading: string,
+  dictLookup: DictLookup | undefined,
+  dictEntries: DictEntry[],
+): string[] {
+  const candidates: string[] = [];
+
+  // 1. Genji DictLookup primary (lightweight, always available when found)
+  if (dictLookup?.found && dictLookup.reading) {
+    candidates.push(dictLookup.reading);
+  }
+
+  // 2. Genji DictEntry readings (primary + alternatives from full query)
+  for (const entry of dictEntries) {
+    candidates.push(entry.reading.primary);
+    candidates.push(...entry.reading.alternatives);
+  }
+
+  // 3. kuromoji reading last (may duplicate Genji; dedup handles it)
+  if (kuromojiReading.length > 0) {
+    candidates.push(kuromojiReading);
+  }
+
+  return deduplicateReadings(candidates);
+}
+
+// ---------------------------------------------------------------------------
+// Batch builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Input descriptor for one kanji-containing segment.
+ */
+export interface SegmentReadingInput {
+  surface: string;
+  kuromojiReading: string;
+  /** From `getDictAccess().lookupBatch()`. Omit / undefined when Genji unavailable. */
+  dictLookup?: DictLookup;
+  /** From `getDictService().query(surface)`. Omit / empty when Genji unavailable. */
+  dictEntries?: DictEntry[];
+}
+
+/**
+ * Per-segment candidate list.
+ */
+export interface SegmentReadingCandidates {
+  surface: string;
+  /** Ordered candidates; first element is the recommended default. */
+  candidates: string[];
+}
+
+/**
+ * Build reading candidates for multiple segments in one call.
+ * Non-kanji segments (hasKanji === false) can be excluded before calling;
+ * they are passed through with `candidates: []` if included.
+ */
+export function buildBatchReadingCandidates(
+  inputs: SegmentReadingInput[],
+): SegmentReadingCandidates[] {
+  return inputs.map((input) => ({
+    surface: input.surface,
+    candidates: buildReadingCandidates(
+      input.kuromojiReading,
+      input.dictLookup,
+      input.dictEntries ?? [],
+    ),
+  }));
+}


### PR DESCRIPTION
エピック #1623 / 共有アクセス層 #1624（dev にマージ済み）の上に実装。

## 変更
- `lib/utils/ruby-readings.ts`（新規・純関数）: kuromoji 読みと幻辞 `reading.primary`/`alternatives` をマージ・重複排除・カタカナ→ひらがな正規化して読み候補リストを構築
- `components/RubyDialog.tsx`: 漢字セグメントの読み input 下に**読み候補チップ**を表示。クリックで読みを差し替え（固有名詞・難読語で幻辞の読みが効く）

## グレースフル劣化
選択語は少数なので ready/web-fallback で幻辞照合。幻辞が無い/破損/オフライン/失敗時は従来どおり kuromoji の読みのみで完全動作（候補が出ないだけ）。失敗は握りつぶしダイアログを壊さない。

## テスト
`lib/utils/__tests__/ruby-readings.test.ts` 21 件（正規化・重複排除・候補マージ・未ヒット時 kuromoji のみ・空入力）。type-check green / eslint 0 error。

Refs #1623
Closes #1629