### PR TITLE
fix(power): 省電力モードをトースト提案化し確実に解除可能に＋品詞/比較の不具合修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -184,6 +184,23 @@ export default function EditorPage() {
     powerSaveMode,
     autoPowerSaveOnBattery,
     onPowerSaveModeChange: handlePowerSaveModeChange,
+    // Suggest (never force) power-save on battery, so the user stays in
+    // control and the mode can always be turned off (#1402 follow-up).
+    onSuggestPowerSave: () => {
+      notificationManager.showMessage(
+        "バッテリー駆動です。省電力モードにすると校正・AI 機能を一時停止してバッテリーを節約できます。",
+        {
+          type: "info",
+          duration: 12000,
+          actions: [
+            {
+              label: "省電力モードにする",
+              onClick: () => void handlePowerSaveModeChange(true),
+            },
+          ],
+        },
+      );
+    },
   });
 
   // --- Panel state hook ---
@@ -213,6 +230,7 @@ export default function EditorPage() {
     handleCloseSearchResults,
     handleOpenLintingSettings,
     handleOpenPosHighlightSettings,
+    handleOpenPowerSettings,
     triggerSwitchToCorrections,
   } = panelHandlers;
 
@@ -1129,6 +1147,7 @@ export default function EditorPage() {
     charUsageRates,
     readabilityAnalysis,
     onOpenPosHighlightSettings: handleOpenPosHighlightSettings,
+    onOpenPowerSettings: handleOpenPowerSettings,
     activeFileName: currentFile?.name,
     activeFilePath: currentFile?.path ?? undefined,
     currentContent: content,

--- a/components/EditorDiffView.tsx
+++ b/components/EditorDiffView.tsx
@@ -84,11 +84,17 @@ export default function EditorDiffView({
             maxWidth,
           }}
         >
-          <DiffContent
-            chunks={chunks}
-            textIndent={textIndent}
-            paragraphSpacing={paragraphSpacing}
-          />
+          {stats.addedChars === 0 && stats.removedChars === 0 ? (
+            <p className="text-center text-sm text-foreground-tertiary py-8">
+              差分はありません（現在の内容と同一です）
+            </p>
+          ) : (
+            <DiffContent
+              chunks={chunks}
+              textIndent={textIndent}
+              paragraphSpacing={paragraphSpacing}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/components/EditorDiffView.tsx
+++ b/components/EditorDiffView.tsx
@@ -86,7 +86,7 @@ export default function EditorDiffView({
         >
           {stats.addedChars === 0 && stats.removedChars === 0 ? (
             <p className="text-center text-sm text-foreground-tertiary py-8">
-              差分はありません（現在の内容と同一です）
+              テキストの差分はありません（現在の内容と同一です）
             </p>
           ) : (
             <DiffContent

--- a/components/HistoryPanel.tsx
+++ b/components/HistoryPanel.tsx
@@ -407,21 +407,33 @@ export default function HistoryPanel({
       try {
         setLoadingDiffId(snapshot.id);
         const historyService = getHistoryService();
-        const snapshotContent = await historyService.getSnapshotContent(snapshot.id);
+        // Use restoreSnapshot (read-only) directly so the SPECIFIC failure
+        // reason — "not found" / "checksum mismatch" / read error — surfaces,
+        // instead of getSnapshotContent collapsing every failure to null.
+        const result = await historyService.restoreSnapshot(snapshot.id);
 
-        if (snapshotContent === null) {
-          setError("スナップショットの読み込みに失敗しました");
+        if (!result.success || result.content == null) {
+          const reason = result.error ?? "内容が空です";
+          console.error("[HistoryCompare] snapshot read failed:", snapshot.id, reason);
+          setError(`スナップショットの読み込みに失敗しました: ${reason}`);
+          return;
+        }
+
+        if (!onCompareInEditor) {
+          console.error("[HistoryCompare] onCompareInEditor is not wired; diff cannot open.");
+          setError("差分ビューを開けませんでした（内部エラー）");
           return;
         }
 
         const label = `${formatTimeJa(snapshot.timestamp)} (${getSnapshotTypeLabel(snapshot.type)})`;
-        onCompareInEditor?.({
-          snapshotContent,
+        onCompareInEditor({
+          snapshotContent: result.content,
           currentContent,
           label,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        console.error("[HistoryCompare] unexpected error:", err);
         setError(`差分の読み込みに失敗しました: ${message}`);
       } finally {
         setLoadingDiffId(null);

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -50,6 +50,7 @@ export default function Inspector({
   charUsageRates,
   readabilityAnalysis,
   onOpenPosHighlightSettings,
+  onOpenPowerSettings,
   onHistoryRestore,
   activeFileName,
   activeFilePath,
@@ -365,6 +366,7 @@ export default function Inspector({
         {activeTab === "corrections" && (
           <CorrectionsPanel
             onOpenPosHighlightSettings={onOpenPosHighlightSettings}
+            onOpenPowerSettings={onOpenPowerSettings}
             lintIssues={lintIssues ?? []}
             onNavigateToIssue={onNavigateToIssue}
             onApplyFix={onApplyFix}

--- a/components/inspector/CorrectionsPanel.tsx
+++ b/components/inspector/CorrectionsPanel.tsx
@@ -21,7 +21,11 @@ import type { CorrectionModeId } from "@/lib/linting/correction-config";
 import { DEFAULT_POS_COLORS } from "@/packages/milkdown-plugin-japanese-novel/pos-highlight/pos-colors";
 import InfoTooltip from "./InfoTooltip";
 import IssueCard from "./IssueCard";
-import { useLintingSettings, usePosHighlightSettings } from "@/contexts/EditorSettingsContext";
+import {
+  useLintingSettings,
+  usePosHighlightSettings,
+  usePowerSettings,
+} from "@/contexts/EditorSettingsContext";
 
 import type { LintIssue, Severity } from "@/lib/linting";
 import type { SeverityFilter, EnrichedLintIssue } from "./types";
@@ -31,6 +35,7 @@ type SortMode = "position" | "severity" | "category";
 
 interface CorrectionsPanelProps {
   onOpenPosHighlightSettings?: () => void;
+  onOpenPowerSettings?: () => void;
   lintIssues: (LintIssue | EnrichedLintIssue)[];
   onNavigateToIssue?: (issue: LintIssue) => void;
   onApplyFix?: (issue: LintIssue) => void;
@@ -79,6 +84,7 @@ const POS_LEGEND_ITEMS = [
 /** Panel for displaying lint corrections and POS highlighting controls */
 export default function CorrectionsPanel({
   onOpenPosHighlightSettings,
+  onOpenPowerSettings,
   lintIssues,
   onNavigateToIssue,
   onApplyFix,
@@ -99,6 +105,7 @@ export default function CorrectionsPanel({
   } = usePosHighlightSettings();
   const { lintingEnabled, lintingRuleConfigs, onLintingEnabledChange, onLintingRuleConfigChange } =
     useLintingSettings();
+  const { powerSaveMode, onTemporarilyDisablePowerSave } = usePowerSettings();
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
   const [sortMode, setSortMode] = useState<SortMode>("category");
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -438,9 +445,34 @@ export default function CorrectionsPanel({
       </div>
 
       {!lintingEnabled ? (
-        <div className="pt-4 text-center">
-          <p className="text-sm text-foreground-tertiary">校正機能が無効です</p>
-        </div>
+        powerSaveMode ? (
+          <div className="bg-background-secondary mt-1 rounded-lg border border-border p-3 text-center">
+            <p className="text-sm text-foreground-secondary">省電力モードのため停止中です</p>
+            <p className="mt-1 text-xs text-foreground-tertiary">
+              バッテリー節約のため校正機能を一時停止しています。
+            </p>
+            <div className="mt-3 flex flex-col items-stretch gap-1.5">
+              <button
+                onClick={() => onTemporarilyDisablePowerSave?.()}
+                className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-foreground transition-colors hover:bg-accent-hover"
+              >
+                5分間だけ有効にする
+              </button>
+              {onOpenPowerSettings && (
+                <button
+                  onClick={onOpenPowerSettings}
+                  className="text-xs text-accent transition-colors hover:text-accent-hover hover:underline"
+                >
+                  省電力設定を開く
+                </button>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="pt-4 text-center">
+            <p className="text-sm text-foreground-tertiary">校正機能が無効です</p>
+          </div>
+        )
       ) : (
         <>
           {/* Header: issue count + controls */}

--- a/components/inspector/types.ts
+++ b/components/inspector/types.ts
@@ -79,6 +79,7 @@ export interface InspectorProps {
     hasMorphologicalAnalysis?: boolean;
   };
   onOpenPosHighlightSettings?: () => void;
+  onOpenPowerSettings?: () => void;
   onHistoryRestore?: (content: string) => void;
   activeFileName?: string;
   activeFilePath?: string;

--- a/contexts/EditorSettingsContext.tsx
+++ b/contexts/EditorSettingsContext.tsx
@@ -164,6 +164,7 @@ export function usePowerSettings() {
       powerSaveMode: settings.powerSaveMode,
       autoPowerSaveOnBattery: settings.autoPowerSaveOnBattery,
       onPowerSaveModeChange: handlers.handlePowerSaveModeChange,
+      onTemporarilyDisablePowerSave: handlers.temporarilyDisablePowerSave,
       onAutoPowerSaveOnBatteryChange: handlers.handleAutoPowerSaveOnBatteryChange,
     }),
     [settings, handlers],

--- a/lib/editor-page/__tests__/pos-highlight-activation.test.tsx
+++ b/lib/editor-page/__tests__/pos-highlight-activation.test.tsx
@@ -140,13 +140,15 @@ describe("#1466 — effective POS highlight follows window activity", () => {
     expect(lastAppliedEnabled()).toBe(false);
   });
 
-  it("stays false in power-save mode even in the foreground", async () => {
+  it("stays enabled in power-save mode while in the foreground (power-save no longer gates POS)", async () => {
     await mountHook(makeParams({ powerSaveMode: true }));
-    expect(lastAppliedEnabled()).toBe(false);
+    expect(lastAppliedEnabled()).toBe(true);
 
+    // Background still suspends it; focus restores it even under power-save.
     await dispatchActivity("blur");
-    await dispatchActivity("focus");
     expect(lastAppliedEnabled()).toBe(false);
+    await dispatchActivity("focus");
+    expect(lastAppliedEnabled()).toBe(true);
   });
 
   it("passes colors/disabledTypes through and applies to the given view only", async () => {

--- a/lib/editor-page/__tests__/power-policy.test.ts
+++ b/lib/editor-page/__tests__/power-policy.test.ts
@@ -62,9 +62,21 @@ describe("shouldEnablePosHighlight", () => {
     ).toBe(false);
   });
 
-  it("disables highlighting in power-save mode even in the foreground", () => {
+  it("keeps highlighting in power-save mode while in the foreground (power-save no longer gates POS)", () => {
+    // The morphology already runs for the vocabulary panel; gating POS off in
+    // power-save only produced a toggle that read ON while nothing was colored.
     expect(
       shouldEnablePosHighlight(foreground, { posHighlightEnabled: true, powerSaveMode: true }),
+    ).toBe(true);
+    // The user's own toggle is still respected.
+    expect(
+      shouldEnablePosHighlight(foreground, { posHighlightEnabled: false, powerSaveMode: true }),
+    ).toBe(false);
+  });
+
+  it("still suspends highlighting while backgrounded even in power-save mode", () => {
+    expect(
+      shouldEnablePosHighlight(background, { posHighlightEnabled: true, powerSaveMode: true }),
     ).toBe(false);
   });
 

--- a/lib/editor-page/__tests__/use-power-saving.test.tsx
+++ b/lib/editor-page/__tests__/use-power-saving.test.tsx
@@ -171,4 +171,24 @@ describe("usePowerSaving", () => {
 
     expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
   });
+
+  it("does NOT auto-disable on the initial AC reading (mount must not race the restore path)", async () => {
+    const props = makeProps({ powerSaveMode: true });
+    initialState = "ac";
+    await mountHook(props);
+
+    // The initial reading only records state; auto-disable is reserved for a
+    // real battery→AC transition so it can't clear prePowerSaveState at boot.
+    expect(props.onPowerSaveModeChange).not.toHaveBeenCalled();
+  });
+
+  it("throttles repeated suggestions across rapid AC/battery bounce", async () => {
+    const props = makeProps();
+    await mountHook(props); // AC
+    await emit("battery"); // suggestion #1
+    await emit("ac");
+    await emit("battery"); // within the throttle window → suppressed
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
+  });
 });

--- a/lib/editor-page/__tests__/use-power-saving.test.tsx
+++ b/lib/editor-page/__tests__/use-power-saving.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Tests for usePowerSaving (#1402 follow-up).
+ *
+ * The previous implementation FORCED power-save ON whenever it saw "battery",
+ * and re-ran on every effect re-subscription — which made power-save
+ * impossible to turn off on battery. The new design:
+ *
+ * 1. SUGGESTS power-save on AC→battery (never forces),
+ * 2. auto-disables power-save on battery→AC,
+ * 3. only reacts to genuine state TRANSITIONS (repeated same-state is a no-op),
+ * 4. never suggests when already in power-save or when the setting is off.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { usePowerSaving } from "../use-power-saving";
+
+type PowerState = "ac" | "battery";
+
+// ---------------------------------------------------------------------------
+// Fake Electron power API
+// ---------------------------------------------------------------------------
+
+let initialState: PowerState = "ac";
+let stateListener: ((state: PowerState) => void) | null = null;
+let resolveInitial: () => void;
+let initialApplied: Promise<void>;
+
+function installPowerApi(): void {
+  initialApplied = new Promise<void>((resolve) => {
+    resolveInitial = resolve;
+  });
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    power: {
+      getPowerState: () =>
+        Promise.resolve(initialState).then((s) => {
+          // Let tests await the mount-time application.
+          queueMicrotask(resolveInitial);
+          return s;
+        }),
+      onPowerStateChange: (cb: (state: PowerState) => void) => {
+        stateListener = cb;
+        return () => {
+          stateListener = null;
+        };
+      },
+    },
+  };
+}
+
+function emit(state: PowerState): Promise<void> {
+  return act(async () => {
+    stateListener?.(state);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface HostProps {
+  powerSaveMode: boolean;
+  autoPowerSaveOnBattery: boolean;
+  onPowerSaveModeChange: (enabled: boolean) => void;
+  onSuggestPowerSave: () => void;
+}
+
+function HookHost(props: HostProps): null {
+  usePowerSaving(props);
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+async function mountHook(props: HostProps): Promise<void> {
+  await act(async () => {
+    root.render(<HookHost {...props} />);
+  });
+  await act(async () => {
+    await initialApplied;
+  });
+}
+
+beforeEach(() => {
+  initialState = "ac";
+  stateListener = null;
+  installPowerApi();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+function makeProps(overrides: Partial<HostProps> = {}): HostProps {
+  return {
+    powerSaveMode: false,
+    autoPowerSaveOnBattery: true,
+    onPowerSaveModeChange: vi.fn(),
+    onSuggestPowerSave: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("usePowerSaving", () => {
+  it("suggests (never forces) power-save when switching to battery", async () => {
+    const props = makeProps();
+    await mountHook(props); // mounts on AC
+    await emit("battery");
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
+    // Crucially, it never FORCES power-save on.
+    expect(props.onPowerSaveModeChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it("auto-disables power-save when AC is restored", async () => {
+    const props = makeProps({ powerSaveMode: true });
+    initialState = "battery";
+    await mountHook(props); // mounts on battery (suggestion skipped: already on)
+    await emit("ac");
+
+    expect(props.onPowerSaveModeChange).toHaveBeenCalledWith(false);
+    // Mounting on battery while already in power-save must not force or suggest.
+    expect(props.onSuggestPowerSave).not.toHaveBeenCalled();
+  });
+
+  it("does not re-suggest on repeated battery readings (no transition)", async () => {
+    const props = makeProps();
+    await mountHook(props); // AC
+    await emit("battery");
+    await emit("battery");
+    await emit("battery");
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not suggest while power-save is already enabled", async () => {
+    const props = makeProps({ powerSaveMode: true });
+    await mountHook(props); // AC
+    await emit("battery");
+
+    expect(props.onSuggestPowerSave).not.toHaveBeenCalled();
+  });
+
+  it("does not suggest when the auto-suggest setting is off", async () => {
+    const props = makeProps({ autoPowerSaveOnBattery: false });
+    await mountHook(props); // AC
+    await emit("battery");
+
+    expect(props.onSuggestPowerSave).not.toHaveBeenCalled();
+  });
+
+  it("suggests on mount when already on battery", async () => {
+    const props = makeProps();
+    initialState = "battery";
+    await mountHook(props);
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/editor-page/power-policy.ts
+++ b/lib/editor-page/power-policy.ts
@@ -103,26 +103,34 @@ export function getAutoSaveIntervalMs(
  *
  * Focus-dependent (#1466, restoring the PR #1427 CPU-saving requirement):
  * the expensive morphological highlighting is suspended while the window
- * is backgrounded or power-save mode is on, and resumes when the user
- * setting allows it. This is safe with respect to #1445 because the sole
- * consumer (use-pos-highlight-activation.ts) subscribes to the
- * framework-free window-activity service — no React re-render on focus
- * switches — and applies the decision via `updatePosHighlightSettings`,
- * which dispatches a meta-only transaction: decorations toggle, the
- * document, selection, and scroll are never touched.
+ * is backgrounded, and resumes when the user setting allows it. This is
+ * safe with respect to #1445 because the sole consumer
+ * (use-pos-highlight-activation.ts) subscribes to the framework-free
+ * window-activity service — no React re-render on focus switches — and
+ * applies the decision via `updatePosHighlightSettings`, which dispatches
+ * a meta-only transaction: decorations toggle, the document, selection,
+ * and scroll are never touched.
+ *
+ * NOTE: power-save mode no longer suspends POS highlighting. POS highlight
+ * decorations are cheap to keep once tokenized (the morphology runs for the
+ * vocabulary panel regardless), so gating them off in power-save only
+ * surprised users — a toggle that read ON while nothing was colored. Only
+ * the focus/background gate remains. `powerSaveMode` is intentionally not
+ * read here; it is still accepted in `settings` so callers can pass the
+ * shared `PowerPolicySettings` object unchanged.
  *
  * The user setting itself is never mutated; this returns an EFFECTIVE
  * value, so regaining focus restores exactly the user's choice.
  *
- * 品詞ハイライトを有効にすべきかどうか（#1466）。バックグラウンド中
- * または省電力モード中は重い形態素ハイライトを一時停止し、フォーカス
- * 復帰時にユーザー設定どおりの状態へ戻す。判断の適用は meta 専用
- * transaction による装飾の付け外しのみで、本文・選択・スクロールには
- * 一切触れない（#1445 ガード）。ユーザー設定自体は変更しない。
+ * 品詞ハイライトを有効にすべきかどうか（#1466）。バックグラウンド中は
+ * 重い形態素ハイライトを一時停止し、フォーカス復帰でユーザー設定どおりへ
+ * 戻す。省電力モードでは停止しない（トグル ON なのに無色になる UX を回避）。
+ * 判断の適用は meta 専用 transaction による装飾の付け外しのみで、本文・
+ * 選択・スクロールには一切触れない（#1445 ガード）。設定自体は変更しない。
  */
 export function shouldEnablePosHighlight(
   activity: WindowActivityState,
   settings: PowerPolicySettings & { posHighlightEnabled: boolean },
 ): boolean {
-  return settings.posHighlightEnabled && !settings.powerSaveMode && !isBackground(activity);
+  return settings.posHighlightEnabled && !isBackground(activity);
 }

--- a/lib/editor-page/use-ai-settings.ts
+++ b/lib/editor-page/use-ai-settings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { fetchAppState, persistAppState } from "@/lib/storage/app-state-manager";
 import { configureAiClient, resetAiClient } from "@/lib/ai/ai-client";
@@ -39,6 +39,8 @@ export interface AiSettingsHandlers {
   handleCharacterExtractionBatchSizeChange: (value: number) => void;
   handleCharacterExtractionConcurrencyChange: (value: number) => void;
   handlePowerSaveModeChange: (enabled: boolean) => Promise<void>;
+  /** Lift power-save mode for a few minutes, then restore it (default 5 min). */
+  temporarilyDisablePowerSave: (durationMs?: number) => void;
   handleAutoPowerSaveOnBatteryChange: (enabled: boolean) => void;
   handleCorrectionConfigChange: (partial: Partial<CorrectionConfig>) => void;
   handleAiApiKeyChange: (apiKey: string) => void;
@@ -78,6 +80,20 @@ export function useAiSettings(): UseAiSettingsResult {
   const [correctionGuidelines, setCorrectionGuidelines] = useState<GuidelineId[]>(
     DEFAULT_CORRECTION_CONFIG.guidelines,
   );
+
+  // Latest-value refs so power-save handlers can stay identity-stable
+  // (deps: []). Without this, `handlePowerSaveModeChange` was re-created on
+  // every `lintingEnabled` change, which re-subscribed `usePowerSaving` and
+  // re-fired the battery auto-trigger — the loop that made power-save
+  // impossible to turn off on battery and clobbered `prePowerSaveState`.
+  const lintingEnabledRef = useRef(lintingEnabled);
+  lintingEnabledRef.current = lintingEnabled;
+  const lintingRuleConfigsRef = useRef(lintingRuleConfigs);
+  lintingRuleConfigsRef.current = lintingRuleConfigs;
+  const powerSaveModeRef = useRef(powerSaveMode);
+  powerSaveModeRef.current = powerSaveMode;
+  /** Pending timer for "temporarily disable power-save for N minutes". */
+  const tempPowerSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const applyPersistedAiSettings = useCallback((appState: Record<string, unknown>) => {
     if (typeof appState.lintingEnabled === "boolean") setLintingEnabled(appState.lintingEnabled);
@@ -227,10 +243,28 @@ export function useAiSettings(): UseAiSettingsResult {
     [],
   );
 
+  const clearTempPowerSaveTimer = useCallback(() => {
+    if (tempPowerSaveTimerRef.current !== null) {
+      clearTimeout(tempPowerSaveTimerRef.current);
+      tempPowerSaveTimerRef.current = null;
+    }
+  }, []);
+
   const handlePowerSaveModeChange = useCallback(
     async (enabled: boolean) => {
+      // Any explicit power-save change cancels a pending "5-minute" re-enable
+      // (e.g. the user plugged into AC, which auto-disables power-save).
+      clearTempPowerSaveTimer();
       if (enabled) {
-        const snapshot = { lintingEnabled, lintingRuleConfigs };
+        // Clobber guard: only snapshot the linting state on the OFF -> ON
+        // transition. Re-entering while already ON would overwrite
+        // `prePowerSaveState` with the already-suppressed `lintingEnabled:false`,
+        // permanently losing the user's real setting.
+        if (powerSaveModeRef.current) return;
+        const snapshot = {
+          lintingEnabled: lintingEnabledRef.current,
+          lintingRuleConfigs: lintingRuleConfigsRef.current,
+        };
         await persistAppState({
           powerSaveMode: true,
           prePowerSaveState: snapshot,
@@ -239,6 +273,12 @@ export function useAiSettings(): UseAiSettingsResult {
         setPowerSaveMode(true);
         setLintingEnabled(false);
       } else {
+        if (!powerSaveModeRef.current) {
+          // Already off — just make sure the persisted flag is clean.
+          await persistAppState({ powerSaveMode: false, prePowerSaveState: null });
+          setPowerSaveMode(false);
+          return;
+        }
         const stored = await fetchAppState();
         const prev = stored?.prePowerSaveState;
         if (prev) {
@@ -256,8 +296,30 @@ export function useAiSettings(): UseAiSettingsResult {
         setPowerSaveMode(false);
       }
     },
-    [lintingEnabled, lintingRuleConfigs],
+    [clearTempPowerSaveTimer],
   );
+
+  /**
+   * Temporarily lift power-save mode for `durationMs`, then restore it.
+   * Lets the user run the proofreader for a few minutes without permanently
+   * turning off battery saving. Restoring re-snapshots the (now restored)
+   * linting state, so the round-trip is lossless.
+   */
+  const temporarilyDisablePowerSave = useCallback(
+    (durationMs: number = 5 * 60 * 1000) => {
+      // handlePowerSaveModeChange(false) clears any existing timer first, so
+      // we set the fresh re-enable timer afterwards.
+      void handlePowerSaveModeChange(false);
+      tempPowerSaveTimerRef.current = setTimeout(() => {
+        tempPowerSaveTimerRef.current = null;
+        void handlePowerSaveModeChange(true);
+      }, durationMs);
+    },
+    [handlePowerSaveModeChange],
+  );
+
+  // Clear the pending re-enable timer on unmount.
+  useEffect(() => clearTempPowerSaveTimer, [clearTempPowerSaveTimer]);
 
   const handleAutoPowerSaveOnBatteryChange = useCallback((enabled: boolean) => {
     setAutoPowerSaveOnBattery(enabled);
@@ -303,6 +365,7 @@ export function useAiSettings(): UseAiSettingsResult {
       handleCharacterExtractionBatchSizeChange,
       handleCharacterExtractionConcurrencyChange,
       handlePowerSaveModeChange,
+      temporarilyDisablePowerSave,
       handleAutoPowerSaveOnBatteryChange,
       handleCorrectionConfigChange,
       handleAiApiKeyChange,

--- a/lib/editor-page/use-ai-settings.ts
+++ b/lib/editor-page/use-ai-settings.ts
@@ -307,13 +307,16 @@ export function useAiSettings(): UseAiSettingsResult {
    */
   const temporarilyDisablePowerSave = useCallback(
     (durationMs: number = 5 * 60 * 1000) => {
-      // handlePowerSaveModeChange(false) clears any existing timer first, so
-      // we set the fresh re-enable timer afterwards.
-      void handlePowerSaveModeChange(false);
-      tempPowerSaveTimerRef.current = setTimeout(() => {
-        tempPowerSaveTimerRef.current = null;
-        void handlePowerSaveModeChange(true);
-      }, durationMs);
+      // Await the OFF transition (which also clears any existing timer) before
+      // scheduling the re-enable, so the OFF state is committed first and the
+      // re-enable's clobber guard never sees a stale "still on" ref.
+      void (async () => {
+        await handlePowerSaveModeChange(false);
+        tempPowerSaveTimerRef.current = setTimeout(() => {
+          tempPowerSaveTimerRef.current = null;
+          void handlePowerSaveModeChange(true);
+        }, durationMs);
+      })();
     },
     [handlePowerSaveModeChange],
   );

--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -108,6 +108,7 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
     handleCharacterExtractionConcurrencyChange:
       aiHandlers.handleCharacterExtractionConcurrencyChange,
     handlePowerSaveModeChange: aiHandlers.handlePowerSaveModeChange,
+    temporarilyDisablePowerSave: aiHandlers.temporarilyDisablePowerSave,
     handleAutoPowerSaveOnBatteryChange: aiHandlers.handleAutoPowerSaveOnBatteryChange,
     handleCorrectionConfigChange: aiHandlers.handleCorrectionConfigChange,
     handleDictAutoCheckUpdatesChange: dictHandlers.handleDictAutoCheckUpdatesChange,

--- a/lib/editor-page/use-panel-state.ts
+++ b/lib/editor-page/use-panel-state.ts
@@ -33,6 +33,7 @@ export interface PanelHandlers {
   handleCloseSearchResults: () => void;
   handleOpenLintingSettings: () => void;
   handleOpenPosHighlightSettings: () => void;
+  handleOpenPowerSettings: () => void;
   triggerSwitchToCorrections: () => void;
 }
 
@@ -111,6 +112,11 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
     setShowSettingsModal(true);
   }, [setShowSettingsModal]);
 
+  const handleOpenPowerSettings = useCallback(() => {
+    setSettingsInitialCategory("power");
+    setShowSettingsModal(true);
+  }, [setShowSettingsModal]);
+
   const triggerSwitchToCorrections = useCallback(() => {
     setSwitchToCorrectionsTrigger((n) => n + 1);
   }, []);
@@ -141,6 +147,7 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
       handleCloseSearchResults,
       handleOpenLintingSettings,
       handleOpenPosHighlightSettings,
+      handleOpenPowerSettings,
       triggerSwitchToCorrections,
     },
   };

--- a/lib/editor-page/use-power-saving.ts
+++ b/lib/editor-page/use-power-saving.ts
@@ -2,6 +2,9 @@ import { useEffect, useRef } from "react";
 
 type PowerState = "ac" | "battery";
 
+/** Minimum gap between battery suggestions, to absorb rapid power bounce. */
+const SUGGEST_THROTTLE_MS = 60_000;
+
 interface UsePowerSavingOptions {
   /** Current power-save mode, so we never re-suggest while already enabled. */
   powerSaveMode: boolean;
@@ -53,6 +56,8 @@ export function usePowerSaving({
 
   /** Last power state we acted on; null until the first reading. */
   const lastStateRef = useRef<PowerState | null>(null);
+  /** Epoch ms of the last suggestion, to throttle rapid AC/battery bounce. */
+  const lastSuggestAtRef = useRef(0);
 
   useEffect(() => {
     const powerAPI = window.electronAPI?.power;
@@ -62,29 +67,44 @@ export function usePowerSaving({
 
     let disposed = false;
 
-    const handleState = (state: PowerState): void => {
+    const handleTransition = (state: PowerState): void => {
       if (disposed) return;
       // Only react to genuine transitions; ignore repeated same-state reads.
       if (lastStateRef.current === state) return;
+      const prev = lastStateRef.current;
       lastStateRef.current = state;
 
       if (state === "battery") {
-        // Suggest, never force. Skip if power-save is already on or the user
-        // opted out of the suggestion.
-        if (autoOnBatteryRef.current && !powerSaveModeRef.current) {
+        // Suggest, never force. Skip if power-save is already on, the user
+        // opted out, or we suggested very recently (debounce bounce).
+        const now = Date.now();
+        if (
+          autoOnBatteryRef.current &&
+          !powerSaveModeRef.current &&
+          now - lastSuggestAtRef.current > SUGGEST_THROTTLE_MS
+        ) {
+          lastSuggestAtRef.current = now;
           onSuggestRef.current();
         }
-      } else {
-        // AC restored: auto-disable power-save to restore full functionality.
+      } else if (prev !== null) {
+        // Auto-disable only on a REAL battery→AC transition. We must NOT act on
+        // the initial mount reading (prev === null): at startup the persisted
+        // powerSaveMode is still hydrating, and disabling here races with the
+        // restore path — it would clear prePowerSaveState and strand linting
+        // off. On mount we respect the persisted/hydrated value instead.
         onChangeRef.current(false);
       }
     };
 
-    // Apply the current state once on mount.
-    powerAPI.getPowerState().then(handleState);
-
-    // Subscribe to future transitions.
-    const unsubscribe = powerAPI.onPowerStateChange(handleState);
+    // Subscribe FIRST so a transition during the initial async read is not
+    // missed, then apply the initial reading only if nothing was observed yet
+    // (guards against an out-of-order initial result overwriting a real
+    // transition that already arrived).
+    const unsubscribe = powerAPI.onPowerStateChange(handleTransition);
+    powerAPI.getPowerState().then((state) => {
+      if (disposed) return;
+      if (lastStateRef.current === null) handleTransition(state);
+    });
 
     return () => {
       disposed = true;

--- a/lib/editor-page/use-power-saving.ts
+++ b/lib/editor-page/use-power-saving.ts
@@ -1,51 +1,96 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+
+type PowerState = "ac" | "battery";
 
 interface UsePowerSavingOptions {
+  /** Current power-save mode, so we never re-suggest while already enabled. */
   powerSaveMode: boolean;
+  /** Whether to surface the battery suggestion at all. */
   autoPowerSaveOnBattery: boolean;
+  /** Apply a concrete power-save change (used to auto-disable on AC). */
   onPowerSaveModeChange: (enabled: boolean) => void;
+  /** Surface a non-forcing "switch to power-save?" suggestion to the user. */
+  onSuggestPowerSave: () => void;
 }
 
 /**
- * Listens for Electron power state changes and auto-switches power saving mode.
+ * Reacts to Electron power-state transitions.
  *
- * - When on battery and `autoPowerSaveOnBattery` is enabled, power saving is turned on.
- * - When AC power is restored, power saving is turned off.
- * - Does nothing on web (no `window.electronAPI?.power`).
+ * Design (#1402 follow-up): the previous implementation *forced* power-save
+ * mode ON whenever it saw `battery`, and did so on every effect re-run — not
+ * just on real transitions. Because the apply callback's identity changed
+ * whenever linting state changed, the effect re-subscribed and re-fired,
+ * instantly re-enabling power-save the moment the user turned it off. That
+ * made power-save impossible to disable on battery.
+ *
+ * Now:
+ * - We only act on genuine power-state TRANSITIONS (tracked via a ref), so an
+ *   effect re-run with the same state is a no-op.
+ * - On AC→battery we SUGGEST power-save via a toast (`onSuggestPowerSave`)
+ *   instead of forcing it. The user stays in control — matching the setting's
+ *   wording, "バッテリー駆動時に自動で省電力モードを提案する".
+ * - On battery→AC we auto-disable power-save (this direction never traps the
+ *   user and restores full functionality).
+ * - All callbacks/flags are read through refs so the effect mounts once and
+ *   never re-subscribes; identity churn can no longer cause spurious toggles.
+ *
+ * Does nothing on web (no `window.electronAPI?.power`).
  */
 export function usePowerSaving({
+  powerSaveMode,
   autoPowerSaveOnBattery,
   onPowerSaveModeChange,
+  onSuggestPowerSave,
 }: UsePowerSavingOptions): void {
+  const powerSaveModeRef = useRef(powerSaveMode);
+  powerSaveModeRef.current = powerSaveMode;
+  const autoOnBatteryRef = useRef(autoPowerSaveOnBattery);
+  autoOnBatteryRef.current = autoPowerSaveOnBattery;
+  const onChangeRef = useRef(onPowerSaveModeChange);
+  onChangeRef.current = onPowerSaveModeChange;
+  const onSuggestRef = useRef(onSuggestPowerSave);
+  onSuggestRef.current = onSuggestPowerSave;
+
+  /** Last power state we acted on; null until the first reading. */
+  const lastStateRef = useRef<PowerState | null>(null);
+
   useEffect(() => {
     const powerAPI = window.electronAPI?.power;
     if (!powerAPI) {
       return;
     }
 
-    // Apply the current state immediately on mount.
-    powerAPI.getPowerState().then((state) => {
-      if (state === "battery" && autoPowerSaveOnBattery) {
-        onPowerSaveModeChange(true);
-      } else if (state === "ac") {
-        onPowerSaveModeChange(false);
-      }
-    });
+    let disposed = false;
 
-    // Subscribe to future state changes.
-    const unsubscribe = powerAPI.onPowerStateChange((state) => {
-      if (state === "battery" && autoPowerSaveOnBattery) {
-        onPowerSaveModeChange(true);
-      } else if (state === "ac") {
-        onPowerSaveModeChange(false);
+    const handleState = (state: PowerState): void => {
+      if (disposed) return;
+      // Only react to genuine transitions; ignore repeated same-state reads.
+      if (lastStateRef.current === state) return;
+      lastStateRef.current = state;
+
+      if (state === "battery") {
+        // Suggest, never force. Skip if power-save is already on or the user
+        // opted out of the suggestion.
+        if (autoOnBatteryRef.current && !powerSaveModeRef.current) {
+          onSuggestRef.current();
+        }
+      } else {
+        // AC restored: auto-disable power-save to restore full functionality.
+        onChangeRef.current(false);
       }
-    });
+    };
+
+    // Apply the current state once on mount.
+    powerAPI.getPowerState().then(handleState);
+
+    // Subscribe to future transitions.
+    const unsubscribe = powerAPI.onPowerStateChange(handleState);
 
     return () => {
+      disposed = true;
       unsubscribe();
     };
-    // Re-run when autoPowerSaveOnBattery changes or when the callback identity
-    // changes (i.e. when the caller's useCallback deps — lintingEnabled,
-    // lintingRuleConfigs — are updated).
-  }, [autoPowerSaveOnBattery, onPowerSaveModeChange]);
+    // Mount once: all inputs are read through refs, so the subscription is
+    // never torn down and re-created by unrelated re-renders.
+  }, []);
 }


### PR DESCRIPTION
## Summary

- バッテリー駆動時に省電力モードが自動 ON のまま **「絶対に解除できない」** 不具合を根治。バッテリーでは強制 ON せず**トースト提案**に変更し、手動 OFF が確実に効くようにした。
- **品詞ハイライト**が省電力モードで無色になる問題を修正（トグル ON なのに色が付かない UX を解消）。
- **校正パネル**に「省電力のため停止中」ヒントと **5分間だけ有効にする** / 省電力設定リンクを追加。
- **履歴「比較」** の失敗が黙殺されていたのを、具体的な失敗理由を画面とコンソールに可視化。内容同一時は明示メッセージを表示。

## Changes

| 領域 | 内容 |
| --- | --- |
| `lib/editor-page/use-power-saving.ts` | 電源状態の**遷移駆動**に再設計。バッテリー→提案（`onSuggestPowerSave`）、AC→auto-disable（遷移時のみ）。mount-once・ref 読み・購読先行・60秒スロットル |
| `lib/editor-page/use-ai-settings.ts` | `handlePowerSaveModeChange` を ref で identity 安定化、OFF→ON 時のみ snapshot するクロバーガード、`temporarilyDisablePowerSave(5分)` 追加 |
| `lib/editor-page/power-policy.ts` | `shouldEnablePosHighlight` から powerSaveMode ゲート除去（フォーカスゲートは維持） |
| `app/page.tsx` | バッテリー提案トースト（アクション付き）を配線 |
| `components/inspector/CorrectionsPanel.tsx` | 省電力理由の停止ヒント＋5分オフ／設定リンク |
| `components/HistoryPanel.tsx` | `restoreSnapshot` 直呼びで失敗理由を可視化（error-mask 解消） |
| `components/EditorDiffView.tsx` | 空 diff 時のメッセージ |
| 配線 | `EditorSettingsContext` / `use-editor-settings` / `use-panel-state` / `Inspector` に temp-disable・省電力設定オープンを追加 |

## 不変条件（壊さないこと）

- バッテリーで**強制 ON しない**（提案のみ）。
- mount の初期 AC 読みで auto-disable しない（設定 hydration との race で `prePowerSaveState` を消すため）。auto-disable は実 battery→AC 遷移のみ。
- `handlePowerSaveModeChange` は identity 安定（deps 実質 `[]`）。OFF→ON 遷移時のみ snapshot。

## Test plan

- [x] type-check / lint / prettier 通過
- [x] `power-policy` / `pos-highlight-activation` テストを新挙動に更新
- [x] `use-power-saving` の遷移ロジック・起動 race・提案スロットルのユニットテスト新規（8件）
- [x] Codex 独立レビュー（refactor gate）findings 5件すべて対応
- [ ] 実機（バッテリー駆動 macOS）：自動 ON されず提案トーストが出る／手動 OFF が維持される
- [ ] 実機：品詞ハイライトが省電力でも色付く／5分オフで校正が戻り5分後に復帰
- [ ] 実機：履歴「比較」で差分表示に切り替わる（失敗時は具体的理由が表示される）

## 備考

- 元の省電力導入起因 issue #1402（バッテリ消耗）は既にクローズ済み。本 PR は同領域の UX 不具合修正のため `Closes` 対象の open issue は無し（関連 issue なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)