### PR TITLE
feat(history): スナップショットのクリックで差分表示＋最初の差分へ自動スクロール

### DIFF
--- a/components/EditorDiffView.tsx
+++ b/components/EditorDiffView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { X } from "lucide-react";
 import { computeDiff, getDiffStats } from "@/lib/services/diff-service";
 import { useTypographySettings } from "@/contexts/EditorSettingsContext";
@@ -32,6 +32,17 @@ export default function EditorDiffView({
   );
 
   const stats = useMemo(() => getDiffStats(chunks), [chunks]);
+
+  // Auto-jump to the first change when the diff opens (or the snapshot changes).
+  const firstChangeRef = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    if (!firstChangeRef.current) return;
+    // Defer to the next frame so layout is settled before scrolling.
+    const id = requestAnimationFrame(() => {
+      firstChangeRef.current?.scrollIntoView({ block: "center", behavior: "auto" });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [chunks]);
 
   // Calculate max-width from charsPerLine using 1em approximation
   const maxWidth = charsPerLine > 0 ? `${charsPerLine}em` : undefined;
@@ -93,6 +104,7 @@ export default function EditorDiffView({
               chunks={chunks}
               textIndent={textIndent}
               paragraphSpacing={paragraphSpacing}
+              firstChangeRef={firstChangeRef}
             />
           )}
         </div>
@@ -109,16 +121,20 @@ function DiffContent({
   chunks,
   textIndent,
   paragraphSpacing,
+  firstChangeRef,
 }: {
   chunks: DiffChunk[];
   textIndent: number;
   paragraphSpacing: number;
+  firstChangeRef?: React.Ref<HTMLSpanElement>;
 }) {
   // Build paragraph-aware rendering:
   // Walk chunks, splitting on \n to create paragraph boundaries
   const elements: React.ReactNode[] = [];
   let currentParagraph: React.ReactNode[] = [];
   let paraIndex = 0;
+  // Attach the scroll anchor to the first rendered added/removed span.
+  let firstChangeAssigned = false;
 
   const flushParagraph = () => {
     if (currentParagraph.length > 0) {
@@ -155,8 +171,16 @@ function DiffContent({
       }
 
       if (text.length > 0) {
+        const isChange = chunk.type !== "unchanged";
+        const assignRef = isChange && !firstChangeAssigned;
+        if (assignRef) firstChangeAssigned = true;
         currentParagraph.push(
-          <DiffChunkSpan key={`c${ci}-l${li}`} type={chunk.type} value={text} />,
+          <DiffChunkSpan
+            key={`c${ci}-l${li}`}
+            type={chunk.type}
+            value={text}
+            innerRef={assignRef ? firstChangeRef : undefined}
+          />,
         );
       }
     }
@@ -168,13 +192,28 @@ function DiffContent({
   return <div>{elements}</div>;
 }
 
-function DiffChunkSpan({ type, value }: { type: DiffChunk["type"]; value: string }) {
+function DiffChunkSpan({
+  type,
+  value,
+  innerRef,
+}: {
+  type: DiffChunk["type"];
+  value: string;
+  innerRef?: React.Ref<HTMLSpanElement>;
+}) {
   switch (type) {
     case "added":
-      return <span className="bg-success/20 text-success border-b border-success/40">{value}</span>;
+      return (
+        <span ref={innerRef} className="bg-success/20 text-success border-b border-success/40">
+          {value}
+        </span>
+      );
     case "removed":
       return (
-        <span className="bg-error/20 text-error line-through border-b border-error/40">
+        <span
+          ref={innerRef}
+          className="bg-error/20 text-error line-through border-b border-error/40"
+        >
           {value}
         </span>
       );

--- a/components/HistoryPanel/SnapshotItem.tsx
+++ b/components/HistoryPanel/SnapshotItem.tsx
@@ -48,7 +48,21 @@ export default function SnapshotItem({
   }, [menuOpen]);
 
   return (
-    <div className="bg-background-secondary rounded-lg p-3 border border-border">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => {
+        if (!isLoadingDiff) onCompare(snapshot);
+      }}
+      onKeyDown={(e) => {
+        if ((e.key === "Enter" || e.key === " ") && !isLoadingDiff) {
+          e.preventDefault();
+          onCompare(snapshot);
+        }
+      }}
+      title="クリックで差分を表示"
+      className="bg-background-secondary rounded-lg p-3 border border-border cursor-pointer hover:border-accent/50 transition-colors"
+    >
       {/* Row 1: Time + type badge + char count */}
       <div className="flex items-center justify-between gap-2 mb-1.5">
         <div className="flex items-center gap-2 min-w-0">
@@ -82,7 +96,10 @@ export default function SnapshotItem({
         <div className="flex items-center gap-0.5 flex-shrink-0">
           {/* Bookmark button */}
           <button
-            onClick={() => onToggleBookmark(snapshot.id)}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleBookmark(snapshot.id);
+            }}
             className={clsx(
               "p-1 rounded transition-colors",
               isBookmarked
@@ -97,7 +114,10 @@ export default function SnapshotItem({
           {/* Three-dot menu */}
           <div className="relative" ref={menuRef}>
             <button
-              onClick={() => setMenuOpen((v) => !v)}
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuOpen((v) => !v);
+              }}
               className="p-1 rounded transition-colors text-foreground-tertiary hover:text-foreground-secondary hover:bg-hover"
               title="メニュー"
             >
@@ -107,7 +127,8 @@ export default function SnapshotItem({
             {menuOpen && (
               <div className="absolute right-0 bottom-full mb-1 z-10 min-w-[120px] rounded-lg border border-border bg-background-secondary shadow-lg py-1">
                 <button
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation();
                     setMenuOpen(false);
                     onRestore(snapshot);
                   }}
@@ -122,7 +143,8 @@ export default function SnapshotItem({
                   復元
                 </button>
                 <button
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation();
                     setMenuOpen(false);
                     onCompare(snapshot);
                   }}


### PR DESCRIPTION
## Summary

- 履歴の**スナップショットカードをクリックするだけで差分を表示**できるようにした（従来は ⋮ メニュー →「比較」が必要）。
- **差分ビューを開いたとき、最初の差分位置へ自動スクロール**するようにした。長文でも変更点まで一気に移動できる。

## Changes

| ファイル | 内容 |
| --- | --- |
| `components/HistoryPanel/SnapshotItem.tsx` | カード本体に `onClick → onCompare` を付与（`role=button` / Enter・Space 対応）。内部のブックマーク・メニュー・メニュー項目は `stopPropagation` でカードクリックと分離 |
| `components/EditorDiffView.tsx` | 最初の追加/削除スパンに ref を付け、表示時に `scrollIntoView({ block: "center" })` で自動ジャンプ |

## Test plan

- [x] type-check / lint / prettier 通過、既存テスト 143 件 green
- [ ] 実機: 履歴カードをクリックすると差分が開く（⋮ メニューの「比較」も従来どおり動作）
- [ ] 実機: 差分を開くと最初の変更箇所まで自動でスクロールする
- [ ] 実機: ブックマーク/⋮ ボタンを押してもカードの差分表示は起動しない

関連 issue なし（履歴 UX 改善）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)