### PR TITLE
fix(editor): 比較が無反応／省電力提案トーストの二重表示を修正

### DIFF
--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -404,6 +404,21 @@ export default function EditorLayout({
                   </div>
                 )}
 
+                {/* Snapshot-diff overlay. Rendered here (not inside the
+                    dockview panel) so it appears as soon as `editorDiff` is
+                    set, independent of dockview's panel re-render timing and
+                    of which panel is active. */}
+                {mainArea.editorDiff && (
+                  <div className="absolute inset-0 z-20 bg-background">
+                    <EditorDiffView
+                      snapshotContent={mainArea.editorDiff.snapshotContent}
+                      currentContent={mainArea.editorDiff.currentContent}
+                      snapshotLabel={mainArea.editorDiff.label}
+                      onClose={() => mainArea.setEditorDiff(null)}
+                    />
+                  </div>
+                )}
+
                 {}
                 <div
                   className="flex-1 flex flex-col overflow-hidden"
@@ -435,17 +450,12 @@ export default function EditorLayout({
                         const panelPendingExternalContent =
                           liveEditorTab?.pendingExternalContent ?? null;
 
-                        if (mainArea.editorDiff && isActivePanel) {
-                          return (
-                            <EditorDiffView
-                              snapshotContent={mainArea.editorDiff.snapshotContent}
-                              currentContent={mainArea.editorDiff.currentContent}
-                              snapshotLabel={mainArea.editorDiff.label}
-                              onClose={() => mainArea.setEditorDiff(null)}
-                            />
-                          );
-                        }
-
+                        // NOTE: the snapshot-diff view is rendered as a
+                        // top-level overlay on <main> (see below), NOT inside
+                        // the dockview panel. Rendering it here depended on the
+                        // panel re-evaluating its closure when `editorDiff`
+                        // changed — which dockview does not reliably do — so
+                        // clicking "比較" appeared to do nothing.
                         if (isActivePanel) {
                           return (
                             <ErrorBoundary sectionName="エディタ">

--- a/lib/editor-page/__tests__/use-power-saving.test.tsx
+++ b/lib/editor-page/__tests__/use-power-saving.test.tsx
@@ -18,7 +18,7 @@ import { act } from "react";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-import { usePowerSaving } from "../use-power-saving";
+import { usePowerSaving, __resetSuggestThrottleForTest } from "../use-power-saving";
 
 type PowerState = "ac" | "battery";
 
@@ -88,6 +88,7 @@ async function mountHook(props: HostProps): Promise<void> {
 }
 
 beforeEach(() => {
+  __resetSuggestThrottleForTest();
   initialState = "ac";
   stateListener = null;
   installPowerApi();
@@ -180,6 +181,23 @@ describe("usePowerSaving", () => {
     // The initial reading only records state; auto-disable is reserved for a
     // real battery→AC transition so it can't clear prePowerSaveState at boot.
     expect(props.onPowerSaveModeChange).not.toHaveBeenCalled();
+  });
+
+  it("does not suggest twice when the consumer remounts on battery (module-scoped throttle)", async () => {
+    // Reproduces the duplicate-toast bug: the editor page remounting during
+    // startup created a second hook instance whose per-instance throttle was
+    // reset to 0, firing a second identical toast.
+    const props = makeProps();
+    initialState = "battery";
+    await mountHook(props); // first mount → suggestion #1
+
+    // Remount a fresh instance (new fiber → fresh per-instance refs).
+    await act(async () => root.unmount());
+    installPowerApi();
+    root = createRoot(container);
+    await mountHook(props); // second mount must be throttled
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
   });
 
   it("throttles repeated suggestions across rapid AC/battery bounce", async () => {

--- a/lib/editor-page/use-power-saving.ts
+++ b/lib/editor-page/use-power-saving.ts
@@ -5,6 +5,19 @@ type PowerState = "ac" | "battery";
 /** Minimum gap between battery suggestions, to absorb rapid power bounce. */
 const SUGGEST_THROTTLE_MS = 60_000;
 
+/**
+ * Last suggestion time, MODULE-scoped on purpose: the notification is a global
+ * singleton, so the throttle must be too. A per-hook ref would reset to 0 when
+ * the consumer (the editor page) remounts during startup — producing a second,
+ * duplicate toast from the fresh instance. Module scope dedupes across mounts.
+ */
+let lastSuggestAt = 0;
+
+/** @internal test-only: reset the module-scoped suggestion throttle. */
+export function __resetSuggestThrottleForTest(): void {
+  lastSuggestAt = 0;
+}
+
 interface UsePowerSavingOptions {
   /** Current power-save mode, so we never re-suggest while already enabled. */
   powerSaveMode: boolean;
@@ -56,8 +69,6 @@ export function usePowerSaving({
 
   /** Last power state we acted on; null until the first reading. */
   const lastStateRef = useRef<PowerState | null>(null);
-  /** Epoch ms of the last suggestion, to throttle rapid AC/battery bounce. */
-  const lastSuggestAtRef = useRef(0);
 
   useEffect(() => {
     const powerAPI = window.electronAPI?.power;
@@ -81,9 +92,9 @@ export function usePowerSaving({
         if (
           autoOnBatteryRef.current &&
           !powerSaveModeRef.current &&
-          now - lastSuggestAtRef.current > SUGGEST_THROTTLE_MS
+          now - lastSuggestAt > SUGGEST_THROTTLE_MS
         ) {
-          lastSuggestAtRef.current = now;
+          lastSuggestAt = now;
           onSuggestRef.current();
         }
       } else if (prev !== null) {


### PR DESCRIPTION
## Summary

- **履歴「比較」が無反応** を修正。スナップショット差分を dockview パネル内ではなく `<main>` のオーバーレイとして描画するよう変更し、押せば確実に差分が表示されるようにした。
- **省電力提案トーストが起動時に2回出る** 不具合を修正。

## 原因と修正

### 比較が無反応
差分ビューは dockview の `editor` パネルコンポーネント内（クロージャ）で `editorDiff && isActivePanel` 条件で描画していた。`setEditorDiff` で page が再描画されても dockview がパネルのクロージャを再評価する保証がなく、エラーも diff も出ず「押しても何も起きない」状態だった。
→ `EditorDiffView` を `<main>`（`relative`）直下の `absolute inset-0 z-20` オーバーレイとして描画。active パネルや dockview の再描画タイミングに依存せず、`editorDiff` がセットされた瞬間に表示される（EmptyEditorState と同じパターン）。

### トーストの二重表示
提案スロットルを per-hook の `useRef` で持っていたため、起動時に EditorPage が一度リマウントすると新しい fiber で `throttle=0` にリセットされ、同一トーストが2回出ていた。
→ 通知は singleton なのでスロットルも**モジュールスコープ**へ移動。リマウントしても重複しない。リマウント重複抑止のユニットテストを追加。

## Changes

| ファイル | 内容 |
| --- | --- |
| `components/EditorLayout.tsx` | 差分ビューを dockview パネル内描画から `<main>` オーバーレイへ移動 |
| `lib/editor-page/use-power-saving.ts` | 提案スロットルをモジュールスコープ化（`__resetSuggestThrottleForTest` 追加） |
| `lib/editor-page/__tests__/use-power-saving.test.tsx` | リマウント重複抑止テスト追加 |

## Test plan

- [x] type-check / lint / prettier 通過
- [x] use-power-saving テスト 9件 green（リマウント重複抑止含む）
- [ ] 実機: 履歴「比較」で差分オーバーレイが表示される（内容同一なら「テキストの差分はありません」）
- [ ] 実機: バッテリー駆動で起動しても提案トーストが1回だけ

関連 issue なし（#1641 の実機フォローアップ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)