### PR TITLE
feat(search): 2つの検索UIを単一stateで同期し非表示時にハイライト消去

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 /* eslint-disable react-hooks/rules-of-hooks, @typescript-eslint/no-unused-vars */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useTheme } from "@/contexts/ThemeContext";
 import EditorLayout from "@/components/EditorLayout";
@@ -46,6 +46,8 @@ import { usePowerSaving } from "@/lib/editor-page/use-power-saving";
 import { useIgnoredCorrections } from "@/lib/editor-page/use-ignored-corrections";
 import { useKeyboardShortcuts } from "@/lib/editor-page/use-keyboard-shortcuts";
 import { usePanelState } from "@/lib/editor-page/use-panel-state";
+import { findSearchMatches } from "@/lib/editor-page/find-search-matches";
+import { useSearchHighlight, isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
 import { useSaveToast } from "@/lib/editor-page/use-save-toast";
 import { useTerminalTabs } from "@/lib/editor-page/use-terminal-tabs";
 import { useDiffTabs } from "@/lib/editor-page/use-diff-tabs";
@@ -191,7 +193,9 @@ export default function EditorPage() {
   const {
     topView,
     bottomView,
-    searchResults,
+    searchTerm,
+    caseSensitive,
+    currentMatchIndex,
     isRightPanelCollapsed,
     dictionarySearchTrigger,
     settingsInitialCategory,
@@ -209,6 +213,9 @@ export default function EditorPage() {
     setRubySelectedText,
     setEditorDiff,
     handleOpenDictionary,
+    setSearchTerm,
+    setCaseSensitive,
+    setCurrentMatchIndex,
     handleShowAllSearchResults,
     handleCloseSearchResults,
     handleOpenLintingSettings,
@@ -298,6 +305,9 @@ export default function EditorPage() {
   // Search state — declared before useDockviewAdapter so it can be passed as options
   const [searchOpenTrigger, setSearchOpenTrigger] = useState(0);
   const [searchInitialTerm, setSearchInitialTerm] = useState<string | undefined>(undefined);
+  // フローティング検索窓（SearchDialog）が開いているか。dockview pane 内の Editor から
+  // 報告される。ハイライトの visibility ゲート（要求2）に使う。
+  const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
 
   // Derive project dockview layout from workspace state (already loaded at project open)
   const projectDockviewLayout = isProjectMode(editorMode)
@@ -377,6 +387,28 @@ export default function EditorPage() {
     editorViewRef.current = view; // ref FIRST so sync consumers see fresh value
     setEditorViewInstanceRaw(view);
   }, []);
+
+  // --- 検索ハイライトの単一ソース ---
+  // いずれかの検索 UI が表示中か。両方非表示ならハイライトを消す（要求2）。
+  const isSearchVisible = isSearchDialogOpen || topView === "search";
+  // 共有 searchTerm/caseSensitive からマッチを算出（唯一の計算箇所）。
+  // `content` を依存に含め、置換や編集で doc が変わった時に再計算させる。
+  // 非表示・空語の時は計算をスキップし空配列を返す。
+  const searchMatches = useMemo(() => {
+    if (!isSearchVisible || !searchTerm || !isEditorViewAlive(editorViewInstance)) {
+      return [];
+    }
+    return findSearchMatches(editorViewInstance.state.doc, searchTerm, caseSensitive);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editorViewInstance, searchTerm, caseSensitive, isSearchVisible, content]);
+
+  useSearchHighlight({
+    editorView: editorViewInstance,
+    matches: searchMatches,
+    currentMatchIndex,
+    searchTerm,
+    isSearchVisible,
+  });
 
   // --- Ruby/TCY hook ---
   const { handleOpenRubyDialog, handleApplyRuby, handleToggleTcy } = useRubyTcy({
@@ -1095,7 +1127,14 @@ export default function EditorPage() {
     compactMode,
     onChapterClick: handleChapterClick,
     onInsertText: handleInsertText,
-    searchResults,
+    // 共有検索 state（SearchResults を controlled 化）
+    searchTerm,
+    caseSensitive,
+    searchMatches,
+    currentMatchIndex,
+    onSearchTermChange: setSearchTerm,
+    onCaseSensitiveChange: setCaseSensitive,
+    onCurrentMatchIndexChange: setCurrentMatchIndex,
     onCloseSearchResults: handleCloseSearchResults,
     editorViewInstance,
     dictionarySearchTrigger,
@@ -1104,7 +1143,8 @@ export default function EditorPage() {
     openProjectFile,
     incrementEditorKey,
     onWordSearch: (word: string) => {
-      setSearchInitialTerm(word);
+      // 共有検索語へ反映し、フローティング検索窓を開く。
+      setSearchTerm(word);
       setSearchOpenTrigger((prev) => prev + 1);
     },
   } as const;
@@ -1284,6 +1324,15 @@ export default function EditorPage() {
         },
         searchOpenTrigger,
         searchInitialTerm,
+        // 共有検索 state（SearchDialog を controlled 化）
+        searchTerm,
+        caseSensitive,
+        searchMatches,
+        currentMatchIndex,
+        onSearchTermChange: setSearchTerm,
+        onCaseSensitiveChange: setCaseSensitive,
+        onCurrentMatchIndexChange: setCurrentMatchIndex,
+        onSearchDialogOpenChange: setIsSearchDialogOpen,
         setEditorViewInstance,
         handleShowAllSearchResults,
         ruleRunner,

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -32,8 +32,20 @@ interface EditorProps {
   className?: string;
   searchOpenTrigger?: number;
   searchInitialTerm?: string;
+  // 共有検索 state（単一 source of truth）。SearchResults と同期する。
+  // 検索を配線しない用途（非アクティブ pane プレビュー / popout window）向けに
+  // すべて optional とし、未指定時は no-op / 空デフォルトで動作する。
+  searchTerm?: string;
+  onSearchTermChange?: (term: string) => void;
+  caseSensitive?: boolean;
+  onCaseSensitiveChange?: (value: boolean) => void;
+  searchMatches?: SearchMatch[];
+  currentMatchIndex?: number;
+  onCurrentMatchIndexChange?: (index: number) => void;
+  /** フローティング検索窓の開閉を親へ通知する（ハイライト visibility ゲート用）。 */
+  onSearchDialogOpenChange?: (open: boolean) => void;
   onEditorViewReady?: (view: EditorView) => void;
-  onShowAllSearchResults?: (matches: SearchMatch[], searchTerm: string) => void;
+  onShowAllSearchResults?: () => void;
   // リンティング設定
   lintingRuleRunner?: RuleRunnerLike | null;
   onLintIssuesUpdated?: (issues: LintIssue[]) => void;
@@ -58,6 +70,9 @@ interface EditorProps {
   onExternalContentApplied?: () => void;
 }
 
+/** 検索を配線しない NovelEditor 用途向けの安定 no-op。 */
+const noop = (): void => {};
+
 export default function NovelEditor({
   initialContent = "",
   onChange,
@@ -65,7 +80,14 @@ export default function NovelEditor({
   onSelectionChange,
   className,
   searchOpenTrigger = 0,
-  searchInitialTerm,
+  searchTerm = "",
+  onSearchTermChange = noop,
+  caseSensitive = false,
+  onCaseSensitiveChange = noop,
+  searchMatches = [],
+  currentMatchIndex = 0,
+  onCurrentMatchIndexChange = noop,
+  onSearchDialogOpenChange,
   onEditorViewReady,
   onShowAllSearchResults,
   lintingRuleRunner,
@@ -92,8 +114,6 @@ export default function NovelEditor({
   });
   const [isMounted, setIsMounted] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-  // コンテキストメニューの「検索」で渡された初期検索語
-  const [contextMenuSearchTerm, setContextMenuSearchTerm] = useState<string | undefined>(undefined);
   const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
   const {
     state: speechState,
@@ -181,11 +201,27 @@ export default function NovelEditor({
     setIsSearchOpen(true);
   }, []);
 
-  /** コンテキストメニューの「検索」アクションを処理する。選択テキストを初期検索語として渡す。 */
-  const handleFind = useCallback((initialTerm?: string) => {
-    setContextMenuSearchTerm(initialTerm);
-    setIsSearchOpen(true);
+  // フローティング検索窓の開閉を親へ通知する（ハイライト visibility ゲート用）。
+  useEffect(() => {
+    onSearchDialogOpenChange?.(isSearchOpen);
+  }, [isSearchOpen, onSearchDialogOpenChange]);
+
+  // pane アンマウント時（タブ閉じ等）に「閉じた」と通知し、ハイライトの取り残しを防ぐ。
+  useEffect(() => {
+    return () => onSearchDialogOpenChange?.(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  /** コンテキストメニューの「検索」アクションを処理する。選択テキストを共有検索語へ反映する。 */
+  const handleFind = useCallback(
+    (initialTerm?: string) => {
+      if (initialTerm !== undefined) {
+        onSearchTermChange(initialTerm);
+      }
+      setIsSearchOpen(true);
+    },
+    [onSearchTermChange],
+  );
 
   const clearHighlight = useCallback(() => {
     cancelSpeechScroll();
@@ -571,11 +607,16 @@ export default function NovelEditor({
 
       {/* 検索ダイアログ */}
       <SearchDialog
-        editorView={editorViewInstance}
         isOpen={isSearchOpen}
         onClose={() => setIsSearchOpen(false)}
         onShowAllResults={onShowAllSearchResults}
-        initialSearchTerm={contextMenuSearchTerm ?? searchInitialTerm}
+        searchTerm={searchTerm}
+        onSearchTermChange={onSearchTermChange}
+        caseSensitive={caseSensitive}
+        onCaseSensitiveChange={onCaseSensitiveChange}
+        matches={searchMatches}
+        currentMatchIndex={currentMatchIndex}
+        onCurrentMatchIndexChange={onCurrentMatchIndexChange}
         anchorRef={searchButtonRef}
       />
     </div>

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -163,6 +163,19 @@ interface EditorLayoutProps {
     ) => void;
     searchOpenTrigger: number;
     searchInitialTerm?: string;
+    // 共有検索 state（SearchDialog を controlled 化）
+    searchTerm: string;
+    caseSensitive: boolean;
+    searchMatches: React.ComponentProps<typeof NovelEditor>["searchMatches"];
+    currentMatchIndex: number;
+    onSearchTermChange: React.ComponentProps<typeof NovelEditor>["onSearchTermChange"];
+    onCaseSensitiveChange: React.ComponentProps<typeof NovelEditor>["onCaseSensitiveChange"];
+    onCurrentMatchIndexChange: React.ComponentProps<
+      typeof NovelEditor
+    >["onCurrentMatchIndexChange"];
+    onSearchDialogOpenChange: NonNullable<
+      React.ComponentProps<typeof NovelEditor>["onSearchDialogOpenChange"]
+    >;
     setEditorViewInstance: NonNullable<
       React.ComponentProps<typeof NovelEditor>["onEditorViewReady"]
     >;
@@ -471,6 +484,14 @@ export default function EditorLayout({
                                   onSelectionChange={mainArea.onSelectionChange}
                                   searchOpenTrigger={panelSearchOpenTrigger}
                                   searchInitialTerm={panelSearchInitialTerm}
+                                  searchTerm={mainArea.searchTerm}
+                                  onSearchTermChange={mainArea.onSearchTermChange}
+                                  caseSensitive={mainArea.caseSensitive}
+                                  onCaseSensitiveChange={mainArea.onCaseSensitiveChange}
+                                  searchMatches={mainArea.searchMatches}
+                                  currentMatchIndex={mainArea.currentMatchIndex}
+                                  onCurrentMatchIndexChange={mainArea.onCurrentMatchIndexChange}
+                                  onSearchDialogOpenChange={mainArea.onSearchDialogOpenChange}
                                   onEditorViewReady={mainArea.setEditorViewInstance}
                                   onShowAllSearchResults={mainArea.handleShowAllSearchResults}
                                   lintingRuleRunner={mainArea.ruleRunner}

--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -3,21 +3,25 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { Search, X, ChevronUp, ChevronDown, List } from "lucide-react";
-import { EditorView, Decoration } from "@milkdown/prose/view";
-import { TextSelection } from "@milkdown/prose/state";
-import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
 import { computeAnchorPos } from "@/lib/search-dialog/compute-anchor-pos";
-import { findSearchMatches, type SearchMatch } from "@/lib/editor-page/find-search-matches";
+import type { SearchMatch } from "@/lib/editor-page/find-search-matches";
 
 const DIALOG_WIDTH = 320; // w-80 と一致させる
 const DIALOG_PADDING = 16; // 8px top offset / 16px right offset の元値と整合
 
 interface SearchDialogProps {
-  editorView: EditorView | null;
   isOpen: boolean;
   onClose: () => void;
-  onShowAllResults?: (matches: SearchMatch[], searchTerm: string) => void;
-  initialSearchTerm?: string;
+  /** サイドバー検索パネルを開く（共有 state を表示）。 */
+  onShowAllResults?: () => void;
+  /** 共有検索 state（単一 source of truth）。SearchResults と同期する。 */
+  searchTerm: string;
+  onSearchTermChange: (term: string) => void;
+  caseSensitive: boolean;
+  onCaseSensitiveChange: (value: boolean) => void;
+  matches: SearchMatch[];
+  currentMatchIndex: number;
+  onCurrentMatchIndexChange: (index: number) => void;
   /** エディタ領域の ref。ダイアログ初期位置計算に使用する。
    *  dockview の CSS transform が position:fixed の containing block を破壊するため、
    *  portal + getBoundingClientRect() でエディタ基準の座標を求める。 */
@@ -27,17 +31,18 @@ interface SearchDialogProps {
 export type { SearchMatch };
 
 export default function SearchDialog({
-  editorView,
   isOpen,
   onClose,
   onShowAllResults,
-  initialSearchTerm,
+  searchTerm,
+  onSearchTermChange,
+  caseSensitive,
+  onCaseSensitiveChange,
+  matches,
+  currentMatchIndex,
+  onCurrentMatchIndexChange,
   anchorRef,
 }: SearchDialogProps) {
-  const [searchTerm, setSearchTerm] = useState("");
-  const [matches, setMatches] = useState<SearchMatch[]>([]);
-  const [currentMatchIndex, setCurrentMatchIndex] = useState(-1);
-  const [caseSensitive, setCaseSensitive] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
 
@@ -123,13 +128,6 @@ export default function SearchDialog({
     document.addEventListener("mouseup", handleMouseUp);
   }, []);
 
-  // initialSearchTerm が変わったら検索語を上書き
-  useEffect(() => {
-    if (initialSearchTerm) {
-      setSearchTerm(initialSearchTerm);
-    }
-  }, [initialSearchTerm]);
-
   // ダイアログ表示時に検索入力へフォーカスする
   useEffect(() => {
     if (isOpen && searchInputRef.current) {
@@ -138,59 +136,17 @@ export default function SearchDialog({
     }
   }, [isOpen]);
 
-  // 文書内の一致箇所を検索する
-  useEffect(() => {
-    if (!editorView || !searchTerm) {
-      setMatches([]);
-      setCurrentMatchIndex(-1);
-      return;
-    }
-
-    const { state } = editorView;
-    const { doc } = state;
-    const foundMatches = findSearchMatches(doc, searchTerm, caseSensitive);
-    setMatches(foundMatches);
-    setCurrentMatchIndex(foundMatches.length > 0 ? 0 : -1);
-  }, [searchTerm, caseSensitive, editorView]);
-
-  // 検索ハイライト装飾
-  useEffect(() => {
-    if (!editorView) return;
-
-    const { state, dispatch } = editorView;
-    const decorations: Decoration[] = [];
-
-    // すべてのマッチ項目に背景ハイライトを追加
-    matches.forEach((match, index) => {
-      const isCurrentMatch = index === currentMatchIndex;
-      decorations.push(
-        Decoration.inline(match.from, match.to, {
-          class: isCurrentMatch ? "search-result-current" : "search-result",
-        }),
-      );
-    });
-
-    // meta を使用して装飾情報を渡す
-    const tr = state.tr.setMeta("searchDecorations", decorations);
-    dispatch(tr);
-
-    // 現在のマッチ項目までスクロール
-    if (currentMatchIndex !== -1 && matches[currentMatchIndex]) {
-      const match = matches[currentMatchIndex];
-      const tr2 = state.tr.setSelection(TextSelection.create(state.doc, match.from, match.from));
-      dispatch(tr2);
-      centerEditorPosition(editorView, match.from);
-    }
-  }, [currentMatchIndex, matches, editorView]);
+  // マッチ検出とハイライト適用は app/page.tsx の useSearchHighlight に集約済み。
+  // ここは共有 state を表示し、入力・ナビを上流へ転送するだけの controlled UI。
 
   const goToNextMatch = () => {
     if (matches.length === 0) return;
-    setCurrentMatchIndex((prev) => (prev + 1) % matches.length);
+    onCurrentMatchIndexChange((currentMatchIndex + 1) % matches.length);
   };
 
   const goToPreviousMatch = () => {
     if (matches.length === 0) return;
-    setCurrentMatchIndex((prev) => (prev - 1 + matches.length) % matches.length);
+    onCurrentMatchIndexChange((currentMatchIndex - 1 + matches.length) % matches.length);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -207,7 +163,7 @@ export default function SearchDialog({
 
   const handleShowAllResults = () => {
     if (matches.length > 0 && searchTerm && onShowAllResults) {
-      onShowAllResults(matches, searchTerm);
+      onShowAllResults();
     }
   };
 
@@ -244,7 +200,7 @@ export default function SearchDialog({
             ref={searchInputRef}
             type="text"
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => onSearchTermChange(e.target.value)}
             placeholder="検索..."
             className="w-full px-3 py-2 pr-20 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
           />
@@ -280,7 +236,7 @@ export default function SearchDialog({
           <input
             type="checkbox"
             checked={caseSensitive}
-            onChange={(e) => setCaseSensitive(e.target.checked)}
+            onChange={(e) => onCaseSensitiveChange(e.target.checked)}
             className="rounded"
           />
           大文字小文字を区別

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,107 +1,41 @@
 "use client";
 
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useState, useRef, useCallback } from "react";
 import { Search, X, Replace, ReplaceAll, ChevronRight, ChevronDown } from "lucide-react";
-import { EditorView, Decoration } from "@milkdown/prose/view";
-import { TextSelection } from "@milkdown/prose/state";
+import type { EditorView } from "@milkdown/prose/view";
 import clsx from "clsx";
-import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
-import { findSearchMatches, type SearchMatch } from "@/lib/editor-page/find-search-matches";
-
-// #1507: After tab switch, the parent's editorViewInstance may still
-// reference a destroyed EditorView for a short window before the new
-// editor's view is ready. ProseMirror sets `docView` to null on destroy.
-// Dispatching on a destroyed view routes through Milkdown plugins whose
-// context has been torn down, throwing "Context editorState not found".
-function isEditorViewAlive(view: EditorView | null): view is EditorView {
-  return view !== null && (view as unknown as { docView: unknown }).docView !== null;
-}
+import { isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
+import { type SearchMatch } from "@/lib/editor-page/find-search-matches";
 
 interface SearchResultsProps {
   editorView: EditorView | null;
-  matches?: SearchMatch[];
-  searchTerm?: string;
+  /** 共有検索 state（単一 source of truth）。SearchDialog と同期する。
+   *  マッチ検出・ハイライト適用は app/page.tsx の useSearchHighlight に集約済み。 */
+  searchTerm: string;
+  onSearchTermChange: (term: string) => void;
+  caseSensitive: boolean;
+  onCaseSensitiveChange: (value: boolean) => void;
+  matches: SearchMatch[];
+  currentMatchIndex: number;
+  onCurrentMatchIndexChange: (index: number) => void;
   onClose: () => void;
 }
 
 export default function SearchResults({
   editorView,
-  matches: initialMatches,
-  searchTerm: initialSearchTerm,
+  searchTerm,
+  onSearchTermChange,
+  caseSensitive,
+  onCaseSensitiveChange,
+  matches,
+  onCurrentMatchIndexChange,
   onClose,
 }: SearchResultsProps) {
-  const [searchTerm, setSearchTerm] = useState(initialSearchTerm || "");
+  // 置換は SearchResults 固有のローカル UI 状態。
   const [replaceTerm, setReplaceTerm] = useState("");
-  const [matches, setMatches] = useState<SearchMatch[]>(initialMatches || []);
-  const [caseSensitive, setCaseSensitive] = useState(false);
   const [showReplace, setShowReplace] = useState(true);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // #1502: Sync incoming props → state during render (React-recommended
-  // "derived state" pattern). useState only reads the initializer on mount,
-  // so without this an already-mounted SearchResults silently ignores props
-  // pushed by SearchDialog's "すべての検索結果を表示" button. Using render-time
-  // detection (vs useEffect) avoids the extra-render flush delay that breaks
-  // jsdom tests and trips React 18+ act() expectations.
-  const [lastInitialSearchTerm, setLastInitialSearchTerm] = useState(initialSearchTerm);
-  if (initialSearchTerm !== lastInitialSearchTerm) {
-    setLastInitialSearchTerm(initialSearchTerm);
-    if (initialSearchTerm !== undefined) {
-      setSearchTerm(initialSearchTerm);
-    }
-  }
-
-  const [lastInitialMatches, setLastInitialMatches] = useState(initialMatches);
-  if (initialMatches !== lastInitialMatches) {
-    setLastInitialMatches(initialMatches);
-    if (initialMatches !== undefined) {
-      setMatches(initialMatches);
-    }
-  }
-
-  // 文書内の一致箇所を検索する
-  useEffect(() => {
-    // #1502: when there's no editor, leave matches as-is so prop-sourced
-    // initialMatches survive. Local recompute only runs against a real editor.
-    // #1507: also guard against destroyed views during tab switch.
-    if (!isEditorViewAlive(editorView)) {
-      return;
-    }
-    if (!searchTerm) {
-      setMatches([]);
-      try {
-        const { state, dispatch } = editorView;
-        const tr = state.tr.setMeta("searchDecorations", []);
-        dispatch(tr);
-      } catch {
-        // Best-effort cleanup — view may have been destroyed mid-dispatch.
-      }
-      return;
-    }
-
-    const { state, dispatch } = editorView;
-    const { doc } = state;
-
-    // Use the shared ProseMirror-position-aware matcher. A previous
-    // textContent-based implementation drifted past hardbreaks (leafText "\n")
-    // and ruby atoms, highlighting the wrong characters.
-    const foundMatches = findSearchMatches(doc, searchTerm, caseSensitive);
-
-    setMatches(foundMatches);
-
-    // Apply highlight decorations
-    const decorations: Decoration[] = foundMatches.map((m) =>
-      Decoration.inline(m.from, m.to, {
-        class: "search-result",
-      }),
-    );
-    try {
-      const tr = state.tr.setMeta("searchDecorations", decorations);
-      dispatch(tr);
-    } catch {
-      // #1507: view torn down mid-search — decorations go with it.
-    }
-  }, [searchTerm, caseSensitive, editorView]);
   // Get context text for match
   const getMatchContext = useCallback(
     (match: SearchMatch): { before: string; text: string; after: string } => {
@@ -134,37 +68,19 @@ export default function SearchResults({
     [editorView],
   );
 
-  // Jump to specified match and highlight
+  // Jump to specified match. 現在マッチ index を共有 state へ反映すると
+  // useSearchHighlight が強調・スクロールを担当する。
   const goToMatch = useCallback(
-    (match: SearchMatch, index: number) => {
+    (_match: SearchMatch, index: number) => {
       if (!isEditorViewAlive(editorView)) return;
-
-      const { state, dispatch } = editorView;
-
-      // Create decoration to mark this match as current
-      const decorations: Decoration[] = [];
-      matches.forEach((m, i) => {
-        const isCurrentMatch = i === index;
-        decorations.push(
-          Decoration.inline(m.from, m.to, {
-            class: isCurrentMatch ? "search-result-current" : "search-result",
-          }),
-        );
-      });
-
-      // Pass decoration info via meta
-      const tr = state.tr.setMeta("searchDecorations", decorations);
-
-      const selectTr = tr.setSelection(TextSelection.create(tr.doc, match.from, match.from));
-      dispatch(selectTr);
-      centerEditorPosition(editorView, match.from);
-
+      onCurrentMatchIndexChange(index);
       editorView.focus();
     },
-    [editorView, matches],
+    [editorView, onCurrentMatchIndexChange],
   );
 
-  // Replace single match
+  // Replace single match. 置換後の再マッチは page 側 useMemo（content 依存）が
+  // 自動で行うため、旧来の setTimeout 再検索ハックは不要。
   const replaceMatch = useCallback(
     (match: SearchMatch) => {
       if (!isEditorViewAlive(editorView)) return;
@@ -172,14 +88,8 @@ export default function SearchResults({
       const { state, dispatch } = editorView;
       const tr = state.tr.replaceWith(match.from, match.to, state.schema.text(replaceTerm));
       dispatch(tr);
-
-      // Re-search
-      setTimeout(() => {
-        setSearchTerm(searchTerm + " ");
-        setTimeout(() => setSearchTerm(searchTerm.trim()), 0);
-      }, 100);
     },
-    [editorView, replaceTerm, searchTerm],
+    [editorView, replaceTerm],
   );
 
   // Replace all matches
@@ -197,11 +107,10 @@ export default function SearchResults({
 
     dispatch(tr);
 
-    // Clear search
-    setMatches([]);
-    setSearchTerm("");
+    // 検索語をクリア → matches が空になり、useSearchHighlight がハイライトを消す。
+    onSearchTermChange("");
     setReplaceTerm("");
-  }, [editorView, matches, replaceTerm]);
+  }, [editorView, matches, replaceTerm, onSearchTermChange]);
 
   return (
     <div className="h-full bg-background-secondary border-r border-border flex flex-col">
@@ -228,7 +137,7 @@ export default function SearchResults({
             ref={searchInputRef}
             type="text"
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => onSearchTermChange(e.target.value)}
             placeholder="検索..."
             className="w-full px-3 py-2 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
           />
@@ -240,7 +149,7 @@ export default function SearchResults({
             <input
               type="checkbox"
               checked={caseSensitive}
-              onChange={(e) => setCaseSensitive(e.target.checked)}
+              onChange={(e) => onCaseSensitiveChange(e.target.checked)}
               className="rounded"
             />
             大文字小文字を区別

--- a/components/SidebarPanel.tsx
+++ b/components/SidebarPanel.tsx
@@ -26,8 +26,14 @@ interface SidebarPanelProps {
   onChapterClick: (anchorId: string) => void;
   /** Called when the editor should insert text at the current cursor. */
   onInsertText: (text: string) => void;
-  /** Current search results for the search panel. */
-  searchResults: { matches: { from: number; to: number }[]; searchTerm: string } | null;
+  /** 共有検索 state（単一 source of truth）。SearchDialog と同期する。 */
+  searchTerm: string;
+  onSearchTermChange: (term: string) => void;
+  caseSensitive: boolean;
+  onCaseSensitiveChange: (value: boolean) => void;
+  searchMatches: { from: number; to: number }[];
+  currentMatchIndex: number;
+  onCurrentMatchIndexChange: (index: number) => void;
   /** Called when the search panel should close. */
   onCloseSearchResults: () => void;
   /** The active ProseMirror EditorView (required by the search panel). */
@@ -59,7 +65,13 @@ export default function SidebarPanel({
   compactMode,
   onChapterClick,
   onInsertText,
-  searchResults,
+  searchTerm,
+  onSearchTermChange,
+  caseSensitive,
+  onCaseSensitiveChange,
+  searchMatches,
+  currentMatchIndex,
+  onCurrentMatchIndexChange,
   onCloseSearchResults,
   editorViewInstance,
   dictionarySearchTrigger,
@@ -104,8 +116,13 @@ export default function SidebarPanel({
       return (
         <SearchResults
           editorView={editorViewInstance}
-          matches={searchResults?.matches}
-          searchTerm={searchResults?.searchTerm}
+          searchTerm={searchTerm}
+          onSearchTermChange={onSearchTermChange}
+          caseSensitive={caseSensitive}
+          onCaseSensitiveChange={onCaseSensitiveChange}
+          matches={searchMatches}
+          currentMatchIndex={currentMatchIndex}
+          onCurrentMatchIndexChange={onCurrentMatchIndexChange}
           onClose={onCloseSearchResults}
         />
       );

--- a/components/__tests__/SearchResults-destroyed-view.test.tsx
+++ b/components/__tests__/SearchResults-destroyed-view.test.tsx
@@ -25,6 +25,15 @@ vi.mock("@/lib/editor-page/center-editor-position", () => ({
 
 import SearchResults from "../SearchResults";
 
+// 共有検索 state の controlled props（このテストでは検索ナビ自体は検証しない）。
+const controlled = {
+  onSearchTermChange: () => {},
+  caseSensitive: false,
+  onCaseSensitiveChange: () => {},
+  currentMatchIndex: 0,
+  onCurrentMatchIndexChange: () => {},
+} as const;
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -64,7 +73,13 @@ describe("SearchResults – destroyed editor view (#1507)", () => {
     expect(() => {
       act(() => {
         root.render(
-          <SearchResults editorView={destroyed} onClose={() => {}} searchTerm="" matches={[]} />,
+          <SearchResults
+            editorView={destroyed}
+            {...controlled}
+            onClose={() => {}}
+            searchTerm=""
+            matches={[]}
+          />,
         );
       });
     }).not.toThrow();
@@ -76,6 +91,7 @@ describe("SearchResults – destroyed editor view (#1507)", () => {
       root.render(
         <SearchResults
           editorView={destroyed}
+          {...controlled}
           onClose={() => {}}
           searchTerm="foo"
           matches={[{ from: 1, to: 4 }]}
@@ -87,7 +103,13 @@ describe("SearchResults – destroyed editor view (#1507)", () => {
     expect(() => {
       act(() => {
         root.render(
-          <SearchResults editorView={destroyed} onClose={() => {}} searchTerm="" matches={[]} />,
+          <SearchResults
+            editorView={destroyed}
+            {...controlled}
+            onClose={() => {}}
+            searchTerm=""
+            matches={[]}
+          />,
         );
       });
     }).not.toThrow();
@@ -97,13 +119,25 @@ describe("SearchResults – destroyed editor view (#1507)", () => {
     const destroyed = makeDestroyedView();
     act(() => {
       root.render(
-        <SearchResults editorView={null} onClose={() => {}} searchTerm="foo" matches={[]} />,
+        <SearchResults
+          editorView={null}
+          {...controlled}
+          onClose={() => {}}
+          searchTerm="foo"
+          matches={[]}
+        />,
       );
     });
     expect(() => {
       act(() => {
         root.render(
-          <SearchResults editorView={destroyed} onClose={() => {}} searchTerm="foo" matches={[]} />,
+          <SearchResults
+            editorView={destroyed}
+            {...controlled}
+            onClose={() => {}}
+            searchTerm="foo"
+            matches={[]}
+          />,
         );
       });
     }).not.toThrow();

--- a/components/__tests__/SearchResults-prop-sync.test.tsx
+++ b/components/__tests__/SearchResults-prop-sync.test.tsx
@@ -44,18 +44,28 @@ afterEach(() => {
  * Wrapper that simulates SidebarPanel's behavior: SearchResults is kept
  * mounted while its props change (the exact scenario from #1502).
  *
- * Note: SearchResults's public prop names are `searchTerm` / `matches`
- * (destructured internally as `initialSearchTerm` / `initialMatches`).
+ * SearchResults is now fully controlled — `searchTerm` / `matches` come
+ * straight from the shared search state in app/page.tsx.
  */
 function Wrapper({
-  searchTerm,
-  matches,
+  searchTerm = "",
+  matches = [],
 }: {
   searchTerm?: string;
   matches?: { from: number; to: number }[];
 }) {
   return (
-    <SearchResults editorView={null} onClose={() => {}} searchTerm={searchTerm} matches={matches} />
+    <SearchResults
+      editorView={null}
+      searchTerm={searchTerm}
+      onSearchTermChange={() => {}}
+      caseSensitive={false}
+      onCaseSensitiveChange={() => {}}
+      matches={matches}
+      currentMatchIndex={0}
+      onCurrentMatchIndexChange={() => {}}
+      onClose={() => {}}
+    />
   );
 }
 

--- a/components/__tests__/search-dialog-anchor-wire.test.tsx
+++ b/components/__tests__/search-dialog-anchor-wire.test.tsx
@@ -48,9 +48,15 @@ function Wrapper({ withAnchor, isOpen }: { withAnchor: boolean; isOpen: boolean 
   const ref = useRef<HTMLButtonElement | null>(anchorEl);
   return (
     <SearchDialog
-      editorView={null}
       isOpen={isOpen}
       onClose={() => {}}
+      searchTerm=""
+      onSearchTermChange={() => {}}
+      caseSensitive={false}
+      onCaseSensitiveChange={() => {}}
+      matches={[]}
+      currentMatchIndex={0}
+      onCurrentMatchIndexChange={() => {}}
       anchorRef={withAnchor ? ref : undefined}
     />
   );

--- a/components/__tests__/search-dialog-drag-cleanup.test.tsx
+++ b/components/__tests__/search-dialog-drag-cleanup.test.tsx
@@ -17,8 +17,8 @@ import { createRoot, type Root } from "react-dom/client";
 import { act } from "react";
 import SearchDialog from "../SearchDialog";
 
-// SearchDialog は editorView を触る effect を持つので、null を渡して decoration path を no-op にする。
-// (editorView == null 時は matches/decorations effect が早期 return する)
+// SearchDialog は controlled 化され、マッチ検出・ハイライトは親（useSearchHighlight）へ
+// 移譲済み。ここでは drag/portal ライフサイクルのみを検証するため、検索 props は静的に渡す。
 
 let root: Root;
 let anchorEl: HTMLDivElement;
@@ -58,7 +58,18 @@ function render(isOpen: boolean) {
   const anchorRef = { current: anchorEl };
   act(() => {
     root.render(
-      <SearchDialog editorView={null} isOpen={isOpen} onClose={() => {}} anchorRef={anchorRef} />,
+      <SearchDialog
+        isOpen={isOpen}
+        onClose={() => {}}
+        searchTerm=""
+        onSearchTermChange={() => {}}
+        caseSensitive={false}
+        onCaseSensitiveChange={() => {}}
+        matches={[]}
+        currentMatchIndex={0}
+        onCurrentMatchIndexChange={() => {}}
+        anchorRef={anchorRef}
+      />,
     );
   });
 }

--- a/lib/editor-page/__tests__/use-search-highlight.test.tsx
+++ b/lib/editor-page/__tests__/use-search-highlight.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for useSearchHighlight — the single source of search-highlight dispatch.
+ *
+ * Covers the two behaviors introduced when SearchDialog / SearchResults were
+ * made controlled and stopped writing `searchDecorations` themselves:
+ *  1. Visibility gate: when no search UI is visible (or the term is empty /
+ *     there are no matches), decorations are cleared (empty dispatch).
+ *  2. Active highlight: when a search UI is visible with matches, the full set
+ *     is dispatched, current match emphasized.
+ *  3. #1507: a destroyed EditorView never throws.
+ */
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import type { EditorView } from "@milkdown/prose/view";
+
+// centerEditorPosition / TextSelection touch real ProseMirror layout — stub them.
+vi.mock("@/lib/editor-page/center-editor-position", () => ({
+  centerEditorPosition: vi.fn(),
+}));
+vi.mock("@milkdown/prose/state", () => ({
+  TextSelection: { create: vi.fn(() => ({})) },
+}));
+
+import { useSearchHighlight } from "../use-search-highlight";
+import type { SearchMatch } from "../find-search-matches";
+
+interface DispatchedMeta {
+  key: string;
+  value: unknown;
+}
+
+function makeView(alive: boolean): { view: EditorView; metas: DispatchedMeta[] } {
+  const metas: DispatchedMeta[] = [];
+  const tr = {
+    setMeta(key: string, value: unknown) {
+      metas.push({ key, value });
+      return tr;
+    },
+    setSelection() {
+      return tr;
+    },
+  };
+  const view = {
+    docView: alive ? {} : null,
+    state: { tr, doc: {} },
+    dispatch: vi.fn(),
+    focus: vi.fn(),
+  } as unknown as EditorView;
+  return { view, metas };
+}
+
+function decorationsDispatched(metas: DispatchedMeta[]): unknown[] | undefined {
+  const entry = metas.filter((m) => m.key === "searchDecorations").pop();
+  return entry?.value as unknown[] | undefined;
+}
+
+function Harness(props: {
+  view: EditorView | null;
+  matches: SearchMatch[];
+  currentMatchIndex: number;
+  searchTerm: string;
+  isSearchVisible: boolean;
+}) {
+  useSearchHighlight({
+    editorView: props.view,
+    matches: props.matches,
+    currentMatchIndex: props.currentMatchIndex,
+    searchTerm: props.searchTerm,
+    isSearchVisible: props.isSearchVisible,
+  });
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("useSearchHighlight – visibility gate (要求2)", () => {
+  it("clears decorations (empty dispatch) when no search UI is visible", () => {
+    const { view, metas } = makeView(true);
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={[{ from: 1, to: 2 }]}
+          currentMatchIndex={0}
+          searchTerm="foo"
+          isSearchVisible={false}
+        />,
+      );
+    });
+    expect(decorationsDispatched(metas)).toEqual([]);
+  });
+
+  it("clears decorations when the term is empty even if visible", () => {
+    const { view, metas } = makeView(true);
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={[]}
+          currentMatchIndex={0}
+          searchTerm=""
+          isSearchVisible={true}
+        />,
+      );
+    });
+    expect(decorationsDispatched(metas)).toEqual([]);
+  });
+
+  it("dispatches the full match set when visible with matches", () => {
+    const { view, metas } = makeView(true);
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={[
+            { from: 1, to: 2 },
+            { from: 5, to: 6 },
+          ]}
+          currentMatchIndex={1}
+          searchTerm="foo"
+          isSearchVisible={true}
+        />,
+      );
+    });
+    const dispatched = decorationsDispatched(metas);
+    expect(dispatched).toHaveLength(2);
+  });
+});
+
+describe("useSearchHighlight – destroyed view (#1507)", () => {
+  it("does not throw when the editorView is destroyed", () => {
+    const { view } = makeView(false /* docView = null */);
+    expect(() => {
+      act(() => {
+        root.render(
+          <Harness
+            view={view}
+            matches={[{ from: 1, to: 2 }]}
+            currentMatchIndex={0}
+            searchTerm="foo"
+            isSearchVisible={true}
+          />,
+        );
+      });
+    }).not.toThrow();
+  });
+});

--- a/lib/editor-page/use-panel-state.ts
+++ b/lib/editor-page/use-panel-state.ts
@@ -8,7 +8,12 @@ import type { SettingsCategory } from "@/components/SettingsModal";
 export interface PanelState {
   topView: ActivityBarView;
   bottomView: ActivityBarView;
-  searchResults: { matches: { from: number; to: number }[]; searchTerm: string } | null;
+  /** 単一の検索 source of truth。SearchDialog（フローティング窓）と SearchResults
+   *  （サイドパネル）の両方がこれを共有し、内容のズレを防ぐ。 */
+  searchTerm: string;
+  caseSensitive: boolean;
+  /** 現在フォーカス中のマッチ index。両 UI のナビ／クリックで共有更新する。 */
+  currentMatchIndex: number;
   isRightPanelCollapsed: boolean;
   dictionarySearchTrigger: { term: string; id: number };
   settingsInitialCategory: SettingsCategory | undefined;
@@ -29,7 +34,11 @@ export interface PanelHandlers {
     diff: { snapshotContent: string; currentContent: string; label: string } | null,
   ) => void;
   handleOpenDictionary: (searchTerm?: string) => void;
-  handleShowAllSearchResults: (matches: { from: number; to: number }[], searchTerm: string) => void;
+  setSearchTerm: (term: string) => void;
+  setCaseSensitive: Dispatch<SetStateAction<boolean>>;
+  setCurrentMatchIndex: Dispatch<SetStateAction<number>>;
+  /** サイドバー検索パネルを開く（共有 searchTerm をそのまま表示）。 */
+  handleShowAllSearchResults: () => void;
   handleCloseSearchResults: () => void;
   handleOpenLintingSettings: () => void;
   handleOpenPosHighlightSettings: () => void;
@@ -49,10 +58,9 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
 } {
   const [topView, setTopView] = useState<ActivityBarView>("explorer");
   const [bottomView, setBottomView] = useState<ActivityBarView>("none");
-  const [searchResults, setSearchResults] = useState<{
-    matches: { from: number; to: number }[];
-    searchTerm: string;
-  } | null>(null);
+  const [searchTerm, setSearchTermRaw] = useState("");
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
   const [isRightPanelCollapsed, setIsRightPanelCollapsed] = useState(false);
   const [dictionarySearchTrigger, setDictionarySearchTrigger] = useState<{
     term: string;
@@ -88,16 +96,17 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
     });
   }, []);
 
-  const handleShowAllSearchResults = useCallback(
-    (matches: { from: number; to: number }[], searchTerm: string) => {
-      setSearchResults({ matches, searchTerm });
-      setTopView("search");
-    },
-    [],
-  );
+  // 検索語変更時は現在マッチ index を先頭へリセットする。
+  const setSearchTerm = useCallback((term: string) => {
+    setSearchTermRaw(term);
+    setCurrentMatchIndex(0);
+  }, []);
+
+  const handleShowAllSearchResults = useCallback(() => {
+    setTopView("search");
+  }, []);
 
   const handleCloseSearchResults = useCallback(() => {
-    setSearchResults(null);
     setTopView("explorer");
   }, []);
 
@@ -119,7 +128,9 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
     state: {
       topView,
       bottomView,
-      searchResults,
+      searchTerm,
+      caseSensitive,
+      currentMatchIndex,
       isRightPanelCollapsed,
       dictionarySearchTrigger,
       settingsInitialCategory,
@@ -137,6 +148,9 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
       setRubySelectedText,
       setEditorDiff,
       handleOpenDictionary,
+      setSearchTerm,
+      setCaseSensitive,
+      setCurrentMatchIndex,
       handleShowAllSearchResults,
       handleCloseSearchResults,
       handleOpenLintingSettings,

--- a/lib/editor-page/use-search-highlight.ts
+++ b/lib/editor-page/use-search-highlight.ts
@@ -1,0 +1,89 @@
+import { useEffect } from "react";
+import { Decoration, type EditorView } from "@milkdown/prose/view";
+import { TextSelection } from "@milkdown/prose/state";
+import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
+import type { SearchMatch } from "@/lib/editor-page/find-search-matches";
+
+/**
+ * #1507: After a tab switch the parent's editorView reference may briefly point
+ * at a destroyed EditorView (ProseMirror sets `docView` to null on destroy).
+ * Dispatching on it routes through torn-down Milkdown plugins and throws
+ * "Context editorState not found". This guard is the single chokepoint for that
+ * check now that highlight dispatch is centralized here.
+ */
+export function isEditorViewAlive(view: EditorView | null): view is EditorView {
+  return view !== null && (view as unknown as { docView: unknown }).docView !== null;
+}
+
+interface UseSearchHighlightParams {
+  editorView: EditorView | null;
+  matches: SearchMatch[];
+  /** 強調表示する現在のマッチ index。範囲外なら現在強調なし。 */
+  currentMatchIndex: number;
+  searchTerm: string;
+  /** いずれかの検索 UI（フローティング窓 or サイドパネル）が表示中か。
+   *  false になったら（＝両方とも非表示）ハイライトを消す。 */
+  isSearchVisible: boolean;
+}
+
+/**
+ * 検索ハイライト適用の唯一の場所。SearchDialog と SearchResults が各自で
+ * `searchDecorations` を dispatch していた double-writer 衝突を解消するため、
+ * 両 UI から dispatch ロジックを引き上げてここへ集約する。
+ *
+ * 責務:
+ *  1. `isEditorViewAlive` で破棄済み view をガード（#1507）
+ *  2. 検索 UI が非表示 or 検索語が空 → decorations を空 dispatch してクリア
+ *  3. それ以外 → 全マッチをハイライト（current は強調クラス）＋現在マッチへスクロール
+ */
+export function useSearchHighlight({
+  editorView,
+  matches,
+  currentMatchIndex,
+  searchTerm,
+  isSearchVisible,
+}: UseSearchHighlightParams): void {
+  useEffect(() => {
+    if (!isEditorViewAlive(editorView)) return;
+    const { state, dispatch } = editorView;
+
+    // 非表示時・検索語空時はハイライトを消す（要求2: 検索窓を閉じた／
+    // 検索パネル非表示でハイライト除去）。
+    if (!isSearchVisible || !searchTerm || matches.length === 0) {
+      try {
+        dispatch(state.tr.setMeta("searchDecorations", []));
+      } catch {
+        // view が dispatch 途中で破棄された場合のベストエフォート
+      }
+      return;
+    }
+
+    const decorations = matches.map((match, index) =>
+      Decoration.inline(match.from, match.to, {
+        class: index === currentMatchIndex ? "search-result-current" : "search-result",
+      }),
+    );
+
+    try {
+      dispatch(state.tr.setMeta("searchDecorations", decorations));
+    } catch {
+      // #1507: view が検索中に破棄された — decorations も一緒に消える
+    }
+
+    // 現在のマッチを画面中央へ。選択も移動して連続ナビを自然にする。
+    const current = matches[currentMatchIndex];
+    if (current) {
+      try {
+        const view = editorView;
+        view.dispatch(
+          view.state.tr.setSelection(
+            TextSelection.create(view.state.doc, current.from, current.from),
+          ),
+        );
+        centerEditorPosition(view, current.from);
+      } catch {
+        // 破棄済み view ではスクロール不要
+      }
+    }
+  }, [editorView, matches, currentMatchIndex, searchTerm, isSearchVisible]);
+}


### PR DESCRIPTION
## Summary

- 右上のフローティング検索窓（SearchDialog）と左サイドバーの検索パネル（SearchResults）が別々の検索内容を入力でき、UX が分裂していた問題を解消。検索語・大文字小文字区別・マッチ・現在位置を**単一の source of truth** に統一し、どちらで入力しても両UIが常に同期するようにした（置換は左パネルのみ）
- 検索窓を閉じた、または検索パネルを非表示にした（＝**どちらの検索UIも表示されていない**）ときに、エディタ上に残っていた検索ハイライトを消去するようにした
- 両UIが個別に `searchDecorations` を dispatch していた double-writer（ハイライトの相互上書き）を構造的に解消

## Changes

| 領域 | 内容 |
|---|---|
| `lib/editor-page/use-panel-state.ts` | 検索の source of truth（`searchTerm`/`caseSensitive`/`currentMatchIndex`）を集約。`setSearchTerm` はマッチ index を先頭リセット |
| `lib/editor-page/use-search-highlight.ts` (新規) | ハイライト適用を一本化。`#1507` 破棄view ガード集約 + visibility ゲート（非表示で空 dispatch）+ 現在マッチへスクロール |
| `app/page.tsx` | マッチ算出を `findSearchMatches` 再利用の `useMemo` に集約、`useSearchHighlight` 呼び出し、共有 state を両UIへ配線。`onWordSearch` を共有 setter へ統一 |
| `components/SearchDialog.tsx` / `SearchResults.tsx` | controlled 化。ローカル state とハイライト dispatch を撤去。置換は SearchResults に維持し再検索ハックを撤去。drag/portal/anchor は不変 |
| `components/Editor.tsx` / `EditorLayout.tsx` / `SidebarPanel.tsx` | 共有検索 props の配線、フローティング窓の開閉を親へ報告（visibility ゲート用） |
| `lib/editor-page/__tests__/use-search-highlight.test.tsx` (新規) ほか | visibility ゲート / 破棄view / controlled 化に追従したテスト更新・追加 |

不変条件として `#1502`(derived-state)・`#1507`(破棄EditorView)・ruby/hardbreak 対応（`findSearchMatches`）・SearchDialog の drag/anchor/portal を保全。

## Test plan

- [x] `npm run type-check` clean
- [x] 全テスト green（検索30件 + 新規 `use-search-highlight` 4件含む 1629 passed）
- [x] eslint / prettier clean
- [ ] 実機: ⌘F の検索窓に語を入力 → 左パネルを開くと同じ語・同じハイライト
- [ ] 実機: 片方で語/大文字小文字を変更 → もう片方に即反映
- [ ] 実機: 両検索UIを非表示にする → エディタのハイライトが消える。片方表示中は残る
- [ ] 実機: 左パネルの置換／全置換後にマッチ・ハイライトが自動更新される

🤖 Generated with [Claude Code](https://claude.com/claude-code)