### PR TITLE
feat(search): 検索パネルを全面強化

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,7 @@ import { usePowerSaving } from "@/lib/editor-page/use-power-saving";
 import { useIgnoredCorrections } from "@/lib/editor-page/use-ignored-corrections";
 import { useKeyboardShortcuts } from "@/lib/editor-page/use-keyboard-shortcuts";
 import { usePanelState } from "@/lib/editor-page/use-panel-state";
-import { findSearchMatches } from "@/lib/editor-page/find-search-matches";
+import { findSearchMatches, type SearchRange } from "@/lib/editor-page/find-search-matches";
 import { useSearchHighlight, isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
 import { useSaveToast } from "@/lib/editor-page/use-save-toast";
 import { useTerminalTabs } from "@/lib/editor-page/use-terminal-tabs";
@@ -212,6 +212,12 @@ export default function EditorPage() {
     bottomView,
     searchTerm,
     caseSensitive,
+    regexSearch,
+    wholeWordSearch,
+    normalizeVariants,
+    excludeComments,
+    searchTarget,
+    selectionOnly,
     currentMatchIndex,
     isRightPanelCollapsed,
     dictionarySearchTrigger,
@@ -232,6 +238,12 @@ export default function EditorPage() {
     handleOpenDictionary,
     setSearchTerm,
     setCaseSensitive,
+    setRegexSearch,
+    setWholeWordSearch,
+    setNormalizeVariants,
+    setExcludeComments,
+    setSearchTarget,
+    setSelectionOnly,
     setCurrentMatchIndex,
     handleShowAllSearchResults,
     handleCloseSearchResults,
@@ -293,6 +305,21 @@ export default function EditorPage() {
   // Keep a live tabs ref for dockview panel renderers captured by stale closures.
   const tabsRef = useRef(tabs);
   tabsRef.current = tabs;
+  const handleProjectSearchBufferChange = useCallback(
+    (path: string, nextContent: string) => {
+      const tab = tabsRef.current.find(
+        (candidate) => isEditorTab(candidate) && candidate.file?.path === path,
+      );
+      if (!tab || !isEditorTab(tab)) return;
+      updateTab(tab.id, {
+        content: nextContent,
+        isDirty: true,
+        fileSyncStatus: "dirty",
+        pendingExternalContent: nextContent,
+      });
+    },
+    [updateTab],
+  );
 
   const { diffTabContextValue, handleCloseTabWithPtyCleanup } = useDiffTabs({
     tabs,
@@ -352,6 +379,15 @@ export default function EditorPage() {
   // Derive editor mode from active tab's fileType
   const activeTab = tabs.find((t) => t.id === activeTabId);
   const activeEditorTab = activeTab && isEditorTab(activeTab) ? activeTab : undefined;
+  const projectSearchBuffers = useMemo(
+    () =>
+      new Map(
+        tabs.flatMap((tab) =>
+          isEditorTab(tab) && tab.file?.path ? [[tab.file.path, tab.content] as const] : [],
+        ),
+      ),
+    [tabs],
+  );
   const activeFileType = activeEditorTab?.fileType ?? ".mdi";
   const mdiExtensionsEnabled = activeFileType === ".mdi";
   const gfmEnabled = activeFileType !== ".txt";
@@ -397,6 +433,7 @@ export default function EditorPage() {
   const [selectedManuscriptCells, setSelectedManuscriptCells] = useState(0);
   const [selectedManuscriptPages, setSelectedManuscriptPages] = useState(0);
   const [selectedWord, setSelectedWord] = useState<string | null>(null);
+  const [searchSelectionRange, setSearchSelectionRange] = useState<SearchRange | null>(null);
   const { menu: tabBarMenu, show: showTabBarMenu, close: closeTabBarMenu } = useContextMenu();
   const hasAutoRecoveredRef = useRef(false);
   const [editorViewInstance, setEditorViewInstanceRaw] = useState<EditorView | null>(null);
@@ -409,16 +446,37 @@ export default function EditorPage() {
   // --- 検索ハイライトの単一ソース ---
   // いずれかの検索 UI が表示中か。両方非表示ならハイライトを消す（要求2）。
   const isSearchVisible = isSearchDialogOpen || topView === "search";
-  // 共有 searchTerm/caseSensitive からマッチを算出（唯一の計算箇所）。
+  // 共有 searchTerm/options からマッチを算出（唯一の計算箇所）。
   // `content` を依存に含め、置換や編集で doc が変わった時に再計算させる。
   // 非表示・空語の時は計算をスキップし空配列を返す。
   const searchMatches = useMemo(() => {
     if (!isSearchVisible || !searchTerm || !isEditorViewAlive(editorViewInstance)) {
       return [];
     }
-    return findSearchMatches(editorViewInstance.state.doc, searchTerm, caseSensitive);
+    return findSearchMatches(editorViewInstance.state.doc, searchTerm, {
+      caseSensitive,
+      regex: regexSearch,
+      wholeWord: wholeWordSearch,
+      normalizeVariants,
+      excludeComments,
+      searchTarget,
+      range: selectionOnly ? (searchSelectionRange ?? undefined) : undefined,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorViewInstance, searchTerm, caseSensitive, isSearchVisible, content]);
+  }, [
+    editorViewInstance,
+    searchTerm,
+    caseSensitive,
+    regexSearch,
+    wholeWordSearch,
+    normalizeVariants,
+    excludeComments,
+    searchTarget,
+    selectionOnly,
+    searchSelectionRange,
+    isSearchVisible,
+    content,
+  ]);
 
   useSearchHighlight({
     editorView: editorViewInstance,
@@ -1163,15 +1221,30 @@ export default function EditorPage() {
     // 共有検索 state（SearchResults を controlled 化）
     searchTerm,
     caseSensitive,
+    regexSearch,
+    wholeWordSearch,
+    normalizeVariants,
+    excludeComments,
+    searchTarget,
+    selectionOnly,
+    hasSearchSelection: searchSelectionRange !== null,
     searchMatches,
     currentMatchIndex,
     onSearchTermChange: setSearchTerm,
     onCaseSensitiveChange: setCaseSensitive,
+    onRegexSearchChange: setRegexSearch,
+    onWholeWordSearchChange: setWholeWordSearch,
+    onNormalizeVariantsChange: setNormalizeVariants,
+    onExcludeCommentsChange: setExcludeComments,
+    onSearchTargetChange: setSearchTarget,
+    onSelectionOnlyChange: setSelectionOnly,
     onCurrentMatchIndexChange: setCurrentMatchIndex,
     onCloseSearchResults: handleCloseSearchResults,
     editorViewInstance,
     dictionarySearchTrigger,
     currentFilePath: currentFile?.path ?? undefined,
+    projectSearchBuffers,
+    onProjectBufferChange: handleProjectSearchBufferChange,
     newFileTrigger,
     openProjectFile,
     incrementEditorKey,
@@ -1355,6 +1428,10 @@ export default function EditorPage() {
           } else {
             setSelectedWord(null);
           }
+        },
+        onSelectionRangeChange: (range: SearchRange | null) => {
+          setSearchSelectionRange(range);
+          if (!range) setSelectionOnly(false);
         },
         searchOpenTrigger,
         searchInitialTerm,

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -17,6 +17,7 @@ import MilkdownEditor from "./editor/MilkdownEditor";
 import { buildSegments, buildSpeechChunks, buildSpeechMap } from "@/lib/hooks/speech-utils";
 import { scrollToSpeechTarget, cancelSpeechScroll } from "@/lib/editor-page/speech-auto-scroll";
 import { useSelectionTracking } from "@/lib/editor-page/use-selection-tracking";
+import type { SelectionSearchRange } from "@/lib/editor-page/use-selection-tracking";
 import { localPreferences } from "@/lib/storage/local-preferences";
 import type { LintIssue } from "@/lib/linting";
 import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
@@ -28,6 +29,7 @@ interface EditorProps {
   onChange?: (content: string) => void;
   onInsertText?: (text: string) => void;
   onSelectionChange?: (charCount: number, manuscriptCells: number, manuscriptPages: number) => void;
+  onSelectionRangeChange?: (range: SelectionSearchRange | null) => void;
   className?: string;
   // フローティング検索窓（SearchDialog）は EditorLayout の <main> でレンダリングされる。
   // Editor はツールバー検索ボタンとコンテキストメニュー「検索」から、共有 state への
@@ -68,6 +70,7 @@ export default function NovelEditor({
   onChange,
   onInsertText,
   onSelectionChange,
+  onSelectionRangeChange,
   className,
   onSearchTermChange = noop,
   onOpenSearchDialog = noop,
@@ -134,6 +137,7 @@ export default function NovelEditor({
     editorViewInstance,
     scrollContainerRef,
     onSelectionChange,
+    onSelectionRangeChange,
   });
   const handleScrollContainerRef = useCallback((node: HTMLDivElement | null) => {
     scrollContainerRef.current = node;

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -162,6 +162,9 @@ interface EditorLayoutProps {
       manuscriptCells: number,
       manuscriptPages: number,
     ) => void;
+    onSelectionRangeChange: NonNullable<
+      React.ComponentProps<typeof NovelEditor>["onSelectionRangeChange"]
+    >;
     searchOpenTrigger: number;
     searchInitialTerm?: string;
     // 共有検索 state。SearchDialog は dockview パネル外（<main>）でレンダリングする。
@@ -490,6 +493,7 @@ export default function EditorLayout({
                                   onChange={mainArea.handleChange}
                                   onInsertText={mainArea.handleInsertText}
                                   onSelectionChange={mainArea.onSelectionChange}
+                                  onSelectionRangeChange={mainArea.onSelectionRangeChange}
                                   // 検索の入力/表示は <main> の SearchDialog が担当。
                                   // pane へは「語を反映」「開く」「トグル」の安定 callback のみ渡す
                                   // （dockview の凍結クロージャでも安定 ref は機能するため）。

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,24 +1,78 @@
 "use client";
 
-import React, { useState, useRef, useCallback } from "react";
-import { Search, X, Replace, ReplaceAll, ChevronRight, ChevronDown } from "lucide-react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  FileText,
+  History,
+  Replace,
+  ReplaceAll,
+  Search,
+  SlidersHorizontal,
+  X,
+} from "lucide-react";
 import type { EditorView } from "@milkdown/prose/view";
 import clsx from "clsx";
+
+import {
+  buildReplacementText,
+  createReplacementSteps,
+  getSearchPatternError,
+  isSearchMatchReplaceable,
+  type SearchMatch,
+  type SearchOptions,
+  type SearchTarget,
+} from "@/lib/editor-page/find-search-matches";
+import {
+  replaceProjectFiles,
+  searchProjectFiles,
+  undoProjectReplacement,
+  type ProjectReplacementChange,
+  type ProjectSearchFileResult,
+} from "@/lib/editor-page/project-search";
+import { ProjectSearchWorkerClient } from "@/lib/editor-page/project-search-worker-client";
+import { addSearchHistoryEntry, loadSearchHistory } from "@/lib/editor-page/search-history";
 import { isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
-import { type SearchMatch } from "@/lib/editor-page/find-search-matches";
+
+type SearchScope = "project" | "current" | "folder";
+const EMPTY_PROJECT_BUFFERS: ReadonlyMap<string, string> = new Map();
 
 interface SearchResultsProps {
   editorView: EditorView | null;
-  /** 共有検索 state（単一 source of truth）。SearchDialog と同期する。
-   *  マッチ検出・ハイライト適用は app/page.tsx の useSearchHighlight に集約済み。 */
   searchTerm: string;
   onSearchTermChange: (term: string) => void;
   caseSensitive: boolean;
   onCaseSensitiveChange: (value: boolean) => void;
+  regexSearch?: boolean;
+  onRegexSearchChange?: (value: boolean) => void;
+  wholeWordSearch?: boolean;
+  onWholeWordSearchChange?: (value: boolean) => void;
+  normalizeVariants?: boolean;
+  onNormalizeVariantsChange?: (value: boolean) => void;
+  excludeComments?: boolean;
+  onExcludeCommentsChange?: (value: boolean) => void;
+  searchTarget?: SearchTarget;
+  onSearchTargetChange?: (value: SearchTarget) => void;
+  selectionOnly?: boolean;
+  onSelectionOnlyChange?: (value: boolean) => void;
+  hasSelection?: boolean;
   matches: SearchMatch[];
   currentMatchIndex: number;
   onCurrentMatchIndexChange: (index: number) => void;
   onClose: () => void;
+  projectSearchEnabled?: boolean;
+  projectOpenBuffers?: ReadonlyMap<string, string>;
+  currentFilePath?: string;
+  onOpenProjectFile?: (path: string) => Promise<void>;
+  onProjectBufferChange?: (path: string, content: string) => void | Promise<void>;
+}
+
+interface MatchGroup {
+  heading: string;
+  matches: Array<{ match: SearchMatch; index: number }>;
 }
 
 export default function SearchResults({
@@ -27,51 +81,173 @@ export default function SearchResults({
   onSearchTermChange,
   caseSensitive,
   onCaseSensitiveChange,
+  regexSearch = false,
+  onRegexSearchChange = () => {},
+  wholeWordSearch = false,
+  onWholeWordSearchChange = () => {},
+  normalizeVariants = false,
+  onNormalizeVariantsChange = () => {},
+  excludeComments = true,
+  onExcludeCommentsChange = () => {},
+  searchTarget = "all",
+  onSearchTargetChange = () => {},
+  selectionOnly = false,
+  onSelectionOnlyChange = () => {},
+  hasSelection = false,
   matches,
+  currentMatchIndex,
   onCurrentMatchIndexChange,
   onClose,
+  projectSearchEnabled = false,
+  projectOpenBuffers = EMPTY_PROJECT_BUFFERS,
+  currentFilePath,
+  onOpenProjectFile,
+  onProjectBufferChange,
 }: SearchResultsProps) {
-  // 置換は SearchResults 固有のローカル UI 状態。
   const [replaceTerm, setReplaceTerm] = useState("");
+  const [replaceTouched, setReplaceTouched] = useState(false);
   const [showReplace, setShowReplace] = useState(true);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [history, setHistory] = useState<string[]>([]);
+  const [scope, setScope] = useState<SearchScope>(projectSearchEnabled ? "project" : "current");
+  const [folderPath, setFolderPath] = useState("");
+  const [projectResults, setProjectResults] = useState<ProjectSearchFileResult[]>([]);
+  const [projectNavigationIndex, setProjectNavigationIndex] = useState(0);
+  const [projectSearchPending, setProjectSearchPending] = useState(false);
+  const [projectProgress, setProjectProgress] = useState({ searched: 0, total: 0 });
+  const [projectSearchError, setProjectSearchError] = useState<string | null>(null);
+  const [confirmReplaceAll, setConfirmReplaceAll] = useState(false);
+  const [projectRefreshToken, setProjectRefreshToken] = useState(0);
+  const [replacementPending, setReplacementPending] = useState(false);
+  const [lastProjectReplacement, setLastProjectReplacement] = useState<ProjectReplacementChange[]>(
+    [],
+  );
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // Get context text for match
+  useEffect(() => setHistory(loadSearchHistory()), []);
+
+  const searchOptions = useMemo<SearchOptions>(
+    () => ({
+      caseSensitive,
+      regex: regexSearch,
+      wholeWord: wholeWordSearch,
+      normalizeVariants,
+      excludeComments,
+      searchTarget,
+    }),
+    [caseSensitive, excludeComments, normalizeVariants, regexSearch, searchTarget, wholeWordSearch],
+  );
+  const patternError = getSearchPatternError(searchTerm, searchOptions);
+
+  useEffect(() => {
+    if (!projectSearchEnabled && scope !== "current") setScope("current");
+    if (scope !== "current" && selectionOnly) onSelectionOnlyChange(false);
+  }, [onSelectionOnlyChange, projectSearchEnabled, scope, selectionOnly]);
+
+  useEffect(() => {
+    if (scope === "current" || !projectSearchEnabled || !searchTerm || patternError) {
+      setProjectResults([]);
+      setProjectNavigationIndex(0);
+      setProjectSearchPending(false);
+      setProjectSearchError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    let workerClient: ProjectSearchWorkerClient | null = null;
+    const timer = window.setTimeout(() => {
+      const activeWorkerClient = new ProjectSearchWorkerClient();
+      workerClient = activeWorkerClient;
+      setProjectSearchPending(true);
+      setProjectResults([]);
+      setProjectNavigationIndex(0);
+      setProjectProgress({ searched: 0, total: 0 });
+      setProjectSearchError(null);
+
+      void import("@/lib/services/project-file-service")
+        .then(({ getProjectFileService }) => {
+          const vfs = getProjectFileService();
+          if (!vfs.isRootOpen()) throw new Error("プロジェクトを開いてください");
+          return searchProjectFiles({
+            vfs,
+            searchTerm,
+            options: searchOptions,
+            rootPath: scope === "folder" ? folderPath.trim() : "",
+            openBuffers: projectOpenBuffers,
+            signal: controller.signal,
+            matchDocument: activeWorkerClient.matchDocument,
+            onFileResult: (result) => {
+              if (!controller.signal.aborted) {
+                setProjectResults((current) => [...current, result]);
+              }
+            },
+            onProgress: (searched, total) => {
+              if (!controller.signal.aborted) setProjectProgress({ searched, total });
+            },
+            onFileError: (path, error) => {
+              if (controller.signal.aborted) return;
+              const message = error instanceof Error ? error.message : String(error);
+              setProjectSearchError(`${path}: ${message}`);
+            },
+          });
+        })
+        .then((results) => {
+          if (!controller.signal.aborted) setProjectResults(results);
+        })
+        .catch((error: unknown) => {
+          if (controller.signal.aborted) return;
+          setProjectSearchError(error instanceof Error ? error.message : "検索に失敗しました");
+          setProjectResults([]);
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setProjectSearchPending(false);
+        });
+    }, 200);
+
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+      workerClient?.dispose();
+    };
+  }, [
+    folderPath,
+    patternError,
+    projectOpenBuffers,
+    projectRefreshToken,
+    projectSearchEnabled,
+    scope,
+    searchOptions,
+    searchTerm,
+  ]);
+
+  const commitSearchHistory = useCallback(() => {
+    setHistory(addSearchHistoryEntry(searchTerm));
+  }, [searchTerm]);
+
   const getMatchContext = useCallback(
     (match: SearchMatch): { before: string; text: string; after: string } => {
-      if (!editorView) {
-        return { before: "", text: "", after: "" };
-      }
+      if (!editorView) return { before: "", text: match.text ?? "", after: "" };
 
-      const { state } = editorView;
-      const { doc } = state;
-
-      // Get match text
-      const matchText = doc.textBetween(match.from, match.to);
-
-      // Get surrounding text (30 characters before and after)
+      const { doc } = editorView.state;
       const contextLength = 30;
       const beforeStart = Math.max(0, match.from - contextLength);
       const afterEnd = Math.min(doc.content.size, match.to + contextLength);
-
       const beforeText = doc.textBetween(beforeStart, match.from);
       const afterText = doc.textBetween(match.to, afterEnd);
 
       return {
         before:
-          beforeText.length > contextLength ? "..." + beforeText.slice(-contextLength) : beforeText,
-        text: matchText,
+          beforeText.length > contextLength ? `...${beforeText.slice(-contextLength)}` : beforeText,
+        text: match.text ?? doc.textBetween(match.from, match.to),
         after:
-          afterText.length > contextLength ? afterText.slice(0, contextLength) + "..." : afterText,
+          afterText.length > contextLength ? `${afterText.slice(0, contextLength)}...` : afterText,
       };
     },
     [editorView],
   );
 
-  // Jump to specified match. 現在マッチ index を共有 state へ反映すると
-  // useSearchHighlight が強調・スクロールを担当する。
   const goToMatch = useCallback(
-    (_match: SearchMatch, index: number) => {
+    (index: number) => {
       if (!isEditorViewAlive(editorView)) return;
       onCurrentMatchIndexChange(index);
       editorView.focus();
@@ -79,42 +255,177 @@ export default function SearchResults({
     [editorView, onCurrentMatchIndexChange],
   );
 
-  // Replace single match. 置換後の再マッチは page 側 useMemo（content 依存）が
-  // 自動で行うため、旧来の setTimeout 再検索ハックは不要。
-  const replaceMatch = useCallback(
-    (match: SearchMatch) => {
-      if (!isEditorViewAlive(editorView)) return;
-
-      const { state, dispatch } = editorView;
-      const tr = state.tr.replaceWith(match.from, match.to, state.schema.text(replaceTerm));
-      dispatch(tr);
+  const navigateCurrentMatches = useCallback(
+    (delta: number) => {
+      if (matches.length === 0) return;
+      const index = (currentMatchIndex + delta + matches.length) % matches.length;
+      onCurrentMatchIndexChange(index);
+      if (isEditorViewAlive(editorView)) editorView.focus();
     },
-    [editorView, replaceTerm],
+    [currentMatchIndex, editorView, matches.length, onCurrentMatchIndexChange],
   );
 
-  // Replace all matches
-  const replaceAllMatches = useCallback(() => {
-    if (!isEditorViewAlive(editorView) || matches.length === 0) return;
+  const replaceMatch = useCallback(
+    (match: SearchMatch) => {
+      if (!isEditorViewAlive(editorView) || !isSearchMatchReplaceable(match)) return;
+      const [step] = createReplacementSteps([match], replaceTerm, searchOptions);
+      if (!step) return;
+
+      const { state, dispatch } = editorView;
+      const tr = step.text
+        ? state.tr.replaceWith(step.from, step.to, state.schema.text(step.text))
+        : state.tr.delete(step.from, step.to);
+      dispatch(tr);
+    },
+    [editorView, replaceTerm, searchOptions],
+  );
+
+  const replaceAllCurrentMatches = useCallback(() => {
+    if (!isEditorViewAlive(editorView)) return;
+    const steps = createReplacementSteps(matches, replaceTerm, searchOptions);
+    if (steps.length === 0) return;
 
     const { state, dispatch } = editorView;
     let tr = state.tr;
-
-    // Replace from end to start to avoid position shift
-    for (let i = matches.length - 1; i >= 0; i--) {
-      const match = matches[i];
-      tr = tr.replaceWith(match.from, match.to, state.schema.text(replaceTerm));
+    for (const step of steps) {
+      tr = step.text
+        ? tr.replaceWith(step.from, step.to, state.schema.text(step.text))
+        : tr.delete(step.from, step.to);
     }
-
     dispatch(tr);
+    setConfirmReplaceAll(false);
+  }, [editorView, matches, replaceTerm, searchOptions]);
 
-    // 検索語をクリア → matches が空になり、useSearchHighlight がハイライトを消す。
-    onSearchTermChange("");
-    setReplaceTerm("");
-  }, [editorView, matches, replaceTerm, onSearchTermChange]);
+  const replaceProjectResults = useCallback(
+    async (results: readonly ProjectSearchFileResult[]) => {
+      if (!onProjectBufferChange) return;
+      setReplacementPending(true);
+      setProjectSearchError(null);
+
+      try {
+        const { getProjectFileService } = await import("@/lib/services/project-file-service");
+        const changes = await replaceProjectFiles({
+          vfs: getProjectFileService(),
+          results,
+          replacement: replaceTerm,
+          options: searchOptions,
+          openBuffers: projectOpenBuffers,
+          onOpenBufferChange: onProjectBufferChange,
+        });
+        setLastProjectReplacement(changes);
+        setConfirmReplaceAll(false);
+        setProjectRefreshToken((token) => token + 1);
+      } catch (error) {
+        setProjectSearchError(error instanceof Error ? error.message : "置換に失敗しました");
+      } finally {
+        setReplacementPending(false);
+      }
+    },
+    [onProjectBufferChange, projectOpenBuffers, replaceTerm, searchOptions],
+  );
+
+  const undoLastProjectReplacement = useCallback(async () => {
+    if (lastProjectReplacement.length === 0 || !onProjectBufferChange) return;
+    setReplacementPending(true);
+    setProjectSearchError(null);
+
+    try {
+      const { getProjectFileService } = await import("@/lib/services/project-file-service");
+      await undoProjectReplacement({
+        vfs: getProjectFileService(),
+        changes: lastProjectReplacement,
+        openBuffers: projectOpenBuffers,
+        onOpenBufferChange: onProjectBufferChange,
+      });
+      setLastProjectReplacement([]);
+      setProjectRefreshToken((token) => token + 1);
+    } catch (error) {
+      setProjectSearchError(error instanceof Error ? error.message : "取り消しに失敗しました");
+    } finally {
+      setReplacementPending(false);
+    }
+  }, [lastProjectReplacement, onProjectBufferChange, projectOpenBuffers]);
+
+  const currentGroups = useMemo(() => groupMatches(matches), [matches]);
+  const projectMatchCount = useMemo(
+    () => projectResults.reduce((total, file) => total + file.matches.length, 0),
+    [projectResults],
+  );
+  const projectMatchLocations = useMemo(
+    () =>
+      projectResults.flatMap((file) =>
+        file.matches.map((_match, matchIndex) => ({ file, matchIndex })),
+      ),
+    [projectResults],
+  );
+  const navigateMatches = useCallback(
+    (delta: number) => {
+      if (scope === "current") {
+        navigateCurrentMatches(delta);
+        return;
+      }
+      if (projectMatchLocations.length === 0 || !onOpenProjectFile) return;
+
+      const nextIndex =
+        (projectNavigationIndex + delta + projectMatchLocations.length) %
+        projectMatchLocations.length;
+      const location = projectMatchLocations[nextIndex];
+      setProjectNavigationIndex(nextIndex);
+      void onOpenProjectFile(location.file.path).then(() => {
+        onCurrentMatchIndexChange(location.matchIndex);
+      });
+    },
+    [
+      navigateCurrentMatches,
+      onCurrentMatchIndexChange,
+      onOpenProjectFile,
+      projectMatchLocations,
+      projectNavigationIndex,
+      scope,
+    ],
+  );
+  const visibleMatchCount = scope === "current" ? matches.length : projectMatchCount;
+  const replaceableMatchCount =
+    scope === "current"
+      ? matches.filter(isSearchMatchReplaceable).length
+      : projectResults.reduce(
+          (total, file) => total + file.matches.filter(isSearchMatchReplaceable).length,
+          0,
+        );
+
+  const renderMatchText = (match: SearchMatch) => {
+    const context = getMatchContext(match);
+    const replacementPreview = buildReplacementText(match, replaceTerm, searchOptions);
+    return (
+      <p className="text-sm text-foreground break-words">
+        <span className="text-foreground-secondary">{context.before}</span>
+        {showReplace && replaceTouched ? (
+          <>
+            <span
+              className="line-through bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 px-1 rounded"
+              data-testid="replace-preview-old"
+            >
+              {context.text}
+            </span>
+            <span
+              className="bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 font-semibold px-1 rounded ml-0.5"
+              data-testid="replace-preview-new"
+            >
+              {replacementPreview || "（削除）"}
+            </span>
+          </>
+        ) : (
+          <span className="bg-accent-light text-accent font-semibold px-1 rounded">
+            {context.text}
+          </span>
+        )}
+        <span className="text-foreground-secondary">{context.after}</span>
+      </p>
+    );
+  };
 
   return (
     <div className="h-full bg-background-secondary border-r border-border flex flex-col">
-      {/* Title bar */}
       <div className="p-4 border-b border-border flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Search className="w-5 h-5 text-foreground-secondary" />
@@ -129,135 +440,252 @@ export default function SearchResults({
         </button>
       </div>
 
-      {/* Search input area */}
       <div className="p-4 border-b border-border space-y-3">
-        {/* Search box */}
-        <div>
+        <div className="flex gap-1">
           <input
             ref={searchInputRef}
             type="text"
             value={searchTerm}
-            onChange={(e) => onSearchTermChange(e.target.value)}
+            onChange={(event) => onSearchTermChange(event.target.value)}
+            onBlur={commitSearchHistory}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") commitSearchHistory();
+            }}
             placeholder="検索..."
-            className="w-full px-3 py-2 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
+            aria-invalid={Boolean(patternError)}
+            className="min-w-0 flex-1 px-3 py-2 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
           />
+          {history.length > 0 && (
+            <div className="relative">
+              <History className="pointer-events-none absolute left-2 top-2.5 w-4 h-4 text-foreground-tertiary" />
+              <select
+                aria-label="検索履歴"
+                value=""
+                onChange={(event) => onSearchTermChange(event.target.value)}
+                className="h-full w-9 pl-8 border border-border-secondary bg-background text-transparent rounded appearance-none cursor-pointer"
+                title="検索履歴"
+              >
+                <option value="">検索履歴</option>
+                {history.map((entry) => (
+                  <option key={entry} value={entry}>
+                    {entry}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
 
-        {/* Options */}
-        <div className="flex items-center justify-between">
+        {patternError && (
+          <p className="flex items-center gap-1 text-xs text-danger" role="alert">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            {patternError}
+          </p>
+        )}
+
+        <div className="space-y-1">
           <label className="flex items-center gap-2 text-xs text-foreground-secondary cursor-pointer">
             <input
               type="checkbox"
               checked={caseSensitive}
-              onChange={(e) => onCaseSensitiveChange(e.target.checked)}
+              onChange={(event) => onCaseSensitiveChange(event.target.checked)}
               className="rounded"
             />
             大文字小文字を区別
           </label>
-          {matches.length > 0 && (
-            <span className="text-xs text-foreground-secondary">
-              {matches.length}件見つかりました
-            </span>
-          )}
+          <div className="flex items-center justify-end gap-1">
+            {visibleMatchCount > 0 && (
+              <span className="text-xs text-foreground-secondary whitespace-nowrap">
+                {visibleMatchCount}件見つかりました
+              </span>
+            )}
+            <button
+              type="button"
+              aria-label="前の一致"
+              title="前の一致"
+              disabled={visibleMatchCount === 0}
+              onClick={() => navigateMatches(-1)}
+              className="p-1 rounded hover:bg-hover disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <ChevronUp className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="次の一致"
+              title="次の一致"
+              disabled={visibleMatchCount === 0}
+              onClick={() => navigateMatches(1)}
+              className="p-1 rounded hover:bg-hover disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <ChevronDown className="w-4 h-4" />
+            </button>
+          </div>
         </div>
 
-        {/* Replace toggle */}
         <button
-          onClick={() => setShowReplace(!showReplace)}
-          className="w-full flex items-center justify-between px-3 py-2 text-sm text-foreground-secondary hover:bg-hover rounded transition-colors"
+          onClick={() => setShowAdvanced((visible) => !visible)}
+          className="w-full flex items-center justify-between px-2 py-1.5 text-sm text-foreground-secondary hover:bg-hover rounded transition-colors"
+          aria-expanded={showAdvanced}
         >
-          <div className="flex items-center gap-2">
-            {showReplace ? (
-              <ChevronDown className="w-4 h-4" />
-            ) : (
-              <ChevronRight className="w-4 h-4" />
-            )}
-            <span>置換</span>
-          </div>
+          <span className="flex items-center gap-2">
+            <SlidersHorizontal className="w-4 h-4" />
+            詳細オプション
+          </span>
+          {showAdvanced ? (
+            <ChevronDown className="w-4 h-4" />
+          ) : (
+            <ChevronRight className="w-4 h-4" />
+          )}
         </button>
 
-        {/* Replace area */}
+        {showAdvanced && (
+          <div className="space-y-2 pl-2 text-xs text-foreground-secondary">
+            <OptionCheckbox
+              label="正規表現を使う"
+              checked={regexSearch}
+              onChange={onRegexSearchChange}
+            />
+            <OptionCheckbox
+              label="単語単位で一致"
+              checked={wholeWordSearch}
+              onChange={onWholeWordSearchChange}
+            />
+            <OptionCheckbox
+              label="表記ゆれを吸収"
+              checked={normalizeVariants}
+              onChange={onNormalizeVariantsChange}
+            />
+            <OptionCheckbox
+              label="コメントを除外"
+              checked={excludeComments}
+              onChange={onExcludeCommentsChange}
+            />
+            <label className="flex items-center justify-between gap-2">
+              検索対象
+              <select
+                value={searchTarget}
+                onChange={(event) => onSearchTargetChange(event.target.value as SearchTarget)}
+                className="px-2 py-1 border border-border-secondary bg-background text-foreground rounded"
+              >
+                <option value="all">本文とルビ</option>
+                <option value="body">本文のみ</option>
+                <option value="ruby">ルビのみ</option>
+              </select>
+            </label>
+            <OptionCheckbox
+              label="選択範囲のみ"
+              checked={selectionOnly}
+              onChange={onSelectionOnlyChange}
+              disabled={!hasSelection || scope !== "current"}
+            />
+            {projectSearchEnabled && (
+              <label className="flex items-center justify-between gap-2">
+                範囲
+                <select
+                  value={scope}
+                  onChange={(event) => setScope(event.target.value as SearchScope)}
+                  className="px-2 py-1 border border-border-secondary bg-background text-foreground rounded"
+                >
+                  <option value="project">プロジェクト全体</option>
+                  <option value="current">現在のファイル</option>
+                  <option value="folder">フォルダ</option>
+                </select>
+              </label>
+            )}
+            {scope === "folder" && projectSearchEnabled && (
+              <input
+                value={folderPath}
+                onChange={(event) => setFolderPath(event.target.value)}
+                placeholder="フォルダのパス"
+                className="w-full px-2 py-1.5 border border-border-secondary bg-background text-foreground rounded"
+              />
+            )}
+          </div>
+        )}
+
+        <button
+          onClick={() => setShowReplace((visible) => !visible)}
+          className="w-full flex items-center justify-between px-2 py-1.5 text-sm text-foreground-secondary hover:bg-hover rounded transition-colors"
+          aria-expanded={showReplace}
+        >
+          <span className="flex items-center gap-2">
+            <Replace className="w-4 h-4" />
+            置換
+          </span>
+          {showReplace ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+        </button>
+
         {showReplace && (
           <div className="space-y-2 pl-6">
             <input
               type="text"
               value={replaceTerm}
-              onChange={(e) => setReplaceTerm(e.target.value)}
+              onFocus={() => setReplaceTouched(true)}
+              onChange={(event) => {
+                setReplaceTouched(true);
+                setReplaceTerm(event.target.value);
+              }}
               placeholder="置換後..."
               className="w-full px-3 py-2 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
             />
-            <div className="flex gap-2">
+            <button
+              onClick={() => setConfirmReplaceAll(true)}
+              disabled={replaceableMatchCount === 0 || !replaceTouched || replacementPending}
+              className={clsx(
+                "w-full flex items-center justify-center gap-2 px-3 py-2 rounded text-sm font-medium transition-colors",
+                replaceableMatchCount === 0 || !replaceTouched || replacementPending
+                  ? "bg-background-tertiary text-foreground-muted cursor-not-allowed"
+                  : "bg-accent text-accent-foreground hover:bg-accent-hover",
+              )}
+            >
+              <ReplaceAll className="w-4 h-4" />
+              すべて置換
+            </button>
+            {lastProjectReplacement.length > 0 && (
               <button
-                onClick={replaceAllMatches}
-                disabled={matches.length === 0 || !replaceTerm}
-                className={clsx(
-                  "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded text-sm font-medium transition-colors",
-                  matches.length === 0 || !replaceTerm
-                    ? "bg-background-tertiary text-foreground-muted cursor-not-allowed"
-                    : "bg-accent text-accent-foreground hover:bg-accent-hover",
-                )}
+                onClick={() => void undoLastProjectReplacement()}
+                disabled={replacementPending}
+                className="w-full px-3 py-2 text-sm rounded border border-border-secondary text-foreground-secondary hover:bg-hover disabled:opacity-50"
               >
-                <ReplaceAll className="w-4 h-4" />
-                すべて置換
+                直前の一括置換を取り消す
               </button>
-            </div>
+            )}
           </div>
         )}
       </div>
 
-      {/* Results list */}
       <div className="flex-1 overflow-y-auto">
-        {searchTerm && matches.length === 0 ? (
-          <div className="p-4 text-center text-foreground-secondary">検索結果がありません</div>
+        {projectSearchPending && projectResults.length === 0 ? (
+          <EmptyMessage text="検索中..." />
+        ) : projectSearchError && visibleMatchCount === 0 ? (
+          <EmptyMessage text={projectSearchError} />
         ) : !searchTerm ? (
-          <div className="p-4 text-center text-foreground-secondary">検索語を入力してください</div>
-        ) : (
-          <div className="divide-y divide-border">
-            {matches.map((match, index) => {
-              const context = getMatchContext(match);
-              return (
-                <div
-                  key={`${match.from}-${match.to}-${index}`}
-                  className="p-4 hover:bg-hover transition-colors group"
-                >
-                  <div className="flex items-start gap-2">
-                    <span className="text-xs font-mono text-foreground-tertiary mt-1 flex-shrink-0">
-                      {index + 1}
-                    </span>
-                    <div className="flex-1 min-w-0">
-                      <button onClick={() => goToMatch(match, index)} className="w-full text-left">
-                        <p className="text-sm text-foreground break-words">
-                          <span className="text-foreground-secondary">{context.before}</span>
-                          {showReplace && replaceTerm ? (
-                            // #1502: VSCode-style replace preview (strikethrough + red old,
-                            // green new). Only when replaceTerm is non-empty; preserves the
-                            // plain highlight rendering otherwise.
-                            <>
-                              <span
-                                className="line-through bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 px-1 rounded"
-                                data-testid="replace-preview-old"
-                              >
-                                {context.text}
-                              </span>
-                              <span
-                                className="bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 font-semibold px-1 rounded ml-0.5"
-                                data-testid="replace-preview-new"
-                              >
-                                {replaceTerm}
-                              </span>
-                            </>
-                          ) : (
-                            <span className="bg-accent-light text-accent font-semibold px-1 rounded">
-                              {context.text}
-                            </span>
-                          )}
-                          <span className="text-foreground-secondary">{context.after}</span>
-                        </p>
+          <EmptyMessage text="検索語を入力してください" />
+        ) : patternError ? null : visibleMatchCount === 0 ? (
+          <EmptyMessage text="検索結果がありません" />
+        ) : scope === "current" ? (
+          <div>
+            {currentGroups.map((group) => (
+              <section key={group.heading}>
+                <h3 className="sticky top-0 px-4 py-2 bg-background-tertiary text-xs font-medium text-foreground-secondary border-b border-border">
+                  {group.heading}
+                </h3>
+                <div className="divide-y divide-border">
+                  {group.matches.map(({ match, index }) => (
+                    <div
+                      key={`${match.from}-${match.to}-${index}`}
+                      className={clsx(
+                        "p-3 hover:bg-hover transition-colors",
+                        currentMatchIndex === index && "bg-active",
+                      )}
+                    >
+                      <button onClick={() => goToMatch(index)} className="w-full text-left">
+                        {renderMatchText(match)}
                         <p className="text-xs text-foreground-tertiary mt-1">
-                          位置: {match.from} - {match.to}
+                          {match.paragraphNumber ? `段落 ${match.paragraphNumber}` : "見出し"}
                         </p>
                       </button>
-                      {showReplace && replaceTerm && (
+                      {showReplace && replaceTouched && isSearchMatchReplaceable(match) && (
                         <button
                           onClick={() => replaceMatch(match)}
                           className="mt-2 flex items-center gap-1 px-2 py-1 text-xs bg-accent-light text-accent hover:bg-active rounded transition-colors"
@@ -266,14 +694,185 @@ export default function SearchResults({
                           置換
                         </button>
                       )}
+                      {!isSearchMatchReplaceable(match) && (
+                        <p className="mt-2 text-xs text-foreground-tertiary">
+                          構造を含むため置換できません
+                        </p>
+                      )}
                     </div>
-                  </div>
+                  ))}
                 </div>
-              );
-            })}
+              </section>
+            ))}
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {projectSearchError && (
+              <p className="px-4 py-2 text-xs text-danger" role="alert">
+                {projectSearchError}
+              </p>
+            )}
+            {projectSearchPending && (
+              <p className="px-4 py-2 text-xs text-foreground-secondary">
+                検索中... {projectProgress.searched}/{projectProgress.total}
+              </p>
+            )}
+            {projectResults.map((file) => (
+              <section key={file.path}>
+                <h3
+                  className={clsx(
+                    "sticky top-0 px-4 py-2 bg-background-tertiary text-xs font-medium text-foreground-secondary flex items-center gap-2",
+                    currentFilePath === file.path && "text-accent",
+                  )}
+                >
+                  <FileText className="w-3.5 h-3.5" />
+                  <span className="truncate">{file.path}</span>
+                  <span className="ml-auto">{file.matches.length}件</span>
+                </h3>
+                {groupMatches(file.matches).map((group) => (
+                  <div key={group.heading}>
+                    <h4 className="px-4 py-1.5 text-xs text-foreground-tertiary border-t border-border">
+                      {group.heading}
+                    </h4>
+                    {group.matches.map(({ match, index }) => {
+                      const projectMatch = file.matches[index];
+                      const navigationIndex = projectMatchLocations.findIndex(
+                        (location) =>
+                          location.file.path === file.path && location.matchIndex === index,
+                      );
+                      return (
+                        <div
+                          key={`${projectMatch.rawFrom}-${projectMatch.rawTo}-${index}`}
+                          className={clsx(
+                            "p-3 hover:bg-hover border-t border-border transition-colors",
+                            projectNavigationIndex === navigationIndex && "bg-active",
+                          )}
+                        >
+                          <button
+                            onClick={() => {
+                              if (!onOpenProjectFile) return;
+                              setProjectNavigationIndex(navigationIndex);
+                              void onOpenProjectFile(file.path).then(() => {
+                                onCurrentMatchIndexChange(index);
+                              });
+                            }}
+                            className="w-full text-left"
+                          >
+                            <p className="text-sm text-foreground break-words">
+                              <span className="bg-accent-light text-accent font-semibold px-1 rounded">
+                                {match.text}
+                              </span>
+                            </p>
+                            <p className="text-xs text-foreground-tertiary mt-1">
+                              段落 {projectMatch.lineNumber}
+                            </p>
+                          </button>
+                          {showReplace &&
+                            replaceTouched &&
+                            isSearchMatchReplaceable(projectMatch) && (
+                              <button
+                                onClick={() =>
+                                  void replaceProjectResults([{ ...file, matches: [projectMatch] }])
+                                }
+                                disabled={replacementPending}
+                                className="mt-2 flex items-center gap-1 px-2 py-1 text-xs bg-accent-light text-accent hover:bg-active rounded transition-colors disabled:opacity-50"
+                              >
+                                <Replace className="w-3 h-3" />
+                                置換
+                              </button>
+                            )}
+                          {!isSearchMatchReplaceable(projectMatch) && (
+                            <p className="mt-2 text-xs text-foreground-tertiary">
+                              構造を含むため置換できません
+                            </p>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+              </section>
+            ))}
           </div>
         )}
       </div>
+
+      {confirmReplaceAll && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-sm rounded border border-border bg-background p-4 shadow-xl">
+            <h3 className="text-base font-semibold text-foreground">置換の確認</h3>
+            <p className="mt-2 text-sm text-foreground-secondary">
+              {replaceableMatchCount}件を置換します。
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={() => setConfirmReplaceAll(false)}
+                className="px-3 py-2 text-sm rounded hover:bg-hover"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={() => {
+                  if (scope === "current") replaceAllCurrentMatches();
+                  else void replaceProjectResults(projectResults);
+                }}
+                disabled={replacementPending}
+                className="px-3 py-2 text-sm rounded bg-accent text-accent-foreground hover:bg-accent-hover"
+              >
+                {replacementPending ? "置換中..." : "置換する"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
+}
+
+function OptionCheckbox({
+  label,
+  checked,
+  onChange,
+  disabled = false,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <label
+      className={clsx(
+        "flex items-center gap-2",
+        disabled ? "text-foreground-muted cursor-not-allowed" : "cursor-pointer",
+      )}
+    >
+      <input
+        type="checkbox"
+        aria-label={label}
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.checked)}
+        className="rounded"
+      />
+      {label}
+    </label>
+  );
+}
+
+function EmptyMessage({ text }: { text: string }) {
+  return <div className="p-4 text-center text-sm text-foreground-secondary">{text}</div>;
+}
+
+function groupMatches(matches: readonly SearchMatch[]): MatchGroup[] {
+  const groups = new Map<string, MatchGroup>();
+
+  matches.forEach((match, index) => {
+    const heading = match.heading || "見出しなし";
+    const group = groups.get(heading) ?? { heading, matches: [] };
+    group.matches.push({ match, index });
+    groups.set(heading, group);
+  });
+
+  return [...groups.values()];
 }

--- a/components/SidebarPanel.tsx
+++ b/components/SidebarPanel.tsx
@@ -11,6 +11,7 @@ import { isProjectMode } from "@/lib/project/project-types";
 
 import type { ActivityBarView } from "@/components/ActivityBar";
 import type { EditorMode } from "@/lib/project/project-types";
+import type { SearchMatch, SearchTarget } from "@/lib/editor-page/find-search-matches";
 import type { EditorView } from "@milkdown/prose/view";
 
 interface SidebarPanelProps {
@@ -31,7 +32,20 @@ interface SidebarPanelProps {
   onSearchTermChange: (term: string) => void;
   caseSensitive: boolean;
   onCaseSensitiveChange: (value: boolean) => void;
-  searchMatches: { from: number; to: number }[];
+  regexSearch: boolean;
+  onRegexSearchChange: (value: boolean) => void;
+  wholeWordSearch: boolean;
+  onWholeWordSearchChange: (value: boolean) => void;
+  normalizeVariants: boolean;
+  onNormalizeVariantsChange: (value: boolean) => void;
+  excludeComments: boolean;
+  onExcludeCommentsChange: (value: boolean) => void;
+  searchTarget: SearchTarget;
+  onSearchTargetChange: (value: SearchTarget) => void;
+  selectionOnly: boolean;
+  onSelectionOnlyChange: (value: boolean) => void;
+  hasSearchSelection: boolean;
+  searchMatches: SearchMatch[];
   currentMatchIndex: number;
   onCurrentMatchIndexChange: (index: number) => void;
   /** Called when the search panel should close. */
@@ -42,6 +56,8 @@ interface SidebarPanelProps {
   dictionarySearchTrigger: { term: string; id: number };
   /** Path of the currently open file (used by the word frequency panel). */
   currentFilePath?: string;
+  projectSearchBuffers: ReadonlyMap<string, string>;
+  onProjectBufferChange: (path: string, content: string) => void | Promise<void>;
   /** Trigger counter for opening the new-file dialog inside the files panel. */
   newFileTrigger: number;
   /** Opens a project file by VFS path. */
@@ -69,6 +85,19 @@ export default function SidebarPanel({
   onSearchTermChange,
   caseSensitive,
   onCaseSensitiveChange,
+  regexSearch,
+  onRegexSearchChange,
+  wholeWordSearch,
+  onWholeWordSearchChange,
+  normalizeVariants,
+  onNormalizeVariantsChange,
+  excludeComments,
+  onExcludeCommentsChange,
+  searchTarget,
+  onSearchTargetChange,
+  selectionOnly,
+  onSelectionOnlyChange,
+  hasSearchSelection,
   searchMatches,
   currentMatchIndex,
   onCurrentMatchIndexChange,
@@ -76,6 +105,8 @@ export default function SidebarPanel({
   editorViewInstance,
   dictionarySearchTrigger,
   currentFilePath,
+  projectSearchBuffers,
+  onProjectBufferChange,
   newFileTrigger,
   openProjectFile,
   onWordSearch,
@@ -120,9 +151,27 @@ export default function SidebarPanel({
           onSearchTermChange={onSearchTermChange}
           caseSensitive={caseSensitive}
           onCaseSensitiveChange={onCaseSensitiveChange}
+          regexSearch={regexSearch}
+          onRegexSearchChange={onRegexSearchChange}
+          wholeWordSearch={wholeWordSearch}
+          onWholeWordSearchChange={onWholeWordSearchChange}
+          normalizeVariants={normalizeVariants}
+          onNormalizeVariantsChange={onNormalizeVariantsChange}
+          excludeComments={excludeComments}
+          onExcludeCommentsChange={onExcludeCommentsChange}
+          searchTarget={searchTarget}
+          onSearchTargetChange={onSearchTargetChange}
+          selectionOnly={selectionOnly}
+          onSelectionOnlyChange={onSelectionOnlyChange}
+          hasSelection={hasSearchSelection}
           matches={searchMatches}
           currentMatchIndex={currentMatchIndex}
           onCurrentMatchIndexChange={onCurrentMatchIndexChange}
+          projectSearchEnabled={isProjectMode(editorMode)}
+          projectOpenBuffers={projectSearchBuffers}
+          currentFilePath={currentFilePath}
+          onOpenProjectFile={(path) => openProjectFile(path, { preview: false })}
+          onProjectBufferChange={onProjectBufferChange}
           onClose={onCloseSearchResults}
         />
       );

--- a/components/__tests__/SearchResults-enhancements.test.tsx
+++ b/components/__tests__/SearchResults-enhancements.test.tsx
@@ -1,0 +1,148 @@
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from "react";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import SearchResults from "../SearchResults";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  localStorage.clear();
+});
+
+function renderSearchResults(
+  overrides: Partial<React.ComponentProps<typeof SearchResults>> = {},
+): void {
+  act(() => {
+    root.render(
+      <SearchResults
+        editorView={null}
+        searchTerm="target"
+        onSearchTermChange={() => {}}
+        caseSensitive={false}
+        onCaseSensitiveChange={() => {}}
+        regexSearch={false}
+        onRegexSearchChange={() => {}}
+        wholeWordSearch={false}
+        onWholeWordSearchChange={() => {}}
+        normalizeVariants={false}
+        onNormalizeVariantsChange={() => {}}
+        excludeComments
+        onExcludeCommentsChange={() => {}}
+        searchTarget="all"
+        onSearchTargetChange={() => {}}
+        selectionOnly={false}
+        onSelectionOnlyChange={() => {}}
+        hasSelection={false}
+        matches={[]}
+        currentMatchIndex={0}
+        onCurrentMatchIndexChange={() => {}}
+        onClose={() => {}}
+        {...overrides}
+      />,
+    );
+  });
+}
+
+describe("SearchResults enhanced options", () => {
+  it("keeps advanced options hidden until requested", () => {
+    renderSearchResults();
+
+    expect(container.textContent).toContain("詳細オプション");
+    expect(container.textContent).not.toContain("正規表現を使う");
+
+    const detailsButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("詳細オプション"),
+    );
+    act(() => detailsButton?.click());
+
+    expect(container.textContent).toContain("正規表現を使う");
+    expect(container.textContent).toContain("単語単位で一致");
+    expect(container.textContent).toContain("表記ゆれを吸収");
+  });
+
+  it("reports invalid regular expressions without throwing", () => {
+    renderSearchResults({ searchTerm: "(", regexSearch: true });
+    expect(container.textContent).toContain("正規表現が正しくありません");
+  });
+
+  it("forwards advanced option changes", () => {
+    const onRegexSearchChange = vi.fn();
+    renderSearchResults({ onRegexSearchChange });
+
+    const detailsButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("詳細オプション"),
+    );
+    act(() => detailsButton?.click());
+    const regexInput = container.querySelector(
+      'input[aria-label="正規表現を使う"]',
+    ) as HTMLInputElement;
+    act(() => regexInput.click());
+
+    expect(onRegexSearchChange).toHaveBeenCalledWith(true);
+  });
+
+  it("does not offer replacement for matches containing MDI structure", () => {
+    renderSearchResults({
+      matches: [
+        {
+          from: 1,
+          to: 2,
+          text: "東京",
+          source: "ruby-base",
+          replaceable: false,
+          paragraphNumber: 1,
+        },
+      ],
+    });
+
+    expect(container.textContent).toContain("構造を含むため置換できません");
+    expect(container.textContent).toContain("段落 1");
+  });
+
+  it("navigates to the previous and next match from the always-visible controls", () => {
+    const onCurrentMatchIndexChange = vi.fn();
+    renderSearchResults({
+      matches: [
+        { from: 1, to: 2, text: "a" },
+        { from: 3, to: 4, text: "a" },
+      ],
+      currentMatchIndex: 0,
+      onCurrentMatchIndexChange,
+    });
+
+    act(() => (container.querySelector('[aria-label="次の一致"]') as HTMLButtonElement).click());
+    expect(onCurrentMatchIndexChange).toHaveBeenLastCalledWith(1);
+
+    act(() => (container.querySelector('[aria-label="前の一致"]') as HTMLButtonElement).click());
+    expect(onCurrentMatchIndexChange).toHaveBeenLastCalledWith(1);
+  });
+
+  it("shows and forwards the comment exclusion filter", () => {
+    const onExcludeCommentsChange = vi.fn();
+    renderSearchResults({ onExcludeCommentsChange });
+    const detailsButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("詳細オプション"),
+    );
+    act(() => detailsButton?.click());
+
+    const comments = container.querySelector(
+      'input[aria-label="コメントを除外"]',
+    ) as HTMLInputElement;
+    expect(comments.checked).toBe(true);
+    act(() => comments.click());
+    expect(onExcludeCommentsChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/components/__tests__/SearchResults-project-navigation.test.tsx
+++ b/components/__tests__/SearchResults-project-navigation.test.tsx
@@ -86,7 +86,11 @@ describe("SearchResults project navigation", () => {
       );
     });
 
-    for (let attempt = 0; attempt < 20 && !container.textContent?.includes("second.mdi"); attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < 20 && !container.textContent?.includes("second.mdi");
+      attempt += 1
+    ) {
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 25));
       });
@@ -134,7 +138,11 @@ describe("SearchResults project navigation", () => {
       );
     });
 
-    for (let attempt = 0; attempt < 20 && !container.textContent?.includes("second.mdi"); attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < 20 && !container.textContent?.includes("second.mdi");
+      attempt += 1
+    ) {
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 25));
       });

--- a/components/__tests__/SearchResults-project-navigation.test.tsx
+++ b/components/__tests__/SearchResults-project-navigation.test.tsx
@@ -1,0 +1,147 @@
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from "react";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const projectVfs = vi.hoisted(() => ({
+  isRootOpen: vi.fn(() => true),
+  listDirectory: vi.fn(async () => [
+    { name: "first.mdi", path: "first.mdi", kind: "file" as const },
+    { name: "second.mdi", path: "second.mdi", kind: "file" as const },
+  ]),
+  readFile: vi.fn(async (path: string) => `${path} target`),
+}));
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => projectVfs,
+}));
+
+vi.mock("@/lib/editor-page/project-search-worker-client", () => ({
+  ProjectSearchWorkerClient: class {
+    matchDocument = async (content: string, _fileType: string, searchTerm: string) => {
+      const from = content.indexOf(searchTerm);
+      return {
+        content,
+        matches:
+          from < 0
+            ? []
+            : [
+                {
+                  from,
+                  to: from + searchTerm.length,
+                  rawFrom: from,
+                  rawTo: from + searchTerm.length,
+                  lineNumber: 1,
+                  text: searchTerm,
+                },
+              ],
+      };
+    };
+    dispose(): void {}
+  },
+}));
+
+import SearchResults from "../SearchResults";
+
+beforeEach(() => {
+  projectVfs.isRootOpen.mockReturnValue(true);
+  projectVfs.listDirectory.mockResolvedValue([
+    { name: "first.mdi", path: "first.mdi", kind: "file" as const },
+    { name: "second.mdi", path: "second.mdi", kind: "file" as const },
+  ]);
+  projectVfs.readFile.mockImplementation(async (path: string) => `${path} target`);
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.clearAllMocks();
+});
+
+describe("SearchResults project navigation", () => {
+  it("opens the exact file before jumping and navigates across files", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onOpenProjectFile = vi.fn(async () => {});
+    const onCurrentMatchIndexChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <SearchResults
+          editorView={null}
+          searchTerm="target"
+          onSearchTermChange={() => {}}
+          caseSensitive={false}
+          onCaseSensitiveChange={() => {}}
+          matches={[]}
+          currentMatchIndex={0}
+          onCurrentMatchIndexChange={onCurrentMatchIndexChange}
+          onClose={() => {}}
+          projectSearchEnabled
+          onOpenProjectFile={onOpenProjectFile}
+          onProjectBufferChange={() => {}}
+        />,
+      );
+    });
+
+    for (let attempt = 0; attempt < 20 && !container.textContent?.includes("second.mdi"); attempt += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+    }
+
+    expect(container.textContent).toContain("first.mdi");
+    expect(container.textContent).toContain("second.mdi");
+
+    await act(async () => {
+      (container.querySelector('[aria-label="次の一致"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+
+    expect(onOpenProjectFile).toHaveBeenCalledWith("second.mdi");
+    expect(onCurrentMatchIndexChange).toHaveBeenCalledWith(0);
+    expect(onOpenProjectFile.mock.invocationCallOrder[0]).toBeLessThan(
+      onCurrentMatchIndexChange.mock.invocationCallOrder[0],
+    );
+
+    act(() => root.unmount());
+  });
+
+  it("shows a file error while retaining successful results", async () => {
+    projectVfs.readFile.mockRejectedValueOnce(new Error("permission denied"));
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SearchResults
+          editorView={null}
+          searchTerm="target"
+          onSearchTermChange={() => {}}
+          caseSensitive={false}
+          onCaseSensitiveChange={() => {}}
+          matches={[]}
+          currentMatchIndex={0}
+          onCurrentMatchIndexChange={() => {}}
+          onClose={() => {}}
+          projectSearchEnabled
+          onOpenProjectFile={async () => {}}
+          onProjectBufferChange={() => {}}
+        />,
+      );
+    });
+
+    for (let attempt = 0; attempt < 20 && !container.textContent?.includes("second.mdi"); attempt += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+    }
+
+    expect(container.textContent).toContain("second.mdi");
+    expect(container.textContent).toContain("first.mdi: permission denied");
+    act(() => root.unmount());
+  });
+});

--- a/lib/editor-page/__tests__/center-editor-position-vertical.test.ts
+++ b/lib/editor-page/__tests__/center-editor-position-vertical.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EditorView } from "@milkdown/prose/view";
+
+import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
+
+describe("centerEditorPosition in vertical writing", () => {
+  it("centers the current match on the horizontal scroll axis", () => {
+    const scrollTo = vi.fn();
+    const container = document.createElement("div");
+    container.style.overflowX = "auto";
+    Object.assign(container, { scrollLeft: 200, scrollTop: 30, scrollTo });
+    container.getBoundingClientRect = () =>
+      ({ left: 10, right: 510, top: 20, bottom: 420, width: 500, height: 400 }) as DOMRect;
+    container.className = "editor-scroll-container";
+    const editorDom = document.createElement("div");
+    container.appendChild(editorDom);
+    document.body.appendChild(container);
+
+    const view = {
+      dom: editorDom,
+      coordsAtPos: () => ({ left: 1000, right: 1020, top: 100, bottom: 120 }),
+    } as unknown as EditorView;
+
+    expect(centerEditorPosition(view, 5, "auto")).toBe(true);
+    expect(scrollTo).toHaveBeenCalledWith({ left: 950, top: -80, behavior: "auto" });
+
+    container.remove();
+  });
+});

--- a/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
+++ b/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { Schema, type Node } from "prosemirror-model";
+
+import {
+  buildReplacementText,
+  createReplacementSteps,
+  findSearchMatches,
+  getSearchPatternError,
+} from "@/lib/editor-page/find-search-matches";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    heading: {
+      group: "block",
+      content: "inline*",
+      attrs: { level: { default: 1 } },
+      toDOM: () => ["h1", 0] as [string, number],
+    },
+    paragraph: {
+      group: "block",
+      content: "inline*",
+      toDOM: () => ["p", 0] as [string, number],
+    },
+    blankParagraph: {
+      group: "block",
+      atom: true,
+      toDOM: () => ["p"],
+    },
+    text: { group: "inline" },
+    hardbreak: {
+      group: "inline",
+      inline: true,
+      selectable: false,
+      leafText: () => "\n",
+      toDOM: () => ["br"],
+    },
+    ruby: atomNode({ base: { default: "" }, text: { default: "" } }, "ruby"),
+    tcy: atomNode({ value: { default: "" } }, "span"),
+    nobreak: atomNode({ text: { default: "" } }, "span"),
+    kern: atomNode({ amount: { default: "" }, text: { default: "" } }, "span"),
+    mdibreak: atomNode({}, "br"),
+  },
+  marks: {},
+});
+
+function atomNode(attrs: Record<string, { default: string }>, tag: string) {
+  return {
+    group: "inline",
+    inline: true,
+    atom: true,
+    attrs,
+    toDOM: () => [tag] as [string],
+  };
+}
+
+function paragraph(...children: Node[]): Node {
+  return schema.node("paragraph", null, children);
+}
+
+function doc(...children: Node[]): Node {
+  return schema.node("doc", null, children);
+}
+
+describe("findSearchMatches enhanced search", () => {
+  it("supports regular expressions, captures, and case sensitivity", () => {
+    const source = doc(paragraph(schema.text("Alpha-12 alpha-34")));
+
+    const matches = findSearchMatches(source, "(alpha)-(\\d+)", {
+      regex: true,
+      caseSensitive: false,
+    });
+
+    expect(matches.map((match) => match.text)).toEqual(["Alpha-12", "alpha-34"]);
+    expect(matches.map((match) => match.captures)).toEqual([
+      ["Alpha", "12"],
+      ["alpha", "34"],
+    ]);
+  });
+
+  it("keeps JavaScript greedy regular expression semantics", () => {
+    const source = doc(paragraph(schema.text("a1b a2b")));
+
+    expect(findSearchMatches(source, "a.*b", { regex: true })).toMatchObject([
+      { text: "a1b a2b" },
+    ]);
+  });
+
+  it("reports invalid patterns and ignores zero-width matches", () => {
+    const source = doc(paragraph(schema.text("abc")));
+
+    expect(getSearchPatternError("(", { regex: true })).toBe("正規表現が正しくありません");
+    expect(findSearchMatches(source, "(?=a)", { regex: true })).toEqual([]);
+  });
+
+  it("matches whole Unicode words without matching inside longer words", () => {
+    const source = doc(paragraph(schema.text("cat scatter cat2 cat 猫 猫舌")));
+
+    expect(findSearchMatches(source, "cat", { wholeWord: true })).toHaveLength(2);
+    expect(findSearchMatches(source, "猫", { wholeWord: true })).toHaveLength(1);
+  });
+
+  it("normalizes kana, width, and old character forms while preserving source positions", () => {
+    const source = doc(paragraph(schema.text("カタカナ ｶﾞ ＡＢＣ 舊體 ㍻")));
+
+    const kana = findSearchMatches(source, "かたかな", { normalizeVariants: true });
+    const width = findSearchMatches(source, "ABC", { normalizeVariants: true });
+    const halfWidthKana = findSearchMatches(source, "が", { normalizeVariants: true });
+    const oldForm = findSearchMatches(source, "旧体", { normalizeVariants: true });
+    const expanded = findSearchMatches(source, "平成", { normalizeVariants: true });
+
+    expect(kana[0].text).toBe("カタカナ");
+    expect(width[0].text).toBe("ＡＢＣ");
+    expect(halfWidthKana[0].text).toBe("ｶﾞ");
+    expect(oldForm[0].text).toBe("舊體");
+    expect(expanded[0].text).toBe("㍻");
+    expect(expanded[0].to - expanded[0].from).toBe(1);
+  });
+
+  it("searches ruby base and reading without making either directly replaceable", () => {
+    const source = doc(
+      paragraph(
+        schema.text("前"),
+        schema.node("ruby", { base: "東京", text: "とう.きょう" }),
+        schema.text("後"),
+      ),
+    );
+
+    const base = findSearchMatches(source, "東京", { searchTarget: "all" });
+    const reading = findSearchMatches(source, "とうきょう", { searchTarget: "ruby" });
+
+    expect(base).toMatchObject([{ source: "ruby-base", replaceable: false }]);
+    expect(reading).toMatchObject([{ source: "ruby-text", replaceable: false }]);
+    expect(findSearchMatches(source, "東京", { searchTarget: "ruby" })).toEqual([]);
+    expect(findSearchMatches(source, "とうきょう", { searchTarget: "body" })).toEqual([]);
+  });
+
+  it("searches displayed MDI atom text but never macro metadata", () => {
+    const source = doc(
+      paragraph(
+        schema.node("kern", { amount: "0.5em", text: "本文" }),
+        schema.node("nobreak", { text: "禁則" }),
+        schema.node("tcy", { value: "12" }),
+      ),
+      schema.node("blankParagraph"),
+    );
+
+    expect(findSearchMatches(source, "本文", {})).toMatchObject([
+      { source: "kern", replaceable: false },
+    ]);
+    expect(findSearchMatches(source, "禁則", {})).toHaveLength(1);
+    expect(findSearchMatches(source, "12", {})).toHaveLength(1);
+    expect(findSearchMatches(source, "0.5em", {})).toEqual([]);
+    expect(findSearchMatches(source, "blank", {})).toEqual([]);
+  });
+
+  it("finds text spanning an atom with exact ProseMirror bounds and blocks replacement", () => {
+    const source = doc(
+      paragraph(
+        schema.text("前"),
+        schema.node("ruby", { base: "東京", text: "とうきょう" }),
+        schema.text("後"),
+      ),
+    );
+
+    const matches = findSearchMatches(source, "前東京後", {});
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({ text: "前東京後", replaceable: false });
+    expect(matches[0].to - matches[0].from).toBe(3);
+  });
+
+  it("limits matches to a selected ProseMirror range", () => {
+    const source = doc(paragraph(schema.text("one two one")));
+
+    expect(findSearchMatches(source, "one", { range: { from: 5, to: 12 } })).toMatchObject([
+      { from: 9, to: 12 },
+    ]);
+  });
+
+  it("handles empty, single-character, and whole-document searches", () => {
+    const source = doc(paragraph(schema.text("abc")));
+
+    expect(findSearchMatches(source, "", {})).toEqual([]);
+    expect(findSearchMatches(source, "a", {})).toMatchObject([{ text: "a" }]);
+    expect(findSearchMatches(source, "abc", {})).toMatchObject([{ text: "abc" }]);
+    expect(findSearchMatches(source, "missing", {})).toEqual([]);
+  });
+
+  it("adds heading and paragraph metadata for grouped results", () => {
+    const source = doc(
+      schema.node("heading", { level: 1 }, schema.text("第一章")),
+      paragraph(schema.text("対象")),
+      paragraph(schema.text("対象")),
+    );
+
+    expect(findSearchMatches(source, "対象", {})).toMatchObject([
+      { heading: "第一章", paragraphNumber: 1 },
+      { heading: "第一章", paragraphNumber: 2 },
+    ]);
+  });
+});
+
+describe("search replacement helpers", () => {
+  it("expands capture references, the full match, and escaped dollars", () => {
+    const match = {
+      from: 3,
+      to: 11,
+      text: "Alpha-12",
+      captures: ["Alpha", "12"],
+    };
+
+    expect(buildReplacementText(match, "$2:$1:$&:$$", { regex: true })).toBe("12:Alpha:Alpha-12:$");
+  });
+
+  it("creates only safe replacement steps in descending position order", () => {
+    const steps = createReplacementSteps(
+      [
+        { from: 1, to: 4, text: "one", replaceable: true },
+        { from: 5, to: 6, text: "東京", replaceable: false, source: "ruby-base" },
+        { from: 7, to: 10, text: "two", replaceable: true },
+      ],
+      "replacement",
+      {},
+    );
+
+    expect(steps).toEqual([
+      { from: 7, to: 10, text: "replacement" },
+      { from: 1, to: 4, text: "replacement" },
+    ]);
+  });
+
+  it("creates replacement steps only for matches inside the selected range", () => {
+    const source = doc(paragraph(schema.text("one two one")));
+    const matches = findSearchMatches(source, "one", { range: { from: 5, to: 12 } });
+
+    expect(createReplacementSteps(matches, "three", {})).toEqual([
+      { from: 9, to: 12, text: "three" },
+    ]);
+  });
+});

--- a/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
+++ b/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
@@ -81,9 +81,7 @@ describe("findSearchMatches enhanced search", () => {
   it("keeps JavaScript greedy regular expression semantics", () => {
     const source = doc(paragraph(schema.text("a1b a2b")));
 
-    expect(findSearchMatches(source, "a.*b", { regex: true })).toMatchObject([
-      { text: "a1b a2b" },
-    ]);
+    expect(findSearchMatches(source, "a.*b", { regex: true })).toMatchObject([{ text: "a1b a2b" }]);
   });
 
   it("reports invalid patterns and ignores zero-width matches", () => {

--- a/lib/editor-page/__tests__/project-search-vfs-integration.test.ts
+++ b/lib/editor-page/__tests__/project-search-vfs-integration.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { searchProjectFiles } from "@/lib/editor-page/project-search";
+import { ElectronVFS } from "@/lib/vfs/electron-vfs";
+import { WebVFS } from "@/lib/vfs/web-vfs";
+
+interface FakeNativeEntry {
+  name: string;
+  kind: "file" | "directory";
+}
+
+function fileHandle(name: string, content: string): FileSystemFileHandle {
+  return {
+    name,
+    kind: "file",
+    getFile: async () => new File([content], name),
+  } as unknown as FileSystemFileHandle;
+}
+
+function directoryHandle(
+  name: string,
+  entries: ReadonlyMap<string, FileSystemHandle>,
+  getDirectoryHandle = vi.fn(async (entryName: string) => {
+    const entry = entries.get(entryName);
+    if (!entry || entry.kind !== "directory") throw new DOMException("not found", "NotFoundError");
+    return entry as FileSystemDirectoryHandle;
+  }),
+): FileSystemDirectoryHandle {
+  return {
+    name,
+    kind: "directory",
+    getDirectoryHandle,
+    getFileHandle: async (entryName: string) => {
+      const entry = entries.get(entryName);
+      if (!entry || entry.kind !== "file") throw new DOMException("not found", "NotFoundError");
+      return entry as FileSystemFileHandle;
+    },
+    async *[Symbol.asyncIterator]() {
+      for (const item of entries) yield item;
+    },
+  } as unknown as FileSystemDirectoryHandle;
+}
+
+const originalElectronApi = window.electronAPI;
+
+afterEach(() => {
+  Object.defineProperty(window, "electronAPI", {
+    configurable: true,
+    writable: true,
+    value: originalElectronApi,
+  });
+});
+
+describe("project search VFS integration", () => {
+  it("uses WebVFS without entering dot-prefixed directories", async () => {
+    const hiddenDirectory = directoryHandle(".illusions", new Map());
+    const hiddenLookup = vi.fn(async () => hiddenDirectory);
+    const root = directoryHandle(
+      "project",
+      new Map<string, FileSystemHandle>([
+        [".illusions", hiddenDirectory],
+        [".draft.mdi", fileHandle(".draft.mdi", "target")],
+        ["chapter.mdi", fileHandle("chapter.mdi", "target")],
+      ]),
+      hiddenLookup,
+    );
+    const vfs = new WebVFS();
+    vfs.setRootHandle(root);
+
+    const results = await searchProjectFiles({ vfs, searchTerm: "target", options: {} });
+
+    expect(results.map((result) => result.path)).toEqual(["/chapter.mdi"]);
+    expect(hiddenLookup).not.toHaveBeenCalled();
+  });
+
+  it("uses ElectronVFS without issuing IPC reads for dot-prefixed paths", async () => {
+    const readFile = vi.fn(async () => "target");
+    const readDirectory = vi.fn(async (path: string): Promise<FakeNativeEntry[]> => {
+      if (path === "/project") {
+        return [
+          { name: ".illusions", kind: "directory" },
+          { name: ".draft.mdi", kind: "file" },
+          { name: "chapter.mdi", kind: "file" },
+        ];
+      }
+      throw new Error(`Unexpected directory read: ${path}`);
+    });
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      writable: true,
+      value: { vfs: { readDirectory, readFile } },
+    });
+    const vfs = new ElectronVFS();
+    await vfs.setRootPath("/project");
+
+    const results = await searchProjectFiles({ vfs, searchTerm: "target", options: {} });
+
+    expect(results.map((result) => result.path)).toEqual(["chapter.mdi"]);
+    expect(readDirectory).toHaveBeenCalledTimes(1);
+    expect(readFile).toHaveBeenCalledWith("/project/chapter.mdi");
+    expect(readFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/editor-page/__tests__/project-search-worker-client.test.ts
+++ b/lib/editor-page/__tests__/project-search-worker-client.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ProjectSearchWorkerClient,
+  type ProjectSearchWorkerRequest,
+  type ProjectSearchWorkerResponse,
+} from "@/lib/editor-page/project-search-worker-client";
+
+class FakeWorker {
+  onmessage: ((event: MessageEvent<ProjectSearchWorkerResponse>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  readonly received: ProjectSearchWorkerRequest[] = [];
+  terminated = false;
+
+  postMessage(message: ProjectSearchWorkerRequest): void {
+    this.received.push(message);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  emit(message: ProjectSearchWorkerResponse): void {
+    this.onmessage?.(new MessageEvent("message", { data: message }));
+  }
+}
+
+describe("ProjectSearchWorkerClient", () => {
+  it("matches a document through a worker round trip", async () => {
+    const worker = new FakeWorker();
+    const client = new ProjectSearchWorkerClient(() => worker as unknown as Worker);
+
+    const pending = client.matchDocument("target", ".mdi", "target", {});
+    expect(worker.received).toMatchObject([
+      { type: "MATCH_DOCUMENT", id: 1, content: "target", fileType: ".mdi" },
+    ]);
+
+    worker.emit({
+      type: "MATCH_RESULT",
+      id: 1,
+      result: {
+        content: "target",
+        matches: [{ from: 0, to: 6, rawFrom: 0, rawTo: 6, lineNumber: 1 }],
+      },
+    });
+
+    await expect(pending).resolves.toMatchObject({ matches: [{ rawFrom: 0, rawTo: 6 }] });
+    client.dispose();
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("rejects pending work when disposed", async () => {
+    const worker = new FakeWorker();
+    const client = new ProjectSearchWorkerClient(() => worker as unknown as Worker);
+    const pending = client.matchDocument("target", ".mdi", "target", {});
+
+    client.dispose();
+
+    await expect(pending).rejects.toThrow("disposed");
+  });
+
+  it("poisons the client after a worker crash", async () => {
+    const worker = new FakeWorker();
+    const client = new ProjectSearchWorkerClient(() => worker as unknown as Worker);
+    const pending = client.matchDocument("first", ".mdi", "first", {});
+
+    worker.onerror?.(new ErrorEvent("error", { message: "worker crashed" }));
+
+    await expect(pending).rejects.toThrow("worker crashed");
+    const afterCrash = client.matchDocument("second", ".mdi", "second", {});
+    expect(worker.received).toHaveLength(1);
+    await expect(afterCrash).rejects.toThrow("worker crashed");
+    expect(worker.terminated).toBe(true);
+  });
+});

--- a/lib/editor-page/__tests__/project-search.test.ts
+++ b/lib/editor-page/__tests__/project-search.test.ts
@@ -232,21 +232,27 @@ describe("project-wide replacement", () => {
   it.each([
     ["a a", "longer", "longer longer"],
     ["target target", "x", "x x"],
-  ])("handles replacement length changes without offset drift", async (content, replacement, expected) => {
-    const searchTerm = content.startsWith("a") ? "a" : "target";
-    const searched = findRawDocumentMatches(content, ".mdi", searchTerm, {});
-    const writeFile = vi.fn(async () => {});
-    const vfs = { readFile: vi.fn(async () => content), writeFile } as unknown as VirtualFileSystem;
+  ])(
+    "handles replacement length changes without offset drift",
+    async (content, replacement, expected) => {
+      const searchTerm = content.startsWith("a") ? "a" : "target";
+      const searched = findRawDocumentMatches(content, ".mdi", searchTerm, {});
+      const writeFile = vi.fn(async () => {});
+      const vfs = {
+        readFile: vi.fn(async () => content),
+        writeFile,
+      } as unknown as VirtualFileSystem;
 
-    await replaceProjectFiles({
-      vfs,
-      results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
-      replacement,
-      options: {},
-    });
+      await replaceProjectFiles({
+        vfs,
+        results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
+        replacement,
+        options: {},
+      });
 
-    expect(writeFile).toHaveBeenCalledWith("chapter.mdi", expected);
-  });
+      expect(writeFile).toHaveBeenCalledWith("chapter.mdi", expected);
+    },
+  );
 
   it("updates open buffers without writing them to disk", async () => {
     const open = findRawDocumentMatches("target", ".mdi", "target", {});

--- a/lib/editor-page/__tests__/project-search.test.ts
+++ b/lib/editor-page/__tests__/project-search.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  findRawDocumentMatches,
+  isSearchableProjectPath,
+  replaceProjectFiles,
+  undoProjectReplacement,
+  searchProjectFiles,
+} from "@/lib/editor-page/project-search";
+import type { VirtualFileSystem, VFSEntry } from "@/lib/vfs/types";
+
+function entry(path: string, kind: VFSEntry["kind"]): VFSEntry {
+  return { name: path.split("/").at(-1) ?? path, path, kind };
+}
+
+describe("project search path filtering", () => {
+  it("returns no results for an empty project", async () => {
+    const vfs = {
+      listDirectory: vi.fn(async () => []),
+    } as unknown as VirtualFileSystem;
+
+    await expect(searchProjectFiles({ vfs, searchTerm: "target", options: {} })).resolves.toEqual(
+      [],
+    );
+  });
+
+  it("excludes every dot-prefixed path segment and unsupported file", () => {
+    expect(isSearchableProjectPath("chapter/one.mdi")).toBe(true);
+    expect(isSearchableProjectPath(".illusions/history/one.mdi")).toBe(false);
+    expect(isSearchableProjectPath("chapter/.vscode/settings.mdi")).toBe(false);
+    expect(isSearchableProjectPath("chapter/.draft.mdi")).toBe(false);
+    expect(isSearchableProjectPath("chapter/cover.png")).toBe(false);
+  });
+
+  it("never descends into hidden directories or reads hidden files", async () => {
+    const directories: Record<string, VFSEntry[]> = {
+      "": [
+        entry(".illusions", "directory"),
+        entry(".vscode", "directory"),
+        entry("chapters", "directory"),
+        entry(".secret.mdi", "file"),
+        entry("root.mdi", "file"),
+      ],
+      chapters: [entry("chapters/one.mdi", "file"), entry("chapters/notes.json", "file")],
+    };
+    const listDirectory = vi.fn(async (path: string) => directories[path] ?? []);
+    const readFile = vi.fn(async (path: string) => `target in ${path}`);
+    const vfs = { listDirectory, readFile } as unknown as VirtualFileSystem;
+
+    const results = await searchProjectFiles({ vfs, searchTerm: "target", options: {} });
+
+    expect(results.map((result) => result.path)).toEqual(["chapters/one.mdi", "root.mdi"]);
+    expect(listDirectory).toHaveBeenCalledTimes(2);
+    expect(listDirectory).not.toHaveBeenCalledWith(".illusions");
+    expect(listDirectory).not.toHaveBeenCalledWith(".vscode");
+    expect(readFile).not.toHaveBeenCalledWith(".secret.mdi");
+  });
+
+  it("does not list a hidden directory selected as the search root", async () => {
+    const listDirectory = vi.fn(async () => [entry(".illusions/history.mdi", "file")]);
+    const vfs = { listDirectory } as unknown as VirtualFileSystem;
+
+    const results = await searchProjectFiles({
+      vfs,
+      searchTerm: "target",
+      options: {},
+      rootPath: ".illusions",
+    });
+
+    expect(results).toEqual([]);
+    expect(listDirectory).not.toHaveBeenCalled();
+  });
+
+  it("stops before reading files when the search is aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const readFile = vi.fn(async () => "target");
+    const vfs = {
+      listDirectory: vi.fn(async () => [entry("chapter.mdi", "file")]),
+      readFile,
+    } as unknown as VirtualFileSystem;
+
+    await expect(
+      searchProjectFiles({
+        vfs,
+        searchTerm: "target",
+        options: {},
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(readFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("raw project document matching", () => {
+  it("searches displayed MDI text without exposing macro names or metadata", () => {
+    const content = [
+      "前{東京|とう.きょう}後",
+      "[[kern:0.5em:本文]]",
+      "[[no-break:禁則]]",
+      "[[blank]]",
+    ].join("\n");
+
+    expect(findRawDocumentMatches(content, ".mdi", "東京", {}).matches).toMatchObject([
+      { text: "東京", source: "ruby-base", replaceable: false },
+    ]);
+    expect(findRawDocumentMatches(content, ".mdi", "とうきょう", {}).matches).toMatchObject([
+      { text: "とうきょう", source: "ruby-text", replaceable: false },
+    ]);
+    expect(findRawDocumentMatches(content, ".mdi", "本文", {}).matches).toMatchObject([
+      { text: "本文", source: "kern", replaceable: false },
+    ]);
+    expect(findRawDocumentMatches(content, ".mdi", "0.5em", {}).matches).toEqual([]);
+    expect(findRawDocumentMatches(content, ".mdi", "blank", {}).matches).toEqual([]);
+  });
+
+  it("returns raw offsets only for plain-text replacements and preserves macros", () => {
+    const content = "対象{対象|たいしょう}対象";
+    const result = findRawDocumentMatches(content, ".mdi", "対象", {});
+
+    expect(result.matches).toMatchObject([
+      { rawFrom: 0, rawTo: 2, replaceable: true },
+      { source: "ruby-base", replaceable: false },
+      { rawFrom: 12, rawTo: 14, replaceable: true },
+    ]);
+  });
+
+  it("uses an unsaved buffer instead of stale VFS content", async () => {
+    const vfs = {
+      listDirectory: vi.fn(async () => [entry("chapter.mdi", "file")]),
+      readFile: vi.fn(async () => "old text"),
+    } as unknown as VirtualFileSystem;
+
+    const results = await searchProjectFiles({
+      vfs,
+      searchTerm: "new text",
+      options: {},
+      openBuffers: new Map([["chapter.mdi", "new text"]]),
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].matches).toHaveLength(1);
+    expect(vfs.readFile).not.toHaveBeenCalled();
+  });
+
+  it("excludes HTML comments by default and can include them as non-replaceable results", () => {
+    const content = "target <!-- target -->";
+
+    expect(findRawDocumentMatches(content, ".mdi", "target", {}).matches).toHaveLength(1);
+    expect(
+      findRawDocumentMatches(content, ".mdi", "target", { excludeComments: false }).matches,
+    ).toMatchObject([
+      { source: "text", replaceable: true },
+      { source: "comment", replaceable: false },
+    ]);
+  });
+
+  it("applies comment filtering to Markdown files", () => {
+    const content = "target <!-- target -->";
+
+    expect(findRawDocumentMatches(content, ".md", "target", {}).matches).toHaveLength(1);
+    expect(
+      findRawDocumentMatches(content, ".md", "target", { excludeComments: false }).matches,
+    ).toMatchObject([
+      { source: "text", replaceable: true },
+      { source: "comment", replaceable: false },
+    ]);
+  });
+
+  it("reports file results incrementally across a large project", async () => {
+    const files = Array.from({ length: 64 }, (_, index) => entry(`chapter-${index}.mdi`, "file"));
+    const vfs = {
+      listDirectory: vi.fn(async () => files),
+      readFile: vi.fn(async (path: string) => `target ${path}`),
+    } as unknown as VirtualFileSystem;
+    const onFileResult = vi.fn();
+    const onProgress = vi.fn();
+
+    const results = await searchProjectFiles({
+      vfs,
+      searchTerm: "target",
+      options: {},
+      onFileResult,
+      onProgress,
+    });
+
+    expect(results).toHaveLength(64);
+    expect(onFileResult).toHaveBeenCalledTimes(64);
+    expect(onProgress).toHaveBeenLastCalledWith(64, 64);
+  });
+
+  it("delegates huge-file matching to the supplied asynchronous matcher", async () => {
+    const content = `${"x".repeat(2_000_000)}target`;
+    const vfs = {
+      listDirectory: vi.fn(async () => [entry("huge.mdi", "file")]),
+      readFile: vi.fn(async () => content),
+    } as unknown as VirtualFileSystem;
+    const matchDocument = vi.fn(async (...args: Parameters<typeof findRawDocumentMatches>) =>
+      findRawDocumentMatches(...args),
+    );
+
+    const results = await searchProjectFiles({
+      vfs,
+      searchTerm: "target",
+      options: {},
+      matchDocument,
+    });
+
+    expect(matchDocument).toHaveBeenCalledTimes(1);
+    expect(results[0].matches[0].rawFrom).toBe(2_000_000);
+  });
+});
+
+describe("project-wide replacement", () => {
+  it("replaces only plain text and preserves MDI atoms", async () => {
+    const content = "対象{対象|たいしょう}対象";
+    const searched = findRawDocumentMatches(content, ".mdi", "対象", {});
+    const writeFile = vi.fn(async () => {});
+    const vfs = { readFile: vi.fn(async () => content), writeFile } as unknown as VirtualFileSystem;
+
+    const changes = await replaceProjectFiles({
+      vfs,
+      results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
+      replacement: "変更",
+      options: {},
+    });
+
+    expect(writeFile).toHaveBeenCalledWith("chapter.mdi", "変更{対象|たいしょう}変更");
+    expect(changes).toMatchObject([{ path: "chapter.mdi", replacementCount: 2 }]);
+  });
+
+  it.each([
+    ["a a", "longer", "longer longer"],
+    ["target target", "x", "x x"],
+  ])("handles replacement length changes without offset drift", async (content, replacement, expected) => {
+    const searchTerm = content.startsWith("a") ? "a" : "target";
+    const searched = findRawDocumentMatches(content, ".mdi", searchTerm, {});
+    const writeFile = vi.fn(async () => {});
+    const vfs = { readFile: vi.fn(async () => content), writeFile } as unknown as VirtualFileSystem;
+
+    await replaceProjectFiles({
+      vfs,
+      results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
+      replacement,
+      options: {},
+    });
+
+    expect(writeFile).toHaveBeenCalledWith("chapter.mdi", expected);
+  });
+
+  it("updates open buffers without writing them to disk", async () => {
+    const open = findRawDocumentMatches("target", ".mdi", "target", {});
+    const closed = findRawDocumentMatches("target", ".mdi", "target", {});
+    const writeFile = vi.fn(async () => {});
+    const onOpenBufferChange = vi.fn(async () => {});
+    const vfs = {
+      readFile: vi.fn(async () => "target"),
+      writeFile,
+    } as unknown as VirtualFileSystem;
+
+    const changes = await replaceProjectFiles({
+      vfs,
+      results: [
+        { ...open, path: "open.mdi", fileName: "open.mdi" },
+        { ...closed, path: "closed.mdi", fileName: "closed.mdi" },
+      ],
+      replacement: "changed",
+      options: {},
+      openBuffers: new Map([["open.mdi", "target"]]),
+      onOpenBufferChange,
+    });
+
+    expect(onOpenBufferChange).toHaveBeenCalledWith("open.mdi", "changed");
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    expect(writeFile).toHaveBeenCalledWith("closed.mdi", "changed");
+    expect(changes).toHaveLength(2);
+  });
+
+  it("aborts before writing when a file changed after the search", async () => {
+    const searched = findRawDocumentMatches("target", ".mdi", "target", {});
+    const writeFile = vi.fn(async () => {});
+    const vfs = {
+      readFile: vi.fn(async () => "newer content"),
+      writeFile,
+    } as unknown as VirtualFileSystem;
+
+    await expect(
+      replaceProjectFiles({
+        vfs,
+        results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
+        replacement: "changed",
+        options: {},
+      }),
+    ).rejects.toThrow("検索後に内容が変更されました");
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("restores both VFS files and open buffers from the operation log", async () => {
+    const writeFile = vi.fn(async () => {});
+    const onOpenBufferChange = vi.fn(async () => {});
+    const vfs = {
+      readFile: vi.fn(async () => "after-closed"),
+      writeFile,
+    } as unknown as VirtualFileSystem;
+    const changes = [
+      {
+        path: "open.mdi",
+        before: "before-open",
+        after: "after-open",
+        replacementCount: 1,
+        openBuffer: true,
+      },
+      {
+        path: "closed.mdi",
+        before: "before-closed",
+        after: "after-closed",
+        replacementCount: 1,
+        openBuffer: false,
+      },
+    ];
+
+    await undoProjectReplacement({
+      vfs,
+      changes,
+      openBuffers: new Map([["open.mdi", "after-open"]]),
+      onOpenBufferChange,
+    });
+
+    expect(onOpenBufferChange).toHaveBeenCalledWith("open.mdi", "before-open");
+    expect(writeFile).toHaveBeenCalledWith("closed.mdi", "before-closed");
+  });
+
+  it("does not undo over content edited after replacement", async () => {
+    const writeFile = vi.fn(async () => {});
+    const vfs = {
+      readFile: vi.fn(async () => "edited-again"),
+      writeFile,
+    } as unknown as VirtualFileSystem;
+
+    await expect(
+      undoProjectReplacement({
+        vfs,
+        changes: [
+          {
+            path: "chapter.mdi",
+            before: "before",
+            after: "after",
+            replacementCount: 1,
+            openBuffer: false,
+          },
+        ],
+      }),
+    ).rejects.toThrow("置換後に内容が変更されました");
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/lib/editor-page/__tests__/search-history.test.ts
+++ b/lib/editor-page/__tests__/search-history.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { addSearchHistoryEntry, loadSearchHistory } from "@/lib/editor-page/search-history";
+
+describe("search history", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("stores unique non-empty terms with the newest first", () => {
+    addSearchHistoryEntry(" first ");
+    addSearchHistoryEntry("second");
+    addSearchHistoryEntry("first");
+    addSearchHistoryEntry("   ");
+
+    expect(loadSearchHistory()).toEqual(["first", "second"]);
+  });
+
+  it("keeps only the ten most recent terms", () => {
+    for (let index = 0; index < 12; index += 1) addSearchHistoryEntry(`term-${index}`);
+
+    expect(loadSearchHistory()).toHaveLength(10);
+    expect(loadSearchHistory()[0]).toBe("term-11");
+    expect(loadSearchHistory().at(-1)).toBe("term-2");
+  });
+
+  it("recovers from malformed persisted data", () => {
+    localStorage.setItem("illusions:search-history", "not-json");
+    expect(loadSearchHistory()).toEqual([]);
+  });
+});

--- a/lib/editor-page/__tests__/selection-search-range.test.ts
+++ b/lib/editor-page/__tests__/selection-search-range.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { getEditorSelectionSearchRange } from "@/lib/editor-page/use-selection-tracking";
+
+describe("getEditorSelectionSearchRange", () => {
+  it("tracks a moved selection even when its length is unchanged", () => {
+    expect(getEditorSelectionSearchRange({ empty: false, from: 2, to: 5 })).toEqual({
+      from: 2,
+      to: 5,
+    });
+    expect(getEditorSelectionSearchRange({ empty: false, from: 8, to: 11 })).toEqual({
+      from: 8,
+      to: 11,
+    });
+  });
+
+  it("uses the editor selection even after DOM focus leaves the editor", () => {
+    expect(getEditorSelectionSearchRange({ empty: false, from: 4, to: 9 })).toEqual({
+      from: 4,
+      to: 9,
+    });
+    expect(getEditorSelectionSearchRange({ empty: true, from: 4, to: 4 })).toBeNull();
+  });
+});

--- a/lib/editor-page/__tests__/use-panel-state-search-options.test.tsx
+++ b/lib/editor-page/__tests__/use-panel-state-search-options.test.tsx
@@ -1,0 +1,70 @@
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act, useEffect } from "react";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { usePanelState } from "@/lib/editor-page/use-panel-state";
+
+type PanelStateResult = ReturnType<typeof usePanelState>;
+
+let container: HTMLDivElement;
+let root: Root;
+let current: PanelStateResult | undefined;
+
+function Harness({ onValue }: { onValue: (value: PanelStateResult) => void }) {
+  const value = usePanelState({ setShowSettingsModal: () => {} });
+  useEffect(() => onValue(value), [onValue, value]);
+  return null;
+}
+
+const captureValue = (value: PanelStateResult) => {
+  current = value;
+};
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(<Harness onValue={captureValue} />));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  current = undefined;
+});
+
+describe("usePanelState search options", () => {
+  it("exposes conservative defaults", () => {
+    expect(current?.state).toMatchObject({
+      regexSearch: false,
+      wholeWordSearch: false,
+      normalizeVariants: false,
+      excludeComments: true,
+      searchTarget: "all",
+      selectionOnly: false,
+    });
+  });
+
+  it("updates every enhanced search option", () => {
+    act(() => {
+      current?.handlers.setRegexSearch(true);
+      current?.handlers.setWholeWordSearch(true);
+      current?.handlers.setNormalizeVariants(true);
+      current?.handlers.setExcludeComments(false);
+      current?.handlers.setSearchTarget("ruby");
+      current?.handlers.setSelectionOnly(true);
+    });
+
+    expect(current?.state).toMatchObject({
+      regexSearch: true,
+      wholeWordSearch: true,
+      normalizeVariants: true,
+      excludeComments: false,
+      searchTarget: "ruby",
+      selectionOnly: true,
+    });
+  });
+});

--- a/lib/editor-page/find-search-matches.ts
+++ b/lib/editor-page/find-search-matches.ts
@@ -1,69 +1,454 @@
 import type { Node } from "@milkdown/prose/model";
 
-export interface SearchMatch {
+import { normalizeJapaneseSearchVariants } from "./japanese-variant-normalization";
+
+export type SearchMatchSource =
+  | "text"
+  | "ruby-base"
+  | "ruby-text"
+  | "tcy"
+  | "nobreak"
+  | "kern"
+  | "hardbreak"
+  | "mdibreak"
+  | "comment"
+  | "mixed";
+
+export type SearchTarget = "all" | "body" | "ruby";
+
+export interface SearchRange {
   from: number;
   to: number;
 }
 
+export interface SearchOptions {
+  caseSensitive?: boolean;
+  regex?: boolean;
+  wholeWord?: boolean;
+  normalizeVariants?: boolean;
+  excludeComments?: boolean;
+  searchTarget?: SearchTarget;
+  range?: SearchRange;
+}
+
+export interface SearchMatch {
+  from: number;
+  to: number;
+  text?: string;
+  source?: SearchMatchSource;
+  replaceable?: boolean;
+  captures?: string[];
+  heading?: string;
+  paragraphNumber?: number;
+}
+
+export interface ReplacementStep {
+  from: number;
+  to: number;
+  text: string;
+}
+
+type ResolvedSearchOptions = Required<Omit<SearchOptions, "range">> & {
+  range?: SearchRange;
+};
+
+export interface SearchTextSegment {
+  text: string;
+  displayFrom: number;
+  displayTo: number;
+  from: number;
+  to: number;
+  source: SearchMatchSource;
+  replaceable: boolean;
+}
+
+export interface SearchTextProjection {
+  text: string;
+  segments: SearchTextSegment[];
+}
+
+interface NormalizedProjection {
+  text: string;
+  sourceFrom: number[];
+  sourceTo: number[];
+}
+
+interface RawMatch {
+  from: number;
+  to: number;
+  captures?: string[];
+}
+
+const DEFAULT_OPTIONS: ResolvedSearchOptions = {
+  caseSensitive: false,
+  regex: false,
+  wholeWord: false,
+  normalizeVariants: false,
+  excludeComments: true,
+  searchTarget: "all",
+};
+
+const WORD_CHAR_RE = /[\p{L}\p{N}_]/u;
+const JAPANESE_GRAPHEME_SEGMENTER = new Intl.Segmenter("ja", { granularity: "grapheme" });
+
 /**
- * Find every occurrence of `searchTerm` in a ProseMirror document and return
- * their positions in ProseMirror coordinates.
- *
- * Why this walks the document with `doc.descendants` instead of searching
- * `doc.textContent`:
- *
- *   `doc.textContent` flattens the document to a plain string, but that string
- *   is NOT aligned 1:1 with ProseMirror positions. Nodes that are not text but
- *   define a `leafText` spec (most importantly Milkdown's `hardbreak`, whose
- *   spec is `leafText: () => "\n"`) contribute characters to `textContent`
- *   while occupying a position that a naive text-offset → position mapping
- *   never accounts for. The result is that every match after a hardbreak (or
- *   any other leafText node) drifts forward by the number of such nodes before
- *   it, so the highlight lands on the wrong character.
- *
- * By visiting each text node directly we use its real `pos`, so the returned
- * positions are always correct regardless of hardbreaks, ruby atoms, or other
- * inline leaf nodes.
- *
- * Ruby (`atom: true`) nodes are not recursed into by `descendants`, so their
- * `base` text is matched explicitly and the whole atom is highlighted.
+ * Search displayed editor text while retaining exact ProseMirror positions.
+ * MDI syntax is represented by atom nodes and is never exposed as raw markup.
  */
 export function findSearchMatches(
   doc: Node,
   searchTerm: string,
-  caseSensitive: boolean,
+  caseSensitiveOrOptions: boolean | SearchOptions,
 ): SearchMatch[] {
-  const foundMatches: SearchMatch[] = [];
-  if (!searchTerm) return foundMatches;
+  if (!searchTerm) return [];
 
-  const searchStr = caseSensitive ? searchTerm : searchTerm.toLowerCase();
+  const options = resolveOptions(caseSensitiveOrOptions);
+  if (options.regex && !compilePattern(searchTerm, options)) return [];
+
+  const matches: SearchMatch[] = [];
+  let currentHeading: string | undefined;
+  let paragraphNumber = 0;
 
   doc.descendants((node, pos) => {
-    if (node.isText && node.text) {
-      const nodeText = caseSensitive ? node.text : node.text.toLowerCase();
-      let searchIndex = 0;
-      while (searchIndex < nodeText.length) {
-        const matchIndex = nodeText.indexOf(searchStr, searchIndex);
-        if (matchIndex === -1) break;
-        foundMatches.push({
-          from: pos + matchIndex,
-          to: pos + matchIndex + searchTerm.length,
-        });
-        searchIndex = matchIndex + 1;
+    if (!node.isTextblock) return;
+
+    const isHeading = node.type.name === "heading";
+    if (!isHeading) paragraphNumber += 1;
+
+    const bodyProjection = createBodyProjection(node, pos + 1, options.excludeComments);
+    const metadata = {
+      heading: isHeading ? bodyProjection.text || currentHeading : currentHeading,
+      paragraphNumber: isHeading ? undefined : paragraphNumber,
+    };
+
+    if (options.searchTarget !== "ruby") {
+      matches.push(...searchProjection(bodyProjection, searchTerm, options, metadata));
+    }
+
+    if (options.searchTarget !== "body") {
+      for (const rubyProjection of createRubyReadingProjections(node, pos + 1)) {
+        matches.push(...searchProjection(rubyProjection, searchTerm, options, metadata));
+      }
+    }
+
+    if (isHeading && bodyProjection.text) currentHeading = bodyProjection.text;
+    return false;
+  });
+
+  return matches.sort((left, right) => left.from - right.from || left.to - right.to);
+}
+
+export function getSearchPatternError(
+  searchTerm: string,
+  caseSensitiveOrOptions: boolean | SearchOptions,
+): string | null {
+  if (!searchTerm) return null;
+  const options = resolveOptions(caseSensitiveOrOptions);
+  if (!options.regex) return null;
+  return compilePattern(searchTerm, options) ? null : "正規表現が正しくありません";
+}
+
+export function findSearchMatchesInProjection(
+  projection: SearchTextProjection,
+  searchTerm: string,
+  caseSensitiveOrOptions: boolean | SearchOptions,
+  metadata: Pick<SearchMatch, "heading" | "paragraphNumber"> = {},
+): SearchMatch[] {
+  if (!searchTerm) return [];
+  return searchProjection(projection, searchTerm, resolveOptions(caseSensitiveOrOptions), metadata);
+}
+
+export function isSearchMatchReplaceable(match: SearchMatch): boolean {
+  return match.replaceable !== false && match.from < match.to;
+}
+
+export function buildReplacementText(
+  match: SearchMatch,
+  replacement: string,
+  caseSensitiveOrOptions: boolean | SearchOptions,
+): string {
+  if (!resolveOptions(caseSensitiveOrOptions).regex) return replacement;
+
+  return replacement.replace(/\$(\$|&|[1-9][0-9]?)/g, (token, reference: string) => {
+    if (reference === "$") return "$";
+    if (reference === "&") return match.text ?? "";
+
+    const captureIndex = Number(reference) - 1;
+    if (!match.captures || captureIndex < 0 || captureIndex >= match.captures.length) return token;
+    return match.captures[captureIndex] ?? "";
+  });
+}
+
+export function createReplacementSteps(
+  matches: readonly SearchMatch[],
+  replacement: string,
+  caseSensitiveOrOptions: boolean | SearchOptions,
+): ReplacementStep[] {
+  const seen = new Set<string>();
+
+  return matches
+    .filter(isSearchMatchReplaceable)
+    .map((match) => ({
+      from: match.from,
+      to: match.to,
+      text: buildReplacementText(match, replacement, caseSensitiveOrOptions),
+    }))
+    .filter((step) => {
+      const key = `${step.from}:${step.to}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .sort((left, right) => right.from - left.from || right.to - left.to);
+}
+
+function resolveOptions(value: boolean | SearchOptions): ResolvedSearchOptions {
+  if (typeof value === "boolean") return { ...DEFAULT_OPTIONS, caseSensitive: value };
+  return { ...DEFAULT_OPTIONS, ...value };
+}
+
+function createBodyProjection(
+  block: Node,
+  blockContentStart: number,
+  excludeComments: boolean,
+): SearchTextProjection {
+  const projection: SearchTextProjection = { text: "", segments: [] };
+
+  block.forEach((child, offset) => {
+    const from = blockContentStart + offset;
+    if (child.isText && child.text) {
+      appendSegment(projection, child.text, from, from + child.nodeSize, "text", true);
+      return;
+    }
+
+    const comment = getCommentText(child);
+    if (comment !== null) {
+      if (!excludeComments) {
+        appendSegment(projection, comment, from, from + child.nodeSize, "comment", false);
       }
       return;
     }
-    if (node.type.name === "ruby") {
-      const baseRaw = (node.attrs.base as string) ?? "";
-      const baseText = caseSensitive ? baseRaw : baseRaw.toLowerCase();
-      let i = 0;
-      while ((i = baseText.indexOf(searchStr, i)) !== -1) {
-        foundMatches.push({ from: pos, to: pos + node.nodeSize });
-        i += searchStr.length; // advance past matched chars to avoid spurious overlapping matches
-      }
-      return false; // atom — do not recurse into ruby internals
+
+    const atom = getDisplayedAtomText(child);
+    if (atom) {
+      appendSegment(projection, atom.text, from, from + child.nodeSize, atom.source, false);
     }
   });
 
-  return foundMatches;
+  return projection;
+}
+
+function getCommentText(node: Node): string | null {
+  if (node.type.name !== "comment" && node.type.name !== "htmlComment") return null;
+  const value = node.attrs.value ?? node.attrs.text ?? node.textContent;
+  return typeof value === "string" ? value.replace(/^<!--\s*|\s*-->$/g, "") : "";
+}
+
+function createRubyReadingProjections(
+  block: Node,
+  blockContentStart: number,
+): SearchTextProjection[] {
+  const projections: SearchTextProjection[] = [];
+
+  block.forEach((child, offset) => {
+    if (child.type.name !== "ruby") return;
+    const text = ((child.attrs.text as string) ?? "").replace(/\./g, "");
+    if (!text) return;
+
+    const from = blockContentStart + offset;
+    const projection: SearchTextProjection = { text: "", segments: [] };
+    appendSegment(projection, text, from, from + child.nodeSize, "ruby-text", false);
+    projections.push(projection);
+  });
+
+  return projections;
+}
+
+function appendSegment(
+  projection: SearchTextProjection,
+  text: string,
+  from: number,
+  to: number,
+  source: SearchMatchSource,
+  replaceable: boolean,
+): void {
+  if (!text) return;
+  const displayFrom = projection.text.length;
+  projection.text += text;
+  projection.segments.push({
+    text,
+    displayFrom,
+    displayTo: projection.text.length,
+    from,
+    to,
+    source,
+    replaceable,
+  });
+}
+
+function getDisplayedAtomText(node: Node): { text: string; source: SearchMatchSource } | null {
+  switch (node.type.name) {
+    case "ruby":
+      return { text: (node.attrs.base as string) ?? "", source: "ruby-base" };
+    case "tcy":
+      return { text: (node.attrs.value as string) ?? "", source: "tcy" };
+    case "nobreak":
+      return { text: (node.attrs.text as string) ?? "", source: "nobreak" };
+    case "kern":
+      return { text: (node.attrs.text as string) ?? "", source: "kern" };
+    case "hardbreak":
+      return { text: "\n", source: "hardbreak" };
+    case "mdibreak":
+      return { text: "\n", source: "mdibreak" };
+    default:
+      return null;
+  }
+}
+
+function searchProjection(
+  projection: SearchTextProjection,
+  searchTerm: string,
+  options: ResolvedSearchOptions,
+  metadata: Pick<SearchMatch, "heading" | "paragraphNumber">,
+): SearchMatch[] {
+  if (!projection.text || projection.segments.length === 0) return [];
+
+  const normalized = normalizeProjection(projection.text, options.normalizeVariants);
+  const normalizedTerm = options.normalizeVariants
+    ? normalizeJapaneseSearchVariants(searchTerm)
+    : searchTerm;
+  const pattern = compilePattern(normalizedTerm, options);
+  if (!pattern) return [];
+
+  const rawMatches = executePattern(normalized.text, normalizedTerm, pattern, options);
+  const matches: SearchMatch[] = [];
+
+  for (const rawMatch of rawMatches) {
+    const sourceFrom = normalized.sourceFrom[rawMatch.from];
+    const sourceTo = normalized.sourceTo[rawMatch.to - 1];
+    if (sourceFrom === undefined || sourceTo === undefined) continue;
+
+    const match = mapProjectionMatch(projection, sourceFrom, sourceTo, rawMatch.captures);
+    if (!match) continue;
+    if (options.range && (match.from < options.range.from || match.to > options.range.to)) continue;
+    matches.push({ ...match, ...metadata });
+  }
+
+  return matches;
+}
+
+function compilePattern(searchTerm: string, options: ResolvedSearchOptions): RegExp | null {
+  try {
+    const source = options.regex ? searchTerm : escapeRegExp(searchTerm);
+    return new RegExp(source, options.caseSensitive ? "gu" : "giu");
+  } catch {
+    return null;
+  }
+}
+
+function executePattern(
+  text: string,
+  searchTerm: string,
+  pattern: RegExp,
+  options: ResolvedSearchOptions,
+): RawMatch[] {
+  if (!searchTerm) return [];
+  const matches: RawMatch[] = [];
+  pattern.lastIndex = 0;
+
+  while (pattern.lastIndex <= text.length) {
+    const match = pattern.exec(text);
+    if (!match) break;
+
+    const matchedText = match[0] ?? "";
+    if (!matchedText) {
+      pattern.lastIndex = advanceCodePoint(text, match.index);
+      continue;
+    }
+
+    const to = match.index + matchedText.length;
+    if (!options.wholeWord || hasWordBoundaries(text, match.index, to)) {
+      matches.push({
+        from: match.index,
+        to,
+        captures: match.slice(1).map((capture) => capture ?? ""),
+      });
+    }
+  }
+
+  return matches;
+}
+
+function mapProjectionMatch(
+  projection: SearchTextProjection,
+  displayFrom: number,
+  displayTo: number,
+  captures: string[] | undefined,
+): SearchMatch | null {
+  const segments = projection.segments.filter(
+    (segment) => segment.displayFrom < displayTo && segment.displayTo > displayFrom,
+  );
+  const first = segments[0];
+  const last = segments.at(-1);
+  if (!first || !last) return null;
+
+  const from = first.replaceable
+    ? first.from + Math.max(0, displayFrom - first.displayFrom)
+    : first.from;
+  const to = last.replaceable
+    ? last.from + Math.min(last.text.length, displayTo - last.displayFrom)
+    : last.to;
+  const sources = new Set(segments.map((segment) => segment.source));
+
+  return {
+    from,
+    to,
+    text: projection.text.slice(displayFrom, displayTo),
+    source: sources.size === 1 ? first.source : "mixed",
+    replaceable: segments.every((segment) => segment.replaceable) && from < to,
+    captures,
+  };
+}
+
+function normalizeProjection(text: string, normalizeVariants: boolean): NormalizedProjection {
+  const projection: NormalizedProjection = { text: "", sourceFrom: [], sourceTo: [] };
+
+  for (const { segment, index: sourceIndex } of JAPANESE_GRAPHEME_SEGMENTER.segment(text)) {
+    const normalizedSegment = normalizeVariants
+      ? normalizeJapaneseSearchVariants(segment)
+      : segment;
+    projection.text += normalizedSegment;
+    for (let index = 0; index < normalizedSegment.length; index += 1) {
+      projection.sourceFrom.push(sourceIndex);
+      projection.sourceTo.push(sourceIndex + segment.length);
+    }
+  }
+
+  return projection;
+}
+
+function hasWordBoundaries(text: string, from: number, to: number): boolean {
+  return !isWordCharacter(codePointBefore(text, from)) && !isWordCharacter(codePointAt(text, to));
+}
+
+function isWordCharacter(value: string): boolean {
+  return value !== "" && WORD_CHAR_RE.test(value);
+}
+
+function codePointBefore(text: string, index: number): string {
+  return Array.from(text.slice(0, index)).at(-1) ?? "";
+}
+
+function codePointAt(text: string, index: number): string {
+  return Array.from(text.slice(index))[0] ?? "";
+}
+
+function advanceCodePoint(text: string, index: number): number {
+  if (index >= text.length) return text.length + 1;
+  const codePoint = text.codePointAt(index);
+  return index + (codePoint !== undefined && codePoint > 0xffff ? 2 : 1);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/lib/editor-page/japanese-variant-normalization.ts
+++ b/lib/editor-page/japanese-variant-normalization.ts
@@ -1,0 +1,31 @@
+import kyujitaiData from "kyujitai/data/kyujitai.json";
+
+interface KyujitaiData {
+  kyuji: Array<[shinjitai: string, kyujitai: string, variationSelector?: string]>;
+}
+
+const SHINJITAI_BY_KYUJITAI = new Map(
+  (kyujitaiData as unknown as KyujitaiData).kyuji
+    .filter(([shinjitai, kyujitai]) => shinjitai !== kyujitai)
+    .map(([shinjitai, kyujitai]) => [kyujitai, shinjitai] as const),
+);
+
+/**
+ * Normalizes width, kana script, and old character forms for search comparison.
+ * The kyujitai table is maintained by the `kyujitai` package rather than in
+ * search logic, so data changes remain independently reviewable.
+ */
+export function normalizeJapaneseSearchVariants(text: string): string {
+  let normalized = "";
+
+  for (const character of text.normalize("NFKC")) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const kana =
+      codePoint >= 0x30a1 && codePoint <= 0x30f6
+        ? String.fromCodePoint(codePoint - 0x60)
+        : character;
+    normalized += SHINJITAI_BY_KYUJITAI.get(kana) ?? kana;
+  }
+
+  return normalized;
+}

--- a/lib/editor-page/project-search-worker-client.ts
+++ b/lib/editor-page/project-search-worker-client.ts
@@ -1,0 +1,102 @@
+import type { SearchOptions } from "./find-search-matches";
+import type { ProjectDocumentMatcher, RawDocumentSearchResult } from "./project-search";
+
+export interface ProjectSearchWorkerRequest {
+  type: "MATCH_DOCUMENT";
+  id: number;
+  content: string;
+  fileType: string;
+  searchTerm: string;
+  options: SearchOptions;
+}
+
+export type ProjectSearchWorkerResponse =
+  | {
+      type: "MATCH_RESULT";
+      id: number;
+      result: RawDocumentSearchResult;
+    }
+  | {
+      type: "MATCH_ERROR";
+      id: number;
+      error: { name: string; message: string };
+    };
+
+export type ProjectSearchWorkerFactory = () => Worker;
+
+const defaultWorkerFactory: ProjectSearchWorkerFactory = () =>
+  new Worker(new URL("./project-search.worker.ts", import.meta.url), { type: "module" });
+
+interface PendingMatch {
+  resolve: (result: RawDocumentSearchResult) => void;
+  reject: (error: Error) => void;
+}
+
+export class ProjectSearchWorkerClient {
+  private readonly worker: Worker;
+  private readonly pending = new Map<number, PendingMatch>();
+  private nextId = 1;
+  private disposed = false;
+  private fatalError: Error | null = null;
+
+  readonly matchDocument: ProjectDocumentMatcher = (content, fileType, searchTerm, options) => {
+    if (this.fatalError) return Promise.reject(this.fatalError);
+    if (this.disposed) return Promise.reject(new Error("Project search worker is disposed"));
+
+    const id = this.nextId++;
+    const result = new Promise<RawDocumentSearchResult>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+    this.worker.postMessage({
+      type: "MATCH_DOCUMENT",
+      id,
+      content,
+      fileType,
+      searchTerm,
+      options,
+    } satisfies ProjectSearchWorkerRequest);
+    return result;
+  };
+
+  constructor(factory: ProjectSearchWorkerFactory = defaultWorkerFactory) {
+    this.worker = factory();
+    this.worker.onmessage = (event: MessageEvent<ProjectSearchWorkerResponse>) => {
+      const message = event.data;
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+
+      if (message.type === "MATCH_RESULT") {
+        pending.resolve(message.result);
+        return;
+      }
+
+      const error = new Error(message.error.message);
+      error.name = message.error.name;
+      pending.reject(error);
+    };
+    this.worker.onerror = (event) => {
+      this.poison(new Error(event.message || "Project search worker failed"));
+    };
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.rejectAll(new Error("Project search worker is disposed"));
+    this.worker.terminate();
+  }
+
+  private rejectAll(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+
+  private poison(error: Error): void {
+    if (this.fatalError) return;
+    this.fatalError = error;
+    this.disposed = true;
+    this.rejectAll(error);
+    this.worker.terminate();
+  }
+}

--- a/lib/editor-page/project-search.ts
+++ b/lib/editor-page/project-search.ts
@@ -294,10 +294,7 @@ function createPlainProjection(content: string): SearchTextProjection {
   };
 }
 
-function createMarkdownProjection(
-  content: string,
-  excludeComments: boolean,
-): SearchTextProjection {
+function createMarkdownProjection(content: string, excludeComments: boolean): SearchTextProjection {
   const projection: SearchTextProjection = { text: "", segments: [] };
   const commentPattern = /<!--[\s\S]*?-->/g;
   let cursor = 0;
@@ -360,14 +357,7 @@ function createMdiProjections(
       appendProjectionSegment(body, content.slice(cursor, rawFrom), cursor, rawFrom, "text", true);
     }
 
-    appendMdiToken(
-      body,
-      rubyReadings,
-      token,
-      rawFrom,
-      rawFrom + token.length,
-      excludeComments,
-    );
+    appendMdiToken(body, rubyReadings, token, rawFrom, rawFrom + token.length, excludeComments);
     cursor = rawFrom + token.length;
   }
 

--- a/lib/editor-page/project-search.ts
+++ b/lib/editor-page/project-search.ts
@@ -1,0 +1,531 @@
+import {
+  createReplacementSteps,
+  findSearchMatchesInProjection,
+  type SearchMatch,
+  type SearchMatchSource,
+  type SearchOptions,
+  type SearchTextProjection,
+} from "./find-search-matches";
+import type { VirtualFileSystem } from "@/lib/vfs/types";
+
+export interface RawDocumentSearchMatch extends SearchMatch {
+  rawFrom: number;
+  rawTo: number;
+  lineNumber: number;
+}
+
+export interface RawDocumentSearchResult {
+  matches: RawDocumentSearchMatch[];
+  content: string;
+}
+
+export interface ProjectSearchFileResult extends RawDocumentSearchResult {
+  path: string;
+  fileName: string;
+}
+
+export interface SearchProjectFilesParams {
+  vfs: VirtualFileSystem;
+  searchTerm: string;
+  options: SearchOptions;
+  rootPath?: string;
+  openBuffers?: ReadonlyMap<string, string>;
+  signal?: AbortSignal;
+  onProgress?: (searchedFiles: number, totalFiles: number) => void;
+  onFileResult?: (result: ProjectSearchFileResult) => void;
+  onFileError?: (path: string, error: unknown) => void;
+  matchDocument?: ProjectDocumentMatcher;
+}
+
+export type ProjectDocumentMatcher = (
+  content: string,
+  fileType: string,
+  searchTerm: string,
+  options: SearchOptions,
+) => RawDocumentSearchResult | Promise<RawDocumentSearchResult>;
+
+export interface ProjectReplacementChange {
+  path: string;
+  before: string;
+  after: string;
+  replacementCount: number;
+  openBuffer: boolean;
+}
+
+interface ReplaceProjectFilesParams {
+  vfs: VirtualFileSystem;
+  results: readonly ProjectSearchFileResult[];
+  replacement: string;
+  options: SearchOptions;
+  openBuffers?: ReadonlyMap<string, string>;
+  onOpenBufferChange?: (path: string, content: string) => void | Promise<void>;
+}
+
+interface UndoProjectReplacementParams {
+  vfs: VirtualFileSystem;
+  changes: readonly ProjectReplacementChange[];
+  openBuffers?: ReadonlyMap<string, string>;
+  onOpenBufferChange?: (path: string, content: string) => void | Promise<void>;
+}
+
+const SEARCHABLE_EXTENSIONS = new Set([".mdi", ".md", ".txt"]);
+const PROJECT_SEARCH_YIELD_INTERVAL = 8;
+const MDI_TOKEN_RE =
+  /<!--[\s\S]*?-->|\{[^{}|\n]+\|[^{}\n]+\}|\^[^^\n]+\^|\[\[(?:blank|br|no-break:[^\]\n]*|kern:[^:\]\n]+:[^\]\n]*)\]\]/g;
+
+export function isSearchableProjectPath(path: string): boolean {
+  if (hasHiddenPathSegment(path)) return false;
+  const fileName = normalizePath(path).split("/").at(-1) ?? "";
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex < 0) return false;
+  return SEARCHABLE_EXTENSIONS.has(fileName.slice(dotIndex).toLowerCase());
+}
+
+export async function searchProjectFiles({
+  vfs,
+  searchTerm,
+  options,
+  rootPath = "",
+  openBuffers = new Map(),
+  signal,
+  onProgress,
+  onFileResult,
+  onFileError,
+  matchDocument = findRawDocumentMatches,
+}: SearchProjectFilesParams): Promise<ProjectSearchFileResult[]> {
+  if (!searchTerm) return [];
+
+  const paths = await collectSearchablePaths(vfs, rootPath, signal);
+  const results: ProjectSearchFileResult[] = [];
+
+  for (let index = 0; index < paths.length; index += 1) {
+    throwIfAborted(signal);
+    const path = paths[index];
+
+    try {
+      const content = openBuffers.get(path) ?? (await vfs.readFile(path));
+      const fileType = getFileExtension(path);
+      const result = await matchDocument(content, fileType, searchTerm, options);
+      if (result.matches.length > 0) {
+        const fileResult = {
+          ...result,
+          path,
+          fileName: path.split("/").at(-1) ?? path,
+        };
+        results.push(fileResult);
+        onFileResult?.(fileResult);
+      }
+    } catch (error) {
+      onFileError?.(path, error);
+    }
+
+    onProgress?.(index + 1, paths.length);
+    if ((index + 1) % PROJECT_SEARCH_YIELD_INTERVAL === 0) await yieldToMainThread();
+  }
+
+  return results;
+}
+
+export function findRawDocumentMatches(
+  content: string,
+  fileType: string,
+  searchTerm: string,
+  options: SearchOptions,
+): RawDocumentSearchResult {
+  if (!searchTerm) return { content, matches: [] };
+
+  const normalizedFileType = fileType.toLowerCase();
+  const { body, rubyReadings } =
+    normalizedFileType === ".mdi"
+      ? createMdiProjections(content, options.excludeComments ?? true)
+      : {
+          body:
+            normalizedFileType === ".md"
+              ? createMarkdownProjection(content, options.excludeComments ?? true)
+              : createPlainProjection(content),
+          rubyReadings: [],
+        };
+  const target = options.searchTarget ?? "all";
+  const matches: SearchMatch[] = [];
+
+  if (target !== "ruby") {
+    matches.push(...findSearchMatchesInProjection(body, searchTerm, options));
+  }
+  if (target !== "body") {
+    for (const reading of rubyReadings) {
+      matches.push(...findSearchMatchesInProjection(reading, searchTerm, options));
+    }
+  }
+
+  return {
+    content,
+    matches: matches
+      .map((match) => addRawMatchMetadata(content, match))
+      .sort((left, right) => left.rawFrom - right.rawFrom || left.rawTo - right.rawTo),
+  };
+}
+
+export async function replaceProjectFiles({
+  vfs,
+  results,
+  replacement,
+  options,
+  openBuffers = new Map(),
+  onOpenBufferChange,
+}: ReplaceProjectFilesParams): Promise<ProjectReplacementChange[]> {
+  const plans: Array<{
+    result: ProjectSearchFileResult;
+    nextContent: string;
+    replacementCount: number;
+    openBuffer: boolean;
+  }> = [];
+  const changes: ProjectReplacementChange[] = [];
+
+  for (const result of results) {
+    if (!isSearchableProjectPath(result.path)) continue;
+    const steps = createReplacementSteps(result.matches, replacement, options);
+    if (steps.length === 0) continue;
+
+    const openBuffer = openBuffers.has(result.path);
+    const currentContent = openBuffer
+      ? (openBuffers.get(result.path) ?? "")
+      : await vfs.readFile(result.path);
+    if (currentContent !== result.content) {
+      throw new Error(`${result.path} は検索後に内容が変更されました`);
+    }
+
+    let nextContent = result.content;
+    for (const step of steps) {
+      nextContent = nextContent.slice(0, step.from) + step.text + nextContent.slice(step.to);
+    }
+    plans.push({ result, nextContent, replacementCount: steps.length, openBuffer });
+  }
+
+  try {
+    for (const plan of plans) {
+      const { result, nextContent, replacementCount, openBuffer } = plan;
+      if (openBuffer) {
+        if (!onOpenBufferChange) {
+          throw new Error(`Open buffer update handler is missing for ${result.path}`);
+        }
+        await onOpenBufferChange(result.path, nextContent);
+      } else {
+        await vfs.writeFile(result.path, nextContent);
+      }
+
+      changes.push({
+        path: result.path,
+        before: result.content,
+        after: nextContent,
+        replacementCount,
+        openBuffer,
+      });
+    }
+  } catch (error) {
+    await restoreProjectChanges(vfs, changes, onOpenBufferChange);
+    throw error;
+  }
+
+  return changes;
+}
+
+export async function undoProjectReplacement({
+  vfs,
+  changes,
+  openBuffers = new Map(),
+  onOpenBufferChange,
+}: UndoProjectReplacementParams): Promise<void> {
+  for (const change of changes) {
+    const currentContent = change.openBuffer
+      ? openBuffers.get(change.path)
+      : await vfs.readFile(change.path);
+    if (currentContent !== change.after) {
+      throw new Error(`${change.path} は置換後に内容が変更されました`);
+    }
+  }
+  await restoreProjectChanges(vfs, [...changes].reverse(), onOpenBufferChange);
+}
+
+async function collectSearchablePaths(
+  vfs: VirtualFileSystem,
+  rootPath: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  if (rootPath && hasHiddenPathSegment(rootPath)) return [];
+  const paths: string[] = [];
+
+  async function visit(directoryPath: string): Promise<void> {
+    throwIfAborted(signal);
+    const entries = [...(await vfs.listDirectory(directoryPath))].sort((left, right) =>
+      left.path.localeCompare(right.path),
+    );
+
+    for (const entry of entries) {
+      throwIfAborted(signal);
+      if (hasHiddenPathSegment(entry.path)) continue;
+      if (entry.kind === "directory") {
+        await visit(entry.path);
+      } else if (isSearchableProjectPath(entry.path)) {
+        paths.push(entry.path);
+      }
+    }
+  }
+
+  await visit(rootPath);
+  return paths;
+}
+
+function createPlainProjection(content: string): SearchTextProjection {
+  return {
+    text: content,
+    segments: content
+      ? [
+          {
+            text: content,
+            displayFrom: 0,
+            displayTo: content.length,
+            from: 0,
+            to: content.length,
+            source: "text",
+            replaceable: true,
+          },
+        ]
+      : [],
+  };
+}
+
+function createMarkdownProjection(
+  content: string,
+  excludeComments: boolean,
+): SearchTextProjection {
+  const projection: SearchTextProjection = { text: "", segments: [] };
+  const commentPattern = /<!--[\s\S]*?-->/g;
+  let cursor = 0;
+
+  for (const match of content.matchAll(commentPattern)) {
+    const rawFrom = match.index;
+    if (rawFrom > cursor) {
+      appendProjectionSegment(
+        projection,
+        content.slice(cursor, rawFrom),
+        cursor,
+        rawFrom,
+        "text",
+        true,
+      );
+    }
+    if (!excludeComments) {
+      appendProjectionSegment(
+        projection,
+        match[0].replace(/^<!--\s*|\s*-->$/g, ""),
+        rawFrom,
+        rawFrom + match[0].length,
+        "comment",
+        false,
+      );
+    }
+    cursor = rawFrom + match[0].length;
+  }
+
+  if (cursor < content.length) {
+    appendProjectionSegment(
+      projection,
+      content.slice(cursor),
+      cursor,
+      content.length,
+      "text",
+      true,
+    );
+  }
+
+  return projection;
+}
+
+function createMdiProjections(
+  content: string,
+  excludeComments: boolean,
+): {
+  body: SearchTextProjection;
+  rubyReadings: SearchTextProjection[];
+} {
+  const body: SearchTextProjection = { text: "", segments: [] };
+  const rubyReadings: SearchTextProjection[] = [];
+  let cursor = 0;
+
+  MDI_TOKEN_RE.lastIndex = 0;
+  for (const tokenMatch of content.matchAll(MDI_TOKEN_RE)) {
+    const rawFrom = tokenMatch.index;
+    const token = tokenMatch[0];
+    if (rawFrom > cursor) {
+      appendProjectionSegment(body, content.slice(cursor, rawFrom), cursor, rawFrom, "text", true);
+    }
+
+    appendMdiToken(
+      body,
+      rubyReadings,
+      token,
+      rawFrom,
+      rawFrom + token.length,
+      excludeComments,
+    );
+    cursor = rawFrom + token.length;
+  }
+
+  if (cursor < content.length) {
+    appendProjectionSegment(body, content.slice(cursor), cursor, content.length, "text", true);
+  }
+
+  return { body, rubyReadings };
+}
+
+function appendMdiToken(
+  body: SearchTextProjection,
+  rubyReadings: SearchTextProjection[],
+  token: string,
+  rawFrom: number,
+  rawTo: number,
+  excludeComments: boolean,
+): void {
+  if (token.startsWith("<!--")) {
+    if (!excludeComments) {
+      appendProjectionSegment(
+        body,
+        token.replace(/^<!--\s*|\s*-->$/g, ""),
+        rawFrom,
+        rawTo,
+        "comment",
+        false,
+      );
+    }
+    return;
+  }
+
+  const ruby = /^\{([^{}|\n]+)\|([^{}\n]+)\}$/.exec(token);
+  if (ruby) {
+    appendProjectionSegment(body, ruby[1], rawFrom, rawTo, "ruby-base", false);
+    const reading: SearchTextProjection = { text: "", segments: [] };
+    appendProjectionSegment(
+      reading,
+      ruby[2].replace(/\./g, ""),
+      rawFrom,
+      rawTo,
+      "ruby-text",
+      false,
+    );
+    rubyReadings.push(reading);
+    return;
+  }
+
+  const tcy = /^\^([^^\n]+)\^$/.exec(token);
+  if (tcy) {
+    appendProjectionSegment(body, tcy[1], rawFrom, rawTo, "tcy", false);
+    return;
+  }
+
+  const noBreak = /^\[\[no-break:([^\]\n]*)\]\]$/.exec(token);
+  if (noBreak) {
+    appendProjectionSegment(body, noBreak[1], rawFrom, rawTo, "nobreak", false);
+    return;
+  }
+
+  const kern = /^\[\[kern:[^:\]\n]+:([^\]\n]*)\]\]$/.exec(token);
+  if (kern) {
+    appendProjectionSegment(body, kern[1], rawFrom, rawTo, "kern", false);
+    return;
+  }
+
+  if (token === "[[blank]]" || token === "[[br]]") {
+    appendProjectionSegment(body, "\n", rawFrom, rawTo, "mdibreak", false);
+  }
+}
+
+function appendProjectionSegment(
+  projection: SearchTextProjection,
+  text: string,
+  from: number,
+  to: number,
+  source: SearchMatchSource,
+  replaceable: boolean,
+): void {
+  if (!text) return;
+  const displayFrom = projection.text.length;
+  projection.text += text;
+  projection.segments.push({
+    text,
+    displayFrom,
+    displayTo: projection.text.length,
+    from,
+    to,
+    source,
+    replaceable,
+  });
+}
+
+function addRawMatchMetadata(content: string, match: SearchMatch): RawDocumentSearchMatch {
+  const rawFrom = match.from;
+  const rawTo = match.to;
+  const before = content.slice(0, rawFrom);
+  const lineNumber = before.split("\n").length;
+  const heading = findPreviousHeading(before);
+
+  return {
+    ...match,
+    rawFrom,
+    rawTo,
+    lineNumber,
+    paragraphNumber: lineNumber,
+    heading,
+  };
+}
+
+function findPreviousHeading(content: string): string | undefined {
+  const lines = content.split("\n");
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const heading = /^#{1,6}\s+(.+?)\s*$/.exec(lines[index]);
+    if (heading) return heading[1];
+  }
+  return undefined;
+}
+
+function hasHiddenPathSegment(path: string): boolean {
+  return normalizePath(path)
+    .split("/")
+    .filter(Boolean)
+    .some((segment) => segment.startsWith("."));
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function getFileExtension(path: string): string {
+  const fileName = normalizePath(path).split("/").at(-1) ?? "";
+  const dotIndex = fileName.lastIndexOf(".");
+  return dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : "";
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw new DOMException("Project search was cancelled", "AbortError");
+}
+
+function yieldToMainThread(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function restoreProjectChanges(
+  vfs: VirtualFileSystem,
+  changes: readonly ProjectReplacementChange[],
+  onOpenBufferChange?: (path: string, content: string) => void | Promise<void>,
+): Promise<void> {
+  for (const change of changes) {
+    if (change.openBuffer) {
+      if (!onOpenBufferChange) {
+        throw new Error(`Open buffer update handler is missing for ${change.path}`);
+      }
+      await onOpenBufferChange(change.path, change.before);
+    } else {
+      await vfs.writeFile(change.path, change.before);
+    }
+  }
+}

--- a/lib/editor-page/project-search.worker.ts
+++ b/lib/editor-page/project-search.worker.ts
@@ -1,0 +1,36 @@
+/// <reference lib="webworker" />
+
+import { findRawDocumentMatches } from "./project-search";
+import type {
+  ProjectSearchWorkerRequest,
+  ProjectSearchWorkerResponse,
+} from "./project-search-worker-client";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+function post(message: ProjectSearchWorkerResponse): void {
+  self.postMessage(message);
+}
+
+self.onmessage = (event: MessageEvent<ProjectSearchWorkerRequest>) => {
+  const message = event.data;
+  try {
+    post({
+      type: "MATCH_RESULT",
+      id: message.id,
+      result: findRawDocumentMatches(
+        message.content,
+        message.fileType,
+        message.searchTerm,
+        message.options,
+      ),
+    });
+  } catch (error) {
+    const cause = error instanceof Error ? error : new Error(String(error));
+    post({
+      type: "MATCH_ERROR",
+      id: message.id,
+      error: { name: cause.name, message: cause.message },
+    });
+  }
+};

--- a/lib/editor-page/search-history.ts
+++ b/lib/editor-page/search-history.ts
@@ -1,0 +1,20 @@
+import { localPreferences } from "@/lib/storage/local-preferences";
+
+const SEARCH_HISTORY_LIMIT = 10;
+
+export function loadSearchHistory(): string[] {
+  return localPreferences.getSearchHistory().slice(0, SEARCH_HISTORY_LIMIT);
+}
+
+export function addSearchHistoryEntry(searchTerm: string): string[] {
+  const normalizedTerm = searchTerm.trim();
+  if (!normalizedTerm) return loadSearchHistory();
+
+  const next = [
+    normalizedTerm,
+    ...loadSearchHistory().filter((entry) => entry !== normalizedTerm),
+  ].slice(0, SEARCH_HISTORY_LIMIT);
+
+  localPreferences.setSearchHistory(next);
+  return next;
+}

--- a/lib/editor-page/use-panel-state.ts
+++ b/lib/editor-page/use-panel-state.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import type { ActivityBarView } from "@/components/ActivityBar";
 import { isBottomView } from "@/components/ActivityBar";
 import type { SettingsCategory } from "@/components/SettingsModal";
+import type { SearchTarget } from "./find-search-matches";
 
 export interface PanelState {
   topView: ActivityBarView;
@@ -12,6 +13,12 @@ export interface PanelState {
    *  （サイドパネル）の両方がこれを共有し、内容のズレを防ぐ。 */
   searchTerm: string;
   caseSensitive: boolean;
+  regexSearch: boolean;
+  wholeWordSearch: boolean;
+  normalizeVariants: boolean;
+  excludeComments: boolean;
+  searchTarget: SearchTarget;
+  selectionOnly: boolean;
   /** 現在フォーカス中のマッチ index。両 UI のナビ／クリックで共有更新する。 */
   currentMatchIndex: number;
   isRightPanelCollapsed: boolean;
@@ -36,6 +43,12 @@ export interface PanelHandlers {
   handleOpenDictionary: (searchTerm?: string) => void;
   setSearchTerm: (term: string) => void;
   setCaseSensitive: Dispatch<SetStateAction<boolean>>;
+  setRegexSearch: Dispatch<SetStateAction<boolean>>;
+  setWholeWordSearch: Dispatch<SetStateAction<boolean>>;
+  setNormalizeVariants: Dispatch<SetStateAction<boolean>>;
+  setExcludeComments: Dispatch<SetStateAction<boolean>>;
+  setSearchTarget: Dispatch<SetStateAction<SearchTarget>>;
+  setSelectionOnly: Dispatch<SetStateAction<boolean>>;
   setCurrentMatchIndex: Dispatch<SetStateAction<number>>;
   /** サイドバー検索パネルを開く（共有 searchTerm をそのまま表示）。 */
   handleShowAllSearchResults: () => void;
@@ -61,6 +74,12 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
   const [bottomView, setBottomView] = useState<ActivityBarView>("none");
   const [searchTerm, setSearchTermRaw] = useState("");
   const [caseSensitive, setCaseSensitive] = useState(false);
+  const [regexSearch, setRegexSearch] = useState(false);
+  const [wholeWordSearch, setWholeWordSearch] = useState(false);
+  const [normalizeVariants, setNormalizeVariants] = useState(false);
+  const [excludeComments, setExcludeComments] = useState(true);
+  const [searchTarget, setSearchTarget] = useState<SearchTarget>("all");
+  const [selectionOnly, setSelectionOnly] = useState(false);
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
   const [isRightPanelCollapsed, setIsRightPanelCollapsed] = useState(false);
   const [dictionarySearchTrigger, setDictionarySearchTrigger] = useState<{
@@ -136,6 +155,12 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
       bottomView,
       searchTerm,
       caseSensitive,
+      regexSearch,
+      wholeWordSearch,
+      normalizeVariants,
+      excludeComments,
+      searchTarget,
+      selectionOnly,
       currentMatchIndex,
       isRightPanelCollapsed,
       dictionarySearchTrigger,
@@ -156,6 +181,12 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
       handleOpenDictionary,
       setSearchTerm,
       setCaseSensitive,
+      setRegexSearch,
+      setWholeWordSearch,
+      setNormalizeVariants,
+      setExcludeComments,
+      setSearchTarget,
+      setSelectionOnly,
       setCurrentMatchIndex,
       handleShowAllSearchResults,
       handleCloseSearchResults,

--- a/lib/editor-page/use-selection-tracking.ts
+++ b/lib/editor-page/use-selection-tracking.ts
@@ -29,10 +29,16 @@ export interface EditorSelectionState {
   pointerClientY: number | null;
 }
 
+export interface SelectionSearchRange {
+  from: number;
+  to: number;
+}
+
 interface UseSelectionTrackingOptions {
   editorViewInstance: EditorView | null;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   onSelectionChange?: (charCount: number, manuscriptCells: number, manuscriptPages: number) => void;
+  onSelectionRangeChange?: (range: SelectionSearchRange | null) => void;
 }
 
 const EMPTY_SELECTION_STATE: EditorSelectionState = {
@@ -81,6 +87,14 @@ function sameSelectionState(a: EditorSelectionState, b: EditorSelectionState): b
   );
 }
 
+export function getEditorSelectionSearchRange(
+  selection: { empty: boolean; from: number; to: number },
+): SelectionSearchRange | null {
+  return !selection.empty && selection.from < selection.to
+    ? { from: selection.from, to: selection.to }
+    : null;
+}
+
 function safeCoordsAtPos(editorViewInstance: EditorView, pos: number): ViewportRect | null {
   try {
     return toViewportRect(editorViewInstance.coordsAtPos(pos));
@@ -101,10 +115,13 @@ export function useSelectionTracking({
   editorViewInstance,
   scrollContainerRef,
   onSelectionChange,
+  onSelectionRangeChange,
 }: UseSelectionTrackingOptions): EditorSelectionState {
   const [selectionState, setSelectionState] = useState<EditorSelectionState>(EMPTY_SELECTION_STATE);
   const selectionStateRef = useRef(selectionState);
   const onSelectionChangeRef = useRef(onSelectionChange);
+  const onSelectionRangeChangeRef = useRef(onSelectionRangeChange);
+  const lastReportedRangeRef = useRef<SelectionSearchRange | null>(null);
   const lastPointerYRef = useRef<number | null>(null);
   const lastReportedCountRef = useRef(0);
   // 原稿用紙マス数も保持する。可視文字数が同じでも禁則処理でマス数は変わり得るため、
@@ -120,6 +137,21 @@ export function useSelectionTracking({
     onSelectionChangeRef.current = onSelectionChange;
   }, [onSelectionChange]);
 
+  useEffect(() => {
+    onSelectionRangeChangeRef.current = onSelectionRangeChange;
+  }, [onSelectionRangeChange]);
+
+  const reportSelectionRange = useCallback(
+    (selection: { empty: boolean; from: number; to: number }) => {
+      const range = getEditorSelectionSearchRange(selection);
+      const previous = lastReportedRangeRef.current;
+      if (previous?.from === range?.from && previous?.to === range?.to) return;
+      lastReportedRangeRef.current = range;
+      onSelectionRangeChangeRef.current?.(range);
+    },
+    [],
+  );
+
   const updateSelectionState = useCallback(() => {
     if (!editorViewInstance) {
       if (lastReportedCountRef.current !== 0 || lastReportedCellsRef.current !== 0) {
@@ -130,6 +162,7 @@ export function useSelectionTracking({
       setSelectionState((prev) =>
         sameSelectionState(prev, EMPTY_SELECTION_STATE) ? prev : EMPTY_SELECTION_STATE,
       );
+      reportSelectionRange({ empty: true, from: 0, to: 0 });
       return;
     }
 
@@ -188,8 +221,9 @@ export function useSelectionTracking({
       onSelectionChangeRef.current?.(0, 0, 0);
     }
 
+    reportSelectionRange(selection);
     setSelectionState((prev) => (sameSelectionState(prev, nextState) ? prev : nextState));
-  }, [editorViewInstance]);
+  }, [editorViewInstance, reportSelectionRange]);
 
   const scheduleUpdate = useCallback(
     (pointerClientY?: number | null) => {

--- a/lib/editor-page/use-selection-tracking.ts
+++ b/lib/editor-page/use-selection-tracking.ts
@@ -87,9 +87,11 @@ function sameSelectionState(a: EditorSelectionState, b: EditorSelectionState): b
   );
 }
 
-export function getEditorSelectionSearchRange(
-  selection: { empty: boolean; from: number; to: number },
-): SelectionSearchRange | null {
+export function getEditorSelectionSearchRange(selection: {
+  empty: boolean;
+  from: number;
+  to: number;
+}): SelectionSearchRange | null {
   return !selection.empty && selection.from < selection.to
     ? { from: selection.from, to: selection.to }
     : null;

--- a/lib/storage/local-preferences.ts
+++ b/lib/storage/local-preferences.ts
@@ -14,6 +14,7 @@ const KEYS = {
   rightTab: `${PREFIX}right-tab`,
   sidebarTopOrder: `${PREFIX}sidebar-top-order`,
   sidebarBottomOrder: `${PREFIX}sidebar-bottom-order`,
+  searchHistory: `${PREFIX}search-history`,
 } as const;
 
 // One-time migration from old keys to new keys
@@ -125,5 +126,22 @@ export const localPreferences = {
   },
   setSidebarBottomOrder(ids: string[]): void {
     set(KEYS.sidebarBottomOrder, JSON.stringify(ids));
+  },
+
+  // --- Search history ---
+  getSearchHistory(): string[] {
+    const raw = get(KEYS.searchHistory);
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return Array.isArray(parsed)
+        ? parsed.filter((value): value is string => typeof value === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  },
+  setSearchHistory(entries: readonly string[]): void {
+    set(KEYS.searchHistory, JSON.stringify(entries));
   },
 } as const;

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "electron-updater": "^6.8.9",
         "fflate": "^0.8.3",
         "kuromoji": "^0.1.2",
+        "kyujitai": "^1.3.0",
         "markdown-it": "^14.2.0",
         "next": "^16.2.9",
         "node-pty": "^1.0.0",
@@ -11763,6 +11764,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ivs": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ivs/-/ivs-2.0.2.tgz",
+      "integrity": "sha512-DxLpE5JtBJ2DEQl9nS8MRsxlXoxanbCCaW/2vdO5AILhxKMoo4OMz/QPRsk1Gf3PeFZYy6Dvm/Ta1WS3t6CXLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -12144,6 +12154,18 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/kyujitai": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/kyujitai/-/kyujitai-1.3.0.tgz",
+      "integrity": "sha512-BSd3fBpTWwkIVGQRDoEiKFdBLSW3vrAAHQlaK3v26+ecQ8AY/G7JLkpCP3kFZ3en8jRPyd1JykyIxvPL76OggA==",
+      "license": "MIT",
+      "dependencies": {
+        "ivs": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/language-subtag-registry": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "electron-updater": "^6.8.9",
     "fflate": "^0.8.3",
     "kuromoji": "^0.1.2",
+    "kyujitai": "^1.3.0",
     "markdown-it": "^14.2.0",
     "next": "^16.2.9",
     "node-pty": "^1.0.0",


### PR DESCRIPTION
## 概要

- 正規表現、キャプチャ置換、単語一致、検索履歴、前後移動を追加
- かな・全半角・旧新字体の表記ゆれ、ルビ本文/読み、選択範囲、コメント除外に対応
- MDI の表示文字を位置投影し、ルビやマクロ構造を壊す置換を禁止
- プロジェクト/現在ファイル/フォルダ検索、見出し別結果、段落移動、一括置換と取り消しを追加
- Web Worker による非同期検索、逐次結果、進捗、Web/Electron VFS、未保存 buffer を統合
- 旧字体対応は `kyujitai` の JSON データを利用し、変換表をコードへハードコードしない
- ドット始まりのファイルとディレクトリを全階層で検索対象外にする

## 検証

- `npm test` (136 files, 1693 tests)
- `npm run build`
- `npm run lint` (0 errors; 既存 115 warnings)
- `git diff --check`
- production build を desktop / 390x844 viewport で手動確認

Closes #1645