### PR TITLE
feat(pos): 型態分析の幻辞連携 — 選択語の語義/レジスター/類義語 (#1625)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -368,6 +368,7 @@ export default function EditorPage() {
   const [selectedCharCount, setSelectedCharCount] = useState(0);
   const [selectedManuscriptCells, setSelectedManuscriptCells] = useState(0);
   const [selectedManuscriptPages, setSelectedManuscriptPages] = useState(0);
+  const [selectedWord, setSelectedWord] = useState<string | null>(null);
   const { menu: tabBarMenu, show: showTabBarMenu, close: closeTabBarMenu } = useContextMenu();
   const hasAutoRecoveredRef = useRef(false);
   const [editorViewInstance, setEditorViewInstanceRaw] = useState<EditorView | null>(null);
@@ -1169,6 +1170,7 @@ export default function EditorPage() {
     },
     switchToCorrectionsTrigger,
     previousDayStats,
+    selectedWord,
   } as const;
 
   return (
@@ -1269,6 +1271,16 @@ export default function EditorPage() {
           setSelectedCharCount(count);
           setSelectedManuscriptCells(cells);
           setSelectedManuscriptPages(pages);
+          // 選択語を幻辞ルックアップ用に保持する
+          if (count > 0 && editorViewRef.current) {
+            const { selection, doc } = editorViewRef.current.state;
+            const text = doc.textBetween(selection.from, selection.to, "").trim();
+            // 単語単位（空白区切り）の先頭語、または選択全体（日本語は空白なし）
+            const word = text.split(/\s+/)[0] ?? null;
+            setSelectedWord(word || null);
+          } else {
+            setSelectedWord(null);
+          }
         },
         searchOpenTrigger,
         searchInitialTerm,

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -67,6 +67,7 @@ export default function Inspector({
   onCorrectionModeChange,
   switchToCorrectionsTrigger = 0,
   previousDayStats,
+  selectedWord,
 }: InspectorProps) {
   const { editorMode, isProject } = useEditorMode();
   const projectMode = isProject ? (editorMode as ProjectMode) : null;
@@ -389,6 +390,7 @@ export default function Inspector({
             charUsageRates={charUsageRates}
             readabilityAnalysis={readabilityAnalysis}
             previousDayStats={previousDayStats}
+            selectedWord={selectedWord}
           />
         )}
         {activeTab === "history" && projectMode && onHistoryRestore && (

--- a/components/inspector/GenjiWordInfoSection.tsx
+++ b/components/inspector/GenjiWordInfoSection.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type React from "react";
+
+import { useGenjiWordInfo } from "@/lib/utils/genji-word-info";
+
+interface GenjiWordInfoSectionProps {
+  /** 選択中の語（空またはnullのとき非表示） */
+  selectedWord: string | null | undefined;
+}
+
+/**
+ * 選択語の幻辞（Genji）辞書情報を表示するインスペクタセクション。
+ *
+ * - 幻辞が未インストール / オフライン / 該当語なし のときは何も表示しない。
+ * - 読み中はスケルトンローダーを表示し、品詞ハイライト本体の動作を一切変えない。
+ */
+export default function GenjiWordInfoSection({
+  selectedWord,
+}: GenjiWordInfoSectionProps): React.ReactElement | null {
+  const state = useGenjiWordInfo(selectedWord);
+
+  if (state.status === "idle" || state.status === "unavailable") {
+    return null;
+  }
+
+  return (
+    <div className="mt-4 border-t border-border pt-4">
+      <p className="text-xs font-medium text-foreground-tertiary uppercase tracking-wide mb-2">
+        選択語の辞書情報
+      </p>
+
+      {state.status === "loading" && (
+        <div className="space-y-1 animate-pulse">
+          <div className="h-3 bg-foreground-muted/20 rounded w-2/3" />
+          <div className="h-3 bg-foreground-muted/20 rounded w-1/2" />
+        </div>
+      )}
+
+      {state.status === "not-found" && (
+        <p className="text-xs text-foreground-tertiary">該当する辞書項目がありません</p>
+      )}
+
+      {state.status === "found" && (
+        <div className="space-y-2">
+          {/* 見出し・読み・品詞 */}
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="text-sm font-semibold text-foreground">{state.viewModel.word}</span>
+            {state.viewModel.reading && (
+              <span className="text-xs text-foreground-secondary">{state.viewModel.reading}</span>
+            )}
+            {state.viewModel.partOfSpeech && (
+              <span className="text-xs px-1.5 py-0.5 rounded bg-accent/10 text-accent font-medium">
+                {state.viewModel.partOfSpeech}
+              </span>
+            )}
+            {state.viewModel.register && (
+              <span className="text-xs px-1.5 py-0.5 rounded bg-foreground-muted/10 text-foreground-secondary">
+                {state.viewModel.register}
+              </span>
+            )}
+          </div>
+
+          {/* 語義 */}
+          {state.viewModel.glosses.length > 0 && (
+            <ol className="list-decimal list-inside space-y-0.5 pl-0.5">
+              {state.viewModel.glosses.map((gloss, i) => (
+                <li key={i} className="text-xs text-foreground-secondary leading-relaxed">
+                  {gloss}
+                </li>
+              ))}
+            </ol>
+          )}
+
+          {/* 類義語 */}
+          {state.viewModel.synonyms.length > 0 && (
+            <div className="flex items-center gap-1 flex-wrap">
+              <span className="text-xs text-foreground-tertiary shrink-0">類義語：</span>
+              {state.viewModel.synonyms.map((syn, i) => (
+                <span
+                  key={i}
+                  className="text-xs px-1.5 py-0.5 rounded bg-foreground-muted/10 text-foreground-secondary"
+                >
+                  {syn}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/inspector/StatsPanel.tsx
+++ b/components/inspector/StatsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import InfoTooltip from "./InfoTooltip";
+import GenjiWordInfoSection from "./GenjiWordInfoSection";
 
 import type { PreviousDayStats } from "@/lib/editor-page/use-previous-day-stats";
 
@@ -46,6 +47,8 @@ interface StatsPanelProps {
     hasMorphologicalAnalysis?: boolean;
   };
   previousDayStats?: PreviousDayStats | null;
+  /** 選択中の語（品詞タブで幻辞情報を表示するために渡す） */
+  selectedWord?: string | null;
 }
 
 /** Format a diff value with sign prefix */
@@ -69,6 +72,7 @@ export default function StatsPanel({
   charUsageRates,
   readabilityAnalysis,
   previousDayStats,
+  selectedWord,
 }: StatsPanelProps) {
   const isSelection = selectedCharCount > 0;
   const activeCharCount = isSelection ? selectedCharCount : charCount;
@@ -669,6 +673,9 @@ export default function StatsPanel({
           </div>
         </div>
       </div>
+
+      {/* 選択語の幻辞情報（品詞ハイライト連携） */}
+      <GenjiWordInfoSection selectedWord={selectedWord} />
     </div>
   );
 }

--- a/components/inspector/types.ts
+++ b/components/inspector/types.ts
@@ -104,4 +104,6 @@ export interface InspectorProps {
   switchToCorrectionsTrigger?: number;
   /** Previous day's stats for comparison display */
   previousDayStats?: PreviousDayStats | null;
+  /** 選択中の語（統計タブで幻辞情報を表示するために渡す） */
+  selectedWord?: string | null;
 }

--- a/lib/utils/__tests__/genji-word-info.test.ts
+++ b/lib/utils/__tests__/genji-word-info.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for buildGenjiWordInfoViewModel.
+ *
+ * We test only the pure function — no React, no DictService.
+ * The hook's async branching is validated by the state machine contracts
+ * documented in genji-word-info.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { buildGenjiWordInfoViewModel } from "../genji-word-info";
+import type { DictQueryResult, DictEntry } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<DictEntry> = {}): DictEntry {
+  return {
+    id: "test-1",
+    entry: "雪",
+    reading: { primary: "ゆき", alternatives: [] },
+    partOfSpeech: "名詞",
+    inflections: [],
+    definitions: [
+      { gloss: "大気中の水蒸気が結晶して降る白いもの", register: "文章語" },
+      { gloss: "白色のたとえ" },
+      { gloss: "冬の風物詩" },
+      { gloss: "余分な四番目の語義" },
+    ],
+    relationships: {
+      homophones: [],
+      synonyms: ["白雪", "積雪", "降雪", "初雪", "粉雪", "余分な類義語"],
+      antonyms: [],
+      related: [],
+    },
+    source: "genji",
+    ...overrides,
+  };
+}
+
+function makeResult(entries: DictEntry[] = [makeEntry()]): DictQueryResult {
+  return { entries, noResults: false, providerUnavailable: false };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildGenjiWordInfoViewModel", () => {
+  it("extracts reading, partOfSpeech, register, glosses, synonyms from the first entry", () => {
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult());
+
+    expect(vm).not.toBeNull();
+    expect(vm!.word).toBe("雪");
+    expect(vm!.reading).toBe("ゆき");
+    expect(vm!.partOfSpeech).toBe("名詞");
+    expect(vm!.register).toBe("文章語");
+  });
+
+  it("limits glosses to 3 items maximum", () => {
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult());
+
+    expect(vm!.glosses).toHaveLength(3);
+    expect(vm!.glosses[0]).toBe("大気中の水蒸気が結晶して降る白いもの");
+    expect(vm!.glosses[2]).toBe("冬の風物詩");
+  });
+
+  it("limits synonyms to 5 items maximum", () => {
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult());
+
+    expect(vm!.synonyms).toHaveLength(5);
+    expect(vm!.synonyms[0]).toBe("白雪");
+    expect(vm!.synonyms[4]).toBe("粉雪");
+    // sixth should be excluded
+  });
+
+  it("returns null when result is null", () => {
+    expect(buildGenjiWordInfoViewModel("雪", null)).toBeNull();
+  });
+
+  it("returns null when result is undefined", () => {
+    expect(buildGenjiWordInfoViewModel("雪", undefined)).toBeNull();
+  });
+
+  it("returns null when providerUnavailable is true", () => {
+    const result: DictQueryResult = { entries: [], noResults: false, providerUnavailable: true };
+    expect(buildGenjiWordInfoViewModel("雪", result)).toBeNull();
+  });
+
+  it("returns null when entries array is empty", () => {
+    const result: DictQueryResult = { entries: [], noResults: true, providerUnavailable: false };
+    expect(buildGenjiWordInfoViewModel("雪", result)).toBeNull();
+  });
+
+  it("returns null when noResults is true with empty entries", () => {
+    const result: DictQueryResult = { entries: [], noResults: true, providerUnavailable: false };
+    expect(buildGenjiWordInfoViewModel("雪", result)).toBeNull();
+  });
+
+  it("handles entry with no definitions gracefully", () => {
+    const entry = makeEntry({ definitions: [] });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm).not.toBeNull();
+    expect(vm!.glosses).toHaveLength(0);
+    expect(vm!.register).toBeNull();
+  });
+
+  it("handles entry with no synonyms gracefully", () => {
+    const entry = makeEntry({
+      relationships: { homophones: [], synonyms: [], antonyms: [], related: [] },
+    });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm).not.toBeNull();
+    expect(vm!.synonyms).toHaveLength(0);
+  });
+
+  it("returns null partOfSpeech when entry has no partOfSpeech", () => {
+    const entry = makeEntry({ partOfSpeech: undefined });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm!.partOfSpeech).toBeNull();
+  });
+
+  it("returns null register when no definition carries a register", () => {
+    const entry = makeEntry({
+      definitions: [{ gloss: "読み込み無しの語義" }],
+    });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm!.register).toBeNull();
+  });
+
+  it("picks the first non-empty register across definitions", () => {
+    const entry = makeEntry({
+      definitions: [
+        { gloss: "最初の語義" },
+        { gloss: "二番目の語義", register: "口語" },
+        { gloss: "三番目の語義", register: "文章語" },
+      ],
+    });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm!.register).toBe("口語");
+  });
+
+  it("uses the word argument as the ViewModel word, not entry.entry", () => {
+    // Useful when the query surface and the headword differ slightly
+    const vm = buildGenjiWordInfoViewModel("QUERY", makeResult());
+    expect(vm!.word).toBe("QUERY");
+  });
+});

--- a/lib/utils/genji-word-info.ts
+++ b/lib/utils/genji-word-info.ts
@@ -1,0 +1,154 @@
+/**
+ * Genji word-info utilities: extract a display-ready ViewModel from a
+ * DictQueryResult / DictEntry[], and a React hook that drives the async lookup.
+ *
+ * Design rules:
+ * - Pure functions are unit-testable without any React / browser env.
+ * - The hook is the only place that calls getDictService().
+ * - All failures are swallowed; callers receive null instead of throwing.
+ */
+
+import { useEffect, useState } from "react";
+
+import type { DictEntry } from "@/lib/dict/dict-types";
+import type { DictQueryResult } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// ViewModel
+// ---------------------------------------------------------------------------
+
+/** Maximum number of glosses shown in the inspector panel */
+const MAX_GLOSSES = 3;
+/** Maximum number of synonyms shown in the inspector panel */
+const MAX_SYNONYMS = 5;
+
+export interface GenjiWordInfoViewModel {
+  /** Surface form that was queried */
+  word: string;
+  /** Primary reading (kana) */
+  reading: string | null;
+  /** Part of speech from the first entry */
+  partOfSpeech: string | null;
+  /** Register label (口語/文章語/雅語 …) from the first definition that carries one */
+  register: string | null;
+  /** Up to MAX_GLOSSES gloss strings */
+  glosses: string[];
+  /** Up to MAX_SYNONYMS synonym strings */
+  synonyms: string[];
+}
+
+/**
+ * Extract the first non-empty register string across all definitions of one entry.
+ */
+function extractRegister(entry: DictEntry): string | null {
+  for (const def of entry.definitions) {
+    if (def.register && def.register.trim().length > 0) {
+      return def.register.trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a display ViewModel from the first matching entry in a DictQueryResult.
+ *
+ * Returns null when:
+ * - `result` is null / undefined
+ * - `result.providerUnavailable` is true
+ * - `result.entries` is empty
+ */
+export function buildGenjiWordInfoViewModel(
+  word: string,
+  result: DictQueryResult | null | undefined,
+): GenjiWordInfoViewModel | null {
+  if (!result || result.providerUnavailable || result.entries.length === 0) {
+    return null;
+  }
+
+  const entry = result.entries[0];
+
+  const reading = entry.reading.primary.trim() || null;
+  const partOfSpeech = entry.partOfSpeech?.trim() || null;
+  const register = extractRegister(entry);
+  const glosses = entry.definitions
+    .map((d) => d.gloss.trim())
+    .filter((g) => g.length > 0)
+    .slice(0, MAX_GLOSSES);
+  const synonyms = (entry.relationships.synonyms ?? [])
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .slice(0, MAX_SYNONYMS);
+
+  return { word, reading, partOfSpeech, register, glosses, synonyms };
+}
+
+// ---------------------------------------------------------------------------
+// React hook
+// ---------------------------------------------------------------------------
+
+export type GenjiWordInfoState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "found"; viewModel: GenjiWordInfoViewModel }
+  | { status: "not-found" }
+  | { status: "unavailable" };
+
+const IDLE: GenjiWordInfoState = { status: "idle" };
+const LOADING: GenjiWordInfoState = { status: "loading" };
+const NOT_FOUND: GenjiWordInfoState = { status: "not-found" };
+const UNAVAILABLE: GenjiWordInfoState = { status: "unavailable" };
+
+/**
+ * Async hook that looks up `selectedWord` in the Genji dictionary and returns
+ * a typed state object for the UI to render.
+ *
+ * - When `selectedWord` is empty/null, returns `{ status: "idle" }`.
+ * - On any error (network, IPC, corrupt DB) falls back gracefully to
+ *   `{ status: "unavailable" }`.
+ */
+export function useGenjiWordInfo(selectedWord: string | null | undefined): GenjiWordInfoState {
+  const [state, setState] = useState<GenjiWordInfoState>(IDLE);
+
+  useEffect(() => {
+    const word = selectedWord?.trim();
+    if (!word) {
+      setState(IDLE);
+      return;
+    }
+
+    let cancelled = false;
+    setState(LOADING);
+
+    void (async () => {
+      try {
+        // Dynamic import keeps getDictService out of SSR / web-worker bundles
+        const { getDictService } = await import("@/lib/dict/dict-service");
+        const result = await getDictService().query(word, 1);
+
+        if (cancelled) return;
+
+        if (result.providerUnavailable) {
+          setState(UNAVAILABLE);
+          return;
+        }
+
+        const viewModel = buildGenjiWordInfoViewModel(word, result);
+        if (viewModel) {
+          setState({ status: "found", viewModel });
+        } else {
+          setState(NOT_FOUND);
+        }
+      } catch {
+        if (!cancelled) {
+          setState(UNAVAILABLE);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedWord]);
+
+  return state;
+}


### PR DESCRIPTION
エピック #1623 / 共有アクセス層 #1624（dev にマージ済み）の上に実装。

## 変更
- `lib/utils/genji-word-info.ts`（新規）: 選択語 → 表示用 ViewModel 整形（`getDictService().query()` の DictEntry から gloss/synonyms/register を上限件数で抽出）＋ `useGenjiWordInfo` フック
- `components/inspector/GenjiWordInfoSection.tsx`（新規・薄い UI）: 統計タブに「選択語の幻辞情報」を表示
- `components/inspector/StatsPanel.tsx` / `Inspector.tsx` / `types.ts` / `app/page.tsx`: 選択語 `selectedWord` を統計タブへ伝播

## グレースフル劣化
幻辞 unavailable 時はセクション完全非表示、該当語なし時は「該当する辞書項目がありません」。品詞ハイライト本体には一切触れていない。失敗は握りつぶす。

## テスト
`lib/utils/__tests__/genji-word-info.test.ts` 14 件（gloss/synonym 上限・null 入力・register 優先・providerUnavailable）。type-check green。

## 注意
`StatsPanel.tsx` は #1627 とも重なる。先にマージされた側に合わせて rebase する。

Refs #1623
Closes #1625