### PR TITLE
fix(analysis): 語彙統計など分析パネルへの [[blank]] マーカー混入を修正

### DIFF
--- a/lib/editor-page/__tests__/text-statistics.test.ts
+++ b/lib/editor-page/__tests__/text-statistics.test.ts
@@ -33,6 +33,14 @@ describe("extractVisibleText", () => {
     expect(extractVisibleText("[[kern:-0.1em:確実]]")).toBe("確実");
   });
 
+  it("MDI 空行マーカー [[blank]] を行ごと削除する", () => {
+    expect(extractVisibleText("前の文。\n[[blank]]\n次の文。")).toBe("前の文。\n\n次の文。");
+  });
+
+  it("serializer エスケープ形 \\[\\[blank]] も行ごと削除する（可視文字に計上しない）", () => {
+    expect(extractVisibleText("前の文。\n\\[\\[blank]]\n次の文。")).toBe("前の文。\n\n次の文。");
+  });
+
   it("HTML タグを除去して内容を残す", () => {
     expect(extractVisibleText("<b>太字</b>")).toBe("太字");
   });
@@ -234,6 +242,12 @@ describe("computeTextStatistics", () => {
     expect(stats.visibleTextCharCount).toBe(2);
     expect(stats.manuscriptCellCount).toBe(20);
     expect(stats.manuscriptPages).toBe(1);
+  });
+
+  it("[[blank]] マーカー（エスケープ形含む）は可視文字数に計上しない", () => {
+    // 「あ」2文字のみが可視。マーカー \[\[blank]] の記号類は数えない。
+    const stats = computeTextStatistics("あ\n\\[\\[blank]]\nあ");
+    expect(stats.visibleTextCharCount).toBe(2);
   });
 
   it("400字 → 1ページ", () => {

--- a/lib/editor-page/text-statistics.ts
+++ b/lib/editor-page/text-statistics.ts
@@ -60,10 +60,11 @@ const LINE_END_PROHIBITED = new Set("（〔［｛〈《「『【".split(""));
  *  6. MDI 縦中横 (`^内容^`) → 内容のみ
  *  7. MDI no-break (`[[no-break:文字列]]`) → 文字列のみ
  *  8. MDI kern (`[[kern:量:文字列]]`) → 文字列のみ
- *  9. HTML タグ (`<tag>`) → タグ記号のみ除去、内容は残す
- * 10. Markdown 見出し記号（行頭の `#+ `）→ 除去（本文は残す）
- * 11. 強調記号 (`**...**`, `__...__`, `*...*`, `_..._`, `~~...~~`) → 内容は残す
- * 12. バックスラッシュエスケープ (`\X`) → バックスラッシュのみ除去
+ *  9. MDI 空行マーカー (`[[blank]]` / serializer エスケープ形 `\[\[blank]]`) → 行ごと削除
+ * 10. HTML タグ (`<tag>`) → タグ記号のみ除去、内容は残す
+ * 11. Markdown 見出し記号（行頭の `#+ `）→ 除去（本文は残す）
+ * 12. 強調記号 (`**...**`, `__...__`, `*...*`, `_..._`, `~~...~~`) → 内容は残す
+ * 13. バックスラッシュエスケープ (`\X`) → バックスラッシュのみ除去
  */
 export function extractVisibleText(rawContent: string): string {
   let text = rawContent;
@@ -92,13 +93,18 @@ export function extractVisibleText(rawContent: string): string {
   // 8. MDI kern [[kern:量:文字列]] → 文字列のみ
   text = text.replace(/\[\[kern:[^\]]*?:([^\]]*)\]\]/g, "$1");
 
-  // 9. HTML タグ → タグ記号を除去、内容は残す
+  // 9. MDI 空行マーカー [[blank]] → 行ごと削除（可視文字としてカウントしない）。
+  // ライブ編集中の content は serializer が `[` をエスケープするため `\[\[blank]]`
+  // となる。各ブラケット前の `\` を任意マッチさせ、クリーン形・エスケープ形の双方を除去する。
+  text = text.replace(/^[ \t]*\\?\[\\?\[blank\\?\]\\?\][ \t]*$/gm, "");
+
+  // 10. HTML タグ → タグ記号を除去、内容は残す
   text = text.replace(/<[^>]*>/g, "");
 
-  // 10. Markdown 見出し記号（行頭の # 記号と直後のスペース）
+  // 11. Markdown 見出し記号（行頭の # 記号と直後のスペース）
   text = text.replace(/^#{1,6} /gm, "");
 
-  // 11. 強調記号のみ除去（内容は残す）
+  // 12. 強調記号のみ除去（内容は残す）
   // ** と __ を先に処理してから単体 * と _ を処理する順番を守ること。
   text = text.replace(/~~([^~]*)~~/g, "$1");
   text = text.replace(/\*\*([^*]*)\*\*/g, "$1");
@@ -108,7 +114,7 @@ export function extractVisibleText(rawContent: string): string {
   text = text.replace(/(?<!\*)\*(?!\*)([^*\n]+?)(?<!\*)\*(?!\*)/g, "$1");
   text = text.replace(/(?<!\w)_(?!_)([^_\n]+?)_(?!\w)(?!_)/g, "$1");
 
-  // 12. バックスラッシュエスケープ（バックスラッシュのみ除去）
+  // 13. バックスラッシュエスケープ（バックスラッシュのみ除去）
   text = text.replace(/\\(.)/g, "$1");
 
   return text;

--- a/packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts
@@ -26,6 +26,27 @@ describe("MdiDocument — typed derivations (#1449)", () => {
     expect(doc.toAnalysisText()).toBe("{漢字|かんじ}と^12^月\n\n");
   });
 
+  // Regression: in-app analysis/statistics panels (語彙統計 / 登場人物 / 読みやすさ)
+  // feed the LIVE editor buffer through `fromRawText().toAnalysisText()`. That
+  // buffer is the Milkdown serializer output, where the marker is escaped to
+  // `\[\[blank]]` (CommonMark escapes the leading `[`). The marker must still be
+  // stripped so kuromoji never tokenizes "blank" into the word-frequency list.
+  it("toAnalysisText strips the serializer-escaped marker \\[\\[blank]] (analysis leak fix)", () => {
+    const escaped = "A段落\n\n\\[\\[blank]]\n\nB段落";
+    const out = MdiDocument.fromRawText(escaped).toAnalysisText();
+    expect(out).not.toContain("blank");
+    expect(out).toBe("A段落\n\n\n\nB段落");
+  });
+
+  it("toAnalysisText strips the fully-escaped marker \\[\\[blank\\]\\]", () => {
+    expect(MdiDocument.fromRawText("\\[\\[blank\\]\\]").toAnalysisText()).not.toContain("blank");
+  });
+
+  it("toAnalysisText preserves an inline escaped occurrence (not a whole-line marker)", () => {
+    const inline = "foo \\[\\[blank]] bar";
+    expect(MdiDocument.fromRawText(inline).toAnalysisText()).toBe(inline);
+  });
+
   it("toExportText('txt') flattens syntax and turns markers into forced blank lines", () => {
     const txt = MdiDocument.fromRawText(RAW).toExportText("txt");
     expect(txt).not.toContain("[[blank]]");

--- a/packages/milkdown-plugin-japanese-novel/mdi-document.ts
+++ b/packages/milkdown-plugin-japanese-novel/mdi-document.ts
@@ -67,8 +67,31 @@ export const MDI_BLANK_MARKER = "[[blank]]";
  * before matching, so an indented "  [[blank]]" renders as a blank paragraph;
  * analysis text must strip the same lines (pre-#1449 the strip regex was
  * line-start-anchored, a marker-handling drift this module exists to end).
+ *
+ * Clean-form ONLY (`[[blank]]`). This must NOT match the serializer-escaped
+ * form `\[\[blank]]`, because the HTML export pipeline (`mdi-to-html.ts`)
+ * applies it AFTER a fileType-gated normalization: for ".md"/".txt" the escaped
+ * literal is intentionally preserved (DATA-LOSS guard, #1608), so matching the
+ * escaped form here would wrongly promote authored `\[\[blank]]` to a blank
+ * paragraph. Analysis-side stripping tolerates the escaped form via
+ * {@link MDI_BLANK_ANALYSIS_RE} instead.
  */
 export const MDI_BLANK_RE = /^[ \t]*\[\[blank\]\][ \t]*\r?$/gm;
+
+/**
+ * Analysis-only blank-marker matcher. Backslashes before each bracket are
+ * optional so it matches BOTH the clean form (`[[blank]]`) and the Milkdown
+ * serializer-escaped form (`\[\[blank]]`).
+ *
+ * In-app analysis/statistics panels (語彙統計 / 登場人物 / 読みやすさ) feed the
+ * LIVE editor buffer through `fromRawText().toAnalysisText()`. That buffer is
+ * serializer output, where the marker is escaped (CommonMark escapes the
+ * leading `[`); `fromRawText` skips the Step 0 un-escape that `fromEditorOutput`
+ * applies, so the escaped marker would otherwise survive into kuromoji and
+ * surface as a spurious "blank" token. Used ONLY by {@link stripMdiBlankMarkers}
+ * — NOT by the fileType-aware export pipeline.
+ */
+export const MDI_BLANK_ANALYSIS_RE = /^[ \t]*\\?\[\\?\[blank\\?\]\\?\][ \t]*\r?$/gm;
 
 /** Escaped MDI opening brace: \{ */
 export const MDI_ESC_BRACE_RE = /\\(\{)/g;
@@ -99,13 +122,16 @@ export function isMdiBlankParagraphLine(line: string): boolean {
  * (NLP, word count, readability, etc.).
  * Replaces the marker line with empty string; surrounding blank lines remain.
  * Inline occurrences (`foo [[blank]] bar`) are preserved as literal text.
+ * Both the clean (`[[blank]]`) and serializer-escaped (`\[\[blank]]`) forms are
+ * stripped (see {@link MDI_BLANK_ANALYSIS_RE}) — analysis consumers read the
+ * live editor buffer, which carries the escaped form.
  * CRLF note: on CRLF files a preceding \r is absorbed; normalize line endings
  * before passing if required.
  *
  * Prefer `MdiDocument.fromRawText(text).toAnalysisText()` in new code.
  */
 export function stripMdiBlankMarkers(content: string): string {
-  return content.replace(MDI_BLANK_RE, "");
+  return content.replace(MDI_BLANK_ANALYSIS_RE, "");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

語彙統計パネルの頻出語に **`blank`（名詞・18回）** が混入する不具合の報告から調査。

export/保存/コピー経路は `MdiDocument.fromEditorOutput()` 経由で正規化済み（#1608 / #1609 / #1632）だが、**アプリ内の分析・統計パネル**だけが取り残されていた。これらはライブ編集中の `content`（= Milkdown serializer 出力）を直接消費する。serializer は CommonMark の都合で先頭 `[` をエスケープするため、`content` 上では `[[blank]]` ではなく **`\[\[blank]]`** になっている。

### リークの連鎖
1. `content` = serializer 出力 → `\[\[blank]]`（エスケープ済み）
2. 分析側は `MdiDocument.fromRawText(content).toAnalysisText()` を使用
3. `fromRawText` は無変換（アンエスケープ Step 0 は `fromEditorOutput` 側のみ）
4. `toAnalysisText()` → `stripMdiBlankMarkers` → `MDI_BLANK_RE` は**非エスケープ形しかマッチしない** → `\[\[blank]]` が素通り
5. kuromoji が英字列 `blank` を名詞として抽出 → 集計に出現

### 同根の波及（類似バグ）
| 機能 | 箇所 |
|------|------|
| 語彙統計（報告分） | `components/WordFrequency.tsx` |
| 登場人物抽出 | `components/Characters.tsx` |
| 読みやすさ/文数/文字種別 | `lib/utils/readability.ts`（`cleanMarkdown`）← `use-text-statistics.ts` |
| 原稿用紙/可視文字数 | `lib/editor-page/text-statistics.ts:extractVisibleText` |

## 修正

- **`MDI_BLANK_RE` はクリーン専用のまま維持**。export の HTML パイプライン（`mdi-to-html.ts`）は fileType 依存で `.md`/`.txt` の `\[\[blank]]` をリテラル保持する（DATA-LOSS ガード #1608）ため、共有正規表現を緩めると破壊する。
- 新規 **`MDI_BLANK_ANALYSIS_RE`**（エスケープ耐性）を追加し、`stripMdiBlankMarkers`（= `toAnalysisText` 専用）だけで使用。→ 語彙統計・登場人物・読みやすさ/文字統計を一括修正。
- `extractVisibleText` に `[[blank]]`（両形式）の行削除ステップを追加。→ 原稿用紙/可視文字数の水増しを解消。

## テスト

- `npm run type-check`：✅ クリーン
- 関連スイート **517 件全パス**（export の `.md` DATA-LOSS ガード含む）
- 追加した回帰テスト:
  - `mdi-document.test.ts`：`\[\[blank]]` の除去・インライン保持
  - `text-statistics.test.ts`：`[[blank]]`/`\[\[blank]]` を可視文字数に計上しない

## 関連 issue
なし（#1633 は export 側の別件で解決済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)