### PR TITLE
fix(search): 検索窓を dockview パネル外へ移し入力が反映されないバグを修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -428,6 +428,21 @@ export default function EditorPage() {
     isSearchVisible,
   });
 
+  // フローティング検索窓は <main> のトップレベル（dockview パネル外）でレンダリングし、
+  // 開閉状態を page 側で持つ。dockview パネル内に置くと、パネルのクロージャが
+  // マウント時に凍結され searchTerm/matches など変化する値が pane へ届かず、入力が
+  // 反映されない（editorDiff 比較ビューを <main> へ移したのと同じ理由）。
+  const openSearchDialog = useCallback(() => setIsSearchDialogOpen(true), []);
+  const closeSearchDialog = useCallback(() => setIsSearchDialogOpen(false), []);
+  const toggleSearchDialog = useCallback(() => setIsSearchDialogOpen((v) => !v), []);
+
+  // ⌘F・辞書語検索などの外部トリガーで検索窓を開く（カウンタ増加で発火）。
+  useEffect(() => {
+    if (searchOpenTrigger > 0) {
+      setIsSearchDialogOpen(true);
+    }
+  }, [searchOpenTrigger]);
+
   // --- Ruby/TCY hook ---
   const { handleOpenRubyDialog, handleApplyRuby, handleToggleTcy } = useRubyTcy({
     editorViewRef,
@@ -1343,15 +1358,18 @@ export default function EditorPage() {
         },
         searchOpenTrigger,
         searchInitialTerm,
-        // 共有検索 state（SearchDialog を controlled 化）
+        // 共有検索 state（SearchDialog は <main> でレンダリング）
         searchTerm,
         caseSensitive,
         searchMatches,
         currentMatchIndex,
+        isSearchDialogOpen,
         onSearchTermChange: setSearchTerm,
         onCaseSensitiveChange: setCaseSensitive,
         onCurrentMatchIndexChange: setCurrentMatchIndex,
-        onSearchDialogOpenChange: setIsSearchDialogOpen,
+        onOpenSearchDialog: openSearchDialog,
+        onCloseSearchDialog: closeSearchDialog,
+        onToggleSearchDialog: toggleSearchDialog,
         setEditorViewInstance,
         handleShowAllSearchResults,
         ruleRunner,

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -11,7 +11,6 @@ import {
   getScrollProgress,
   setScrollProgress,
 } from "@/packages/milkdown-plugin-japanese-novel/scroll-progress";
-import SearchDialog, { type SearchMatch } from "./SearchDialog";
 import SelectionCounter from "./SelectionCounter";
 import EditorToolbar from "./editor/EditorToolbar";
 import MilkdownEditor from "./editor/MilkdownEditor";
@@ -30,22 +29,13 @@ interface EditorProps {
   onInsertText?: (text: string) => void;
   onSelectionChange?: (charCount: number, manuscriptCells: number, manuscriptPages: number) => void;
   className?: string;
-  searchOpenTrigger?: number;
-  searchInitialTerm?: string;
-  // 共有検索 state（単一 source of truth）。SearchResults と同期する。
-  // 検索を配線しない用途（非アクティブ pane プレビュー / popout window）向けに
-  // すべて optional とし、未指定時は no-op / 空デフォルトで動作する。
-  searchTerm?: string;
+  // フローティング検索窓（SearchDialog）は EditorLayout の <main> でレンダリングされる。
+  // Editor はツールバー検索ボタンとコンテキストメニュー「検索」から、共有 state への
+  // 反映と開閉だけを安定 callback で上流へ伝える（dockview 凍結クロージャでも安定 ref は機能）。
   onSearchTermChange?: (term: string) => void;
-  caseSensitive?: boolean;
-  onCaseSensitiveChange?: (value: boolean) => void;
-  searchMatches?: SearchMatch[];
-  currentMatchIndex?: number;
-  onCurrentMatchIndexChange?: (index: number) => void;
-  /** フローティング検索窓の開閉を親へ通知する（ハイライト visibility ゲート用）。 */
-  onSearchDialogOpenChange?: (open: boolean) => void;
+  onOpenSearchDialog?: () => void;
+  onToggleSearchDialog?: () => void;
   onEditorViewReady?: (view: EditorView) => void;
-  onShowAllSearchResults?: () => void;
   // リンティング設定
   lintingRuleRunner?: RuleRunnerLike | null;
   onLintIssuesUpdated?: (issues: LintIssue[]) => void;
@@ -79,17 +69,10 @@ export default function NovelEditor({
   onInsertText,
   onSelectionChange,
   className,
-  searchOpenTrigger = 0,
-  searchTerm = "",
   onSearchTermChange = noop,
-  caseSensitive = false,
-  onCaseSensitiveChange = noop,
-  searchMatches = [],
-  currentMatchIndex = 0,
-  onCurrentMatchIndexChange = noop,
-  onSearchDialogOpenChange,
+  onOpenSearchDialog = noop,
+  onToggleSearchDialog = noop,
   onEditorViewReady,
-  onShowAllSearchResults,
   lintingRuleRunner,
   onLintIssuesUpdated,
   onNlpError,
@@ -113,7 +96,6 @@ export default function NovelEditor({
     return localPreferences.getWritingMode() === "vertical";
   });
   const [isMounted, setIsMounted] = useState(false);
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
   const {
     state: speechState,
@@ -131,8 +113,8 @@ export default function NovelEditor({
   const speechMapRef = useRef<{ text: string; positions: number[] } | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const isVerticalRef = useRef(false);
-  // #1504: ref to the toolbar 検索 button — SearchDialog uses this to anchor
-  // its floating position to the clicked pane instead of the viewport corner.
+  // ツールバー検索ボタンの ref（EditorToolbar が利用）。検索窓のアンカーは
+  // EditorLayout 側でアクティブエディタ DOM を使うため、ここでは保持のみ。
   const searchButtonRef = useRef<HTMLButtonElement | null>(null);
   const [scrollContainerElement, setScrollContainerElement] = useState<HTMLDivElement | null>(null);
   /** Doc position to resume TTS from after the current chunk ends. null = no continuation. */
@@ -193,34 +175,15 @@ export default function NovelEditor({
   //
   // 将来、再マウント無しでファイル切替が必要なら、明確な fileId prop を追加して追跡可能
 
-  const handleSearchToggle = () => {
-    setIsSearchOpen((prev) => !prev);
-  };
-
-  const handleSearchOpen = useCallback(() => {
-    setIsSearchOpen(true);
-  }, []);
-
-  // フローティング検索窓の開閉を親へ通知する（ハイライト visibility ゲート用）。
-  useEffect(() => {
-    onSearchDialogOpenChange?.(isSearchOpen);
-  }, [isSearchOpen, onSearchDialogOpenChange]);
-
-  // pane アンマウント時（タブ閉じ等）に「閉じた」と通知し、ハイライトの取り残しを防ぐ。
-  useEffect(() => {
-    return () => onSearchDialogOpenChange?.(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  /** コンテキストメニューの「検索」アクションを処理する。選択テキストを共有検索語へ反映する。 */
+  /** コンテキストメニューの「検索」アクション。選択テキストを共有検索語へ反映して窓を開く。 */
   const handleFind = useCallback(
     (initialTerm?: string) => {
       if (initialTerm !== undefined) {
         onSearchTermChange(initialTerm);
       }
-      setIsSearchOpen(true);
+      onOpenSearchDialog();
     },
-    [onSearchTermChange],
+    [onSearchTermChange, onOpenSearchDialog],
   );
 
   const clearHighlight = useCallback(() => {
@@ -342,13 +305,6 @@ export default function NovelEditor({
     container.addEventListener("click", handleClick);
     return () => container.removeEventListener("click", handleClick);
   }, [startSpeechFromCursor]);
-
-  // 親からのトリガーで検索ダイアログを開く（ショートカット）
-  useEffect(() => {
-    if (searchOpenTrigger > 0) {
-      handleSearchOpen();
-    }
-  }, [searchOpenTrigger, handleSearchOpen]);
 
   // Track whether initial vertical scroll has been performed for this pane instance.
   const hasVerticalInitialScrollRef = useRef(false);
@@ -523,7 +479,7 @@ export default function NovelEditor({
       <EditorToolbar
         isVertical={isVertical}
         onToggleVertical={handleToggleVertical}
-        onSearchClick={handleSearchToggle}
+        onSearchClick={onToggleSearchDialog}
         searchButtonRef={searchButtonRef}
         speechState={speechState}
         onSpeakToggle={handleSpeakToggle}
@@ -604,21 +560,6 @@ export default function NovelEditor({
           containerElement={scrollContainerElement}
         />
       )}
-
-      {/* 検索ダイアログ */}
-      <SearchDialog
-        isOpen={isSearchOpen}
-        onClose={() => setIsSearchOpen(false)}
-        onShowAllResults={onShowAllSearchResults}
-        searchTerm={searchTerm}
-        onSearchTermChange={onSearchTermChange}
-        caseSensitive={caseSensitive}
-        onCaseSensitiveChange={onCaseSensitiveChange}
-        matches={searchMatches}
-        currentMatchIndex={currentMatchIndex}
-        onCurrentMatchIndexChange={onCurrentMatchIndexChange}
-        anchorRef={searchButtonRef}
-      />
     </div>
   );
 }

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -12,6 +12,7 @@ import NovelEditor from "@/components/Editor";
 import ResizablePanel from "@/components/ResizablePanel";
 import ExportDialog from "@/components/ExportDialog";
 import RubyDialog from "@/components/RubyDialog";
+import SearchDialog from "@/components/SearchDialog";
 import SettingsModal from "@/components/SettingsModal";
 import SidebarPanel from "@/components/SidebarPanel";
 import SidebarSplitter from "@/components/SidebarSplitter";
@@ -163,24 +164,25 @@ interface EditorLayoutProps {
     ) => void;
     searchOpenTrigger: number;
     searchInitialTerm?: string;
-    // 共有検索 state（SearchDialog を controlled 化）
+    // 共有検索 state。SearchDialog は dockview パネル外（<main>）でレンダリングする。
     searchTerm: string;
     caseSensitive: boolean;
-    searchMatches: React.ComponentProps<typeof NovelEditor>["searchMatches"];
+    searchMatches: React.ComponentProps<typeof SearchDialog>["matches"];
     currentMatchIndex: number;
-    onSearchTermChange: React.ComponentProps<typeof NovelEditor>["onSearchTermChange"];
-    onCaseSensitiveChange: React.ComponentProps<typeof NovelEditor>["onCaseSensitiveChange"];
+    isSearchDialogOpen: boolean;
+    onSearchTermChange: React.ComponentProps<typeof SearchDialog>["onSearchTermChange"];
+    onCaseSensitiveChange: React.ComponentProps<typeof SearchDialog>["onCaseSensitiveChange"];
     onCurrentMatchIndexChange: React.ComponentProps<
-      typeof NovelEditor
+      typeof SearchDialog
     >["onCurrentMatchIndexChange"];
-    onSearchDialogOpenChange: NonNullable<
-      React.ComponentProps<typeof NovelEditor>["onSearchDialogOpenChange"]
-    >;
+    onOpenSearchDialog: () => void;
+    onCloseSearchDialog: () => void;
+    onToggleSearchDialog: () => void;
     setEditorViewInstance: NonNullable<
       React.ComponentProps<typeof NovelEditor>["onEditorViewReady"]
     >;
     handleShowAllSearchResults: NonNullable<
-      React.ComponentProps<typeof NovelEditor>["onShowAllSearchResults"]
+      React.ComponentProps<typeof SearchDialog>["onShowAllResults"]
     >;
     ruleRunner: RuleRunnerLike | null;
     handleLintIssuesUpdated: (issues: LintIssue[]) => void;
@@ -446,10 +448,6 @@ export default function EditorLayout({
                         const panelFileType = (panelParams?.fileType ?? ".mdi") as string;
                         const panelEditorKey = panelParams?.editorKey ?? 0;
                         const panelActiveTabId = panelParams?.activeTabId ?? "";
-                        const panelSearchOpenTrigger = panelParams?.searchOpenTrigger ?? 0;
-                        const panelSearchInitialTerm = panelParams?.searchInitialTerm as
-                          | string
-                          | undefined;
                         const isActivePanel = panelBufferId === panelActiveTabId;
                         const panelMdiEnabled = panelFileType === ".mdi";
                         const panelGfmEnabled = panelFileType !== ".txt";
@@ -492,18 +490,13 @@ export default function EditorLayout({
                                   onChange={mainArea.handleChange}
                                   onInsertText={mainArea.handleInsertText}
                                   onSelectionChange={mainArea.onSelectionChange}
-                                  searchOpenTrigger={panelSearchOpenTrigger}
-                                  searchInitialTerm={panelSearchInitialTerm}
-                                  searchTerm={mainArea.searchTerm}
+                                  // 検索の入力/表示は <main> の SearchDialog が担当。
+                                  // pane へは「語を反映」「開く」「トグル」の安定 callback のみ渡す
+                                  // （dockview の凍結クロージャでも安定 ref は機能するため）。
                                   onSearchTermChange={mainArea.onSearchTermChange}
-                                  caseSensitive={mainArea.caseSensitive}
-                                  onCaseSensitiveChange={mainArea.onCaseSensitiveChange}
-                                  searchMatches={mainArea.searchMatches}
-                                  currentMatchIndex={mainArea.currentMatchIndex}
-                                  onCurrentMatchIndexChange={mainArea.onCurrentMatchIndexChange}
-                                  onSearchDialogOpenChange={mainArea.onSearchDialogOpenChange}
+                                  onOpenSearchDialog={mainArea.onOpenSearchDialog}
+                                  onToggleSearchDialog={mainArea.onToggleSearchDialog}
                                   onEditorViewReady={mainArea.setEditorViewInstance}
-                                  onShowAllSearchResults={mainArea.handleShowAllSearchResults}
                                   lintingRuleRunner={mainArea.ruleRunner}
                                   onLintIssuesUpdated={mainArea.handleLintIssuesUpdated}
                                   onNlpError={mainArea.handleNlpError}
@@ -577,6 +570,24 @@ export default function EditorLayout({
                     <span className="text-foreground-secondary text-sm">保存完了</span>
                   </div>
                 )}
+
+                {/* フローティング検索窓。dockview パネル外（<main> 直下）でレンダリング
+                    することで、共有検索 state（searchTerm/matches など変化する値）を
+                    live に受け取れる。portal で document.body 直下に出るため、anchorRef
+                    にはアクティブエディタの DOM を渡して初期位置を計算する。 */}
+                <SearchDialog
+                  isOpen={mainArea.isSearchDialogOpen}
+                  onClose={mainArea.onCloseSearchDialog}
+                  onShowAllResults={mainArea.handleShowAllSearchResults}
+                  searchTerm={mainArea.searchTerm}
+                  onSearchTermChange={mainArea.onSearchTermChange}
+                  caseSensitive={mainArea.caseSensitive}
+                  onCaseSensitiveChange={mainArea.onCaseSensitiveChange}
+                  matches={mainArea.searchMatches}
+                  currentMatchIndex={mainArea.currentMatchIndex}
+                  onCurrentMatchIndexChange={mainArea.onCurrentMatchIndexChange}
+                  anchorRef={mainArea.editorDomRef}
+                />
               </main>
 
               <ResizablePanel


### PR DESCRIPTION
## Summary

- 右上のフローティング検索窓に入力しても**表示されない**（左パネルとハイライトには反映される）、かつ**日本語IMEに非友好**な不具合を修正
- 直前の PR #1643（検索UIの状態同期）の回帰。dev のみで未リリースのため fix-forward で対応

## 根本原因

`SearchDialog` は **dockview パネル内**でレンダリングされており、dockview はパネルのクロージャを**マウント時に凍結**する。そのため：
- 安定 ref の callback（`setSearchTerm`）は発火する → 入力した語は page に届き、**左パネルとハイライトは更新される**
- しかし `searchTerm` / `searchMatches` など**変化する値は page→pane へ伝わらない** → controlled input の `value` が空のまま固まり、IME 合成も壊れる

これはコードベースに既出の問題で、`editorDiff`（比較ビュー）も同じ理由で dockview パネル外へ移されている（EditorLayout のコメント参照）。

## Changes

| ファイル | 内容 |
|---|---|
| `components/EditorLayout.tsx` | `SearchDialog` を `<main>` 直下（dockview パネル外）でレンダリングし、live な共有検索 state を受け取る。anchor はアクティブエディタ DOM（`editorDomRef`）。dockview の `NovelEditor` へは安定 callback のみ渡す |
| `app/page.tsx` | 検索窓の開閉状態を page 側（`isSearchDialogOpen`）へ集約。`searchOpenTrigger`→effect で開く。`onOpen`/`onClose`/`onToggle` ハンドラを追加 |
| `components/Editor.tsx` | `SearchDialog` のレンダリングと開閉ローカル state を撤去。ツールバー検索ボタン／コンテキストメニュー「検索」は安定 callback 経由で page に委譲 |

要求1（2窓の同期）・要求2（非表示でハイライト消去）は維持。`findSearchMatches`・`useSearchHighlight`・visibility ゲートは不変。

## Test plan

- [x] `npm run type-check` clean
- [x] 全テスト green（1639 passed）
- [x] eslint / prettier clean（既存 warning のみ、0 errors）
- [ ] 実機: 右上検索窓に「はな」と入力 → **窓内に表示され**、エディタがハイライト、左パネルも同期
- [ ] 実機: 日本語IMEで変換入力しても文字が消えない／確定できる
- [ ] 実機: ⌘F・コンテキストメニュー「検索」・辞書語検索から窓が開く
- [ ] 実機: 窓を閉じ、検索パネルも非表示 → ハイライトが消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)