### PR TITLE
fix: #1639 検証フィードバック（辞書UI/分析/自動DL）＋縦書きスクロール修正

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,6 +57,11 @@ import { usePreviousDayStats } from "@/lib/editor-page/use-previous-day-stats";
 import type { EditorView } from "@milkdown/prose/view";
 import type { SupportedFileExtension } from "@/lib/project/project-types";
 
+// Selections larger than this are never treated as a single-word dictionary
+// lookup. Caps the synchronous textBetween() cost on段落/全選択 and avoids
+// pointless Genji lookups while dragging across大量のテキスト (#1639).
+const SELECTED_WORD_MAX_CHARS = 30;
+
 // Module-level flag: persists across React StrictMode/HMR remounts,
 // but resets on page refresh (module re-evaluated).
 // Each Electron BrowserWindow has its own JS context, so no cross-window contamination.
@@ -1418,8 +1423,11 @@ export default function EditorPage() {
           setSelectedCharCount(count);
           setSelectedManuscriptCells(cells);
           setSelectedManuscriptPages(pages);
-          // 選択語を幻辞ルックアップ用に保持する
-          if (count > 0 && editorViewRef.current) {
+          // 選択語を幻辞ルックアップ用に保持する。
+          // 大きな選択（段落・全選択）では textBetween が O(n) で重く、語の辞書引きにも
+          // 不向きなので閾値を超えたら早期に null。実際の辞書引きの debounce は
+          // useGenjiWordInfo 側で行う（選択ドラッグ中の連続 IPC を抑制）。
+          if (count > 0 && count <= SELECTED_WORD_MAX_CHARS && editorViewRef.current) {
             const { selection, doc } = editorViewRef.current.state;
             const text = doc.textBetween(selection.from, selection.to, "").trim();
             // 単語単位（空白区切り）の先頭語、または選択全体（日本語は空白なし）

--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -281,17 +281,17 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   return (
     <div className="h-full bg-background-secondary border-r border-border flex flex-col">
       {/* Header */}
-      <div className="p-4 border-b border-border">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold text-foreground">辞書</h2>
-          <BookOpen className="w-5 h-5 text-foreground-secondary" />
+      <div className="px-4 py-2.5 border-b border-border">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-base font-semibold text-foreground">辞書</h2>
+          <BookOpen className="w-4 h-4 text-foreground-secondary" />
         </div>
 
         {/* Tabs */}
-        <div className="flex gap-1 bg-background rounded-md p-1 mb-3">
+        <div className="flex gap-1 bg-background rounded-md p-0.5 mb-2">
           <button
             onClick={() => setActiveTab("web")}
-            className={`flex-1 px-2 py-1.5 text-sm font-medium rounded transition-colors ${
+            className={`flex-1 px-2 py-1 text-sm font-medium rounded transition-colors ${
               activeTab === "web"
                 ? "bg-accent text-accent-foreground"
                 : "text-foreground-secondary hover:text-foreground hover:bg-hover"
@@ -301,7 +301,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
           </button>
           <button
             onClick={() => setActiveTab("user")}
-            className={`flex-1 px-2 py-1.5 text-sm font-medium rounded transition-colors ${
+            className={`flex-1 px-2 py-1 text-sm font-medium rounded transition-colors ${
               activeTab === "user"
                 ? "bg-accent text-accent-foreground"
                 : "text-foreground-secondary hover:text-foreground hover:bg-hover"
@@ -324,18 +324,18 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
             placeholder="検索語を入力..."
             value={globalSearchQuery}
             onChange={(e) => setGlobalSearchQuery(e.target.value)}
-            className="flex-1 px-3 py-1.5 bg-background border border-border rounded text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
+            className="flex-1 px-3 py-1 bg-background border border-border rounded text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
           />
           <button
             type="submit"
             disabled={!globalSearchQuery.trim()}
-            className="px-3 py-1.5 bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-3 py-1 bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Search className="w-4 h-4" />
           </button>
         </form>
         {activeSearchQuery && (
-          <div className="text-xs text-foreground-secondary mt-2">
+          <div className="text-xs text-foreground-secondary mt-1.5">
             検索中: 「{activeSearchQuery}」
           </div>
         )}
@@ -494,7 +494,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
           <div className="flex flex-col h-full">
             <div className="flex-1 overflow-y-auto">
               {activeSearchQuery ? (
-                <div className="p-4 space-y-3">
+                <div className="px-2 py-3 space-y-3">
                   {/* Loading indicator */}
                   {masterLoading && (
                     <div className="flex items-center gap-2 text-sm text-foreground-secondary">
@@ -518,8 +518,28 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                   {/* Master dict results */}
                   {!masterLoading && masterResults.length > 0 && (
                     <div className="space-y-1.5">
-                      <div className="text-xs font-semibold text-foreground-tertiary">
-                        幻辞 ({masterResults.length} 件)
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="text-xs font-semibold text-foreground-tertiary">
+                          幻辞 ({masterResults.length} 件)
+                        </div>
+                        <button
+                          onClick={() => {
+                            const url = `https://dict.illusions.app/results?q=${encodeURIComponent(activeSearchQuery)}`;
+                            if (isElectronRenderer() && window.electronAPI?.openDictionaryPopup) {
+                              window.electronAPI.openDictionaryPopup(
+                                url,
+                                `幻辞 - ${activeSearchQuery}`,
+                              );
+                            } else {
+                              window.open(url, "_blank", "noopener,noreferrer");
+                            }
+                          }}
+                          className="flex items-center gap-1 text-xs text-foreground-tertiary hover:text-foreground transition-colors flex-shrink-0"
+                          title="幻辞.com をブラウザで開く"
+                        >
+                          <ExternalLink className="w-3 h-3" />
+                          ブラウザで開く
+                        </button>
                       </div>
                       {masterResults.map((entry) => (
                         <MasterDictCard

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -500,10 +500,13 @@ export default function NovelEditor({
           overscrollBehavior: "contain",
           // Disable browser scroll anchoring to prevent auto-scroll adjustment during DOM updates in vertical mode
           overflowAnchor: "none",
-          // In vertical-rl, padding on child elements causes Chromium to miscalculate scrollWidth.
-          // Move horizontal padding to the scroll container itself, where the browser handles it correctly.
+          // In vertical-rl the document start is the RIGHT edge. The scroll container's
+          // end-side (right) padding is dropped from scrollWidth by Chromium on real
+          // Electron, so paddingRight never shows (title sticks to the frame). Keep only
+          // the start-side (left) padding here, and provide the right-side gap as an
+          // in-flow flex spacer inside the content (always counted in scrollWidth). (#1639)
           // scrollbar-gutter keeps the bottom line clear of the horizontal scrollbar (non-overlay platforms).
-          ...(isVertical ? { paddingLeft: 64, paddingRight: 64, scrollbarGutter: "stable" } : {}),
+          ...(isVertical ? { paddingLeft: 64, scrollbarGutter: "stable" } : {}),
         }}
       >
         {/* Hidden character width measurement element for auto chars-per-line calculation */}

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -9,6 +9,7 @@ import { localPreferences } from "@/lib/storage/local-preferences";
 import HistoryPanel from "./HistoryPanel";
 import CorrectionsPanel from "./inspector/CorrectionsPanel";
 import StatsPanel from "./inspector/StatsPanel";
+import GenjiWordInfoSection from "./inspector/GenjiWordInfoSection";
 
 import type { ProjectMode } from "@/lib/project/project-types";
 import type { InspectorProps } from "./inspector/types";
@@ -361,6 +362,10 @@ export default function Inspector({
         )}
       </div>
 
+      {/* 選択語の辞書情報（幻辞）— タブバー直下に常駐し、どのタブでも表示される（#1639）。
+          語が未選択 / 辞書未導入 / 該当なし のときは null を返し場所を取らない。 */}
+      <GenjiWordInfoSection selectedWord={selectedWord} compact={compactMode} />
+
       {/* 本文 */}
       <div className={clsx("flex-1 overflow-y-auto", compactMode ? "p-3" : "p-4")}>
         {activeTab === "corrections" && (
@@ -392,7 +397,6 @@ export default function Inspector({
             charUsageRates={charUsageRates}
             readabilityAnalysis={readabilityAnalysis}
             previousDayStats={previousDayStats}
-            selectedWord={selectedWord}
           />
         )}
         {activeTab === "history" && projectMode && onHistoryRestore && (

--- a/components/WordFrequency.tsx
+++ b/components/WordFrequency.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback, memo, useRef } from "react";
-import { RefreshCw, LoaderCircle } from "lucide-react";
+import { RefreshCw, LoaderCircle, ChevronRight, ChevronDown } from "lucide-react";
 import clsx from "clsx";
 
 import ContextMenu from "@/components/ContextMenu";
@@ -10,6 +10,7 @@ import { getNlpClient } from "@/lib/nlp-client/nlp-client";
 import { getProjectFileService } from "@/lib/services/project-file-service";
 import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import { getDictAccess } from "@/lib/dict/dict-access";
+import { localPreferences } from "@/lib/storage/local-preferences";
 import {
   summarizeGenjiVocabulary,
   freqRankDistributionToRows,
@@ -18,8 +19,18 @@ import {
 import type { WordEntry } from "@/lib/nlp-client/types";
 import type { GenjiVocabularySummary } from "@/lib/utils/vocabulary-genji";
 
+/**
+ * Cache schema version. Bump whenever the analysis OUTPUT changes so stale
+ * on-disk caches are discarded instead of being served verbatim.
+ * v2: #1640 strips serializer-escaped `\[\[blank]]` markers — pre-v2 caches
+ *     still contain spurious "blank" tokens (#1639).
+ */
+const CACHE_SCHEMA_VERSION = 2;
+
 /** Cache file schema for word frequency results */
 interface WordFrequencyCache {
+  /** Schema version; missing/older => cache is stale and re-analyzed. */
+  schemaVersion?: number;
   lastModified: number;
   fileSize: number;
   words: WordEntry[];
@@ -40,7 +51,7 @@ interface WordFrequencyProps {
 /** Dictionary lookup action map */
 const DICTIONARY_ACTIONS: Record<string, (word: string) => { url: string; title: string }> = {
   genji: (word) => ({
-    url: `https://genji.illusions.app/${encodeURIComponent(word)}`,
+    url: `https://dict.illusions.app/results?q=${encodeURIComponent(word)}`,
     title: `${word} - 幻辞`,
   }),
   kotobank: (word) => ({
@@ -89,6 +100,15 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
   const [genjiLoading, setGenjiLoading] = useState(false);
   /** Set to true when the Genji DB is ready (health.state === "ready"). False means graceful hide. */
   const [genjiReady, setGenjiReady] = useState(false);
+  /**
+   * 「辞書データからの分析」セクションの開閉。既定は展開。
+   * 開閉状態は localPreferences に永続化し、次回以降も記憶する（#1639）。
+   * 幻辞セクションは genjiReady（client-only async）後にのみ描画されるため、
+   * lazy initializer による localStorage 読み取りで hydration mismatch は起きない。
+   */
+  const [genjiExpanded, setGenjiExpanded] = useState<boolean>(() =>
+    localPreferences.getGenjiAnalysisExpanded(),
+  );
 
   /** Generation counter — incremented on each analysis start; stale async results are discarded (#1078) */
   const genRef = useRef(0);
@@ -167,7 +187,11 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
           const cache = JSON.parse(cacheText) as WordFrequencyCache;
           const meta = await vfs.getFileMetadata(filePath);
 
-          if (cache.lastModified === meta.lastModified && cache.fileSize === meta.size) {
+          if (
+            cache.schemaVersion === CACHE_SCHEMA_VERSION &&
+            cache.lastModified === meta.lastModified &&
+            cache.fileSize === meta.size
+          ) {
             // Discard stale result if a newer analysis was started (#1078)
             if (genRef.current !== myGen) return;
             setWords(cache.words);
@@ -202,6 +226,7 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
           const meta = await vfs.getFileMetadata(filePath);
           const totalWords = wordEntries.reduce((sum, w) => sum + w.count, 0);
           const cacheData: WordFrequencyCache = {
+            schemaVersion: CACHE_SCHEMA_VERSION,
             lastModified: meta.lastModified,
             fileSize: meta.size,
             words: wordEntries,
@@ -405,19 +430,39 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
         )}
       </div>
 
-      {/* 幻辞メトリクスセクション — Genji DB が ready のときのみ表示 */}
+      {/* 辞書データからの分析セクション — Genji DB が ready のときのみ表示。デフォルト折り畳み（#1639） */}
       {genjiReady && (
         <div className="flex-shrink-0 border-t border-border">
           <div className="px-3 py-2">
-            <div className="flex items-center justify-between mb-1.5">
-              <h3 className="text-xs font-medium text-foreground-secondary">幻辞分析</h3>
+            <button
+              type="button"
+              onClick={() =>
+                setGenjiExpanded((v) => {
+                  const next = !v;
+                  localPreferences.setGenjiAnalysisExpanded(next);
+                  return next;
+                })
+              }
+              aria-expanded={genjiExpanded}
+              className="w-full flex items-center justify-between gap-1.5 -mx-1 px-1 py-0.5 rounded hover:bg-hover transition-colors"
+            >
+              <span className="flex items-center gap-1 min-w-0">
+                {genjiExpanded ? (
+                  <ChevronDown className="w-3 h-3 text-foreground-tertiary flex-shrink-0" />
+                ) : (
+                  <ChevronRight className="w-3 h-3 text-foreground-tertiary flex-shrink-0" />
+                )}
+                <h3 className="text-xs font-medium text-foreground-secondary truncate">
+                  辞書データからの分析
+                </h3>
+              </span>
               {genjiLoading && (
-                <LoaderCircle className="w-3 h-3 text-foreground-tertiary animate-spin" />
+                <LoaderCircle className="w-3 h-3 text-foreground-tertiary animate-spin flex-shrink-0" />
               )}
-            </div>
+            </button>
 
-            {genjiSummary !== null && !genjiLoading && (
-              <>
+            {genjiExpanded && genjiSummary !== null && !genjiLoading && (
+              <div className="mt-1.5">
                 {/* 頻度ランク分布 */}
                 <div className="mb-2">
                   <p className="text-xs text-foreground-tertiary mb-1">頻度ランク分布</p>
@@ -446,9 +491,9 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
                   </div>
                 )}
 
-                {/* 辞書外語数 */}
+                {/* 辞書にない語彙数 */}
                 <p className="text-xs text-foreground-tertiary">
-                  辞書外語:{" "}
+                  辞書にない語彙数:{" "}
                   <span className="text-foreground font-medium">
                     {genjiSummary.unknownWordCount}
                   </span>
@@ -456,7 +501,7 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
                     （固有名詞・造語・誤記の候補）
                   </span>
                 </p>
-              </>
+              </div>
             )}
           </div>
         </div>
@@ -466,7 +511,7 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
       {!genjiReady && typeof window !== "undefined" && window.electronAPI !== undefined && (
         <div className="flex-shrink-0 border-t border-border px-3 py-2">
           <p className="text-xs text-foreground-tertiary">
-            幻辞辞書をダウンロードすると、頻度ランク・文体・辞書外語分析が使えます。
+            辞書データをダウンロードすると、頻度ランク・文体・辞書にない語彙の分析が使えます。
           </p>
         </div>
       )}

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -382,7 +382,10 @@ export default function MilkdownEditor({
       });
   }, [editorViewInstance, lintingEnabled, lintingRuleRunner]);
 
-  // 縦書き時: マウスホイールの縦スクロールを横スクロールへ変換する
+  // 縦書き時: ホイール/トラックパッドの入力を横スクロールへ変換する。
+  // 縦書きはコンテナの overflowY が hidden で縦スクロールが無いため、縦スワイプも
+  // 横スワイプも scrollLeft に集約する（横スワイプを scrollTop に流すと「横に払うと
+  // 本文が横へ動かず上下に引っ張られる」体感になっていた, #1639）。
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container || !isVertical) return;
@@ -404,7 +407,7 @@ export default function MilkdownEditor({
           container.scrollLeft += mouseHorizontalDelta;
           event.preventDefault();
         } else if (absX > 0) {
-          container.scrollTop += event.deltaX * sensitivity;
+          container.scrollLeft += event.deltaX * sensitivity;
           event.preventDefault();
         }
         return;
@@ -415,7 +418,7 @@ export default function MilkdownEditor({
           container.scrollLeft += event.deltaY * sensitivity;
         }
         if (absX > 0) {
-          container.scrollTop += event.deltaX * sensitivity;
+          container.scrollLeft += event.deltaX * sensitivity;
         }
         event.preventDefault();
         return;
@@ -427,7 +430,7 @@ export default function MilkdownEditor({
         container.scrollLeft += mouseHorizontalDelta;
         event.preventDefault();
       } else if (absX > 0) {
-        container.scrollTop += event.deltaX * sensitivity;
+        container.scrollLeft += event.deltaX * sensitivity;
         event.preventDefault();
       }
     };

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -407,18 +407,19 @@ export default function MilkdownEditor({
           container.scrollLeft += mouseHorizontalDelta;
           event.preventDefault();
         } else if (absX > 0) {
-          container.scrollLeft += event.deltaX * sensitivity;
+          container.scrollLeft -= event.deltaX * sensitivity;
           event.preventDefault();
         }
         return;
       }
 
       if (isTrackpadInput) {
-        if (absY > 0) {
-          container.scrollLeft += event.deltaY * sensitivity;
-        }
-        if (absX > 0) {
-          container.scrollLeft += event.deltaX * sensitivity;
+        // 縦書きは横スクロールのみ（overflowY hidden）。2本指パンは支配的な軸だけを
+        // 横スクロールへ写像し、対角・慣性入力で deltaX/deltaY が競合して引っかかるのを防ぐ。
+        // 横スワイプは指の向きに追従（-deltaX）、縦スワイプは読み進み方向（+deltaY）。
+        if (absX > 0 || absY > 0) {
+          const primaryDelta = absX >= absY ? -event.deltaX : event.deltaY;
+          container.scrollLeft += primaryDelta * sensitivity;
         }
         event.preventDefault();
         return;
@@ -430,7 +431,7 @@ export default function MilkdownEditor({
         container.scrollLeft += mouseHorizontalDelta;
         event.preventDefault();
       } else if (absX > 0) {
-        container.scrollLeft += event.deltaX * sensitivity;
+        container.scrollLeft -= event.deltaX * sensitivity;
         event.preventDefault();
       }
     };

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -998,6 +998,12 @@ export default function MilkdownEditor({
           <Milkdown />
         </div>
       </div>
+      {/* 縦書きの右端（文書の先頭側）の余白。スクロールコンテナの padding-right は
+          Chromium が scrollWidth に含めず実機 Electron で消えるため、scrollWidth に
+          確実に算入される in-flow なフレックススペーサーで右余白を作る（#1639）。 */}
+      {isVertical && (
+        <div aria-hidden="true" style={{ flex: "0 0 64px", minWidth: 64, alignSelf: "stretch" }} />
+      )}
     </div>
   );
 

--- a/components/inspector/GenjiWordInfoSection.tsx
+++ b/components/inspector/GenjiWordInfoSection.tsx
@@ -1,22 +1,27 @@
 "use client";
 
 import type React from "react";
+import clsx from "clsx";
 
 import { useGenjiWordInfo } from "@/lib/utils/genji-word-info";
 
 interface GenjiWordInfoSectionProps {
   /** 選択中の語（空またはnullのとき非表示） */
   selectedWord: string | null | undefined;
+  /** 余白を詰めた compact レイアウトにする（Inspector の compactMode 連動） */
+  compact?: boolean;
 }
 
 /**
  * 選択語の幻辞（Genji）辞書情報を表示するインスペクタセクション。
  *
- * - 幻辞が未インストール / オフライン / 該当語なし のときは何も表示しない。
+ * Inspector のタブバー直下に常駐し、どのタブでも語を選択すると表示される（#1639）。
+ * - 幻辞が未インストール / オフライン / 該当語なし のときは何も表示しない（null）。
  * - 読み中はスケルトンローダーを表示し、品詞ハイライト本体の動作を一切変えない。
  */
 export default function GenjiWordInfoSection({
   selectedWord,
+  compact = false,
 }: GenjiWordInfoSectionProps): React.ReactElement | null {
   const state = useGenjiWordInfo(selectedWord);
 
@@ -25,7 +30,12 @@ export default function GenjiWordInfoSection({
   }
 
   return (
-    <div className="mt-4 border-t border-border pt-4">
+    <div
+      className={clsx(
+        "flex-shrink-0 border-b border-border bg-background-secondary",
+        compact ? "px-3 py-2" : "px-4 py-3",
+      )}
+    >
       <p className="text-xs font-medium text-foreground-tertiary uppercase tracking-wide mb-2">
         選択語の辞書情報
       </p>

--- a/components/inspector/StatsPanel.tsx
+++ b/components/inspector/StatsPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import InfoTooltip from "./InfoTooltip";
-import GenjiWordInfoSection from "./GenjiWordInfoSection";
 
 import type { PreviousDayStats } from "@/lib/editor-page/use-previous-day-stats";
 
@@ -48,8 +47,6 @@ interface StatsPanelProps {
     hasDictAnalysis?: boolean;
   };
   previousDayStats?: PreviousDayStats | null;
-  /** 選択中の語（品詞タブで幻辞情報を表示するために渡す） */
-  selectedWord?: string | null;
 }
 
 /** Format a diff value with sign prefix */
@@ -73,7 +70,6 @@ export default function StatsPanel({
   charUsageRates,
   readabilityAnalysis,
   previousDayStats,
-  selectedWord,
 }: StatsPanelProps) {
   const isSelection = selectedCharCount > 0;
   const activeCharCount = isSelection ? selectedCharCount : charCount;
@@ -680,9 +676,6 @@ export default function StatsPanel({
           </div>
         </div>
       </div>
-
-      {/* 選択語の幻辞情報（品詞ハイライト連携） */}
-      <GenjiWordInfoSection selectedWord={selectedWord} />
     </div>
   );
 }

--- a/electron/ipc/shell-ipc.js
+++ b/electron/ipc/shell-ipc.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 // Shell and OS integration IPC handlers
 
-const { ipcMain, BrowserWindow, Menu, shell } = require("electron");
+const { ipcMain, BrowserWindow, Menu, shell, app } = require("electron");
 const path = require("path");
 const log = require("electron-log");
 const { SHELL_CHANNELS } = require("../lib/ipc-channels");
@@ -101,7 +101,14 @@ function registerShellHandlers() {
 
     popupWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
 
-    popupWindow.loadURL(url);
+    // Tag the popup browser's User-Agent so the dictionary site (dict.illusions.app)
+    // can identify in-app requests. Append a token to the default Chromium UA rather
+    // than replacing it, to keep compatibility with sites that sniff the browser.
+    const baseUserAgent = popupWindow.webContents.getUserAgent();
+    const appVersion = app.getVersion();
+    const userAgent = `${baseUserAgent} illusions/${appVersion}`;
+
+    popupWindow.loadURL(url, { userAgent });
     return true;
   });
 

--- a/lib/services/notification-manager.ts
+++ b/lib/services/notification-manager.ts
@@ -3,6 +3,7 @@ import type {
   NotificationOptions,
   ProgressNotificationOptions,
   NotificationType,
+  NotificationAction,
 } from "@/types/notification";
 
 type NotificationListener = (notifications: NotificationItem[]) => void;
@@ -147,6 +148,21 @@ class NotificationManager {
         this.timers.set(id, timerId);
       }
     }
+  }
+
+  /**
+   * 既存メッセージの本文（と任意でアクション）を差し替える。
+   * カウントダウン表示など、同じトーストを生かしたまま内容だけ更新する用途。
+   * 対象が存在しなければ何もしない。
+   */
+  updateMessage(id: string, message: string, actions?: NotificationAction[]): void {
+    const notification = this.notifications.find((n) => n.id === id);
+    if (!notification) return;
+    notification.message = message;
+    if (actions !== undefined) {
+      notification.actions = actions;
+    }
+    this.notify();
   }
 
   /**

--- a/lib/services/startup-checks/__tests__/dict-auto-download.test.ts
+++ b/lib/services/startup-checks/__tests__/dict-auto-download.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { loadAppState } = vi.hoisted(() => ({ loadAppState: vi.fn() }));
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({ loadAppState }),
+}));
+vi.mock("@/lib/dict/dict-access", () => ({
+  getDictAccess: () => ({ invalidate: vi.fn() }),
+}));
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: {
+    showProgress: vi.fn(() => "id"),
+    updateProgress: vi.fn(),
+    updateMessage: vi.fn(),
+    showMessage: vi.fn(() => "id"),
+    dismiss: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { isAutoDownloadAllowed } from "@/lib/services/startup-checks/dict-auto-download";
+
+type ConnectionLike = { type?: string; saveData?: boolean };
+
+function setOnline(online: boolean) {
+  Object.defineProperty(navigator, "onLine", { value: online, configurable: true });
+}
+function setConnection(conn: ConnectionLike | undefined) {
+  Object.defineProperty(navigator, "connection", { value: conn, configurable: true });
+}
+
+describe("isAutoDownloadAllowed", () => {
+  beforeEach(() => {
+    loadAppState.mockReset();
+    loadAppState.mockResolvedValue(null);
+    setOnline(true);
+    setConnection(undefined);
+  });
+  afterEach(() => {
+    setConnection(undefined);
+    setOnline(true);
+  });
+
+  it("allows when online, no connection info, and power-save off", async () => {
+    expect(await isAutoDownloadAllowed()).toBe(true);
+  });
+
+  it("blocks when offline", async () => {
+    setOnline(false);
+    expect(await isAutoDownloadAllowed()).toBe(false);
+  });
+
+  it("blocks on a cellular connection (metered radio)", async () => {
+    setConnection({ type: "cellular" });
+    expect(await isAutoDownloadAllowed()).toBe(false);
+  });
+
+  it("blocks when the OS data-saver is on", async () => {
+    setConnection({ type: "wifi", saveData: true });
+    expect(await isAutoDownloadAllowed()).toBe(false);
+  });
+
+  it("allows on wifi without data-saver", async () => {
+    setConnection({ type: "wifi", saveData: false });
+    expect(await isAutoDownloadAllowed()).toBe(true);
+  });
+
+  it("blocks when the app power-save (throttle) mode is on", async () => {
+    loadAppState.mockResolvedValue({ powerSaveMode: true });
+    expect(await isAutoDownloadAllowed()).toBe(false);
+  });
+
+  it("allows when loadAppState throws (no signal → fall back to other gates)", async () => {
+    loadAppState.mockRejectedValue(new Error("storage error"));
+    expect(await isAutoDownloadAllowed()).toBe(true);
+  });
+});

--- a/lib/services/startup-checks/__tests__/dict-update-check.test.ts
+++ b/lib/services/startup-checks/__tests__/dict-update-check.test.ts
@@ -7,34 +7,31 @@ const { getDownloadState, checkForUpdate } = vi.hoisted(() => ({
 const { loadAppState } = vi.hoisted(() => ({
   loadAppState: vi.fn(),
 }));
-const { notifInfo, notifError } = vi.hoisted(() => ({
-  notifInfo: vi.fn(),
-  notifError: vi.fn(),
-}));
+const { isAutoDownloadAllowed, runDictDownloadWithProgress, startCountdownDownload } = vi.hoisted(
+  () => ({
+    isAutoDownloadAllowed: vi.fn(),
+    runDictDownloadWithProgress: vi.fn(),
+    startCountdownDownload: vi.fn(),
+  }),
+);
 vi.mock("@/lib/dict/dict-service", () => ({
   getDictService: () => ({ getDownloadState, checkForUpdate }),
 }));
 vi.mock("@/lib/storage/storage-service", () => ({
   getStorageService: () => ({ loadAppState }),
 }));
-vi.mock("@/lib/services/notification-manager", () => ({
-  notificationManager: { info: notifInfo, error: notifError, showMessage: vi.fn() },
+vi.mock("@/lib/services/startup-checks/dict-auto-download", () => ({
+  isAutoDownloadAllowed,
+  runDictDownloadWithProgress,
+  startCountdownDownload,
 }));
 
 import { dictUpdateCheck } from "@/lib/services/startup-checks/dict-update-check";
 
-const lastDownloadMock = { current: vi.fn(async (): Promise<unknown> => ({ success: true })) };
-
-function setElectronDict(present: boolean, download?: () => Promise<unknown>) {
+function setElectronDict(present: boolean) {
   if (present) {
-    const downloadFn = vi.fn(download ?? (async () => ({ success: true })));
-    lastDownloadMock.current = downloadFn;
     (window as unknown as { electronAPI?: unknown }).electronAPI = {
-      dict: {
-        download: downloadFn,
-        getStatus: vi.fn(async () => ({})),
-        checkUpdate: vi.fn(async () => ({})),
-      },
+      dict: { download: vi.fn(), getStatus: vi.fn(async () => ({})) },
     };
   } else {
     delete (window as unknown as { electronAPI?: unknown }).electronAPI;
@@ -46,10 +43,11 @@ describe("dictUpdateCheck", () => {
     getDownloadState.mockReset();
     checkForUpdate.mockReset();
     loadAppState.mockReset();
-    // Default: preference unset → update checking enabled.
-    loadAppState.mockResolvedValue(null);
-    notifInfo.mockReset();
-    notifError.mockReset();
+    loadAppState.mockResolvedValue(null); // preference unset → update checking enabled
+    isAutoDownloadAllowed.mockReset();
+    isAutoDownloadAllowed.mockResolvedValue(false); // default: manual-notice path
+    runDictDownloadWithProgress.mockReset();
+    startCountdownDownload.mockReset();
   });
   afterEach(() => setElectronDict(false));
 
@@ -60,18 +58,28 @@ describe("dictUpdateCheck", () => {
     expect(getDownloadState).not.toHaveBeenCalled();
   });
 
-  it("warns when the dictionary is not installed (Electron)", async () => {
+  it("warns when the dictionary is not installed (auto-download not allowed)", async () => {
     setElectronDict(true);
     getDownloadState.mockResolvedValue({ providerId: "genji", status: "not-installed" });
     const notice = await dictUpdateCheck.evaluate();
     expect(getDownloadState).toHaveBeenCalledWith("genji");
     expect(notice).toMatchObject({ id: "dict-not-installed", type: "warning" });
     expect(notice?.actions?.[0]?.label).toBe("今すぐダウンロード");
-    // Should not call checkForUpdate when not-installed
     expect(checkForUpdate).not.toHaveBeenCalled();
+    expect(startCountdownDownload).not.toHaveBeenCalled();
   });
 
-  it("informs when an update is available (via checkForUpdate)", async () => {
+  it("starts a 10s countdown (no notice) when not installed and auto-download is allowed", async () => {
+    setElectronDict(true);
+    getDownloadState.mockResolvedValue({ providerId: "genji", status: "not-installed" });
+    isAutoDownloadAllowed.mockResolvedValue(true);
+    const notice = await dictUpdateCheck.evaluate();
+    expect(notice).toBeNull();
+    expect(startCountdownDownload).toHaveBeenCalledTimes(1);
+    expect(startCountdownDownload.mock.calls[0][0]).toMatchObject({ seconds: 10 });
+  });
+
+  it("informs when an update is available (auto-download not allowed)", async () => {
     setElectronDict(true);
     getDownloadState.mockResolvedValue({ providerId: "genji", status: "installed" });
     checkForUpdate.mockResolvedValue({
@@ -84,6 +92,22 @@ describe("dictUpdateCheck", () => {
     expect(notice).toMatchObject({ id: "dict-update-available", type: "info" });
     expect(notice?.message).toContain("1.0.0");
     expect(notice?.message).toContain("1.1.0");
+    expect(startCountdownDownload).not.toHaveBeenCalled();
+  });
+
+  it("starts a 30s countdown (no notice) when an update is available and allowed", async () => {
+    setElectronDict(true);
+    getDownloadState.mockResolvedValue({ providerId: "genji", status: "installed" });
+    checkForUpdate.mockResolvedValue({
+      latestVersion: "1.1.0",
+      installedVersion: "1.0.0",
+      updateAvailable: true,
+    });
+    isAutoDownloadAllowed.mockResolvedValue(true);
+    const notice = await dictUpdateCheck.evaluate();
+    expect(notice).toBeNull();
+    expect(startCountdownDownload).toHaveBeenCalledTimes(1);
+    expect(startCountdownDownload.mock.calls[0][0]).toMatchObject({ seconds: 30 });
   });
 
   it("returns null when installed and up to date", async () => {
@@ -121,7 +145,6 @@ describe("dictUpdateCheck", () => {
       progress: 42,
     });
     expect(await dictUpdateCheck.evaluate()).toBeNull();
-    // Should not hit the network while a download is in progress
     expect(checkForUpdate).not.toHaveBeenCalled();
   });
 
@@ -131,7 +154,6 @@ describe("dictUpdateCheck", () => {
     loadAppState.mockResolvedValue({ dictAutoCheckUpdates: false });
     const notice = await dictUpdateCheck.evaluate();
     expect(notice).toBeNull();
-    // The network update check must NOT fire when the preference is OFF.
     expect(checkForUpdate).not.toHaveBeenCalled();
   });
 
@@ -141,8 +163,6 @@ describe("dictUpdateCheck", () => {
     loadAppState.mockResolvedValue({ dictAutoCheckUpdates: false });
     const notice = await dictUpdateCheck.evaluate();
     expect(notice).toMatchObject({ id: "dict-not-installed", type: "warning" });
-    // The "not installed" warning is independent of the auto-check preference,
-    // and must not trigger a network update check.
     expect(checkForUpdate).not.toHaveBeenCalled();
   });
 
@@ -155,41 +175,13 @@ describe("dictUpdateCheck", () => {
     expect(checkForUpdate).toHaveBeenCalledWith("genji");
   });
 
-  it("surfaces an error (not a success toast) when download resolves { success: false }", async () => {
-    setElectronDict(true, async () => ({
-      success: false,
-      error: "ダウンロードはすでに進行中です",
-    }));
+  it("manual download action delegates to runDictDownloadWithProgress", async () => {
+    setElectronDict(true);
     getDownloadState.mockResolvedValue({ providerId: "genji", status: "not-installed" });
     const notice = await dictUpdateCheck.evaluate();
-    expect(notice).toMatchObject({ id: "dict-not-installed" });
-
-    // Trigger the download action and let the resolved-failure path run.
     const onClick = notice?.actions?.[0]?.onClick;
     expect(onClick).toBeTypeOf("function");
     onClick?.();
-    // The optimistic "started" info toast fires synchronously.
-    expect(notifInfo).toHaveBeenCalledWith("辞書のダウンロードを開始しました。");
-    // Let the resolved promise's .then handler run.
-    await lastDownloadMock.current.mock.results[0]?.value;
-    await Promise.resolve();
-    expect(notifError).toHaveBeenCalledWith(
-      expect.stringContaining("ダウンロードはすでに進行中です"),
-    );
-  });
-
-  it("surfaces an error when download rejects", async () => {
-    setElectronDict(true, async () => {
-      throw new Error("checksum mismatch");
-    });
-    getDownloadState.mockResolvedValue({ providerId: "genji", status: "not-installed" });
-    const notice = await dictUpdateCheck.evaluate();
-    const onClick = notice?.actions?.[0]?.onClick;
-    onClick?.();
-    expect(notifInfo).toHaveBeenCalledWith("辞書のダウンロードを開始しました。");
-    // Let the rejected promise's .catch handler run.
-    await lastDownloadMock.current.mock.results[0]?.value.catch(() => {});
-    await Promise.resolve();
-    expect(notifError).toHaveBeenCalledWith(expect.stringContaining("checksum mismatch"));
+    expect(runDictDownloadWithProgress).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/services/startup-checks/dict-auto-download.ts
+++ b/lib/services/startup-checks/dict-auto-download.ts
@@ -1,0 +1,170 @@
+/**
+ * 辞書（幻辞）の自動ダウンロード共通ロジック。
+ *
+ * dict-corrupt-check / dict-update-check の両方から使う:
+ * - {@link isAutoDownloadAllowed} — 無人での ~526MB ダウンロードを許してよい回線か
+ *   （WiFi 等の非従量回線・データセーバー OFF・省電力モード OFF）を判定する。
+ * - {@link runDictDownloadWithProgress} — 実際のダウンロードを進捗トーストつきで実行。
+ * - {@link startCountdownDownload} — 「あと N 秒で自動ダウンロード」のキャンセル可能な
+ *   カウントダウントーストを表示し、0 で自動的にダウンロードを開始する。
+ *
+ * すべて Electron 専用（web には electronAPI.dict が無い）。
+ */
+import { getDictAccess } from "@/lib/dict/dict-access";
+import { getStorageService } from "@/lib/storage/storage-service";
+import { notificationManager } from "../notification-manager";
+import type { NotificationAction } from "@/types/notification";
+
+interface DictDownloadResult {
+  success: boolean;
+  version?: string;
+  error?: string;
+}
+
+interface ElectronDictApi {
+  download?: () => Promise<DictDownloadResult | undefined>;
+  onDownloadProgress?: (cb: (data: { progress: number }) => void) => () => void;
+}
+
+/** Network Information API（Chromium）の最小型。lib.dom に型が無いため自前定義。 */
+interface NetworkInformationLike {
+  type?: string;
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+function getElectronDict(): ElectronDictApi | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict;
+}
+
+/**
+ * 無人での自動ダウンロードを許可してよいか。
+ *
+ * 重い辞書（~526MB）を従量回線や省電力中に勝手に落とさないためのゲート。
+ * 判定材料（取得できないものは "安全側=許可" に倒す。確実に危険なときだけ拒否）:
+ * - オフライン（navigator.onLine === false）→ 拒否
+ * - セルラー回線（connection.type === "cellular"）→ 拒否（従量の可能性大）
+ * - OS データセーバー（connection.saveData === true）→ 拒否
+ * - アプリの省電力（節流）モード ON → 拒否
+ */
+export async function isAutoDownloadAllowed(): Promise<boolean> {
+  if (typeof navigator !== "undefined") {
+    if (navigator.onLine === false) return false;
+
+    const connection = (navigator as Navigator & { connection?: NetworkInformationLike })
+      .connection;
+    if (connection) {
+      // type が取れる環境（"wifi"/"ethernet"/"cellular"/"none"/"unknown" …）では
+      // セルラーのみ拒否。desktop では "unknown"/undefined が多いので許可側に倒す。
+      if (connection.type === "cellular" || connection.type === "none") return false;
+      if (connection.saveData === true) return false;
+    }
+  }
+
+  // アプリの省電力（節流）モード中は重いダウンロードを自動起動しない。
+  try {
+    const appState = await getStorageService().loadAppState();
+    if (appState?.powerSaveMode === true) return false;
+  } catch {
+    // 設定が読めない場合は判断材料が無いので、他の条件のみで許可する。
+  }
+
+  return true;
+}
+
+/**
+ * 辞書ダウンロードを進捗トーストつきで実行する（手動ボタン・カウントダウン共通）。
+ * 既定 UA の Chromium と同様、進捗 95% 以降は「展開中」に切り替える。
+ */
+export function runDictDownloadWithProgress(startMessage = "辞書をダウンロード中..."): void {
+  const dict = getElectronDict();
+  if (!dict?.download) return;
+
+  const progressId = notificationManager.showProgress(startMessage, { type: "info" });
+  const cleanup = dict.onDownloadProgress?.(({ progress }) => {
+    notificationManager.updateProgress(
+      progressId,
+      progress,
+      progress < 95 ? startMessage : "辞書を展開中...",
+    );
+  });
+
+  dict
+    .download()
+    .then((result) => {
+      if (result?.success === false) {
+        notificationManager.dismiss(progressId);
+        notificationManager.error(
+          `辞書のダウンロードに失敗しました：${result.error ?? "不明なエラー"}`,
+        );
+      } else {
+        // updateProgress(100) は 3 秒後に自動クローズする。最終イベントが
+        // 100 未満で coalesce された場合に備えて明示的に 100 にする。
+        notificationManager.updateProgress(progressId, 100, "辞書のダウンロードが完了しました");
+        // 新鮮な DB になったので "corrupt" ヘルス・負ルックアップのキャッシュを破棄。
+        getDictAccess().invalidate();
+      }
+    })
+    .catch((e: unknown) => {
+      console.warn("[dict] auto download failed:", e);
+      notificationManager.dismiss(progressId);
+      notificationManager.error(
+        `辞書のダウンロードに失敗しました：${e instanceof Error ? e.message : String(e)}`,
+      );
+    })
+    .finally(() => {
+      cleanup?.();
+    });
+}
+
+interface CountdownOptions {
+  /** カウントダウン秒数（未導入/破損は 10、更新は 30 を想定）。 */
+  seconds: number;
+  /** 残り秒数からトースト本文を生成する。 */
+  buildMessage: (remaining: number) => string;
+  /** ダウンロード進捗トーストの開始メッセージ。 */
+  downloadMessage: string;
+}
+
+/**
+ * キャンセル可能なカウントダウントーストを表示し、0 で自動ダウンロードを開始する。
+ * 「今すぐ」で即時開始、「キャンセル」で中止できる。
+ */
+export function startCountdownDownload(options: CountdownOptions): void {
+  let remaining = options.seconds;
+  // 開閉アクションが id/timer を先に参照する（カウントダウン開始前にクロージャを
+  // 生成する）ため、可変ホルダーに保持する。
+  const ctl: { id: string; timer: ReturnType<typeof setInterval> | null } = {
+    id: "",
+    timer: null,
+  };
+
+  const stop = (): void => {
+    if (ctl.timer !== null) clearInterval(ctl.timer);
+    notificationManager.dismiss(ctl.id);
+  };
+  const startNow = (): void => {
+    stop();
+    runDictDownloadWithProgress(options.downloadMessage);
+  };
+  const actions = (): NotificationAction[] => [
+    { label: "今すぐ", onClick: startNow },
+    { label: "キャンセル", onClick: stop },
+  ];
+
+  ctl.id = notificationManager.showMessage(options.buildMessage(remaining), {
+    type: "info",
+    duration: 0, // カウントダウン中は自動クローズしない
+    actions: actions(),
+  });
+
+  ctl.timer = setInterval(() => {
+    remaining -= 1;
+    if (remaining <= 0) {
+      startNow();
+      return;
+    }
+    notificationManager.updateMessage(ctl.id, options.buildMessage(remaining), actions());
+  }, 1000);
+}

--- a/lib/services/startup-checks/dict-corrupt-check.ts
+++ b/lib/services/startup-checks/dict-corrupt-check.ts
@@ -6,19 +6,20 @@
  * (truncated download, bad header, missing table) — surface a warning that
  * offers to re-download. This runs alongside {@link dictUpdateCheck}; the
  * corrupt state takes precedence conceptually (a corrupt DB answers no queries).
+ *
+ * WiFi 等の非従量回線かつ省電力 OFF のときは、10 秒カウントダウンで自動的に
+ * 再ダウンロードを開始する（#1639 follow-up）。それ以外は手動ボタンのみ。
  */
 import { getDictAccess } from "@/lib/dict/dict-access";
-import { notificationManager } from "../notification-manager";
+import {
+  isAutoDownloadAllowed,
+  runDictDownloadWithProgress,
+  startCountdownDownload,
+} from "./dict-auto-download";
 import type { StartupCheck, StartupNotice } from "../startup-check-queue";
 
-interface DictDownloadResult {
-  success: boolean;
-  version?: string;
-  error?: string;
-}
-
 interface ElectronDictApi {
-  download?: () => Promise<DictDownloadResult | undefined>;
+  download?: () => Promise<unknown>;
 }
 
 function getElectronDict(): ElectronDictApi | undefined {
@@ -26,29 +27,7 @@ function getElectronDict(): ElectronDictApi | undefined {
   return (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict;
 }
 
-function startRedownload(): void {
-  const dict = getElectronDict();
-  if (!dict?.download) return;
-  notificationManager.info("辞書の再ダウンロードを開始しました。");
-  dict
-    .download()
-    .then((result) => {
-      if (result?.success === false) {
-        notificationManager.error(
-          `辞書の再ダウンロードに失敗しました：${result.error ?? "不明なエラー"}`,
-        );
-      } else {
-        // Clear cached "corrupt" health + negative lookups now that the DB is fresh.
-        getDictAccess().invalidate();
-      }
-    })
-    .catch((e: unknown) => {
-      console.warn("[dict] re-download failed:", e);
-      notificationManager.error(
-        `辞書の再ダウンロードに失敗しました：${e instanceof Error ? e.message : String(e)}`,
-      );
-    });
-}
+const REDOWNLOAD_MESSAGE = "辞書を再ダウンロード中...";
 
 export const dictCorruptCheck: StartupCheck = {
   id: "dict-corrupt",
@@ -59,12 +38,27 @@ export const dictCorruptCheck: StartupCheck = {
     const health = await getDictAccess().getHealth();
     if (health.state !== "corrupt") return null;
 
+    // 回線・省電力が許せば 10 秒カウントダウンで自動再ダウンロード。
+    // その場合トーストはカウントダウン側が出すので、ここでは notice を返さない。
+    if (await isAutoDownloadAllowed()) {
+      startCountdownDownload({
+        seconds: 10,
+        buildMessage: (remaining) =>
+          `辞書データが破損しています。${remaining} 秒後に自動で再ダウンロードします。`,
+        downloadMessage: REDOWNLOAD_MESSAGE,
+      });
+      return null;
+    }
+
+    // 自動ダウンロード不可（オフライン/従量回線/省電力中）。手動ボタンのみ提示。
     return {
       id: "dict-corrupt",
       type: "warning",
       message: health.message ?? "辞書データが破損しています。再ダウンロードしてください。",
       duration: 0, // keep until dismissed
-      actions: [{ label: "再ダウンロード", onClick: startRedownload }],
+      actions: [
+        { label: "再ダウンロード", onClick: () => runDictDownloadWithProgress(REDOWNLOAD_MESSAGE) },
+      ],
     };
   },
 };

--- a/lib/services/startup-checks/dict-update-check.ts
+++ b/lib/services/startup-checks/dict-update-check.ts
@@ -13,58 +13,33 @@
  * API and returns `{ latestVersion, installedVersion, updateAvailable }`.
  * Network failures are swallowed so startup is never blocked by connectivity
  * problems and no error toast is surfaced.
+ *
+ * 自動化（#1639 follow-up）: WiFi 等の非従量回線かつ省電力 OFF のときは、
+ * - 未導入   → 10 秒カウントダウンで自動ダウンロード
+ * - 更新あり → 30 秒カウントダウンで自動更新
+ * を行う。条件を満たさない場合は従来どおり手動ボタンのトーストを出す。
  */
 import { getDictService } from "@/lib/dict/dict-service";
 import { getStorageService } from "@/lib/storage/storage-service";
-import { notificationManager } from "../notification-manager";
+import {
+  isAutoDownloadAllowed,
+  runDictDownloadWithProgress,
+  startCountdownDownload,
+} from "./dict-auto-download";
 import type { StartupCheck, StartupNotice } from "../startup-check-queue";
 
 const GENJI_PROVIDER_ID = "genji";
-
-/**
- * Result shape resolved by `electronAPI.dict.download()` (IPC `dict:download`).
- * The handler RESOLVES `{ success: false, error }` on recoverable failures
- * (another download running, checksum/URL validation, etc.) rather than
- * rejecting, so the caller must inspect `success` — not just rely on `.catch`.
- */
-interface DictDownloadResult {
-  success: boolean;
-  version?: string;
-  error?: string;
-}
+const DOWNLOAD_MESSAGE = "辞書をダウンロード中...";
+const UPDATE_MESSAGE = "辞書を更新中...";
 
 interface ElectronDictApi {
-  download?: () => Promise<DictDownloadResult | undefined>;
+  download?: () => Promise<unknown>;
   getStatus?: () => Promise<unknown>;
 }
 
 function getElectronDict(): ElectronDictApi | undefined {
   if (typeof window === "undefined") return undefined;
   return (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict;
-}
-
-function startDictDownload(): void {
-  const dict = getElectronDict();
-  if (!dict?.download) return;
-  notificationManager.info("辞書のダウンロードを開始しました。");
-  // The IPC handler resolves `{ success: false, error }` on recoverable
-  // failures instead of rejecting, so inspect the resolved result and surface
-  // the error rather than leaving the optimistic "started" toast standing.
-  dict
-    .download()
-    .then((result) => {
-      if (result?.success === false) {
-        notificationManager.error(
-          `辞書のダウンロードに失敗しました：${result.error ?? "不明なエラー"}`,
-        );
-      }
-    })
-    .catch((e: unknown) => {
-      console.warn("[dict] download failed:", e);
-      notificationManager.error(
-        `辞書のダウンロードに失敗しました：${e instanceof Error ? e.message : String(e)}`,
-      );
-    });
 }
 
 export const dictUpdateCheck: StartupCheck = {
@@ -76,13 +51,28 @@ export const dictUpdateCheck: StartupCheck = {
     const state = await getDictService().getDownloadState(GENJI_PROVIDER_ID);
 
     if (state.status === "not-installed") {
+      // 回線・省電力が許せば 10 秒カウントダウンで自動ダウンロード。
+      if (await isAutoDownloadAllowed()) {
+        startCountdownDownload({
+          seconds: 10,
+          buildMessage: (remaining) =>
+            `日本語辞書が未ダウンロードです。${remaining} 秒後に自動でダウンロードします。`,
+          downloadMessage: DOWNLOAD_MESSAGE,
+        });
+        return null;
+      }
       return {
         id: "dict-not-installed",
         type: "warning",
         message:
           "日本語辞書が未ダウンロードです。ダウンロードすると校正と辞書引きがより正確になります。",
         duration: 0, // keep until dismissed
-        actions: [{ label: "今すぐダウンロード", onClick: startDictDownload }],
+        actions: [
+          {
+            label: "今すぐダウンロード",
+            onClick: () => runDictDownloadWithProgress(DOWNLOAD_MESSAGE),
+          },
+        ],
       };
     }
 
@@ -121,12 +111,24 @@ export const dictUpdateCheck: StartupCheck = {
 
     const from = updateResult.installedVersion ?? "?";
     const to = updateResult.latestVersion ?? "?";
+
+    // 回線・省電力が許せば 30 秒カウントダウンで自動更新。
+    if (await isAutoDownloadAllowed()) {
+      startCountdownDownload({
+        seconds: 30,
+        buildMessage: (remaining) =>
+          `日本語辞書の更新があります（${from} → ${to}）。${remaining} 秒後に自動で更新します。`,
+        downloadMessage: UPDATE_MESSAGE,
+      });
+      return null;
+    }
+
     return {
       id: "dict-update-available",
       type: "info",
       message: `日本語辞書の更新があります（${from} → ${to}）。`,
       duration: 0,
-      actions: [{ label: "更新", onClick: startDictDownload }],
+      actions: [{ label: "更新", onClick: () => runDictDownloadWithProgress(UPDATE_MESSAGE) }],
     };
   },
 };

--- a/lib/storage/local-preferences.ts
+++ b/lib/storage/local-preferences.ts
@@ -15,6 +15,7 @@ const KEYS = {
   sidebarTopOrder: `${PREFIX}sidebar-top-order`,
   sidebarBottomOrder: `${PREFIX}sidebar-bottom-order`,
   searchHistory: `${PREFIX}search-history`,
+  genjiAnalysisExpanded: `${PREFIX}genji-analysis-expanded`,
 } as const;
 
 // One-time migration from old keys to new keys
@@ -143,5 +144,14 @@ export const localPreferences = {
   },
   setSearchHistory(entries: readonly string[]): void {
     set(KEYS.searchHistory, JSON.stringify(entries));
+  },
+
+  // --- 語彙統計「辞書データからの分析」セクションの開閉（既定: 展開）---
+  getGenjiAnalysisExpanded(): boolean {
+    // 未保存 (null) のときは既定で展開。明示的に "0" のときだけ折り畳み。
+    return get(KEYS.genjiAnalysisExpanded) !== "0";
+  },
+  setGenjiAnalysisExpanded(expanded: boolean): void {
+    set(KEYS.genjiAnalysisExpanded, expanded ? "1" : "0");
   },
 } as const;

--- a/lib/utils/__tests__/readability-genji.test.ts
+++ b/lib/utils/__tests__/readability-genji.test.ts
@@ -76,6 +76,20 @@ describe("enrichReadabilityWithDict (Tier 3, #1627)", () => {
     expect(result.detail.vocabulary.rareWordRate).toBe(0);
   });
 
+  it("treats mid-rank words (10,000–50,000) as rare so the score actually moves (#1639)", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    // 12,000 / 18,000 / 25,000 はかつての RARE_THRESHOLD (50,000) では稀少扱いされず
+    // スコアが動かなかった。新境界 (10,000) では稀少語率 = 1.0 で語彙スコアが下がる。
+    const tokens = [noun("逡巡"), noun("邂逅"), noun("泡沫")];
+    const result = enrichReadabilityWithDict(
+      base,
+      tokens,
+      lookup({ 逡巡: 12000, 邂逅: 18000, 泡沫: 25000 }),
+    );
+    expect(result.detail.vocabulary.rareWordRate).toBe(1);
+    expect(result.subScores.vocabulary).toBeLessThan(base.subScores.vocabulary);
+  });
+
   it("recomputes the composite score and level from the adjusted subscores", () => {
     const base = analyzeReadability(BASE_TEXT);
     const tokens = [noun("顰蹙"), noun("邂逅")];

--- a/lib/utils/genji-word-info.ts
+++ b/lib/utils/genji-word-info.ts
@@ -106,6 +106,14 @@ const UNAVAILABLE: GenjiWordInfoState = { status: "unavailable" };
  * - On any error (network, IPC, corrupt DB) falls back gracefully to
  *   `{ status: "unavailable" }`.
  */
+/**
+ * Debounce window before the dictionary lookup fires after the selection
+ * settles. Selecting text dispatches selection-change continuously while the
+ * pointer drags; without this every intermediate selection would kick off a
+ * Genji IPC query and freeze the UI (#1639).
+ */
+const LOOKUP_DEBOUNCE_MS = 250;
+
 export function useGenjiWordInfo(selectedWord: string | null | undefined): GenjiWordInfoState {
   const [state, setState] = useState<GenjiWordInfoState>(IDLE);
 
@@ -117,36 +125,43 @@ export function useGenjiWordInfo(selectedWord: string | null | undefined): Genji
     }
 
     let cancelled = false;
-    setState(LOADING);
 
-    void (async () => {
-      try {
-        // Dynamic import keeps getDictService out of SSR / web-worker bundles
-        const { getDictService } = await import("@/lib/dict/dict-service");
-        const result = await getDictService().query(word, 1);
+    // Defer the (potentially IPC-backed) lookup until the selection stops
+    // changing. The previous result stays visible during the debounce window
+    // so the panel doesn't flicker to a loading state on every drag tick.
+    const timer = setTimeout(() => {
+      setState(LOADING);
 
-        if (cancelled) return;
+      void (async () => {
+        try {
+          // Dynamic import keeps getDictService out of SSR / web-worker bundles
+          const { getDictService } = await import("@/lib/dict/dict-service");
+          const result = await getDictService().query(word, 1);
 
-        if (result.providerUnavailable) {
-          setState(UNAVAILABLE);
-          return;
+          if (cancelled) return;
+
+          if (result.providerUnavailable) {
+            setState(UNAVAILABLE);
+            return;
+          }
+
+          const viewModel = buildGenjiWordInfoViewModel(word, result);
+          if (viewModel) {
+            setState({ status: "found", viewModel });
+          } else {
+            setState(NOT_FOUND);
+          }
+        } catch {
+          if (!cancelled) {
+            setState(UNAVAILABLE);
+          }
         }
-
-        const viewModel = buildGenjiWordInfoViewModel(word, result);
-        if (viewModel) {
-          setState({ status: "found", viewModel });
-        } else {
-          setState(NOT_FOUND);
-        }
-      } catch {
-        if (!cancelled) {
-          setState(UNAVAILABLE);
-        }
-      }
-    })();
+      })();
+    }, LOOKUP_DEBOUNCE_MS);
 
     return () => {
       cancelled = true;
+      clearTimeout(timer);
     };
   }, [selectedWord]);
 

--- a/lib/utils/readability.ts
+++ b/lib/utils/readability.ts
@@ -475,15 +475,19 @@ export function enrichReadabilityWithMorphology(
  *   「稀少語率」は小説における語彙の難度に直接影響する指標（JIS X 4051 準拠評価や
  *   文化庁「公用文作成の考え方」（2022）が「平易な語の選択」を求める背景から妥当）。
  *
- *   スコア補正: 平均 freq_rank が高いほど（稀少語が多いほど）語彙スコアを下げる。
- *   - 稀少語率 > 0.3 → -15 pt（明らかに難語が多い）
- *   - 稀少語率 0.2〜0.3 → -8 pt
- *   - 稀少語率 0.1〜0.2 → -4 pt
- *   - 平均 freq_rank > 30,000 → 追加 -10 pt
- *   - 平均 freq_rank 10,000〜30,000 → 追加 -5 pt
- *   - 平均 freq_rank < 3,000（平易語が多い）→ +5 pt ボーナス
+ *   スコア補正: 稀少語率（と補助的に平均 freq_rank）が高いほど語彙スコアを下げる。
+ *   - 稀少語率 > 0.4 → -25 pt（難語が支配的）
+ *   - 稀少語率 0.3〜0.4 → -18 pt
+ *   - 稀少語率 0.2〜0.3 → -12 pt
+ *   - 稀少語率 0.1〜0.2 → -6 pt
+ *   - 稀少語率 0.05〜0.1 → -3 pt
+ *   - 平均 freq_rank > 15,000 → 追加 -8 pt
+ *   - 平均 freq_rank 8,000〜15,000 → 追加 -4 pt
+ *   - 平均 freq_rank < 2,000（平易語が多い）→ +5 pt ボーナス
  */
-const RARE_THRESHOLD = 50_000;
+// 「稀少」の判定境界。語彙統計パネルの 稀少 バケット（FREQ_RANK_GENERAL = 10,000）と
+// 揃える。以前は 50,000 と過度に厳しく、稀少語が多い文章でもスコアがほぼ動かなかった（#1639）。
+const RARE_THRESHOLD = 10_000;
 
 /**
  * 幻辞（Genji）の freq_rank バッチ照合結果で語彙難易度サブスコアを補強する（Tier 3）。
@@ -535,16 +539,20 @@ export function enrichReadabilityWithDict(
   const avgFreqRank = Math.round(freqRanks.reduce((a, b) => a + b, 0) / freqRanks.length);
   const rareWordRate = rareCount / freqRanks.length;
 
-  // 語彙スコア補正: 稀少語率・平均 freq_rank に基づいてペナルティ/ボーナスを加算
+  // 語彙スコア補正: 稀少語率を主シグナル、平均 freq_rank を補助シグナルとして
+  // ペナルティ/ボーナスを加算。平均は高頻度の機能語・常用語に引っ張られて鈍いため、
+  // 稀少語率に重みを置く（#1639）。
   let vocabDelta = 0;
 
-  if (rareWordRate > 0.3) vocabDelta -= 15;
-  else if (rareWordRate > 0.2) vocabDelta -= 8;
-  else if (rareWordRate > 0.1) vocabDelta -= 4;
+  if (rareWordRate > 0.4) vocabDelta -= 25;
+  else if (rareWordRate > 0.3) vocabDelta -= 18;
+  else if (rareWordRate > 0.2) vocabDelta -= 12;
+  else if (rareWordRate > 0.1) vocabDelta -= 6;
+  else if (rareWordRate > 0.05) vocabDelta -= 3;
 
-  if (avgFreqRank > 30_000) vocabDelta -= 10;
-  else if (avgFreqRank > 10_000) vocabDelta -= 5;
-  else if (avgFreqRank < 3_000) vocabDelta += 5;
+  if (avgFreqRank > 15_000) vocabDelta -= 8;
+  else if (avgFreqRank > 8_000) vocabDelta -= 4;
+  else if (avgFreqRank < 2_000) vocabDelta += 5;
 
   const newVocabScore = Math.max(0, Math.min(100, base.subScores.vocabulary + vocabDelta));
 


### PR DESCRIPTION
## 概要

#1639（幻辞分析統合の dev 手動テスト）で報告された不具合・改善要望への対応と、縦書きスクロール周りの修正をまとめたもの。手元で type-check / 1702 tests / bundle:electron すべて green。

## 含まれる変更

### 辞書 UI / 分析 / UX（#1639 フィードバック）
- 選択語の辞書引きを debounce 化＋大選択を早期 null で、選択時のフリーズを解消
- 選択語の辞書情報を統計タブからインスペクタ常駐スロットへ移設（全タブで表示）
- 「幻辞分析」→「辞書データからの分析」へ改称・折り畳み可（既定展開・開閉状態を永続化）
- 「辞書外語」→「辞書にない語彙数」へ改称、語彙統計キャッシュに schemaVersion を追加し旧キャッシュの `[[blank]]` 混入を自動無効化
- 読みやすさの稀少語閾値を 50,000→10,000 に整合（語彙統計の稀少バケットと一致）＋ペナルティ曲線強化
- 幻辞検索URLを `dict.illusions.app/results?q=` へ更新
- 辞書パネルのヘッダー/結果をコンパクト化＋幻辞をブラウザで開くリンク追加
- 辞書ポップアップの User-Agent に `illusions/<version>` を付加

### 辞書 自動ダウンロード（新機能）
- 未導入/破損=10秒・更新=30秒のキャンセル可能カウントダウンで自動DL
- WiFi 等の非従量回線かつ省電力（節流）モード OFF のときのみ起動（`navigator.connection` / `powerSaveMode` を確認）
- 進捗トースト付きDLを共通化、`notification-manager` に汎用 `updateMessage` を追加

### 縦書きスクロール
- 右端余白が出ない問題の候補修正（`padding-right` が scrollWidth から脱落する Chromium 挙動を in-flow スペーサーで回避、**実機検証要**）
- トラックパッド横スワイプが上下に動く／方向逆／競合する問題を修正（支配軸のみ・`-deltaX`）

## テスト
- 新規: `dict-auto-download` ゲート、readability 中間ランク稀少語、dict-update-check カウントダウン
- type-check green / 1702 tests green / bundle:electron green

関連: #1639

🤖 Generated with [Claude Code](https://claude.com/claude-code)