### PR TITLE
release: weekly release v1.2.16

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -428,6 +428,21 @@ export default function EditorPage() {
     isSearchVisible,
   });
 
+  // フローティング検索窓は <main> のトップレベル（dockview パネル外）でレンダリングし、
+  // 開閉状態を page 側で持つ。dockview パネル内に置くと、パネルのクロージャが
+  // マウント時に凍結され searchTerm/matches など変化する値が pane へ届かず、入力が
+  // 反映されない（editorDiff 比較ビューを <main> へ移したのと同じ理由）。
+  const openSearchDialog = useCallback(() => setIsSearchDialogOpen(true), []);
+  const closeSearchDialog = useCallback(() => setIsSearchDialogOpen(false), []);
+  const toggleSearchDialog = useCallback(() => setIsSearchDialogOpen((v) => !v), []);
+
+  // ⌘F・辞書語検索などの外部トリガーで検索窓を開く（カウンタ増加で発火）。
+  useEffect(() => {
+    if (searchOpenTrigger > 0) {
+      setIsSearchDialogOpen(true);
+    }
+  }, [searchOpenTrigger]);
+
   // --- Ruby/TCY hook ---
   const { handleOpenRubyDialog, handleApplyRuby, handleToggleTcy } = useRubyTcy({
     editorViewRef,
@@ -1343,15 +1358,18 @@ export default function EditorPage() {
         },
         searchOpenTrigger,
         searchInitialTerm,
-        // 共有検索 state（SearchDialog を controlled 化）
+        // 共有検索 state（SearchDialog は <main> でレンダリング）
         searchTerm,
         caseSensitive,
         searchMatches,
         currentMatchIndex,
+        isSearchDialogOpen,
         onSearchTermChange: setSearchTerm,
         onCaseSensitiveChange: setCaseSensitive,
         onCurrentMatchIndexChange: setCurrentMatchIndex,
-        onSearchDialogOpenChange: setIsSearchDialogOpen,
+        onOpenSearchDialog: openSearchDialog,
+        onCloseSearchDialog: closeSearchDialog,
+        onToggleSearchDialog: toggleSearchDialog,
         setEditorViewInstance,
         handleShowAllSearchResults,
         ruleRunner,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -46,7 +46,7 @@ import { usePowerSaving } from "@/lib/editor-page/use-power-saving";
 import { useIgnoredCorrections } from "@/lib/editor-page/use-ignored-corrections";
 import { useKeyboardShortcuts } from "@/lib/editor-page/use-keyboard-shortcuts";
 import { usePanelState } from "@/lib/editor-page/use-panel-state";
-import { findSearchMatches } from "@/lib/editor-page/find-search-matches";
+import { findSearchMatches, type SearchRange } from "@/lib/editor-page/find-search-matches";
 import { useSearchHighlight, isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
 import { useSaveToast } from "@/lib/editor-page/use-save-toast";
 import { useTerminalTabs } from "@/lib/editor-page/use-terminal-tabs";
@@ -212,6 +212,12 @@ export default function EditorPage() {
     bottomView,
     searchTerm,
     caseSensitive,
+    regexSearch,
+    wholeWordSearch,
+    normalizeVariants,
+    excludeComments,
+    searchTarget,
+    selectionOnly,
     currentMatchIndex,
     isRightPanelCollapsed,
     dictionarySearchTrigger,
@@ -232,6 +238,12 @@ export default function EditorPage() {
     handleOpenDictionary,
     setSearchTerm,
     setCaseSensitive,
+    setRegexSearch,
+    setWholeWordSearch,
+    setNormalizeVariants,
+    setExcludeComments,
+    setSearchTarget,
+    setSelectionOnly,
     setCurrentMatchIndex,
     handleShowAllSearchResults,
     handleCloseSearchResults,
@@ -293,6 +305,21 @@ export default function EditorPage() {
   // Keep a live tabs ref for dockview panel renderers captured by stale closures.
   const tabsRef = useRef(tabs);
   tabsRef.current = tabs;
+  const handleProjectSearchBufferChange = useCallback(
+    (path: string, nextContent: string) => {
+      const tab = tabsRef.current.find(
+        (candidate) => isEditorTab(candidate) && candidate.file?.path === path,
+      );
+      if (!tab || !isEditorTab(tab)) return;
+      updateTab(tab.id, {
+        content: nextContent,
+        isDirty: true,
+        fileSyncStatus: "dirty",
+        pendingExternalContent: nextContent,
+      });
+    },
+    [updateTab],
+  );
 
   const { diffTabContextValue, handleCloseTabWithPtyCleanup } = useDiffTabs({
     tabs,
@@ -352,6 +379,15 @@ export default function EditorPage() {
   // Derive editor mode from active tab's fileType
   const activeTab = tabs.find((t) => t.id === activeTabId);
   const activeEditorTab = activeTab && isEditorTab(activeTab) ? activeTab : undefined;
+  const projectSearchBuffers = useMemo(
+    () =>
+      new Map(
+        tabs.flatMap((tab) =>
+          isEditorTab(tab) && tab.file?.path ? [[tab.file.path, tab.content] as const] : [],
+        ),
+      ),
+    [tabs],
+  );
   const activeFileType = activeEditorTab?.fileType ?? ".mdi";
   const mdiExtensionsEnabled = activeFileType === ".mdi";
   const gfmEnabled = activeFileType !== ".txt";
@@ -397,6 +433,7 @@ export default function EditorPage() {
   const [selectedManuscriptCells, setSelectedManuscriptCells] = useState(0);
   const [selectedManuscriptPages, setSelectedManuscriptPages] = useState(0);
   const [selectedWord, setSelectedWord] = useState<string | null>(null);
+  const [searchSelectionRange, setSearchSelectionRange] = useState<SearchRange | null>(null);
   const { menu: tabBarMenu, show: showTabBarMenu, close: closeTabBarMenu } = useContextMenu();
   const hasAutoRecoveredRef = useRef(false);
   const [editorViewInstance, setEditorViewInstanceRaw] = useState<EditorView | null>(null);
@@ -409,16 +446,37 @@ export default function EditorPage() {
   // --- 検索ハイライトの単一ソース ---
   // いずれかの検索 UI が表示中か。両方非表示ならハイライトを消す（要求2）。
   const isSearchVisible = isSearchDialogOpen || topView === "search";
-  // 共有 searchTerm/caseSensitive からマッチを算出（唯一の計算箇所）。
+  // 共有 searchTerm/options からマッチを算出（唯一の計算箇所）。
   // `content` を依存に含め、置換や編集で doc が変わった時に再計算させる。
   // 非表示・空語の時は計算をスキップし空配列を返す。
   const searchMatches = useMemo(() => {
     if (!isSearchVisible || !searchTerm || !isEditorViewAlive(editorViewInstance)) {
       return [];
     }
-    return findSearchMatches(editorViewInstance.state.doc, searchTerm, caseSensitive);
+    return findSearchMatches(editorViewInstance.state.doc, searchTerm, {
+      caseSensitive,
+      regex: regexSearch,
+      wholeWord: wholeWordSearch,
+      normalizeVariants,
+      excludeComments,
+      searchTarget,
+      range: selectionOnly ? (searchSelectionRange ?? undefined) : undefined,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorViewInstance, searchTerm, caseSensitive, isSearchVisible, content]);
+  }, [
+    editorViewInstance,
+    searchTerm,
+    caseSensitive,
+    regexSearch,
+    wholeWordSearch,
+    normalizeVariants,
+    excludeComments,
+    searchTarget,
+    selectionOnly,
+    searchSelectionRange,
+    isSearchVisible,
+    content,
+  ]);
 
   useSearchHighlight({
     editorView: editorViewInstance,
@@ -1163,15 +1221,30 @@ export default function EditorPage() {
     // 共有検索 state（SearchResults を controlled 化）
     searchTerm,
     caseSensitive,
+    regexSearch,
+    wholeWordSearch,
+    normalizeVariants,
+    excludeComments,
+    searchTarget,
+    selectionOnly,
+    hasSearchSelection: searchSelectionRange !== null,
     searchMatches,
     currentMatchIndex,
     onSearchTermChange: setSearchTerm,
     onCaseSensitiveChange: setCaseSensitive,
+    onRegexSearchChange: setRegexSearch,
+    onWholeWordSearchChange: setWholeWordSearch,
+    onNormalizeVariantsChange: setNormalizeVariants,
+    onExcludeCommentsChange: setExcludeComments,
+    onSearchTargetChange: setSearchTarget,
+    onSelectionOnlyChange: setSelectionOnly,
     onCurrentMatchIndexChange: setCurrentMatchIndex,
     onCloseSearchResults: handleCloseSearchResults,
     editorViewInstance,
     dictionarySearchTrigger,
     currentFilePath: currentFile?.path ?? undefined,
+    projectSearchBuffers,
+    onProjectBufferChange: handleProjectSearchBufferChange,
     newFileTrigger,
     openProjectFile,
     incrementEditorKey,
@@ -1355,6 +1428,10 @@ export default function EditorPage() {
           } else {
             setSelectedWord(null);
           }
+        },
+        onSelectionRangeChange: (range: SearchRange | null) => {
+          setSearchSelectionRange(range);
+          if (!range) setSelectionOnly(false);
         },
         searchOpenTrigger,
         searchInitialTerm,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -184,6 +184,23 @@ export default function EditorPage() {
     powerSaveMode,
     autoPowerSaveOnBattery,
     onPowerSaveModeChange: handlePowerSaveModeChange,
+    // Suggest (never force) power-save on battery, so the user stays in
+    // control and the mode can always be turned off (#1402 follow-up).
+    onSuggestPowerSave: () => {
+      notificationManager.showMessage(
+        "バッテリー駆動です。省電力モードにすると校正・AI 機能を一時停止してバッテリーを節約できます。",
+        {
+          type: "info",
+          duration: 12000,
+          actions: [
+            {
+              label: "省電力モードにする",
+              onClick: () => void handlePowerSaveModeChange(true),
+            },
+          ],
+        },
+      );
+    },
   });
 
   // --- Panel state hook ---
@@ -213,6 +230,7 @@ export default function EditorPage() {
     handleCloseSearchResults,
     handleOpenLintingSettings,
     handleOpenPosHighlightSettings,
+    handleOpenPowerSettings,
     triggerSwitchToCorrections,
   } = panelHandlers;
 
@@ -1129,6 +1147,7 @@ export default function EditorPage() {
     charUsageRates,
     readabilityAnalysis,
     onOpenPosHighlightSettings: handleOpenPosHighlightSettings,
+    onOpenPowerSettings: handleOpenPowerSettings,
     activeFileName: currentFile?.name,
     activeFilePath: currentFile?.path ?? undefined,
     currentContent: content,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -574,6 +574,10 @@ export default function EditorPage() {
           pageNumberPosition: settings.pageNumberPosition,
           textIndent: settings.textIndent,
           googleFontFamily: settings.googleFontFamily,
+          // Thread the active tab's snapshotted file type so the HTML pipeline
+          // un-escapes MDI macros only for ".mdi" and preserves \[\[blank]]
+          // literals authored in ".md"/".txt".
+          fileType: dialogState.fileType,
         });
 
         notificationManager.dismiss(progressId);
@@ -598,7 +602,12 @@ export default function EditorPage() {
 
     // Web path: browser print preview (static import — no await before window.open)
     try {
-      const opened = await openWebPrintPreview(dialogState.content, dialogState.metadata, settings);
+      const opened = await openWebPrintPreview(
+        dialogState.content,
+        dialogState.metadata,
+        settings,
+        dialogState.fileType,
+      );
       if (!opened) {
         notificationManager.warning(
           "ポップアップがブロックされました。ブラウザの設定を確認してください。",
@@ -745,6 +754,11 @@ export default function EditorPage() {
     const dialogState = exportDialogStateRef.current;
     if (!dialogState) return;
 
+    // Thread the active tab's snapshotted file type so the HTML pipeline
+    // un-escapes MDI macros only for ".mdi" and preserves \[\[blank]] literals
+    // authored in ".md"/".txt".
+    const epubOptions: EpubExportOptions = { ...options, fileType: dialogState.fileType };
+
     // Electron path: use IPC
     if (window.electronAPI?.exportEPUB) {
       setExportDialogState(null);
@@ -755,7 +769,7 @@ export default function EditorPage() {
 
       try {
         // Electron IPC serializes Uint8Array automatically
-        const result = await window.electronAPI.exportEPUB(dialogState.content, options);
+        const result = await window.electronAPI.exportEPUB(dialogState.content, epubOptions);
 
         notificationManager.dismiss(progressId);
 
@@ -784,7 +798,7 @@ export default function EditorPage() {
 
     try {
       const { generateEpubBlob } = await import("@/lib/export/epub-web");
-      const blob = await generateEpubBlob(dialogState.content, options);
+      const blob = await generateEpubBlob(dialogState.content, epubOptions);
       const baseName = (options.metadata.title || "untitled")
         .replace(/[<>:"/\\|?*]/g, "_")
         .replace(/\.[^.]+$/, "");
@@ -1201,6 +1215,7 @@ export default function EditorPage() {
           onEpubExport: handleEpubExportConfirm,
           content: exportDialogState?.content ?? "",
           metadata: exportDialogState?.metadata ?? { title: "" },
+          fileType: exportDialogState?.fileType,
         },
         printDialog: {
           state: printDialogState,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -57,6 +57,11 @@ import { usePreviousDayStats } from "@/lib/editor-page/use-previous-day-stats";
 import type { EditorView } from "@milkdown/prose/view";
 import type { SupportedFileExtension } from "@/lib/project/project-types";
 
+// Selections larger than this are never treated as a single-word dictionary
+// lookup. Caps the synchronous textBetween() cost on段落/全選択 and avoids
+// pointless Genji lookups while dragging across大量のテキスト (#1639).
+const SELECTED_WORD_MAX_CHARS = 30;
+
 // Module-level flag: persists across React StrictMode/HMR remounts,
 // but resets on page refresh (module re-evaluated).
 // Each Electron BrowserWindow has its own JS context, so no cross-window contamination.
@@ -1418,8 +1423,11 @@ export default function EditorPage() {
           setSelectedCharCount(count);
           setSelectedManuscriptCells(cells);
           setSelectedManuscriptPages(pages);
-          // 選択語を幻辞ルックアップ用に保持する
-          if (count > 0 && editorViewRef.current) {
+          // 選択語を幻辞ルックアップ用に保持する。
+          // 大きな選択（段落・全選択）では textBetween が O(n) で重く、語の辞書引きにも
+          // 不向きなので閾値を超えたら早期に null。実際の辞書引きの debounce は
+          // useGenjiWordInfo 側で行う（選択ドラッグ中の連続 IPC を抑制）。
+          if (count > 0 && count <= SELECTED_WORD_MAX_CHARS && editorViewRef.current) {
             const { selection, doc } = editorViewRef.current.state;
             const text = doc.textBetween(selection.from, selection.to, "").trim();
             // 単語単位（空白区切り）の先頭語、または選択全体（日本語は空白なし）

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 /* eslint-disable react-hooks/rules-of-hooks, @typescript-eslint/no-unused-vars */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useTheme } from "@/contexts/ThemeContext";
 import EditorLayout from "@/components/EditorLayout";
@@ -46,6 +46,8 @@ import { usePowerSaving } from "@/lib/editor-page/use-power-saving";
 import { useIgnoredCorrections } from "@/lib/editor-page/use-ignored-corrections";
 import { useKeyboardShortcuts } from "@/lib/editor-page/use-keyboard-shortcuts";
 import { usePanelState } from "@/lib/editor-page/use-panel-state";
+import { findSearchMatches } from "@/lib/editor-page/find-search-matches";
+import { useSearchHighlight, isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
 import { useSaveToast } from "@/lib/editor-page/use-save-toast";
 import { useTerminalTabs } from "@/lib/editor-page/use-terminal-tabs";
 import { useDiffTabs } from "@/lib/editor-page/use-diff-tabs";
@@ -208,7 +210,9 @@ export default function EditorPage() {
   const {
     topView,
     bottomView,
-    searchResults,
+    searchTerm,
+    caseSensitive,
+    currentMatchIndex,
     isRightPanelCollapsed,
     dictionarySearchTrigger,
     settingsInitialCategory,
@@ -226,6 +230,9 @@ export default function EditorPage() {
     setRubySelectedText,
     setEditorDiff,
     handleOpenDictionary,
+    setSearchTerm,
+    setCaseSensitive,
+    setCurrentMatchIndex,
     handleShowAllSearchResults,
     handleCloseSearchResults,
     handleOpenLintingSettings,
@@ -316,6 +323,9 @@ export default function EditorPage() {
   // Search state — declared before useDockviewAdapter so it can be passed as options
   const [searchOpenTrigger, setSearchOpenTrigger] = useState(0);
   const [searchInitialTerm, setSearchInitialTerm] = useState<string | undefined>(undefined);
+  // フローティング検索窓（SearchDialog）が開いているか。dockview pane 内の Editor から
+  // 報告される。ハイライトの visibility ゲート（要求2）に使う。
+  const [isSearchDialogOpen, setIsSearchDialogOpen] = useState(false);
 
   // Derive project dockview layout from workspace state (already loaded at project open)
   const projectDockviewLayout = isProjectMode(editorMode)
@@ -395,6 +405,28 @@ export default function EditorPage() {
     editorViewRef.current = view; // ref FIRST so sync consumers see fresh value
     setEditorViewInstanceRaw(view);
   }, []);
+
+  // --- 検索ハイライトの単一ソース ---
+  // いずれかの検索 UI が表示中か。両方非表示ならハイライトを消す（要求2）。
+  const isSearchVisible = isSearchDialogOpen || topView === "search";
+  // 共有 searchTerm/caseSensitive からマッチを算出（唯一の計算箇所）。
+  // `content` を依存に含め、置換や編集で doc が変わった時に再計算させる。
+  // 非表示・空語の時は計算をスキップし空配列を返す。
+  const searchMatches = useMemo(() => {
+    if (!isSearchVisible || !searchTerm || !isEditorViewAlive(editorViewInstance)) {
+      return [];
+    }
+    return findSearchMatches(editorViewInstance.state.doc, searchTerm, caseSensitive);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editorViewInstance, searchTerm, caseSensitive, isSearchVisible, content]);
+
+  useSearchHighlight({
+    editorView: editorViewInstance,
+    matches: searchMatches,
+    currentMatchIndex,
+    searchTerm,
+    isSearchVisible,
+  });
 
   // --- Ruby/TCY hook ---
   const { handleOpenRubyDialog, handleApplyRuby, handleToggleTcy } = useRubyTcy({
@@ -1113,7 +1145,14 @@ export default function EditorPage() {
     compactMode,
     onChapterClick: handleChapterClick,
     onInsertText: handleInsertText,
-    searchResults,
+    // 共有検索 state（SearchResults を controlled 化）
+    searchTerm,
+    caseSensitive,
+    searchMatches,
+    currentMatchIndex,
+    onSearchTermChange: setSearchTerm,
+    onCaseSensitiveChange: setCaseSensitive,
+    onCurrentMatchIndexChange: setCurrentMatchIndex,
     onCloseSearchResults: handleCloseSearchResults,
     editorViewInstance,
     dictionarySearchTrigger,
@@ -1122,7 +1161,8 @@ export default function EditorPage() {
     openProjectFile,
     incrementEditorKey,
     onWordSearch: (word: string) => {
-      setSearchInitialTerm(word);
+      // 共有検索語へ反映し、フローティング検索窓を開く。
+      setSearchTerm(word);
       setSearchOpenTrigger((prev) => prev + 1);
     },
   } as const;
@@ -1303,6 +1343,15 @@ export default function EditorPage() {
         },
         searchOpenTrigger,
         searchInitialTerm,
+        // 共有検索 state（SearchDialog を controlled 化）
+        searchTerm,
+        caseSensitive,
+        searchMatches,
+        currentMatchIndex,
+        onSearchTermChange: setSearchTerm,
+        onCaseSensitiveChange: setCaseSensitive,
+        onCurrentMatchIndexChange: setCurrentMatchIndex,
+        onSearchDialogOpenChange: setIsSearchDialogOpen,
         setEditorViewInstance,
         handleShowAllSearchResults,
         ruleRunner,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -368,6 +368,7 @@ export default function EditorPage() {
   const [selectedCharCount, setSelectedCharCount] = useState(0);
   const [selectedManuscriptCells, setSelectedManuscriptCells] = useState(0);
   const [selectedManuscriptPages, setSelectedManuscriptPages] = useState(0);
+  const [selectedWord, setSelectedWord] = useState<string | null>(null);
   const { menu: tabBarMenu, show: showTabBarMenu, close: closeTabBarMenu } = useContextMenu();
   const hasAutoRecoveredRef = useRef(false);
   const [editorViewInstance, setEditorViewInstanceRaw] = useState<EditorView | null>(null);
@@ -1169,6 +1170,7 @@ export default function EditorPage() {
     },
     switchToCorrectionsTrigger,
     previousDayStats,
+    selectedWord,
   } as const;
 
   return (
@@ -1269,6 +1271,16 @@ export default function EditorPage() {
           setSelectedCharCount(count);
           setSelectedManuscriptCells(cells);
           setSelectedManuscriptPages(pages);
+          // 選択語を幻辞ルックアップ用に保持する
+          if (count > 0 && editorViewRef.current) {
+            const { selection, doc } = editorViewRef.current.state;
+            const text = doc.textBetween(selection.from, selection.to, "").trim();
+            // 単語単位（空白区切り）の先頭語、または選択全体（日本語は空白なし）
+            const word = text.split(/\s+/)[0] ?? null;
+            setSelectedWord(word || null);
+          } else {
+            setSelectedWord(null);
+          }
         },
         searchOpenTrigger,
         searchInitialTerm,

--- a/components/BubbleMenu.tsx
+++ b/components/BubbleMenu.tsx
@@ -14,6 +14,7 @@ import {
   Heading2,
   Heading3,
   Code,
+  RemoveFormatting,
 } from "lucide-react";
 import clsx from "clsx";
 
@@ -34,7 +35,8 @@ export type FormatType =
   | "bulletList"
   | "orderedList"
   | "blockquote"
-  | "code";
+  | "code"
+  | "clearFormatting";
 
 export default function BubbleMenu({
   selectionState,
@@ -126,6 +128,11 @@ export default function BubbleMenu({
     { icon: List, label: "箇条書き", format: "bulletList" },
     { icon: ListOrdered, label: "番号付き", format: "orderedList" },
     { icon: Code, label: "コード", format: "code" },
+    {
+      icon: RemoveFormatting,
+      label: "標準本文に戻す（書式をすべて解除）",
+      format: "clearFormatting",
+    },
   ];
 
   const menu = (

--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -20,7 +20,7 @@ import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
 import { getUserDictionaryService } from "@/lib/services/user-dictionary-service";
 import DictionaryEntryDialog from "./Dictionary/DictionaryEntryDialog";
 import { getDictService } from "@/lib/dict/dict-service";
-import type { DictEntry, DictExample } from "@/lib/dict/dict-types";
+import type { DictEntry, DictExample, DictDownloadStatus } from "@/lib/dict/dict-types";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
 
 // Web dictionary sources
@@ -76,9 +76,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   // Master dict state
   const [masterResults, setMasterResults] = useState<DictEntry[]>([]);
   const [masterLoading, setMasterLoading] = useState(false);
-  const [localInstallStatus, setLocalInstallStatus] = useState<
-    "not-installed" | "downloading" | "installing" | "installed" | "error"
-  >("not-installed");
+  const [localInstallStatus, setLocalInstallStatus] = useState<DictDownloadStatus>("not-installed");
   const [downloadProgress, setDownloadProgress] = useState<number | null>(null);
   const [expandedMasterId, setExpandedMasterId] = useState<string | null>(null);
 

--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -281,17 +281,17 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   return (
     <div className="h-full bg-background-secondary border-r border-border flex flex-col">
       {/* Header */}
-      <div className="p-4 border-b border-border">
-        <div className="flex items-center justify-between mb-3">
-          <h2 className="text-lg font-semibold text-foreground">辞書</h2>
-          <BookOpen className="w-5 h-5 text-foreground-secondary" />
+      <div className="px-4 py-2.5 border-b border-border">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-base font-semibold text-foreground">辞書</h2>
+          <BookOpen className="w-4 h-4 text-foreground-secondary" />
         </div>
 
         {/* Tabs */}
-        <div className="flex gap-1 bg-background rounded-md p-1 mb-3">
+        <div className="flex gap-1 bg-background rounded-md p-0.5 mb-2">
           <button
             onClick={() => setActiveTab("web")}
-            className={`flex-1 px-2 py-1.5 text-sm font-medium rounded transition-colors ${
+            className={`flex-1 px-2 py-1 text-sm font-medium rounded transition-colors ${
               activeTab === "web"
                 ? "bg-accent text-accent-foreground"
                 : "text-foreground-secondary hover:text-foreground hover:bg-hover"
@@ -301,7 +301,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
           </button>
           <button
             onClick={() => setActiveTab("user")}
-            className={`flex-1 px-2 py-1.5 text-sm font-medium rounded transition-colors ${
+            className={`flex-1 px-2 py-1 text-sm font-medium rounded transition-colors ${
               activeTab === "user"
                 ? "bg-accent text-accent-foreground"
                 : "text-foreground-secondary hover:text-foreground hover:bg-hover"
@@ -324,18 +324,18 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
             placeholder="検索語を入力..."
             value={globalSearchQuery}
             onChange={(e) => setGlobalSearchQuery(e.target.value)}
-            className="flex-1 px-3 py-1.5 bg-background border border-border rounded text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
+            className="flex-1 px-3 py-1 bg-background border border-border rounded text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
           />
           <button
             type="submit"
             disabled={!globalSearchQuery.trim()}
-            className="px-3 py-1.5 bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-3 py-1 bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Search className="w-4 h-4" />
           </button>
         </form>
         {activeSearchQuery && (
-          <div className="text-xs text-foreground-secondary mt-2">
+          <div className="text-xs text-foreground-secondary mt-1.5">
             検索中: 「{activeSearchQuery}」
           </div>
         )}
@@ -494,7 +494,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
           <div className="flex flex-col h-full">
             <div className="flex-1 overflow-y-auto">
               {activeSearchQuery ? (
-                <div className="p-4 space-y-3">
+                <div className="px-2 py-3 space-y-3">
                   {/* Loading indicator */}
                   {masterLoading && (
                     <div className="flex items-center gap-2 text-sm text-foreground-secondary">
@@ -518,8 +518,28 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
                   {/* Master dict results */}
                   {!masterLoading && masterResults.length > 0 && (
                     <div className="space-y-1.5">
-                      <div className="text-xs font-semibold text-foreground-tertiary">
-                        幻辞 ({masterResults.length} 件)
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="text-xs font-semibold text-foreground-tertiary">
+                          幻辞 ({masterResults.length} 件)
+                        </div>
+                        <button
+                          onClick={() => {
+                            const url = `https://dict.illusions.app/results?q=${encodeURIComponent(activeSearchQuery)}`;
+                            if (isElectronRenderer() && window.electronAPI?.openDictionaryPopup) {
+                              window.electronAPI.openDictionaryPopup(
+                                url,
+                                `幻辞 - ${activeSearchQuery}`,
+                              );
+                            } else {
+                              window.open(url, "_blank", "noopener,noreferrer");
+                            }
+                          }}
+                          className="flex items-center gap-1 text-xs text-foreground-tertiary hover:text-foreground transition-colors flex-shrink-0"
+                          title="幻辞.com をブラウザで開く"
+                        >
+                          <ExternalLink className="w-3 h-3" />
+                          ブラウザで開く
+                        </button>
                       </div>
                       {masterResults.map((entry) => (
                         <MasterDictCard

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -17,6 +17,7 @@ import MilkdownEditor from "./editor/MilkdownEditor";
 import { buildSegments, buildSpeechChunks, buildSpeechMap } from "@/lib/hooks/speech-utils";
 import { scrollToSpeechTarget, cancelSpeechScroll } from "@/lib/editor-page/speech-auto-scroll";
 import { useSelectionTracking } from "@/lib/editor-page/use-selection-tracking";
+import type { SelectionSearchRange } from "@/lib/editor-page/use-selection-tracking";
 import { localPreferences } from "@/lib/storage/local-preferences";
 import type { LintIssue } from "@/lib/linting";
 import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
@@ -28,6 +29,7 @@ interface EditorProps {
   onChange?: (content: string) => void;
   onInsertText?: (text: string) => void;
   onSelectionChange?: (charCount: number, manuscriptCells: number, manuscriptPages: number) => void;
+  onSelectionRangeChange?: (range: SelectionSearchRange | null) => void;
   className?: string;
   // フローティング検索窓（SearchDialog）は EditorLayout の <main> でレンダリングされる。
   // Editor はツールバー検索ボタンとコンテキストメニュー「検索」から、共有 state への
@@ -68,6 +70,7 @@ export default function NovelEditor({
   onChange,
   onInsertText,
   onSelectionChange,
+  onSelectionRangeChange,
   className,
   onSearchTermChange = noop,
   onOpenSearchDialog = noop,
@@ -134,6 +137,7 @@ export default function NovelEditor({
     editorViewInstance,
     scrollContainerRef,
     onSelectionChange,
+    onSelectionRangeChange,
   });
   const handleScrollContainerRef = useCallback((node: HTMLDivElement | null) => {
     scrollContainerRef.current = node;

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -32,8 +32,20 @@ interface EditorProps {
   className?: string;
   searchOpenTrigger?: number;
   searchInitialTerm?: string;
+  // 共有検索 state（単一 source of truth）。SearchResults と同期する。
+  // 検索を配線しない用途（非アクティブ pane プレビュー / popout window）向けに
+  // すべて optional とし、未指定時は no-op / 空デフォルトで動作する。
+  searchTerm?: string;
+  onSearchTermChange?: (term: string) => void;
+  caseSensitive?: boolean;
+  onCaseSensitiveChange?: (value: boolean) => void;
+  searchMatches?: SearchMatch[];
+  currentMatchIndex?: number;
+  onCurrentMatchIndexChange?: (index: number) => void;
+  /** フローティング検索窓の開閉を親へ通知する（ハイライト visibility ゲート用）。 */
+  onSearchDialogOpenChange?: (open: boolean) => void;
   onEditorViewReady?: (view: EditorView) => void;
-  onShowAllSearchResults?: (matches: SearchMatch[], searchTerm: string) => void;
+  onShowAllSearchResults?: () => void;
   // リンティング設定
   lintingRuleRunner?: RuleRunnerLike | null;
   onLintIssuesUpdated?: (issues: LintIssue[]) => void;
@@ -58,6 +70,9 @@ interface EditorProps {
   onExternalContentApplied?: () => void;
 }
 
+/** 検索を配線しない NovelEditor 用途向けの安定 no-op。 */
+const noop = (): void => {};
+
 export default function NovelEditor({
   initialContent = "",
   onChange,
@@ -65,7 +80,14 @@ export default function NovelEditor({
   onSelectionChange,
   className,
   searchOpenTrigger = 0,
-  searchInitialTerm,
+  searchTerm = "",
+  onSearchTermChange = noop,
+  caseSensitive = false,
+  onCaseSensitiveChange = noop,
+  searchMatches = [],
+  currentMatchIndex = 0,
+  onCurrentMatchIndexChange = noop,
+  onSearchDialogOpenChange,
   onEditorViewReady,
   onShowAllSearchResults,
   lintingRuleRunner,
@@ -92,8 +114,6 @@ export default function NovelEditor({
   });
   const [isMounted, setIsMounted] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
-  // コンテキストメニューの「検索」で渡された初期検索語
-  const [contextMenuSearchTerm, setContextMenuSearchTerm] = useState<string | undefined>(undefined);
   const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
   const {
     state: speechState,
@@ -181,11 +201,27 @@ export default function NovelEditor({
     setIsSearchOpen(true);
   }, []);
 
-  /** コンテキストメニューの「検索」アクションを処理する。選択テキストを初期検索語として渡す。 */
-  const handleFind = useCallback((initialTerm?: string) => {
-    setContextMenuSearchTerm(initialTerm);
-    setIsSearchOpen(true);
+  // フローティング検索窓の開閉を親へ通知する（ハイライト visibility ゲート用）。
+  useEffect(() => {
+    onSearchDialogOpenChange?.(isSearchOpen);
+  }, [isSearchOpen, onSearchDialogOpenChange]);
+
+  // pane アンマウント時（タブ閉じ等）に「閉じた」と通知し、ハイライトの取り残しを防ぐ。
+  useEffect(() => {
+    return () => onSearchDialogOpenChange?.(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  /** コンテキストメニューの「検索」アクションを処理する。選択テキストを共有検索語へ反映する。 */
+  const handleFind = useCallback(
+    (initialTerm?: string) => {
+      if (initialTerm !== undefined) {
+        onSearchTermChange(initialTerm);
+      }
+      setIsSearchOpen(true);
+    },
+    [onSearchTermChange],
+  );
 
   const clearHighlight = useCallback(() => {
     cancelSpeechScroll();
@@ -571,11 +607,16 @@ export default function NovelEditor({
 
       {/* 検索ダイアログ */}
       <SearchDialog
-        editorView={editorViewInstance}
         isOpen={isSearchOpen}
         onClose={() => setIsSearchOpen(false)}
         onShowAllResults={onShowAllSearchResults}
-        initialSearchTerm={contextMenuSearchTerm ?? searchInitialTerm}
+        searchTerm={searchTerm}
+        onSearchTermChange={onSearchTermChange}
+        caseSensitive={caseSensitive}
+        onCaseSensitiveChange={onCaseSensitiveChange}
+        matches={searchMatches}
+        currentMatchIndex={currentMatchIndex}
+        onCurrentMatchIndexChange={onCurrentMatchIndexChange}
         anchorRef={searchButtonRef}
       />
     </div>

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -11,7 +11,6 @@ import {
   getScrollProgress,
   setScrollProgress,
 } from "@/packages/milkdown-plugin-japanese-novel/scroll-progress";
-import SearchDialog, { type SearchMatch } from "./SearchDialog";
 import SelectionCounter from "./SelectionCounter";
 import EditorToolbar from "./editor/EditorToolbar";
 import MilkdownEditor from "./editor/MilkdownEditor";
@@ -30,22 +29,13 @@ interface EditorProps {
   onInsertText?: (text: string) => void;
   onSelectionChange?: (charCount: number, manuscriptCells: number, manuscriptPages: number) => void;
   className?: string;
-  searchOpenTrigger?: number;
-  searchInitialTerm?: string;
-  // 共有検索 state（単一 source of truth）。SearchResults と同期する。
-  // 検索を配線しない用途（非アクティブ pane プレビュー / popout window）向けに
-  // すべて optional とし、未指定時は no-op / 空デフォルトで動作する。
-  searchTerm?: string;
+  // フローティング検索窓（SearchDialog）は EditorLayout の <main> でレンダリングされる。
+  // Editor はツールバー検索ボタンとコンテキストメニュー「検索」から、共有 state への
+  // 反映と開閉だけを安定 callback で上流へ伝える（dockview 凍結クロージャでも安定 ref は機能）。
   onSearchTermChange?: (term: string) => void;
-  caseSensitive?: boolean;
-  onCaseSensitiveChange?: (value: boolean) => void;
-  searchMatches?: SearchMatch[];
-  currentMatchIndex?: number;
-  onCurrentMatchIndexChange?: (index: number) => void;
-  /** フローティング検索窓の開閉を親へ通知する（ハイライト visibility ゲート用）。 */
-  onSearchDialogOpenChange?: (open: boolean) => void;
+  onOpenSearchDialog?: () => void;
+  onToggleSearchDialog?: () => void;
   onEditorViewReady?: (view: EditorView) => void;
-  onShowAllSearchResults?: () => void;
   // リンティング設定
   lintingRuleRunner?: RuleRunnerLike | null;
   onLintIssuesUpdated?: (issues: LintIssue[]) => void;
@@ -79,17 +69,10 @@ export default function NovelEditor({
   onInsertText,
   onSelectionChange,
   className,
-  searchOpenTrigger = 0,
-  searchTerm = "",
   onSearchTermChange = noop,
-  caseSensitive = false,
-  onCaseSensitiveChange = noop,
-  searchMatches = [],
-  currentMatchIndex = 0,
-  onCurrentMatchIndexChange = noop,
-  onSearchDialogOpenChange,
+  onOpenSearchDialog = noop,
+  onToggleSearchDialog = noop,
   onEditorViewReady,
-  onShowAllSearchResults,
   lintingRuleRunner,
   onLintIssuesUpdated,
   onNlpError,
@@ -113,7 +96,6 @@ export default function NovelEditor({
     return localPreferences.getWritingMode() === "vertical";
   });
   const [isMounted, setIsMounted] = useState(false);
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [editorViewInstance, setEditorViewInstance] = useState<EditorView | null>(null);
   const {
     state: speechState,
@@ -131,8 +113,8 @@ export default function NovelEditor({
   const speechMapRef = useRef<{ text: string; positions: number[] } | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const isVerticalRef = useRef(false);
-  // #1504: ref to the toolbar 検索 button — SearchDialog uses this to anchor
-  // its floating position to the clicked pane instead of the viewport corner.
+  // ツールバー検索ボタンの ref（EditorToolbar が利用）。検索窓のアンカーは
+  // EditorLayout 側でアクティブエディタ DOM を使うため、ここでは保持のみ。
   const searchButtonRef = useRef<HTMLButtonElement | null>(null);
   const [scrollContainerElement, setScrollContainerElement] = useState<HTMLDivElement | null>(null);
   /** Doc position to resume TTS from after the current chunk ends. null = no continuation. */
@@ -193,34 +175,15 @@ export default function NovelEditor({
   //
   // 将来、再マウント無しでファイル切替が必要なら、明確な fileId prop を追加して追跡可能
 
-  const handleSearchToggle = () => {
-    setIsSearchOpen((prev) => !prev);
-  };
-
-  const handleSearchOpen = useCallback(() => {
-    setIsSearchOpen(true);
-  }, []);
-
-  // フローティング検索窓の開閉を親へ通知する（ハイライト visibility ゲート用）。
-  useEffect(() => {
-    onSearchDialogOpenChange?.(isSearchOpen);
-  }, [isSearchOpen, onSearchDialogOpenChange]);
-
-  // pane アンマウント時（タブ閉じ等）に「閉じた」と通知し、ハイライトの取り残しを防ぐ。
-  useEffect(() => {
-    return () => onSearchDialogOpenChange?.(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  /** コンテキストメニューの「検索」アクションを処理する。選択テキストを共有検索語へ反映する。 */
+  /** コンテキストメニューの「検索」アクション。選択テキストを共有検索語へ反映して窓を開く。 */
   const handleFind = useCallback(
     (initialTerm?: string) => {
       if (initialTerm !== undefined) {
         onSearchTermChange(initialTerm);
       }
-      setIsSearchOpen(true);
+      onOpenSearchDialog();
     },
-    [onSearchTermChange],
+    [onSearchTermChange, onOpenSearchDialog],
   );
 
   const clearHighlight = useCallback(() => {
@@ -342,13 +305,6 @@ export default function NovelEditor({
     container.addEventListener("click", handleClick);
     return () => container.removeEventListener("click", handleClick);
   }, [startSpeechFromCursor]);
-
-  // 親からのトリガーで検索ダイアログを開く（ショートカット）
-  useEffect(() => {
-    if (searchOpenTrigger > 0) {
-      handleSearchOpen();
-    }
-  }, [searchOpenTrigger, handleSearchOpen]);
 
   // Track whether initial vertical scroll has been performed for this pane instance.
   const hasVerticalInitialScrollRef = useRef(false);
@@ -523,7 +479,7 @@ export default function NovelEditor({
       <EditorToolbar
         isVertical={isVertical}
         onToggleVertical={handleToggleVertical}
-        onSearchClick={handleSearchToggle}
+        onSearchClick={onToggleSearchDialog}
         searchButtonRef={searchButtonRef}
         speechState={speechState}
         onSpeakToggle={handleSpeakToggle}
@@ -604,21 +560,6 @@ export default function NovelEditor({
           containerElement={scrollContainerElement}
         />
       )}
-
-      {/* 検索ダイアログ */}
-      <SearchDialog
-        isOpen={isSearchOpen}
-        onClose={() => setIsSearchOpen(false)}
-        onShowAllResults={onShowAllSearchResults}
-        searchTerm={searchTerm}
-        onSearchTermChange={onSearchTermChange}
-        caseSensitive={caseSensitive}
-        onCaseSensitiveChange={onCaseSensitiveChange}
-        matches={searchMatches}
-        currentMatchIndex={currentMatchIndex}
-        onCurrentMatchIndexChange={onCurrentMatchIndexChange}
-        anchorRef={searchButtonRef}
-      />
     </div>
   );
 }

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -500,10 +500,13 @@ export default function NovelEditor({
           overscrollBehavior: "contain",
           // Disable browser scroll anchoring to prevent auto-scroll adjustment during DOM updates in vertical mode
           overflowAnchor: "none",
-          // In vertical-rl, padding on child elements causes Chromium to miscalculate scrollWidth.
-          // Move horizontal padding to the scroll container itself, where the browser handles it correctly.
+          // In vertical-rl the document start is the RIGHT edge. The scroll container's
+          // end-side (right) padding is dropped from scrollWidth by Chromium on real
+          // Electron, so paddingRight never shows (title sticks to the frame). Keep only
+          // the start-side (left) padding here, and provide the right-side gap as an
+          // in-flow flex spacer inside the content (always counted in scrollWidth). (#1639)
           // scrollbar-gutter keeps the bottom line clear of the horizontal scrollbar (non-overlay platforms).
-          ...(isVertical ? { paddingLeft: 64, paddingRight: 64, scrollbarGutter: "stable" } : {}),
+          ...(isVertical ? { paddingLeft: 64, scrollbarGutter: "stable" } : {}),
         }}
       >
         {/* Hidden character width measurement element for auto chars-per-line calculation */}

--- a/components/EditorDiffView.tsx
+++ b/components/EditorDiffView.tsx
@@ -84,11 +84,17 @@ export default function EditorDiffView({
             maxWidth,
           }}
         >
-          <DiffContent
-            chunks={chunks}
-            textIndent={textIndent}
-            paragraphSpacing={paragraphSpacing}
-          />
+          {stats.addedChars === 0 && stats.removedChars === 0 ? (
+            <p className="text-center text-sm text-foreground-tertiary py-8">
+              テキストの差分はありません（現在の内容と同一です）
+            </p>
+          ) : (
+            <DiffContent
+              chunks={chunks}
+              textIndent={textIndent}
+              paragraphSpacing={paragraphSpacing}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/components/EditorDiffView.tsx
+++ b/components/EditorDiffView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { X } from "lucide-react";
 import { computeDiff, getDiffStats } from "@/lib/services/diff-service";
 import { useTypographySettings } from "@/contexts/EditorSettingsContext";
@@ -32,6 +32,17 @@ export default function EditorDiffView({
   );
 
   const stats = useMemo(() => getDiffStats(chunks), [chunks]);
+
+  // Auto-jump to the first change when the diff opens (or the snapshot changes).
+  const firstChangeRef = useRef<HTMLSpanElement>(null);
+  useEffect(() => {
+    if (!firstChangeRef.current) return;
+    // Defer to the next frame so layout is settled before scrolling.
+    const id = requestAnimationFrame(() => {
+      firstChangeRef.current?.scrollIntoView({ block: "center", behavior: "auto" });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [chunks]);
 
   // Calculate max-width from charsPerLine using 1em approximation
   const maxWidth = charsPerLine > 0 ? `${charsPerLine}em` : undefined;
@@ -93,6 +104,7 @@ export default function EditorDiffView({
               chunks={chunks}
               textIndent={textIndent}
               paragraphSpacing={paragraphSpacing}
+              firstChangeRef={firstChangeRef}
             />
           )}
         </div>
@@ -109,16 +121,20 @@ function DiffContent({
   chunks,
   textIndent,
   paragraphSpacing,
+  firstChangeRef,
 }: {
   chunks: DiffChunk[];
   textIndent: number;
   paragraphSpacing: number;
+  firstChangeRef?: React.Ref<HTMLSpanElement>;
 }) {
   // Build paragraph-aware rendering:
   // Walk chunks, splitting on \n to create paragraph boundaries
   const elements: React.ReactNode[] = [];
   let currentParagraph: React.ReactNode[] = [];
   let paraIndex = 0;
+  // Attach the scroll anchor to the first rendered added/removed span.
+  let firstChangeAssigned = false;
 
   const flushParagraph = () => {
     if (currentParagraph.length > 0) {
@@ -155,8 +171,16 @@ function DiffContent({
       }
 
       if (text.length > 0) {
+        const isChange = chunk.type !== "unchanged";
+        const assignRef = isChange && !firstChangeAssigned;
+        if (assignRef) firstChangeAssigned = true;
         currentParagraph.push(
-          <DiffChunkSpan key={`c${ci}-l${li}`} type={chunk.type} value={text} />,
+          <DiffChunkSpan
+            key={`c${ci}-l${li}`}
+            type={chunk.type}
+            value={text}
+            innerRef={assignRef ? firstChangeRef : undefined}
+          />,
         );
       }
     }
@@ -168,13 +192,28 @@ function DiffContent({
   return <div>{elements}</div>;
 }
 
-function DiffChunkSpan({ type, value }: { type: DiffChunk["type"]; value: string }) {
+function DiffChunkSpan({
+  type,
+  value,
+  innerRef,
+}: {
+  type: DiffChunk["type"];
+  value: string;
+  innerRef?: React.Ref<HTMLSpanElement>;
+}) {
   switch (type) {
     case "added":
-      return <span className="bg-success/20 text-success border-b border-success/40">{value}</span>;
+      return (
+        <span ref={innerRef} className="bg-success/20 text-success border-b border-success/40">
+          {value}
+        </span>
+      );
     case "removed":
       return (
-        <span className="bg-error/20 text-error line-through border-b border-error/40">
+        <span
+          ref={innerRef}
+          className="bg-error/20 text-error line-through border-b border-error/40"
+        >
           {value}
         </span>
       );

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -163,6 +163,19 @@ interface EditorLayoutProps {
     ) => void;
     searchOpenTrigger: number;
     searchInitialTerm?: string;
+    // 共有検索 state（SearchDialog を controlled 化）
+    searchTerm: string;
+    caseSensitive: boolean;
+    searchMatches: React.ComponentProps<typeof NovelEditor>["searchMatches"];
+    currentMatchIndex: number;
+    onSearchTermChange: React.ComponentProps<typeof NovelEditor>["onSearchTermChange"];
+    onCaseSensitiveChange: React.ComponentProps<typeof NovelEditor>["onCaseSensitiveChange"];
+    onCurrentMatchIndexChange: React.ComponentProps<
+      typeof NovelEditor
+    >["onCurrentMatchIndexChange"];
+    onSearchDialogOpenChange: NonNullable<
+      React.ComponentProps<typeof NovelEditor>["onSearchDialogOpenChange"]
+    >;
     setEditorViewInstance: NonNullable<
       React.ComponentProps<typeof NovelEditor>["onEditorViewReady"]
     >;
@@ -481,6 +494,14 @@ export default function EditorLayout({
                                   onSelectionChange={mainArea.onSelectionChange}
                                   searchOpenTrigger={panelSearchOpenTrigger}
                                   searchInitialTerm={panelSearchInitialTerm}
+                                  searchTerm={mainArea.searchTerm}
+                                  onSearchTermChange={mainArea.onSearchTermChange}
+                                  caseSensitive={mainArea.caseSensitive}
+                                  onCaseSensitiveChange={mainArea.onCaseSensitiveChange}
+                                  searchMatches={mainArea.searchMatches}
+                                  currentMatchIndex={mainArea.currentMatchIndex}
+                                  onCurrentMatchIndexChange={mainArea.onCurrentMatchIndexChange}
+                                  onSearchDialogOpenChange={mainArea.onSearchDialogOpenChange}
                                   onEditorViewReady={mainArea.setEditorViewInstance}
                                   onShowAllSearchResults={mainArea.handleShowAllSearchResults}
                                   lintingRuleRunner={mainArea.ruleRunner}

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -12,6 +12,7 @@ import NovelEditor from "@/components/Editor";
 import ResizablePanel from "@/components/ResizablePanel";
 import ExportDialog from "@/components/ExportDialog";
 import RubyDialog from "@/components/RubyDialog";
+import SearchDialog from "@/components/SearchDialog";
 import SettingsModal from "@/components/SettingsModal";
 import SidebarPanel from "@/components/SidebarPanel";
 import SidebarSplitter from "@/components/SidebarSplitter";
@@ -163,24 +164,25 @@ interface EditorLayoutProps {
     ) => void;
     searchOpenTrigger: number;
     searchInitialTerm?: string;
-    // 共有検索 state（SearchDialog を controlled 化）
+    // 共有検索 state。SearchDialog は dockview パネル外（<main>）でレンダリングする。
     searchTerm: string;
     caseSensitive: boolean;
-    searchMatches: React.ComponentProps<typeof NovelEditor>["searchMatches"];
+    searchMatches: React.ComponentProps<typeof SearchDialog>["matches"];
     currentMatchIndex: number;
-    onSearchTermChange: React.ComponentProps<typeof NovelEditor>["onSearchTermChange"];
-    onCaseSensitiveChange: React.ComponentProps<typeof NovelEditor>["onCaseSensitiveChange"];
+    isSearchDialogOpen: boolean;
+    onSearchTermChange: React.ComponentProps<typeof SearchDialog>["onSearchTermChange"];
+    onCaseSensitiveChange: React.ComponentProps<typeof SearchDialog>["onCaseSensitiveChange"];
     onCurrentMatchIndexChange: React.ComponentProps<
-      typeof NovelEditor
+      typeof SearchDialog
     >["onCurrentMatchIndexChange"];
-    onSearchDialogOpenChange: NonNullable<
-      React.ComponentProps<typeof NovelEditor>["onSearchDialogOpenChange"]
-    >;
+    onOpenSearchDialog: () => void;
+    onCloseSearchDialog: () => void;
+    onToggleSearchDialog: () => void;
     setEditorViewInstance: NonNullable<
       React.ComponentProps<typeof NovelEditor>["onEditorViewReady"]
     >;
     handleShowAllSearchResults: NonNullable<
-      React.ComponentProps<typeof NovelEditor>["onShowAllSearchResults"]
+      React.ComponentProps<typeof SearchDialog>["onShowAllResults"]
     >;
     ruleRunner: RuleRunnerLike | null;
     handleLintIssuesUpdated: (issues: LintIssue[]) => void;
@@ -446,10 +448,6 @@ export default function EditorLayout({
                         const panelFileType = (panelParams?.fileType ?? ".mdi") as string;
                         const panelEditorKey = panelParams?.editorKey ?? 0;
                         const panelActiveTabId = panelParams?.activeTabId ?? "";
-                        const panelSearchOpenTrigger = panelParams?.searchOpenTrigger ?? 0;
-                        const panelSearchInitialTerm = panelParams?.searchInitialTerm as
-                          | string
-                          | undefined;
                         const isActivePanel = panelBufferId === panelActiveTabId;
                         const panelMdiEnabled = panelFileType === ".mdi";
                         const panelGfmEnabled = panelFileType !== ".txt";
@@ -492,18 +490,13 @@ export default function EditorLayout({
                                   onChange={mainArea.handleChange}
                                   onInsertText={mainArea.handleInsertText}
                                   onSelectionChange={mainArea.onSelectionChange}
-                                  searchOpenTrigger={panelSearchOpenTrigger}
-                                  searchInitialTerm={panelSearchInitialTerm}
-                                  searchTerm={mainArea.searchTerm}
+                                  // 検索の入力/表示は <main> の SearchDialog が担当。
+                                  // pane へは「語を反映」「開く」「トグル」の安定 callback のみ渡す
+                                  // （dockview の凍結クロージャでも安定 ref は機能するため）。
                                   onSearchTermChange={mainArea.onSearchTermChange}
-                                  caseSensitive={mainArea.caseSensitive}
-                                  onCaseSensitiveChange={mainArea.onCaseSensitiveChange}
-                                  searchMatches={mainArea.searchMatches}
-                                  currentMatchIndex={mainArea.currentMatchIndex}
-                                  onCurrentMatchIndexChange={mainArea.onCurrentMatchIndexChange}
-                                  onSearchDialogOpenChange={mainArea.onSearchDialogOpenChange}
+                                  onOpenSearchDialog={mainArea.onOpenSearchDialog}
+                                  onToggleSearchDialog={mainArea.onToggleSearchDialog}
                                   onEditorViewReady={mainArea.setEditorViewInstance}
-                                  onShowAllSearchResults={mainArea.handleShowAllSearchResults}
                                   lintingRuleRunner={mainArea.ruleRunner}
                                   onLintIssuesUpdated={mainArea.handleLintIssuesUpdated}
                                   onNlpError={mainArea.handleNlpError}
@@ -577,6 +570,24 @@ export default function EditorLayout({
                     <span className="text-foreground-secondary text-sm">保存完了</span>
                   </div>
                 )}
+
+                {/* フローティング検索窓。dockview パネル外（<main> 直下）でレンダリング
+                    することで、共有検索 state（searchTerm/matches など変化する値）を
+                    live に受け取れる。portal で document.body 直下に出るため、anchorRef
+                    にはアクティブエディタの DOM を渡して初期位置を計算する。 */}
+                <SearchDialog
+                  isOpen={mainArea.isSearchDialogOpen}
+                  onClose={mainArea.onCloseSearchDialog}
+                  onShowAllResults={mainArea.handleShowAllSearchResults}
+                  searchTerm={mainArea.searchTerm}
+                  onSearchTermChange={mainArea.onSearchTermChange}
+                  caseSensitive={mainArea.caseSensitive}
+                  onCaseSensitiveChange={mainArea.onCaseSensitiveChange}
+                  matches={mainArea.searchMatches}
+                  currentMatchIndex={mainArea.currentMatchIndex}
+                  onCurrentMatchIndexChange={mainArea.onCurrentMatchIndexChange}
+                  anchorRef={mainArea.editorDomRef}
+                />
               </main>
 
               <ResizablePanel

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -404,6 +404,21 @@ export default function EditorLayout({
                   </div>
                 )}
 
+                {/* Snapshot-diff overlay. Rendered here (not inside the
+                    dockview panel) so it appears as soon as `editorDiff` is
+                    set, independent of dockview's panel re-render timing and
+                    of which panel is active. */}
+                {mainArea.editorDiff && (
+                  <div className="absolute inset-0 z-20 bg-background">
+                    <EditorDiffView
+                      snapshotContent={mainArea.editorDiff.snapshotContent}
+                      currentContent={mainArea.editorDiff.currentContent}
+                      snapshotLabel={mainArea.editorDiff.label}
+                      onClose={() => mainArea.setEditorDiff(null)}
+                    />
+                  </div>
+                )}
+
                 {}
                 <div
                   className="flex-1 flex flex-col overflow-hidden"
@@ -435,17 +450,12 @@ export default function EditorLayout({
                         const panelPendingExternalContent =
                           liveEditorTab?.pendingExternalContent ?? null;
 
-                        if (mainArea.editorDiff && isActivePanel) {
-                          return (
-                            <EditorDiffView
-                              snapshotContent={mainArea.editorDiff.snapshotContent}
-                              currentContent={mainArea.editorDiff.currentContent}
-                              snapshotLabel={mainArea.editorDiff.label}
-                              onClose={() => mainArea.setEditorDiff(null)}
-                            />
-                          );
-                        }
-
+                        // NOTE: the snapshot-diff view is rendered as a
+                        // top-level overlay on <main> (see below), NOT inside
+                        // the dockview panel. Rendering it here depended on the
+                        // panel re-evaluating its closure when `editorDiff`
+                        // changed — which dockview does not reliably do — so
+                        // clicking "比較" appeared to do nothing.
                         if (isActivePanel) {
                           return (
                             <ErrorBoundary sectionName="エディタ">

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -162,6 +162,9 @@ interface EditorLayoutProps {
       manuscriptCells: number,
       manuscriptPages: number,
     ) => void;
+    onSelectionRangeChange: NonNullable<
+      React.ComponentProps<typeof NovelEditor>["onSelectionRangeChange"]
+    >;
     searchOpenTrigger: number;
     searchInitialTerm?: string;
     // 共有検索 state。SearchDialog は dockview パネル外（<main>）でレンダリングする。
@@ -490,6 +493,7 @@ export default function EditorLayout({
                                   onChange={mainArea.handleChange}
                                   onInsertText={mainArea.handleInsertText}
                                   onSelectionChange={mainArea.onSelectionChange}
+                                  onSelectionRangeChange={mainArea.onSelectionRangeChange}
                                   // 検索の入力/表示は <main> の SearchDialog が担当。
                                   // pane へは「語を反映」「開く」「トグル」の安定 callback のみ渡す
                                   // （dockview の凍結クロージャでも安定 ref は機能するため）。

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -105,6 +105,7 @@ interface EditorLayoutProps {
       onEpubExport: (options: EpubExportOptions) => void;
       content: string;
       metadata: ExportMetadata;
+      fileType?: string;
     };
     printDialog: {
       state: { content: string; metadata: ExportMetadata } | null;
@@ -112,6 +113,7 @@ interface EditorLayoutProps {
       onPrint: (settings: PdfExportSettings) => void;
       content: string;
       metadata: ExportMetadata;
+      fileType?: string;
     };
   };
   recovery: {
@@ -289,6 +291,7 @@ export default function EditorLayout({
               onExportEpub={dialogs.exportDialog.onEpubExport}
               content={dialogs.exportDialog.content}
               metadata={dialogs.exportDialog.metadata}
+              fileType={dialogs.exportDialog.fileType}
             />
 
             <ExportDialog
@@ -300,6 +303,7 @@ export default function EditorLayout({
               onExportDocx={() => {}}
               content={dialogs.printDialog.content}
               metadata={dialogs.printDialog.metadata}
+              fileType={dialogs.printDialog.fileType}
             />
 
             {!chrome.isElectron && recovery.wasAutoRecovered && !recovery.dismissedRecovery && (

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -46,6 +46,12 @@ interface ExportDialogProps {
   onExportEpub?: (options: EpubExportOptions) => void;
   content: string;
   metadata: ExportMetadata;
+  /**
+   * Active document file type. Forwarded to the PDF preview IPC so the HTML
+   * pipeline un-escapes MDI macros only for ".mdi" and preserves \[\[blank]]
+   * literals in ".md"/".txt". Absent → ".mdi".
+   */
+  fileType?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -114,6 +120,7 @@ export default function ExportDialog({
   onExportEpub,
   content,
   metadata,
+  fileType,
 }: ExportDialogProps): React.ReactNode {
   if (!isOpen) return null;
   return (
@@ -126,6 +133,7 @@ export default function ExportDialog({
       onExportEpub={onExportEpub}
       content={content}
       metadata={metadata}
+      fileType={fileType}
     />
   );
 }
@@ -139,6 +147,7 @@ function ExportDialogInner({
   onExportEpub,
   content,
   metadata,
+  fileType,
 }: Omit<ExportDialogProps, "isOpen">) {
   const [selectedFormat, setSelectedFormat] = useState<ExportDialogFormat>(initialFormat);
   const [settings, setSettings] = useState<UnifiedExportSettings>(() => ({
@@ -314,6 +323,7 @@ function ExportDialogInner({
           pageNumberPosition: previewSettings.pageNumberPosition,
           textIndent: previewSettings.textIndent,
           googleFontFamily: previewSettings.googleFontFamily,
+          fileType,
         });
 
         if (id !== generationIdRef.current) return;
@@ -343,7 +353,7 @@ function ExportDialogInner({
       if (previewTimeoutRef.current) clearTimeout(previewTimeoutRef.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasPreviewApi, settings, selectedFormat, content, metadata]);
+  }, [hasPreviewApi, settings, selectedFormat, content, metadata, fileType]);
 
   // Cleanup blob URLs on unmount (refs always hold the latest values)
   useEffect(() => {

--- a/components/HistoryPanel.tsx
+++ b/components/HistoryPanel.tsx
@@ -407,21 +407,33 @@ export default function HistoryPanel({
       try {
         setLoadingDiffId(snapshot.id);
         const historyService = getHistoryService();
-        const snapshotContent = await historyService.getSnapshotContent(snapshot.id);
+        // Use restoreSnapshot (read-only) directly so the SPECIFIC failure
+        // reason — "not found" / "checksum mismatch" / read error — surfaces,
+        // instead of getSnapshotContent collapsing every failure to null.
+        const result = await historyService.restoreSnapshot(snapshot.id);
 
-        if (snapshotContent === null) {
-          setError("スナップショットの読み込みに失敗しました");
+        if (!result.success || result.content == null) {
+          const reason = result.error ?? "内容が空です";
+          console.error("[HistoryCompare] snapshot read failed:", snapshot.id, reason);
+          setError(`スナップショットの読み込みに失敗しました: ${reason}`);
+          return;
+        }
+
+        if (!onCompareInEditor) {
+          console.error("[HistoryCompare] onCompareInEditor is not wired; diff cannot open.");
+          setError("差分ビューを開けませんでした（内部エラー）");
           return;
         }
 
         const label = `${formatTimeJa(snapshot.timestamp)} (${getSnapshotTypeLabel(snapshot.type)})`;
-        onCompareInEditor?.({
-          snapshotContent,
+        onCompareInEditor({
+          snapshotContent: result.content,
           currentContent,
           label,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        console.error("[HistoryCompare] unexpected error:", err);
         setError(`差分の読み込みに失敗しました: ${message}`);
       } finally {
         setLoadingDiffId(null);

--- a/components/HistoryPanel/SnapshotItem.tsx
+++ b/components/HistoryPanel/SnapshotItem.tsx
@@ -48,7 +48,21 @@ export default function SnapshotItem({
   }, [menuOpen]);
 
   return (
-    <div className="bg-background-secondary rounded-lg p-3 border border-border">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => {
+        if (!isLoadingDiff) onCompare(snapshot);
+      }}
+      onKeyDown={(e) => {
+        if ((e.key === "Enter" || e.key === " ") && !isLoadingDiff) {
+          e.preventDefault();
+          onCompare(snapshot);
+        }
+      }}
+      title="クリックで差分を表示"
+      className="bg-background-secondary rounded-lg p-3 border border-border cursor-pointer hover:border-accent/50 transition-colors"
+    >
       {/* Row 1: Time + type badge + char count */}
       <div className="flex items-center justify-between gap-2 mb-1.5">
         <div className="flex items-center gap-2 min-w-0">
@@ -82,7 +96,10 @@ export default function SnapshotItem({
         <div className="flex items-center gap-0.5 flex-shrink-0">
           {/* Bookmark button */}
           <button
-            onClick={() => onToggleBookmark(snapshot.id)}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleBookmark(snapshot.id);
+            }}
             className={clsx(
               "p-1 rounded transition-colors",
               isBookmarked
@@ -97,7 +114,10 @@ export default function SnapshotItem({
           {/* Three-dot menu */}
           <div className="relative" ref={menuRef}>
             <button
-              onClick={() => setMenuOpen((v) => !v)}
+              onClick={(e) => {
+                e.stopPropagation();
+                setMenuOpen((v) => !v);
+              }}
               className="p-1 rounded transition-colors text-foreground-tertiary hover:text-foreground-secondary hover:bg-hover"
               title="メニュー"
             >
@@ -107,7 +127,8 @@ export default function SnapshotItem({
             {menuOpen && (
               <div className="absolute right-0 bottom-full mb-1 z-10 min-w-[120px] rounded-lg border border-border bg-background-secondary shadow-lg py-1">
                 <button
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation();
                     setMenuOpen(false);
                     onRestore(snapshot);
                   }}
@@ -122,7 +143,8 @@ export default function SnapshotItem({
                   復元
                 </button>
                 <button
-                  onClick={() => {
+                  onClick={(e) => {
+                    e.stopPropagation();
                     setMenuOpen(false);
                     onCompare(snapshot);
                   }}

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -50,6 +50,7 @@ export default function Inspector({
   charUsageRates,
   readabilityAnalysis,
   onOpenPosHighlightSettings,
+  onOpenPowerSettings,
   onHistoryRestore,
   activeFileName,
   activeFilePath,
@@ -365,6 +366,7 @@ export default function Inspector({
         {activeTab === "corrections" && (
           <CorrectionsPanel
             onOpenPosHighlightSettings={onOpenPosHighlightSettings}
+            onOpenPowerSettings={onOpenPowerSettings}
             lintIssues={lintIssues ?? []}
             onNavigateToIssue={onNavigateToIssue}
             onApplyFix={onApplyFix}

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -67,6 +67,7 @@ export default function Inspector({
   onCorrectionModeChange,
   switchToCorrectionsTrigger = 0,
   previousDayStats,
+  selectedWord,
 }: InspectorProps) {
   const { editorMode, isProject } = useEditorMode();
   const projectMode = isProject ? (editorMode as ProjectMode) : null;
@@ -389,6 +390,7 @@ export default function Inspector({
             charUsageRates={charUsageRates}
             readabilityAnalysis={readabilityAnalysis}
             previousDayStats={previousDayStats}
+            selectedWord={selectedWord}
           />
         )}
         {activeTab === "history" && projectMode && onHistoryRestore && (

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -9,6 +9,7 @@ import { localPreferences } from "@/lib/storage/local-preferences";
 import HistoryPanel from "./HistoryPanel";
 import CorrectionsPanel from "./inspector/CorrectionsPanel";
 import StatsPanel from "./inspector/StatsPanel";
+import GenjiWordInfoSection from "./inspector/GenjiWordInfoSection";
 
 import type { ProjectMode } from "@/lib/project/project-types";
 import type { InspectorProps } from "./inspector/types";
@@ -361,6 +362,10 @@ export default function Inspector({
         )}
       </div>
 
+      {/* 選択語の辞書情報（幻辞）— タブバー直下に常駐し、どのタブでも表示される（#1639）。
+          語が未選択 / 辞書未導入 / 該当なし のときは null を返し場所を取らない。 */}
+      <GenjiWordInfoSection selectedWord={selectedWord} compact={compactMode} />
+
       {/* 本文 */}
       <div className={clsx("flex-1 overflow-y-auto", compactMode ? "p-3" : "p-4")}>
         {activeTab === "corrections" && (
@@ -392,7 +397,6 @@ export default function Inspector({
             charUsageRates={charUsageRates}
             readabilityAnalysis={readabilityAnalysis}
             previousDayStats={previousDayStats}
-            selectedWord={selectedWord}
           />
         )}
         {activeTab === "history" && projectMode && onHistoryRestore && (

--- a/components/RubyDialog.tsx
+++ b/components/RubyDialog.tsx
@@ -4,8 +4,12 @@ import { useState, useEffect, useCallback } from "react";
 import { Loader2 } from "lucide-react";
 import GlassDialog from "./GlassDialog";
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
+import { getDictAccess } from "@/lib/dict/dict-access";
+import { getDictService } from "@/lib/dict/dict-service";
+import { buildBatchReadingCandidates } from "@/lib/utils/ruby-readings";
 
 import type { Token } from "@/lib/nlp-client/types";
+import type { DictLookup, DictEntry } from "@/lib/dict/dict-types";
 
 /** A segment of text with its editable reading */
 interface RubySegment {
@@ -23,11 +27,11 @@ interface RubyDialogProps {
 }
 
 /** Regex to detect kanji characters */
-const KANJI_REGEX = /[\u4e00-\u9faf\u3400-\u4dbf]/;
+const KANJI_REGEX = /[一-龯㐀-䶿]/;
 
 /** Convert katakana to hiragana */
 function katakanaToHiragana(str: string): string {
-  return str.replace(/[\u30a1-\u30f6]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0x60));
+  return str.replace(/[ァ-ヶ]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0x60));
 }
 
 /** Group consecutive tokens into Ruby segments */
@@ -60,10 +64,75 @@ function buildRubyMarkup(segments: RubySegment[]): string {
     .join("");
 }
 
+/**
+ * Fetch Genji reading candidates for kanji segments.
+ * Returns a map from surface → ordered candidate list.
+ * Silently swallows all errors to avoid breaking the dialog.
+ */
+async function fetchGenjiCandidates(segments: RubySegment[]): Promise<Map<string, string[]>> {
+  const result = new Map<string, string[]>();
+
+  const kanjiSegments = segments.filter((s) => s.hasKanji);
+  if (kanjiSegments.length === 0) return result;
+
+  try {
+    const access = getDictAccess();
+    const health = await access.getHealth();
+    // Proceed for both "ready" (local DB) and "web-fallback" (remote API)
+    if (health.state !== "ready" && health.state !== "web-fallback") {
+      return result;
+    }
+
+    const surfaces = kanjiSegments.map((s) => s.surface);
+    const lookupMap = await access.lookupBatch(surfaces);
+
+    // For richer alternatives, query DictService per kanji segment.
+    // ルビ選択語は少数なので個別クエリで OK。
+    const entriesMap = new Map<string, DictEntry[]>();
+    await Promise.all(
+      kanjiSegments.map(async (seg) => {
+        try {
+          const queryResult = await getDictService().query(seg.surface, 5);
+          // Keep only entries that are exact-match headwords
+          const exact = queryResult.entries.filter((e) => e.entry === seg.surface);
+          entriesMap.set(seg.surface, exact);
+        } catch {
+          // Silently ignore per-term failures
+          entriesMap.set(seg.surface, []);
+        }
+      }),
+    );
+
+    const inputs = kanjiSegments.map((seg) => ({
+      surface: seg.surface,
+      kuromojiReading: seg.reading,
+      dictLookup: lookupMap.get(seg.surface) as DictLookup | undefined,
+      dictEntries: entriesMap.get(seg.surface) ?? [],
+    }));
+
+    const batchResult = buildBatchReadingCandidates(inputs);
+    for (const item of batchResult) {
+      // Only populate map when Genji adds extra candidates beyond kuromoji
+      if (item.candidates.length > 1) {
+        result.set(item.surface, item.candidates);
+      } else if (item.candidates.length === 1 && item.candidates[0] !== "") {
+        // Even a single candidate is useful for confirmation
+        result.set(item.surface, item.candidates);
+      }
+    }
+  } catch {
+    // Swallow all Genji errors; dialog must remain functional
+  }
+
+  return result;
+}
+
 export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: RubyDialogProps) {
   const [segments, setSegments] = useState<RubySegment[]>([]);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** surface → ordered reading candidates from Genji (empty map = Genji unavailable) */
+  const [candidatesMap, setCandidatesMap] = useState<Map<string, string[]>>(new Map());
 
   // Analyze text when dialog opens
   useEffect(() => {
@@ -74,6 +143,7 @@ export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: R
     const analyze = async () => {
       setIsAnalyzing(true);
       setError(null);
+      setCandidatesMap(new Map());
 
       try {
         let nlpClient;
@@ -90,7 +160,14 @@ export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: R
 
         if (cancelled) return;
 
-        setSegments(tokensToSegments(tokens));
+        const segs = tokensToSegments(tokens);
+        setSegments(segs);
+
+        // Fetch Genji candidates in the background; do not block dialog display
+        const genjiMap = await fetchGenjiCandidates(segs);
+        if (!cancelled) {
+          setCandidatesMap(genjiMap);
+        }
       } catch (err) {
         if (cancelled) return;
         setError(`形態素解析に失敗しました: ${err instanceof Error ? err.message : String(err)}`);
@@ -156,29 +233,54 @@ export default function RubyDialog({ isOpen, onClose, selectedText, onApply }: R
       {!isAnalyzing && !error && segments.length > 0 && (
         <>
           <div className="space-y-2 max-h-64 overflow-y-auto mb-4">
-            {segments.map((seg, i) => (
-              <div
-                key={`${seg.surface}-${i}`}
-                className="flex items-center gap-3 p-2 bg-background-secondary rounded-lg border border-border"
-              >
-                <span className="text-sm font-medium text-foreground min-w-[3rem] text-center">
-                  {seg.surface}
-                </span>
-                {seg.hasKanji ? (
-                  <input
-                    type="text"
-                    value={seg.reading}
-                    onChange={(e) => handleReadingChange(i, e.target.value)}
-                    className="flex-1 text-sm px-2 py-1 border border-border-secondary rounded bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
-                    placeholder="読み"
-                  />
-                ) : (
-                  <span className="flex-1 text-sm text-foreground-tertiary px-2 py-1">
-                    {seg.reading}
-                  </span>
-                )}
-              </div>
-            ))}
+            {segments.map((seg, i) => {
+              const candidates = candidatesMap.get(seg.surface) ?? [];
+              return (
+                <div
+                  key={`${seg.surface}-${i}`}
+                  className="flex flex-col gap-1 p-2 bg-background-secondary rounded-lg border border-border"
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-medium text-foreground min-w-[3rem] text-center">
+                      {seg.surface}
+                    </span>
+                    {seg.hasKanji ? (
+                      <input
+                        type="text"
+                        value={seg.reading}
+                        onChange={(e) => handleReadingChange(i, e.target.value)}
+                        className="flex-1 text-sm px-2 py-1 border border-border-secondary rounded bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+                        placeholder="読み"
+                      />
+                    ) : (
+                      <span className="flex-1 text-sm text-foreground-tertiary px-2 py-1">
+                        {seg.reading}
+                      </span>
+                    )}
+                  </div>
+                  {/* 幻辞の読み候補チップ */}
+                  {seg.hasKanji && candidates.length > 1 && (
+                    <div className="flex flex-wrap gap-1 pl-[calc(3rem+0.75rem)]">
+                      {candidates.map((candidate) => (
+                        <button
+                          key={candidate}
+                          type="button"
+                          onClick={() => handleReadingChange(i, candidate)}
+                          className={[
+                            "text-xs px-2 py-0.5 rounded-full border transition-colors",
+                            seg.reading === candidate
+                              ? "border-accent bg-accent/10 text-accent font-medium"
+                              : "border-border text-foreground-tertiary hover:border-accent hover:text-accent",
+                          ].join(" ")}
+                        >
+                          {candidate}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
           </div>
 
           {/* Preview */}

--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -3,21 +3,25 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { Search, X, ChevronUp, ChevronDown, List } from "lucide-react";
-import { EditorView, Decoration } from "@milkdown/prose/view";
-import { TextSelection } from "@milkdown/prose/state";
-import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
 import { computeAnchorPos } from "@/lib/search-dialog/compute-anchor-pos";
-import { findSearchMatches, type SearchMatch } from "@/lib/editor-page/find-search-matches";
+import type { SearchMatch } from "@/lib/editor-page/find-search-matches";
 
 const DIALOG_WIDTH = 320; // w-80 と一致させる
 const DIALOG_PADDING = 16; // 8px top offset / 16px right offset の元値と整合
 
 interface SearchDialogProps {
-  editorView: EditorView | null;
   isOpen: boolean;
   onClose: () => void;
-  onShowAllResults?: (matches: SearchMatch[], searchTerm: string) => void;
-  initialSearchTerm?: string;
+  /** サイドバー検索パネルを開く（共有 state を表示）。 */
+  onShowAllResults?: () => void;
+  /** 共有検索 state（単一 source of truth）。SearchResults と同期する。 */
+  searchTerm: string;
+  onSearchTermChange: (term: string) => void;
+  caseSensitive: boolean;
+  onCaseSensitiveChange: (value: boolean) => void;
+  matches: SearchMatch[];
+  currentMatchIndex: number;
+  onCurrentMatchIndexChange: (index: number) => void;
   /** エディタ領域の ref。ダイアログ初期位置計算に使用する。
    *  dockview の CSS transform が position:fixed の containing block を破壊するため、
    *  portal + getBoundingClientRect() でエディタ基準の座標を求める。 */
@@ -27,17 +31,18 @@ interface SearchDialogProps {
 export type { SearchMatch };
 
 export default function SearchDialog({
-  editorView,
   isOpen,
   onClose,
   onShowAllResults,
-  initialSearchTerm,
+  searchTerm,
+  onSearchTermChange,
+  caseSensitive,
+  onCaseSensitiveChange,
+  matches,
+  currentMatchIndex,
+  onCurrentMatchIndexChange,
   anchorRef,
 }: SearchDialogProps) {
-  const [searchTerm, setSearchTerm] = useState("");
-  const [matches, setMatches] = useState<SearchMatch[]>([]);
-  const [currentMatchIndex, setCurrentMatchIndex] = useState(-1);
-  const [caseSensitive, setCaseSensitive] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
 
@@ -123,13 +128,6 @@ export default function SearchDialog({
     document.addEventListener("mouseup", handleMouseUp);
   }, []);
 
-  // initialSearchTerm が変わったら検索語を上書き
-  useEffect(() => {
-    if (initialSearchTerm) {
-      setSearchTerm(initialSearchTerm);
-    }
-  }, [initialSearchTerm]);
-
   // ダイアログ表示時に検索入力へフォーカスする
   useEffect(() => {
     if (isOpen && searchInputRef.current) {
@@ -138,59 +136,17 @@ export default function SearchDialog({
     }
   }, [isOpen]);
 
-  // 文書内の一致箇所を検索する
-  useEffect(() => {
-    if (!editorView || !searchTerm) {
-      setMatches([]);
-      setCurrentMatchIndex(-1);
-      return;
-    }
-
-    const { state } = editorView;
-    const { doc } = state;
-    const foundMatches = findSearchMatches(doc, searchTerm, caseSensitive);
-    setMatches(foundMatches);
-    setCurrentMatchIndex(foundMatches.length > 0 ? 0 : -1);
-  }, [searchTerm, caseSensitive, editorView]);
-
-  // 検索ハイライト装飾
-  useEffect(() => {
-    if (!editorView) return;
-
-    const { state, dispatch } = editorView;
-    const decorations: Decoration[] = [];
-
-    // すべてのマッチ項目に背景ハイライトを追加
-    matches.forEach((match, index) => {
-      const isCurrentMatch = index === currentMatchIndex;
-      decorations.push(
-        Decoration.inline(match.from, match.to, {
-          class: isCurrentMatch ? "search-result-current" : "search-result",
-        }),
-      );
-    });
-
-    // meta を使用して装飾情報を渡す
-    const tr = state.tr.setMeta("searchDecorations", decorations);
-    dispatch(tr);
-
-    // 現在のマッチ項目までスクロール
-    if (currentMatchIndex !== -1 && matches[currentMatchIndex]) {
-      const match = matches[currentMatchIndex];
-      const tr2 = state.tr.setSelection(TextSelection.create(state.doc, match.from, match.from));
-      dispatch(tr2);
-      centerEditorPosition(editorView, match.from);
-    }
-  }, [currentMatchIndex, matches, editorView]);
+  // マッチ検出とハイライト適用は app/page.tsx の useSearchHighlight に集約済み。
+  // ここは共有 state を表示し、入力・ナビを上流へ転送するだけの controlled UI。
 
   const goToNextMatch = () => {
     if (matches.length === 0) return;
-    setCurrentMatchIndex((prev) => (prev + 1) % matches.length);
+    onCurrentMatchIndexChange((currentMatchIndex + 1) % matches.length);
   };
 
   const goToPreviousMatch = () => {
     if (matches.length === 0) return;
-    setCurrentMatchIndex((prev) => (prev - 1 + matches.length) % matches.length);
+    onCurrentMatchIndexChange((currentMatchIndex - 1 + matches.length) % matches.length);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -207,7 +163,7 @@ export default function SearchDialog({
 
   const handleShowAllResults = () => {
     if (matches.length > 0 && searchTerm && onShowAllResults) {
-      onShowAllResults(matches, searchTerm);
+      onShowAllResults();
     }
   };
 
@@ -244,7 +200,7 @@ export default function SearchDialog({
             ref={searchInputRef}
             type="text"
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => onSearchTermChange(e.target.value)}
             placeholder="検索..."
             className="w-full px-3 py-2 pr-20 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
           />
@@ -280,7 +236,7 @@ export default function SearchDialog({
           <input
             type="checkbox"
             checked={caseSensitive}
-            onChange={(e) => setCaseSensitive(e.target.checked)}
+            onChange={(e) => onCaseSensitiveChange(e.target.checked)}
             className="rounded"
           />
           大文字小文字を区別

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,107 +1,41 @@
 "use client";
 
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useState, useRef, useCallback } from "react";
 import { Search, X, Replace, ReplaceAll, ChevronRight, ChevronDown } from "lucide-react";
-import { EditorView, Decoration } from "@milkdown/prose/view";
-import { TextSelection } from "@milkdown/prose/state";
+import type { EditorView } from "@milkdown/prose/view";
 import clsx from "clsx";
-import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
-import { findSearchMatches, type SearchMatch } from "@/lib/editor-page/find-search-matches";
-
-// #1507: After tab switch, the parent's editorViewInstance may still
-// reference a destroyed EditorView for a short window before the new
-// editor's view is ready. ProseMirror sets `docView` to null on destroy.
-// Dispatching on a destroyed view routes through Milkdown plugins whose
-// context has been torn down, throwing "Context editorState not found".
-function isEditorViewAlive(view: EditorView | null): view is EditorView {
-  return view !== null && (view as unknown as { docView: unknown }).docView !== null;
-}
+import { isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
+import { type SearchMatch } from "@/lib/editor-page/find-search-matches";
 
 interface SearchResultsProps {
   editorView: EditorView | null;
-  matches?: SearchMatch[];
-  searchTerm?: string;
+  /** 共有検索 state（単一 source of truth）。SearchDialog と同期する。
+   *  マッチ検出・ハイライト適用は app/page.tsx の useSearchHighlight に集約済み。 */
+  searchTerm: string;
+  onSearchTermChange: (term: string) => void;
+  caseSensitive: boolean;
+  onCaseSensitiveChange: (value: boolean) => void;
+  matches: SearchMatch[];
+  currentMatchIndex: number;
+  onCurrentMatchIndexChange: (index: number) => void;
   onClose: () => void;
 }
 
 export default function SearchResults({
   editorView,
-  matches: initialMatches,
-  searchTerm: initialSearchTerm,
+  searchTerm,
+  onSearchTermChange,
+  caseSensitive,
+  onCaseSensitiveChange,
+  matches,
+  onCurrentMatchIndexChange,
   onClose,
 }: SearchResultsProps) {
-  const [searchTerm, setSearchTerm] = useState(initialSearchTerm || "");
+  // 置換は SearchResults 固有のローカル UI 状態。
   const [replaceTerm, setReplaceTerm] = useState("");
-  const [matches, setMatches] = useState<SearchMatch[]>(initialMatches || []);
-  const [caseSensitive, setCaseSensitive] = useState(false);
   const [showReplace, setShowReplace] = useState(true);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // #1502: Sync incoming props → state during render (React-recommended
-  // "derived state" pattern). useState only reads the initializer on mount,
-  // so without this an already-mounted SearchResults silently ignores props
-  // pushed by SearchDialog's "すべての検索結果を表示" button. Using render-time
-  // detection (vs useEffect) avoids the extra-render flush delay that breaks
-  // jsdom tests and trips React 18+ act() expectations.
-  const [lastInitialSearchTerm, setLastInitialSearchTerm] = useState(initialSearchTerm);
-  if (initialSearchTerm !== lastInitialSearchTerm) {
-    setLastInitialSearchTerm(initialSearchTerm);
-    if (initialSearchTerm !== undefined) {
-      setSearchTerm(initialSearchTerm);
-    }
-  }
-
-  const [lastInitialMatches, setLastInitialMatches] = useState(initialMatches);
-  if (initialMatches !== lastInitialMatches) {
-    setLastInitialMatches(initialMatches);
-    if (initialMatches !== undefined) {
-      setMatches(initialMatches);
-    }
-  }
-
-  // 文書内の一致箇所を検索する
-  useEffect(() => {
-    // #1502: when there's no editor, leave matches as-is so prop-sourced
-    // initialMatches survive. Local recompute only runs against a real editor.
-    // #1507: also guard against destroyed views during tab switch.
-    if (!isEditorViewAlive(editorView)) {
-      return;
-    }
-    if (!searchTerm) {
-      setMatches([]);
-      try {
-        const { state, dispatch } = editorView;
-        const tr = state.tr.setMeta("searchDecorations", []);
-        dispatch(tr);
-      } catch {
-        // Best-effort cleanup — view may have been destroyed mid-dispatch.
-      }
-      return;
-    }
-
-    const { state, dispatch } = editorView;
-    const { doc } = state;
-
-    // Use the shared ProseMirror-position-aware matcher. A previous
-    // textContent-based implementation drifted past hardbreaks (leafText "\n")
-    // and ruby atoms, highlighting the wrong characters.
-    const foundMatches = findSearchMatches(doc, searchTerm, caseSensitive);
-
-    setMatches(foundMatches);
-
-    // Apply highlight decorations
-    const decorations: Decoration[] = foundMatches.map((m) =>
-      Decoration.inline(m.from, m.to, {
-        class: "search-result",
-      }),
-    );
-    try {
-      const tr = state.tr.setMeta("searchDecorations", decorations);
-      dispatch(tr);
-    } catch {
-      // #1507: view torn down mid-search — decorations go with it.
-    }
-  }, [searchTerm, caseSensitive, editorView]);
   // Get context text for match
   const getMatchContext = useCallback(
     (match: SearchMatch): { before: string; text: string; after: string } => {
@@ -134,37 +68,19 @@ export default function SearchResults({
     [editorView],
   );
 
-  // Jump to specified match and highlight
+  // Jump to specified match. 現在マッチ index を共有 state へ反映すると
+  // useSearchHighlight が強調・スクロールを担当する。
   const goToMatch = useCallback(
-    (match: SearchMatch, index: number) => {
+    (_match: SearchMatch, index: number) => {
       if (!isEditorViewAlive(editorView)) return;
-
-      const { state, dispatch } = editorView;
-
-      // Create decoration to mark this match as current
-      const decorations: Decoration[] = [];
-      matches.forEach((m, i) => {
-        const isCurrentMatch = i === index;
-        decorations.push(
-          Decoration.inline(m.from, m.to, {
-            class: isCurrentMatch ? "search-result-current" : "search-result",
-          }),
-        );
-      });
-
-      // Pass decoration info via meta
-      const tr = state.tr.setMeta("searchDecorations", decorations);
-
-      const selectTr = tr.setSelection(TextSelection.create(tr.doc, match.from, match.from));
-      dispatch(selectTr);
-      centerEditorPosition(editorView, match.from);
-
+      onCurrentMatchIndexChange(index);
       editorView.focus();
     },
-    [editorView, matches],
+    [editorView, onCurrentMatchIndexChange],
   );
 
-  // Replace single match
+  // Replace single match. 置換後の再マッチは page 側 useMemo（content 依存）が
+  // 自動で行うため、旧来の setTimeout 再検索ハックは不要。
   const replaceMatch = useCallback(
     (match: SearchMatch) => {
       if (!isEditorViewAlive(editorView)) return;
@@ -172,14 +88,8 @@ export default function SearchResults({
       const { state, dispatch } = editorView;
       const tr = state.tr.replaceWith(match.from, match.to, state.schema.text(replaceTerm));
       dispatch(tr);
-
-      // Re-search
-      setTimeout(() => {
-        setSearchTerm(searchTerm + " ");
-        setTimeout(() => setSearchTerm(searchTerm.trim()), 0);
-      }, 100);
     },
-    [editorView, replaceTerm, searchTerm],
+    [editorView, replaceTerm],
   );
 
   // Replace all matches
@@ -197,11 +107,10 @@ export default function SearchResults({
 
     dispatch(tr);
 
-    // Clear search
-    setMatches([]);
-    setSearchTerm("");
+    // 検索語をクリア → matches が空になり、useSearchHighlight がハイライトを消す。
+    onSearchTermChange("");
     setReplaceTerm("");
-  }, [editorView, matches, replaceTerm]);
+  }, [editorView, matches, replaceTerm, onSearchTermChange]);
 
   return (
     <div className="h-full bg-background-secondary border-r border-border flex flex-col">
@@ -228,7 +137,7 @@ export default function SearchResults({
             ref={searchInputRef}
             type="text"
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => onSearchTermChange(e.target.value)}
             placeholder="検索..."
             className="w-full px-3 py-2 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
           />
@@ -240,7 +149,7 @@ export default function SearchResults({
             <input
               type="checkbox"
               checked={caseSensitive}
-              onChange={(e) => setCaseSensitive(e.target.checked)}
+              onChange={(e) => onCaseSensitiveChange(e.target.checked)}
               className="rounded"
             />
             大文字小文字を区別

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -1,24 +1,78 @@
 "use client";
 
-import React, { useState, useRef, useCallback } from "react";
-import { Search, X, Replace, ReplaceAll, ChevronRight, ChevronDown } from "lucide-react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  ChevronDown,
+  ChevronRight,
+  ChevronUp,
+  FileText,
+  History,
+  Replace,
+  ReplaceAll,
+  Search,
+  SlidersHorizontal,
+  X,
+} from "lucide-react";
 import type { EditorView } from "@milkdown/prose/view";
 import clsx from "clsx";
+
+import {
+  buildReplacementText,
+  createReplacementSteps,
+  getSearchPatternError,
+  isSearchMatchReplaceable,
+  type SearchMatch,
+  type SearchOptions,
+  type SearchTarget,
+} from "@/lib/editor-page/find-search-matches";
+import {
+  replaceProjectFiles,
+  searchProjectFiles,
+  undoProjectReplacement,
+  type ProjectReplacementChange,
+  type ProjectSearchFileResult,
+} from "@/lib/editor-page/project-search";
+import { ProjectSearchWorkerClient } from "@/lib/editor-page/project-search-worker-client";
+import { addSearchHistoryEntry, loadSearchHistory } from "@/lib/editor-page/search-history";
 import { isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
-import { type SearchMatch } from "@/lib/editor-page/find-search-matches";
+
+type SearchScope = "project" | "current" | "folder";
+const EMPTY_PROJECT_BUFFERS: ReadonlyMap<string, string> = new Map();
 
 interface SearchResultsProps {
   editorView: EditorView | null;
-  /** 共有検索 state（単一 source of truth）。SearchDialog と同期する。
-   *  マッチ検出・ハイライト適用は app/page.tsx の useSearchHighlight に集約済み。 */
   searchTerm: string;
   onSearchTermChange: (term: string) => void;
   caseSensitive: boolean;
   onCaseSensitiveChange: (value: boolean) => void;
+  regexSearch?: boolean;
+  onRegexSearchChange?: (value: boolean) => void;
+  wholeWordSearch?: boolean;
+  onWholeWordSearchChange?: (value: boolean) => void;
+  normalizeVariants?: boolean;
+  onNormalizeVariantsChange?: (value: boolean) => void;
+  excludeComments?: boolean;
+  onExcludeCommentsChange?: (value: boolean) => void;
+  searchTarget?: SearchTarget;
+  onSearchTargetChange?: (value: SearchTarget) => void;
+  selectionOnly?: boolean;
+  onSelectionOnlyChange?: (value: boolean) => void;
+  hasSelection?: boolean;
   matches: SearchMatch[];
   currentMatchIndex: number;
   onCurrentMatchIndexChange: (index: number) => void;
   onClose: () => void;
+  projectSearchEnabled?: boolean;
+  projectOpenBuffers?: ReadonlyMap<string, string>;
+  currentFilePath?: string;
+  onOpenProjectFile?: (path: string) => Promise<void>;
+  onProjectBufferChange?: (path: string, content: string) => void | Promise<void>;
+}
+
+interface MatchGroup {
+  heading: string;
+  matches: Array<{ match: SearchMatch; index: number }>;
 }
 
 export default function SearchResults({
@@ -27,51 +81,173 @@ export default function SearchResults({
   onSearchTermChange,
   caseSensitive,
   onCaseSensitiveChange,
+  regexSearch = false,
+  onRegexSearchChange = () => {},
+  wholeWordSearch = false,
+  onWholeWordSearchChange = () => {},
+  normalizeVariants = false,
+  onNormalizeVariantsChange = () => {},
+  excludeComments = true,
+  onExcludeCommentsChange = () => {},
+  searchTarget = "all",
+  onSearchTargetChange = () => {},
+  selectionOnly = false,
+  onSelectionOnlyChange = () => {},
+  hasSelection = false,
   matches,
+  currentMatchIndex,
   onCurrentMatchIndexChange,
   onClose,
+  projectSearchEnabled = false,
+  projectOpenBuffers = EMPTY_PROJECT_BUFFERS,
+  currentFilePath,
+  onOpenProjectFile,
+  onProjectBufferChange,
 }: SearchResultsProps) {
-  // 置換は SearchResults 固有のローカル UI 状態。
   const [replaceTerm, setReplaceTerm] = useState("");
+  const [replaceTouched, setReplaceTouched] = useState(false);
   const [showReplace, setShowReplace] = useState(true);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [history, setHistory] = useState<string[]>([]);
+  const [scope, setScope] = useState<SearchScope>(projectSearchEnabled ? "project" : "current");
+  const [folderPath, setFolderPath] = useState("");
+  const [projectResults, setProjectResults] = useState<ProjectSearchFileResult[]>([]);
+  const [projectNavigationIndex, setProjectNavigationIndex] = useState(0);
+  const [projectSearchPending, setProjectSearchPending] = useState(false);
+  const [projectProgress, setProjectProgress] = useState({ searched: 0, total: 0 });
+  const [projectSearchError, setProjectSearchError] = useState<string | null>(null);
+  const [confirmReplaceAll, setConfirmReplaceAll] = useState(false);
+  const [projectRefreshToken, setProjectRefreshToken] = useState(0);
+  const [replacementPending, setReplacementPending] = useState(false);
+  const [lastProjectReplacement, setLastProjectReplacement] = useState<ProjectReplacementChange[]>(
+    [],
+  );
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // Get context text for match
+  useEffect(() => setHistory(loadSearchHistory()), []);
+
+  const searchOptions = useMemo<SearchOptions>(
+    () => ({
+      caseSensitive,
+      regex: regexSearch,
+      wholeWord: wholeWordSearch,
+      normalizeVariants,
+      excludeComments,
+      searchTarget,
+    }),
+    [caseSensitive, excludeComments, normalizeVariants, regexSearch, searchTarget, wholeWordSearch],
+  );
+  const patternError = getSearchPatternError(searchTerm, searchOptions);
+
+  useEffect(() => {
+    if (!projectSearchEnabled && scope !== "current") setScope("current");
+    if (scope !== "current" && selectionOnly) onSelectionOnlyChange(false);
+  }, [onSelectionOnlyChange, projectSearchEnabled, scope, selectionOnly]);
+
+  useEffect(() => {
+    if (scope === "current" || !projectSearchEnabled || !searchTerm || patternError) {
+      setProjectResults([]);
+      setProjectNavigationIndex(0);
+      setProjectSearchPending(false);
+      setProjectSearchError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    let workerClient: ProjectSearchWorkerClient | null = null;
+    const timer = window.setTimeout(() => {
+      const activeWorkerClient = new ProjectSearchWorkerClient();
+      workerClient = activeWorkerClient;
+      setProjectSearchPending(true);
+      setProjectResults([]);
+      setProjectNavigationIndex(0);
+      setProjectProgress({ searched: 0, total: 0 });
+      setProjectSearchError(null);
+
+      void import("@/lib/services/project-file-service")
+        .then(({ getProjectFileService }) => {
+          const vfs = getProjectFileService();
+          if (!vfs.isRootOpen()) throw new Error("プロジェクトを開いてください");
+          return searchProjectFiles({
+            vfs,
+            searchTerm,
+            options: searchOptions,
+            rootPath: scope === "folder" ? folderPath.trim() : "",
+            openBuffers: projectOpenBuffers,
+            signal: controller.signal,
+            matchDocument: activeWorkerClient.matchDocument,
+            onFileResult: (result) => {
+              if (!controller.signal.aborted) {
+                setProjectResults((current) => [...current, result]);
+              }
+            },
+            onProgress: (searched, total) => {
+              if (!controller.signal.aborted) setProjectProgress({ searched, total });
+            },
+            onFileError: (path, error) => {
+              if (controller.signal.aborted) return;
+              const message = error instanceof Error ? error.message : String(error);
+              setProjectSearchError(`${path}: ${message}`);
+            },
+          });
+        })
+        .then((results) => {
+          if (!controller.signal.aborted) setProjectResults(results);
+        })
+        .catch((error: unknown) => {
+          if (controller.signal.aborted) return;
+          setProjectSearchError(error instanceof Error ? error.message : "検索に失敗しました");
+          setProjectResults([]);
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setProjectSearchPending(false);
+        });
+    }, 200);
+
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+      workerClient?.dispose();
+    };
+  }, [
+    folderPath,
+    patternError,
+    projectOpenBuffers,
+    projectRefreshToken,
+    projectSearchEnabled,
+    scope,
+    searchOptions,
+    searchTerm,
+  ]);
+
+  const commitSearchHistory = useCallback(() => {
+    setHistory(addSearchHistoryEntry(searchTerm));
+  }, [searchTerm]);
+
   const getMatchContext = useCallback(
     (match: SearchMatch): { before: string; text: string; after: string } => {
-      if (!editorView) {
-        return { before: "", text: "", after: "" };
-      }
+      if (!editorView) return { before: "", text: match.text ?? "", after: "" };
 
-      const { state } = editorView;
-      const { doc } = state;
-
-      // Get match text
-      const matchText = doc.textBetween(match.from, match.to);
-
-      // Get surrounding text (30 characters before and after)
+      const { doc } = editorView.state;
       const contextLength = 30;
       const beforeStart = Math.max(0, match.from - contextLength);
       const afterEnd = Math.min(doc.content.size, match.to + contextLength);
-
       const beforeText = doc.textBetween(beforeStart, match.from);
       const afterText = doc.textBetween(match.to, afterEnd);
 
       return {
         before:
-          beforeText.length > contextLength ? "..." + beforeText.slice(-contextLength) : beforeText,
-        text: matchText,
+          beforeText.length > contextLength ? `...${beforeText.slice(-contextLength)}` : beforeText,
+        text: match.text ?? doc.textBetween(match.from, match.to),
         after:
-          afterText.length > contextLength ? afterText.slice(0, contextLength) + "..." : afterText,
+          afterText.length > contextLength ? `${afterText.slice(0, contextLength)}...` : afterText,
       };
     },
     [editorView],
   );
 
-  // Jump to specified match. 現在マッチ index を共有 state へ反映すると
-  // useSearchHighlight が強調・スクロールを担当する。
   const goToMatch = useCallback(
-    (_match: SearchMatch, index: number) => {
+    (index: number) => {
       if (!isEditorViewAlive(editorView)) return;
       onCurrentMatchIndexChange(index);
       editorView.focus();
@@ -79,42 +255,177 @@ export default function SearchResults({
     [editorView, onCurrentMatchIndexChange],
   );
 
-  // Replace single match. 置換後の再マッチは page 側 useMemo（content 依存）が
-  // 自動で行うため、旧来の setTimeout 再検索ハックは不要。
-  const replaceMatch = useCallback(
-    (match: SearchMatch) => {
-      if (!isEditorViewAlive(editorView)) return;
-
-      const { state, dispatch } = editorView;
-      const tr = state.tr.replaceWith(match.from, match.to, state.schema.text(replaceTerm));
-      dispatch(tr);
+  const navigateCurrentMatches = useCallback(
+    (delta: number) => {
+      if (matches.length === 0) return;
+      const index = (currentMatchIndex + delta + matches.length) % matches.length;
+      onCurrentMatchIndexChange(index);
+      if (isEditorViewAlive(editorView)) editorView.focus();
     },
-    [editorView, replaceTerm],
+    [currentMatchIndex, editorView, matches.length, onCurrentMatchIndexChange],
   );
 
-  // Replace all matches
-  const replaceAllMatches = useCallback(() => {
-    if (!isEditorViewAlive(editorView) || matches.length === 0) return;
+  const replaceMatch = useCallback(
+    (match: SearchMatch) => {
+      if (!isEditorViewAlive(editorView) || !isSearchMatchReplaceable(match)) return;
+      const [step] = createReplacementSteps([match], replaceTerm, searchOptions);
+      if (!step) return;
+
+      const { state, dispatch } = editorView;
+      const tr = step.text
+        ? state.tr.replaceWith(step.from, step.to, state.schema.text(step.text))
+        : state.tr.delete(step.from, step.to);
+      dispatch(tr);
+    },
+    [editorView, replaceTerm, searchOptions],
+  );
+
+  const replaceAllCurrentMatches = useCallback(() => {
+    if (!isEditorViewAlive(editorView)) return;
+    const steps = createReplacementSteps(matches, replaceTerm, searchOptions);
+    if (steps.length === 0) return;
 
     const { state, dispatch } = editorView;
     let tr = state.tr;
-
-    // Replace from end to start to avoid position shift
-    for (let i = matches.length - 1; i >= 0; i--) {
-      const match = matches[i];
-      tr = tr.replaceWith(match.from, match.to, state.schema.text(replaceTerm));
+    for (const step of steps) {
+      tr = step.text
+        ? tr.replaceWith(step.from, step.to, state.schema.text(step.text))
+        : tr.delete(step.from, step.to);
     }
-
     dispatch(tr);
+    setConfirmReplaceAll(false);
+  }, [editorView, matches, replaceTerm, searchOptions]);
 
-    // 検索語をクリア → matches が空になり、useSearchHighlight がハイライトを消す。
-    onSearchTermChange("");
-    setReplaceTerm("");
-  }, [editorView, matches, replaceTerm, onSearchTermChange]);
+  const replaceProjectResults = useCallback(
+    async (results: readonly ProjectSearchFileResult[]) => {
+      if (!onProjectBufferChange) return;
+      setReplacementPending(true);
+      setProjectSearchError(null);
+
+      try {
+        const { getProjectFileService } = await import("@/lib/services/project-file-service");
+        const changes = await replaceProjectFiles({
+          vfs: getProjectFileService(),
+          results,
+          replacement: replaceTerm,
+          options: searchOptions,
+          openBuffers: projectOpenBuffers,
+          onOpenBufferChange: onProjectBufferChange,
+        });
+        setLastProjectReplacement(changes);
+        setConfirmReplaceAll(false);
+        setProjectRefreshToken((token) => token + 1);
+      } catch (error) {
+        setProjectSearchError(error instanceof Error ? error.message : "置換に失敗しました");
+      } finally {
+        setReplacementPending(false);
+      }
+    },
+    [onProjectBufferChange, projectOpenBuffers, replaceTerm, searchOptions],
+  );
+
+  const undoLastProjectReplacement = useCallback(async () => {
+    if (lastProjectReplacement.length === 0 || !onProjectBufferChange) return;
+    setReplacementPending(true);
+    setProjectSearchError(null);
+
+    try {
+      const { getProjectFileService } = await import("@/lib/services/project-file-service");
+      await undoProjectReplacement({
+        vfs: getProjectFileService(),
+        changes: lastProjectReplacement,
+        openBuffers: projectOpenBuffers,
+        onOpenBufferChange: onProjectBufferChange,
+      });
+      setLastProjectReplacement([]);
+      setProjectRefreshToken((token) => token + 1);
+    } catch (error) {
+      setProjectSearchError(error instanceof Error ? error.message : "取り消しに失敗しました");
+    } finally {
+      setReplacementPending(false);
+    }
+  }, [lastProjectReplacement, onProjectBufferChange, projectOpenBuffers]);
+
+  const currentGroups = useMemo(() => groupMatches(matches), [matches]);
+  const projectMatchCount = useMemo(
+    () => projectResults.reduce((total, file) => total + file.matches.length, 0),
+    [projectResults],
+  );
+  const projectMatchLocations = useMemo(
+    () =>
+      projectResults.flatMap((file) =>
+        file.matches.map((_match, matchIndex) => ({ file, matchIndex })),
+      ),
+    [projectResults],
+  );
+  const navigateMatches = useCallback(
+    (delta: number) => {
+      if (scope === "current") {
+        navigateCurrentMatches(delta);
+        return;
+      }
+      if (projectMatchLocations.length === 0 || !onOpenProjectFile) return;
+
+      const nextIndex =
+        (projectNavigationIndex + delta + projectMatchLocations.length) %
+        projectMatchLocations.length;
+      const location = projectMatchLocations[nextIndex];
+      setProjectNavigationIndex(nextIndex);
+      void onOpenProjectFile(location.file.path).then(() => {
+        onCurrentMatchIndexChange(location.matchIndex);
+      });
+    },
+    [
+      navigateCurrentMatches,
+      onCurrentMatchIndexChange,
+      onOpenProjectFile,
+      projectMatchLocations,
+      projectNavigationIndex,
+      scope,
+    ],
+  );
+  const visibleMatchCount = scope === "current" ? matches.length : projectMatchCount;
+  const replaceableMatchCount =
+    scope === "current"
+      ? matches.filter(isSearchMatchReplaceable).length
+      : projectResults.reduce(
+          (total, file) => total + file.matches.filter(isSearchMatchReplaceable).length,
+          0,
+        );
+
+  const renderMatchText = (match: SearchMatch) => {
+    const context = getMatchContext(match);
+    const replacementPreview = buildReplacementText(match, replaceTerm, searchOptions);
+    return (
+      <p className="text-sm text-foreground break-words">
+        <span className="text-foreground-secondary">{context.before}</span>
+        {showReplace && replaceTouched ? (
+          <>
+            <span
+              className="line-through bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 px-1 rounded"
+              data-testid="replace-preview-old"
+            >
+              {context.text}
+            </span>
+            <span
+              className="bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 font-semibold px-1 rounded ml-0.5"
+              data-testid="replace-preview-new"
+            >
+              {replacementPreview || "（削除）"}
+            </span>
+          </>
+        ) : (
+          <span className="bg-accent-light text-accent font-semibold px-1 rounded">
+            {context.text}
+          </span>
+        )}
+        <span className="text-foreground-secondary">{context.after}</span>
+      </p>
+    );
+  };
 
   return (
     <div className="h-full bg-background-secondary border-r border-border flex flex-col">
-      {/* Title bar */}
       <div className="p-4 border-b border-border flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Search className="w-5 h-5 text-foreground-secondary" />
@@ -129,135 +440,252 @@ export default function SearchResults({
         </button>
       </div>
 
-      {/* Search input area */}
       <div className="p-4 border-b border-border space-y-3">
-        {/* Search box */}
-        <div>
+        <div className="flex gap-1">
           <input
             ref={searchInputRef}
             type="text"
             value={searchTerm}
-            onChange={(e) => onSearchTermChange(e.target.value)}
+            onChange={(event) => onSearchTermChange(event.target.value)}
+            onBlur={commitSearchHistory}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") commitSearchHistory();
+            }}
             placeholder="検索..."
-            className="w-full px-3 py-2 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
+            aria-invalid={Boolean(patternError)}
+            className="min-w-0 flex-1 px-3 py-2 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
           />
+          {history.length > 0 && (
+            <div className="relative">
+              <History className="pointer-events-none absolute left-2 top-2.5 w-4 h-4 text-foreground-tertiary" />
+              <select
+                aria-label="検索履歴"
+                value=""
+                onChange={(event) => onSearchTermChange(event.target.value)}
+                className="h-full w-9 pl-8 border border-border-secondary bg-background text-transparent rounded appearance-none cursor-pointer"
+                title="検索履歴"
+              >
+                <option value="">検索履歴</option>
+                {history.map((entry) => (
+                  <option key={entry} value={entry}>
+                    {entry}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
 
-        {/* Options */}
-        <div className="flex items-center justify-between">
+        {patternError && (
+          <p className="flex items-center gap-1 text-xs text-danger" role="alert">
+            <AlertTriangle className="w-3.5 h-3.5" />
+            {patternError}
+          </p>
+        )}
+
+        <div className="space-y-1">
           <label className="flex items-center gap-2 text-xs text-foreground-secondary cursor-pointer">
             <input
               type="checkbox"
               checked={caseSensitive}
-              onChange={(e) => onCaseSensitiveChange(e.target.checked)}
+              onChange={(event) => onCaseSensitiveChange(event.target.checked)}
               className="rounded"
             />
             大文字小文字を区別
           </label>
-          {matches.length > 0 && (
-            <span className="text-xs text-foreground-secondary">
-              {matches.length}件見つかりました
-            </span>
-          )}
+          <div className="flex items-center justify-end gap-1">
+            {visibleMatchCount > 0 && (
+              <span className="text-xs text-foreground-secondary whitespace-nowrap">
+                {visibleMatchCount}件見つかりました
+              </span>
+            )}
+            <button
+              type="button"
+              aria-label="前の一致"
+              title="前の一致"
+              disabled={visibleMatchCount === 0}
+              onClick={() => navigateMatches(-1)}
+              className="p-1 rounded hover:bg-hover disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <ChevronUp className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              aria-label="次の一致"
+              title="次の一致"
+              disabled={visibleMatchCount === 0}
+              onClick={() => navigateMatches(1)}
+              className="p-1 rounded hover:bg-hover disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              <ChevronDown className="w-4 h-4" />
+            </button>
+          </div>
         </div>
 
-        {/* Replace toggle */}
         <button
-          onClick={() => setShowReplace(!showReplace)}
-          className="w-full flex items-center justify-between px-3 py-2 text-sm text-foreground-secondary hover:bg-hover rounded transition-colors"
+          onClick={() => setShowAdvanced((visible) => !visible)}
+          className="w-full flex items-center justify-between px-2 py-1.5 text-sm text-foreground-secondary hover:bg-hover rounded transition-colors"
+          aria-expanded={showAdvanced}
         >
-          <div className="flex items-center gap-2">
-            {showReplace ? (
-              <ChevronDown className="w-4 h-4" />
-            ) : (
-              <ChevronRight className="w-4 h-4" />
-            )}
-            <span>置換</span>
-          </div>
+          <span className="flex items-center gap-2">
+            <SlidersHorizontal className="w-4 h-4" />
+            詳細オプション
+          </span>
+          {showAdvanced ? (
+            <ChevronDown className="w-4 h-4" />
+          ) : (
+            <ChevronRight className="w-4 h-4" />
+          )}
         </button>
 
-        {/* Replace area */}
+        {showAdvanced && (
+          <div className="space-y-2 pl-2 text-xs text-foreground-secondary">
+            <OptionCheckbox
+              label="正規表現を使う"
+              checked={regexSearch}
+              onChange={onRegexSearchChange}
+            />
+            <OptionCheckbox
+              label="単語単位で一致"
+              checked={wholeWordSearch}
+              onChange={onWholeWordSearchChange}
+            />
+            <OptionCheckbox
+              label="表記ゆれを吸収"
+              checked={normalizeVariants}
+              onChange={onNormalizeVariantsChange}
+            />
+            <OptionCheckbox
+              label="コメントを除外"
+              checked={excludeComments}
+              onChange={onExcludeCommentsChange}
+            />
+            <label className="flex items-center justify-between gap-2">
+              検索対象
+              <select
+                value={searchTarget}
+                onChange={(event) => onSearchTargetChange(event.target.value as SearchTarget)}
+                className="px-2 py-1 border border-border-secondary bg-background text-foreground rounded"
+              >
+                <option value="all">本文とルビ</option>
+                <option value="body">本文のみ</option>
+                <option value="ruby">ルビのみ</option>
+              </select>
+            </label>
+            <OptionCheckbox
+              label="選択範囲のみ"
+              checked={selectionOnly}
+              onChange={onSelectionOnlyChange}
+              disabled={!hasSelection || scope !== "current"}
+            />
+            {projectSearchEnabled && (
+              <label className="flex items-center justify-between gap-2">
+                範囲
+                <select
+                  value={scope}
+                  onChange={(event) => setScope(event.target.value as SearchScope)}
+                  className="px-2 py-1 border border-border-secondary bg-background text-foreground rounded"
+                >
+                  <option value="project">プロジェクト全体</option>
+                  <option value="current">現在のファイル</option>
+                  <option value="folder">フォルダ</option>
+                </select>
+              </label>
+            )}
+            {scope === "folder" && projectSearchEnabled && (
+              <input
+                value={folderPath}
+                onChange={(event) => setFolderPath(event.target.value)}
+                placeholder="フォルダのパス"
+                className="w-full px-2 py-1.5 border border-border-secondary bg-background text-foreground rounded"
+              />
+            )}
+          </div>
+        )}
+
+        <button
+          onClick={() => setShowReplace((visible) => !visible)}
+          className="w-full flex items-center justify-between px-2 py-1.5 text-sm text-foreground-secondary hover:bg-hover rounded transition-colors"
+          aria-expanded={showReplace}
+        >
+          <span className="flex items-center gap-2">
+            <Replace className="w-4 h-4" />
+            置換
+          </span>
+          {showReplace ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+        </button>
+
         {showReplace && (
           <div className="space-y-2 pl-6">
             <input
               type="text"
               value={replaceTerm}
-              onChange={(e) => setReplaceTerm(e.target.value)}
+              onFocus={() => setReplaceTouched(true)}
+              onChange={(event) => {
+                setReplaceTouched(true);
+                setReplaceTerm(event.target.value);
+              }}
               placeholder="置換後..."
               className="w-full px-3 py-2 border border-border-secondary bg-background text-foreground rounded focus:outline-none focus:ring-2 focus:ring-accent text-sm"
             />
-            <div className="flex gap-2">
+            <button
+              onClick={() => setConfirmReplaceAll(true)}
+              disabled={replaceableMatchCount === 0 || !replaceTouched || replacementPending}
+              className={clsx(
+                "w-full flex items-center justify-center gap-2 px-3 py-2 rounded text-sm font-medium transition-colors",
+                replaceableMatchCount === 0 || !replaceTouched || replacementPending
+                  ? "bg-background-tertiary text-foreground-muted cursor-not-allowed"
+                  : "bg-accent text-accent-foreground hover:bg-accent-hover",
+              )}
+            >
+              <ReplaceAll className="w-4 h-4" />
+              すべて置換
+            </button>
+            {lastProjectReplacement.length > 0 && (
               <button
-                onClick={replaceAllMatches}
-                disabled={matches.length === 0 || !replaceTerm}
-                className={clsx(
-                  "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded text-sm font-medium transition-colors",
-                  matches.length === 0 || !replaceTerm
-                    ? "bg-background-tertiary text-foreground-muted cursor-not-allowed"
-                    : "bg-accent text-accent-foreground hover:bg-accent-hover",
-                )}
+                onClick={() => void undoLastProjectReplacement()}
+                disabled={replacementPending}
+                className="w-full px-3 py-2 text-sm rounded border border-border-secondary text-foreground-secondary hover:bg-hover disabled:opacity-50"
               >
-                <ReplaceAll className="w-4 h-4" />
-                すべて置換
+                直前の一括置換を取り消す
               </button>
-            </div>
+            )}
           </div>
         )}
       </div>
 
-      {/* Results list */}
       <div className="flex-1 overflow-y-auto">
-        {searchTerm && matches.length === 0 ? (
-          <div className="p-4 text-center text-foreground-secondary">検索結果がありません</div>
+        {projectSearchPending && projectResults.length === 0 ? (
+          <EmptyMessage text="検索中..." />
+        ) : projectSearchError && visibleMatchCount === 0 ? (
+          <EmptyMessage text={projectSearchError} />
         ) : !searchTerm ? (
-          <div className="p-4 text-center text-foreground-secondary">検索語を入力してください</div>
-        ) : (
-          <div className="divide-y divide-border">
-            {matches.map((match, index) => {
-              const context = getMatchContext(match);
-              return (
-                <div
-                  key={`${match.from}-${match.to}-${index}`}
-                  className="p-4 hover:bg-hover transition-colors group"
-                >
-                  <div className="flex items-start gap-2">
-                    <span className="text-xs font-mono text-foreground-tertiary mt-1 flex-shrink-0">
-                      {index + 1}
-                    </span>
-                    <div className="flex-1 min-w-0">
-                      <button onClick={() => goToMatch(match, index)} className="w-full text-left">
-                        <p className="text-sm text-foreground break-words">
-                          <span className="text-foreground-secondary">{context.before}</span>
-                          {showReplace && replaceTerm ? (
-                            // #1502: VSCode-style replace preview (strikethrough + red old,
-                            // green new). Only when replaceTerm is non-empty; preserves the
-                            // plain highlight rendering otherwise.
-                            <>
-                              <span
-                                className="line-through bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 px-1 rounded"
-                                data-testid="replace-preview-old"
-                              >
-                                {context.text}
-                              </span>
-                              <span
-                                className="bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 font-semibold px-1 rounded ml-0.5"
-                                data-testid="replace-preview-new"
-                              >
-                                {replaceTerm}
-                              </span>
-                            </>
-                          ) : (
-                            <span className="bg-accent-light text-accent font-semibold px-1 rounded">
-                              {context.text}
-                            </span>
-                          )}
-                          <span className="text-foreground-secondary">{context.after}</span>
-                        </p>
+          <EmptyMessage text="検索語を入力してください" />
+        ) : patternError ? null : visibleMatchCount === 0 ? (
+          <EmptyMessage text="検索結果がありません" />
+        ) : scope === "current" ? (
+          <div>
+            {currentGroups.map((group) => (
+              <section key={group.heading}>
+                <h3 className="sticky top-0 px-4 py-2 bg-background-tertiary text-xs font-medium text-foreground-secondary border-b border-border">
+                  {group.heading}
+                </h3>
+                <div className="divide-y divide-border">
+                  {group.matches.map(({ match, index }) => (
+                    <div
+                      key={`${match.from}-${match.to}-${index}`}
+                      className={clsx(
+                        "p-3 hover:bg-hover transition-colors",
+                        currentMatchIndex === index && "bg-active",
+                      )}
+                    >
+                      <button onClick={() => goToMatch(index)} className="w-full text-left">
+                        {renderMatchText(match)}
                         <p className="text-xs text-foreground-tertiary mt-1">
-                          位置: {match.from} - {match.to}
+                          {match.paragraphNumber ? `段落 ${match.paragraphNumber}` : "見出し"}
                         </p>
                       </button>
-                      {showReplace && replaceTerm && (
+                      {showReplace && replaceTouched && isSearchMatchReplaceable(match) && (
                         <button
                           onClick={() => replaceMatch(match)}
                           className="mt-2 flex items-center gap-1 px-2 py-1 text-xs bg-accent-light text-accent hover:bg-active rounded transition-colors"
@@ -266,14 +694,185 @@ export default function SearchResults({
                           置換
                         </button>
                       )}
+                      {!isSearchMatchReplaceable(match) && (
+                        <p className="mt-2 text-xs text-foreground-tertiary">
+                          構造を含むため置換できません
+                        </p>
+                      )}
                     </div>
-                  </div>
+                  ))}
                 </div>
-              );
-            })}
+              </section>
+            ))}
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {projectSearchError && (
+              <p className="px-4 py-2 text-xs text-danger" role="alert">
+                {projectSearchError}
+              </p>
+            )}
+            {projectSearchPending && (
+              <p className="px-4 py-2 text-xs text-foreground-secondary">
+                検索中... {projectProgress.searched}/{projectProgress.total}
+              </p>
+            )}
+            {projectResults.map((file) => (
+              <section key={file.path}>
+                <h3
+                  className={clsx(
+                    "sticky top-0 px-4 py-2 bg-background-tertiary text-xs font-medium text-foreground-secondary flex items-center gap-2",
+                    currentFilePath === file.path && "text-accent",
+                  )}
+                >
+                  <FileText className="w-3.5 h-3.5" />
+                  <span className="truncate">{file.path}</span>
+                  <span className="ml-auto">{file.matches.length}件</span>
+                </h3>
+                {groupMatches(file.matches).map((group) => (
+                  <div key={group.heading}>
+                    <h4 className="px-4 py-1.5 text-xs text-foreground-tertiary border-t border-border">
+                      {group.heading}
+                    </h4>
+                    {group.matches.map(({ match, index }) => {
+                      const projectMatch = file.matches[index];
+                      const navigationIndex = projectMatchLocations.findIndex(
+                        (location) =>
+                          location.file.path === file.path && location.matchIndex === index,
+                      );
+                      return (
+                        <div
+                          key={`${projectMatch.rawFrom}-${projectMatch.rawTo}-${index}`}
+                          className={clsx(
+                            "p-3 hover:bg-hover border-t border-border transition-colors",
+                            projectNavigationIndex === navigationIndex && "bg-active",
+                          )}
+                        >
+                          <button
+                            onClick={() => {
+                              if (!onOpenProjectFile) return;
+                              setProjectNavigationIndex(navigationIndex);
+                              void onOpenProjectFile(file.path).then(() => {
+                                onCurrentMatchIndexChange(index);
+                              });
+                            }}
+                            className="w-full text-left"
+                          >
+                            <p className="text-sm text-foreground break-words">
+                              <span className="bg-accent-light text-accent font-semibold px-1 rounded">
+                                {match.text}
+                              </span>
+                            </p>
+                            <p className="text-xs text-foreground-tertiary mt-1">
+                              段落 {projectMatch.lineNumber}
+                            </p>
+                          </button>
+                          {showReplace &&
+                            replaceTouched &&
+                            isSearchMatchReplaceable(projectMatch) && (
+                              <button
+                                onClick={() =>
+                                  void replaceProjectResults([{ ...file, matches: [projectMatch] }])
+                                }
+                                disabled={replacementPending}
+                                className="mt-2 flex items-center gap-1 px-2 py-1 text-xs bg-accent-light text-accent hover:bg-active rounded transition-colors disabled:opacity-50"
+                              >
+                                <Replace className="w-3 h-3" />
+                                置換
+                              </button>
+                            )}
+                          {!isSearchMatchReplaceable(projectMatch) && (
+                            <p className="mt-2 text-xs text-foreground-tertiary">
+                              構造を含むため置換できません
+                            </p>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                ))}
+              </section>
+            ))}
           </div>
         )}
       </div>
+
+      {confirmReplaceAll && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-sm rounded border border-border bg-background p-4 shadow-xl">
+            <h3 className="text-base font-semibold text-foreground">置換の確認</h3>
+            <p className="mt-2 text-sm text-foreground-secondary">
+              {replaceableMatchCount}件を置換します。
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                onClick={() => setConfirmReplaceAll(false)}
+                className="px-3 py-2 text-sm rounded hover:bg-hover"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={() => {
+                  if (scope === "current") replaceAllCurrentMatches();
+                  else void replaceProjectResults(projectResults);
+                }}
+                disabled={replacementPending}
+                className="px-3 py-2 text-sm rounded bg-accent text-accent-foreground hover:bg-accent-hover"
+              >
+                {replacementPending ? "置換中..." : "置換する"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
+}
+
+function OptionCheckbox({
+  label,
+  checked,
+  onChange,
+  disabled = false,
+}: {
+  label: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <label
+      className={clsx(
+        "flex items-center gap-2",
+        disabled ? "text-foreground-muted cursor-not-allowed" : "cursor-pointer",
+      )}
+    >
+      <input
+        type="checkbox"
+        aria-label={label}
+        checked={checked}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.checked)}
+        className="rounded"
+      />
+      {label}
+    </label>
+  );
+}
+
+function EmptyMessage({ text }: { text: string }) {
+  return <div className="p-4 text-center text-sm text-foreground-secondary">{text}</div>;
+}
+
+function groupMatches(matches: readonly SearchMatch[]): MatchGroup[] {
+  const groups = new Map<string, MatchGroup>();
+
+  matches.forEach((match, index) => {
+    const heading = match.heading || "見出しなし";
+    const group = groups.get(heading) ?? { heading, matches: [] };
+    group.matches.push({ match, index });
+    groups.set(heading, group);
+  });
+
+  return [...groups.values()];
 }

--- a/components/SidebarPanel.tsx
+++ b/components/SidebarPanel.tsx
@@ -11,6 +11,7 @@ import { isProjectMode } from "@/lib/project/project-types";
 
 import type { ActivityBarView } from "@/components/ActivityBar";
 import type { EditorMode } from "@/lib/project/project-types";
+import type { SearchMatch, SearchTarget } from "@/lib/editor-page/find-search-matches";
 import type { EditorView } from "@milkdown/prose/view";
 
 interface SidebarPanelProps {
@@ -31,7 +32,20 @@ interface SidebarPanelProps {
   onSearchTermChange: (term: string) => void;
   caseSensitive: boolean;
   onCaseSensitiveChange: (value: boolean) => void;
-  searchMatches: { from: number; to: number }[];
+  regexSearch: boolean;
+  onRegexSearchChange: (value: boolean) => void;
+  wholeWordSearch: boolean;
+  onWholeWordSearchChange: (value: boolean) => void;
+  normalizeVariants: boolean;
+  onNormalizeVariantsChange: (value: boolean) => void;
+  excludeComments: boolean;
+  onExcludeCommentsChange: (value: boolean) => void;
+  searchTarget: SearchTarget;
+  onSearchTargetChange: (value: SearchTarget) => void;
+  selectionOnly: boolean;
+  onSelectionOnlyChange: (value: boolean) => void;
+  hasSearchSelection: boolean;
+  searchMatches: SearchMatch[];
   currentMatchIndex: number;
   onCurrentMatchIndexChange: (index: number) => void;
   /** Called when the search panel should close. */
@@ -42,6 +56,8 @@ interface SidebarPanelProps {
   dictionarySearchTrigger: { term: string; id: number };
   /** Path of the currently open file (used by the word frequency panel). */
   currentFilePath?: string;
+  projectSearchBuffers: ReadonlyMap<string, string>;
+  onProjectBufferChange: (path: string, content: string) => void | Promise<void>;
   /** Trigger counter for opening the new-file dialog inside the files panel. */
   newFileTrigger: number;
   /** Opens a project file by VFS path. */
@@ -69,6 +85,19 @@ export default function SidebarPanel({
   onSearchTermChange,
   caseSensitive,
   onCaseSensitiveChange,
+  regexSearch,
+  onRegexSearchChange,
+  wholeWordSearch,
+  onWholeWordSearchChange,
+  normalizeVariants,
+  onNormalizeVariantsChange,
+  excludeComments,
+  onExcludeCommentsChange,
+  searchTarget,
+  onSearchTargetChange,
+  selectionOnly,
+  onSelectionOnlyChange,
+  hasSearchSelection,
   searchMatches,
   currentMatchIndex,
   onCurrentMatchIndexChange,
@@ -76,6 +105,8 @@ export default function SidebarPanel({
   editorViewInstance,
   dictionarySearchTrigger,
   currentFilePath,
+  projectSearchBuffers,
+  onProjectBufferChange,
   newFileTrigger,
   openProjectFile,
   onWordSearch,
@@ -120,9 +151,27 @@ export default function SidebarPanel({
           onSearchTermChange={onSearchTermChange}
           caseSensitive={caseSensitive}
           onCaseSensitiveChange={onCaseSensitiveChange}
+          regexSearch={regexSearch}
+          onRegexSearchChange={onRegexSearchChange}
+          wholeWordSearch={wholeWordSearch}
+          onWholeWordSearchChange={onWholeWordSearchChange}
+          normalizeVariants={normalizeVariants}
+          onNormalizeVariantsChange={onNormalizeVariantsChange}
+          excludeComments={excludeComments}
+          onExcludeCommentsChange={onExcludeCommentsChange}
+          searchTarget={searchTarget}
+          onSearchTargetChange={onSearchTargetChange}
+          selectionOnly={selectionOnly}
+          onSelectionOnlyChange={onSelectionOnlyChange}
+          hasSelection={hasSearchSelection}
           matches={searchMatches}
           currentMatchIndex={currentMatchIndex}
           onCurrentMatchIndexChange={onCurrentMatchIndexChange}
+          projectSearchEnabled={isProjectMode(editorMode)}
+          projectOpenBuffers={projectSearchBuffers}
+          currentFilePath={currentFilePath}
+          onOpenProjectFile={(path) => openProjectFile(path, { preview: false })}
+          onProjectBufferChange={onProjectBufferChange}
           onClose={onCloseSearchResults}
         />
       );

--- a/components/SidebarPanel.tsx
+++ b/components/SidebarPanel.tsx
@@ -26,8 +26,14 @@ interface SidebarPanelProps {
   onChapterClick: (anchorId: string) => void;
   /** Called when the editor should insert text at the current cursor. */
   onInsertText: (text: string) => void;
-  /** Current search results for the search panel. */
-  searchResults: { matches: { from: number; to: number }[]; searchTerm: string } | null;
+  /** 共有検索 state（単一 source of truth）。SearchDialog と同期する。 */
+  searchTerm: string;
+  onSearchTermChange: (term: string) => void;
+  caseSensitive: boolean;
+  onCaseSensitiveChange: (value: boolean) => void;
+  searchMatches: { from: number; to: number }[];
+  currentMatchIndex: number;
+  onCurrentMatchIndexChange: (index: number) => void;
   /** Called when the search panel should close. */
   onCloseSearchResults: () => void;
   /** The active ProseMirror EditorView (required by the search panel). */
@@ -59,7 +65,13 @@ export default function SidebarPanel({
   compactMode,
   onChapterClick,
   onInsertText,
-  searchResults,
+  searchTerm,
+  onSearchTermChange,
+  caseSensitive,
+  onCaseSensitiveChange,
+  searchMatches,
+  currentMatchIndex,
+  onCurrentMatchIndexChange,
   onCloseSearchResults,
   editorViewInstance,
   dictionarySearchTrigger,
@@ -104,8 +116,13 @@ export default function SidebarPanel({
       return (
         <SearchResults
           editorView={editorViewInstance}
-          matches={searchResults?.matches}
-          searchTerm={searchResults?.searchTerm}
+          searchTerm={searchTerm}
+          onSearchTermChange={onSearchTermChange}
+          caseSensitive={caseSensitive}
+          onCaseSensitiveChange={onCaseSensitiveChange}
+          matches={searchMatches}
+          currentMatchIndex={currentMatchIndex}
+          onCurrentMatchIndexChange={onCurrentMatchIndexChange}
           onClose={onCloseSearchResults}
         />
       );

--- a/components/WordFrequency.tsx
+++ b/components/WordFrequency.tsx
@@ -9,7 +9,14 @@ import { useContextMenu } from "@/lib/hooks/use-context-menu";
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
 import { getProjectFileService } from "@/lib/services/project-file-service";
 import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
+import { getDictAccess } from "@/lib/dict/dict-access";
+import {
+  summarizeGenjiVocabulary,
+  freqRankDistributionToRows,
+  registerDistributionToRows,
+} from "@/lib/utils/vocabulary-genji";
 import type { WordEntry } from "@/lib/nlp-client/types";
+import type { GenjiVocabularySummary } from "@/lib/utils/vocabulary-genji";
 
 /** Cache file schema for word frequency results */
 interface WordFrequencyCache {
@@ -76,6 +83,12 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
   const [error, setError] = useState<string | null>(null);
   const [lastAnalyzedContent, setLastAnalyzedContent] = useState<string>("");
   const [cacheTimestamp, setCacheTimestamp] = useState<number>(0);
+
+  // Genji vocabulary enrichment state
+  const [genjiSummary, setGenjiSummary] = useState<GenjiVocabularySummary | null>(null);
+  const [genjiLoading, setGenjiLoading] = useState(false);
+  /** Set to true when the Genji DB is ready (health.state === "ready"). False means graceful hide. */
+  const [genjiReady, setGenjiReady] = useState(false);
 
   /** Generation counter — incremented on each analysis start; stale async results are discarded (#1078) */
   const genRef = useRef(0);
@@ -224,6 +237,54 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
     }
   }, [content, lastAnalyzedContent]);
 
+  // Genji vocabulary enrichment — run after words list changes
+  useEffect(() => {
+    if (words.length === 0) {
+      setGenjiSummary(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const runGenji = async (): Promise<void> => {
+      const access = getDictAccess();
+      const health = await access.getHealth();
+
+      if (cancelled) return;
+
+      // Graceful degradation: only enrich when the local Electron DB is ready.
+      // Web-fallback and not-installed states skip bulk lookup.
+      if (health.state !== "ready") {
+        setGenjiReady(false);
+        setGenjiSummary(null);
+        return;
+      }
+
+      setGenjiReady(true);
+      setGenjiLoading(true);
+
+      try {
+        const wordStrings = words.map((w) => w.word);
+        const lookupMap = await access.lookupBatch(wordStrings);
+        if (cancelled) return;
+        const summary = summarizeGenjiVocabulary(wordStrings, lookupMap);
+        setGenjiSummary(summary);
+      } catch (err) {
+        console.warn("[WordFrequency] Genji enrichment failed:", err);
+        // Non-critical — swallow and hide the section
+        setGenjiSummary(null);
+      } finally {
+        if (!cancelled) setGenjiLoading(false);
+      }
+    };
+
+    void runGenji();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [words]);
+
   const stats = useMemo(() => {
     const totalWords = words.reduce((sum, w) => sum + w.count, 0);
     const uniqueWords = words.length;
@@ -343,6 +404,72 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
           </div>
         )}
       </div>
+
+      {/* 幻辞メトリクスセクション — Genji DB が ready のときのみ表示 */}
+      {genjiReady && (
+        <div className="flex-shrink-0 border-t border-border">
+          <div className="px-3 py-2">
+            <div className="flex items-center justify-between mb-1.5">
+              <h3 className="text-xs font-medium text-foreground-secondary">幻辞分析</h3>
+              {genjiLoading && (
+                <LoaderCircle className="w-3 h-3 text-foreground-tertiary animate-spin" />
+              )}
+            </div>
+
+            {genjiSummary !== null && !genjiLoading && (
+              <>
+                {/* 頻度ランク分布 */}
+                <div className="mb-2">
+                  <p className="text-xs text-foreground-tertiary mb-1">頻度ランク分布</p>
+                  <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+                    {freqRankDistributionToRows(genjiSummary.freqRankDistribution).map((row) => (
+                      <span key={row.label} className="text-xs text-foreground-tertiary">
+                        {row.label}:{" "}
+                        <span className="text-foreground font-medium">{row.count}</span>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                {/* レジスター分布（文体ラベルが1種類以上あるときのみ） */}
+                {Object.keys(genjiSummary.registerDistribution).length > 0 && (
+                  <div className="mb-2">
+                    <p className="text-xs text-foreground-tertiary mb-1">文体</p>
+                    <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+                      {registerDistributionToRows(genjiSummary.registerDistribution).map((row) => (
+                        <span key={row.label} className="text-xs text-foreground-tertiary">
+                          {row.label}:{" "}
+                          <span className="text-foreground font-medium">{row.count}</span>
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* 辞書外語数 */}
+                <p className="text-xs text-foreground-tertiary">
+                  辞書外語:{" "}
+                  <span className="text-foreground font-medium">
+                    {genjiSummary.unknownWordCount}
+                  </span>
+                  <span className="ml-1 text-foreground-tertiary">
+                    （固有名詞・造語・誤記の候補）
+                  </span>
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* 幻辞未導入時の案内（Electron のみ、web では非表示） */}
+      {!genjiReady && typeof window !== "undefined" && window.electronAPI !== undefined && (
+        <div className="flex-shrink-0 border-t border-border px-3 py-2">
+          <p className="text-xs text-foreground-tertiary">
+            幻辞辞書をダウンロードすると、頻度ランク・文体・辞書外語分析が使えます。
+          </p>
+        </div>
+      )}
 
       {/* Web context menu */}
       {contextMenu.menu && (

--- a/components/WordFrequency.tsx
+++ b/components/WordFrequency.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback, memo, useRef } from "react";
-import { RefreshCw, LoaderCircle } from "lucide-react";
+import { RefreshCw, LoaderCircle, ChevronRight, ChevronDown } from "lucide-react";
 import clsx from "clsx";
 
 import ContextMenu from "@/components/ContextMenu";
@@ -10,6 +10,7 @@ import { getNlpClient } from "@/lib/nlp-client/nlp-client";
 import { getProjectFileService } from "@/lib/services/project-file-service";
 import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import { getDictAccess } from "@/lib/dict/dict-access";
+import { localPreferences } from "@/lib/storage/local-preferences";
 import {
   summarizeGenjiVocabulary,
   freqRankDistributionToRows,
@@ -18,8 +19,18 @@ import {
 import type { WordEntry } from "@/lib/nlp-client/types";
 import type { GenjiVocabularySummary } from "@/lib/utils/vocabulary-genji";
 
+/**
+ * Cache schema version. Bump whenever the analysis OUTPUT changes so stale
+ * on-disk caches are discarded instead of being served verbatim.
+ * v2: #1640 strips serializer-escaped `\[\[blank]]` markers — pre-v2 caches
+ *     still contain spurious "blank" tokens (#1639).
+ */
+const CACHE_SCHEMA_VERSION = 2;
+
 /** Cache file schema for word frequency results */
 interface WordFrequencyCache {
+  /** Schema version; missing/older => cache is stale and re-analyzed. */
+  schemaVersion?: number;
   lastModified: number;
   fileSize: number;
   words: WordEntry[];
@@ -40,7 +51,7 @@ interface WordFrequencyProps {
 /** Dictionary lookup action map */
 const DICTIONARY_ACTIONS: Record<string, (word: string) => { url: string; title: string }> = {
   genji: (word) => ({
-    url: `https://genji.illusions.app/${encodeURIComponent(word)}`,
+    url: `https://dict.illusions.app/results?q=${encodeURIComponent(word)}`,
     title: `${word} - 幻辞`,
   }),
   kotobank: (word) => ({
@@ -89,6 +100,15 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
   const [genjiLoading, setGenjiLoading] = useState(false);
   /** Set to true when the Genji DB is ready (health.state === "ready"). False means graceful hide. */
   const [genjiReady, setGenjiReady] = useState(false);
+  /**
+   * 「辞書データからの分析」セクションの開閉。既定は展開。
+   * 開閉状態は localPreferences に永続化し、次回以降も記憶する（#1639）。
+   * 幻辞セクションは genjiReady（client-only async）後にのみ描画されるため、
+   * lazy initializer による localStorage 読み取りで hydration mismatch は起きない。
+   */
+  const [genjiExpanded, setGenjiExpanded] = useState<boolean>(() =>
+    localPreferences.getGenjiAnalysisExpanded(),
+  );
 
   /** Generation counter — incremented on each analysis start; stale async results are discarded (#1078) */
   const genRef = useRef(0);
@@ -167,7 +187,11 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
           const cache = JSON.parse(cacheText) as WordFrequencyCache;
           const meta = await vfs.getFileMetadata(filePath);
 
-          if (cache.lastModified === meta.lastModified && cache.fileSize === meta.size) {
+          if (
+            cache.schemaVersion === CACHE_SCHEMA_VERSION &&
+            cache.lastModified === meta.lastModified &&
+            cache.fileSize === meta.size
+          ) {
             // Discard stale result if a newer analysis was started (#1078)
             if (genRef.current !== myGen) return;
             setWords(cache.words);
@@ -202,6 +226,7 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
           const meta = await vfs.getFileMetadata(filePath);
           const totalWords = wordEntries.reduce((sum, w) => sum + w.count, 0);
           const cacheData: WordFrequencyCache = {
+            schemaVersion: CACHE_SCHEMA_VERSION,
             lastModified: meta.lastModified,
             fileSize: meta.size,
             words: wordEntries,
@@ -405,19 +430,39 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
         )}
       </div>
 
-      {/* 幻辞メトリクスセクション — Genji DB が ready のときのみ表示 */}
+      {/* 辞書データからの分析セクション — Genji DB が ready のときのみ表示。デフォルト折り畳み（#1639） */}
       {genjiReady && (
         <div className="flex-shrink-0 border-t border-border">
           <div className="px-3 py-2">
-            <div className="flex items-center justify-between mb-1.5">
-              <h3 className="text-xs font-medium text-foreground-secondary">幻辞分析</h3>
+            <button
+              type="button"
+              onClick={() =>
+                setGenjiExpanded((v) => {
+                  const next = !v;
+                  localPreferences.setGenjiAnalysisExpanded(next);
+                  return next;
+                })
+              }
+              aria-expanded={genjiExpanded}
+              className="w-full flex items-center justify-between gap-1.5 -mx-1 px-1 py-0.5 rounded hover:bg-hover transition-colors"
+            >
+              <span className="flex items-center gap-1 min-w-0">
+                {genjiExpanded ? (
+                  <ChevronDown className="w-3 h-3 text-foreground-tertiary flex-shrink-0" />
+                ) : (
+                  <ChevronRight className="w-3 h-3 text-foreground-tertiary flex-shrink-0" />
+                )}
+                <h3 className="text-xs font-medium text-foreground-secondary truncate">
+                  辞書データからの分析
+                </h3>
+              </span>
               {genjiLoading && (
-                <LoaderCircle className="w-3 h-3 text-foreground-tertiary animate-spin" />
+                <LoaderCircle className="w-3 h-3 text-foreground-tertiary animate-spin flex-shrink-0" />
               )}
-            </div>
+            </button>
 
-            {genjiSummary !== null && !genjiLoading && (
-              <>
+            {genjiExpanded && genjiSummary !== null && !genjiLoading && (
+              <div className="mt-1.5">
                 {/* 頻度ランク分布 */}
                 <div className="mb-2">
                   <p className="text-xs text-foreground-tertiary mb-1">頻度ランク分布</p>
@@ -446,9 +491,9 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
                   </div>
                 )}
 
-                {/* 辞書外語数 */}
+                {/* 辞書にない語彙数 */}
                 <p className="text-xs text-foreground-tertiary">
-                  辞書外語:{" "}
+                  辞書にない語彙数:{" "}
                   <span className="text-foreground font-medium">
                     {genjiSummary.unknownWordCount}
                   </span>
@@ -456,7 +501,7 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
                     （固有名詞・造語・誤記の候補）
                   </span>
                 </p>
-              </>
+              </div>
             )}
           </div>
         </div>
@@ -466,7 +511,7 @@ function WordFrequency({ content, onWordSearch, filePath }: WordFrequencyProps) 
       {!genjiReady && typeof window !== "undefined" && window.electronAPI !== undefined && (
         <div className="flex-shrink-0 border-t border-border px-3 py-2">
           <p className="text-xs text-foreground-tertiary">
-            幻辞辞書をダウンロードすると、頻度ランク・文体・辞書外語分析が使えます。
+            辞書データをダウンロードすると、頻度ランク・文体・辞書にない語彙の分析が使えます。
           </p>
         </div>
       )}

--- a/components/__tests__/SearchResults-destroyed-view.test.tsx
+++ b/components/__tests__/SearchResults-destroyed-view.test.tsx
@@ -25,6 +25,15 @@ vi.mock("@/lib/editor-page/center-editor-position", () => ({
 
 import SearchResults from "../SearchResults";
 
+// 共有検索 state の controlled props（このテストでは検索ナビ自体は検証しない）。
+const controlled = {
+  onSearchTermChange: () => {},
+  caseSensitive: false,
+  onCaseSensitiveChange: () => {},
+  currentMatchIndex: 0,
+  onCurrentMatchIndexChange: () => {},
+} as const;
+
 let container: HTMLDivElement;
 let root: Root;
 
@@ -64,7 +73,13 @@ describe("SearchResults – destroyed editor view (#1507)", () => {
     expect(() => {
       act(() => {
         root.render(
-          <SearchResults editorView={destroyed} onClose={() => {}} searchTerm="" matches={[]} />,
+          <SearchResults
+            editorView={destroyed}
+            {...controlled}
+            onClose={() => {}}
+            searchTerm=""
+            matches={[]}
+          />,
         );
       });
     }).not.toThrow();
@@ -76,6 +91,7 @@ describe("SearchResults – destroyed editor view (#1507)", () => {
       root.render(
         <SearchResults
           editorView={destroyed}
+          {...controlled}
           onClose={() => {}}
           searchTerm="foo"
           matches={[{ from: 1, to: 4 }]}
@@ -87,7 +103,13 @@ describe("SearchResults – destroyed editor view (#1507)", () => {
     expect(() => {
       act(() => {
         root.render(
-          <SearchResults editorView={destroyed} onClose={() => {}} searchTerm="" matches={[]} />,
+          <SearchResults
+            editorView={destroyed}
+            {...controlled}
+            onClose={() => {}}
+            searchTerm=""
+            matches={[]}
+          />,
         );
       });
     }).not.toThrow();
@@ -97,13 +119,25 @@ describe("SearchResults – destroyed editor view (#1507)", () => {
     const destroyed = makeDestroyedView();
     act(() => {
       root.render(
-        <SearchResults editorView={null} onClose={() => {}} searchTerm="foo" matches={[]} />,
+        <SearchResults
+          editorView={null}
+          {...controlled}
+          onClose={() => {}}
+          searchTerm="foo"
+          matches={[]}
+        />,
       );
     });
     expect(() => {
       act(() => {
         root.render(
-          <SearchResults editorView={destroyed} onClose={() => {}} searchTerm="foo" matches={[]} />,
+          <SearchResults
+            editorView={destroyed}
+            {...controlled}
+            onClose={() => {}}
+            searchTerm="foo"
+            matches={[]}
+          />,
         );
       });
     }).not.toThrow();

--- a/components/__tests__/SearchResults-enhancements.test.tsx
+++ b/components/__tests__/SearchResults-enhancements.test.tsx
@@ -1,0 +1,148 @@
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from "react";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import SearchResults from "../SearchResults";
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  localStorage.clear();
+});
+
+function renderSearchResults(
+  overrides: Partial<React.ComponentProps<typeof SearchResults>> = {},
+): void {
+  act(() => {
+    root.render(
+      <SearchResults
+        editorView={null}
+        searchTerm="target"
+        onSearchTermChange={() => {}}
+        caseSensitive={false}
+        onCaseSensitiveChange={() => {}}
+        regexSearch={false}
+        onRegexSearchChange={() => {}}
+        wholeWordSearch={false}
+        onWholeWordSearchChange={() => {}}
+        normalizeVariants={false}
+        onNormalizeVariantsChange={() => {}}
+        excludeComments
+        onExcludeCommentsChange={() => {}}
+        searchTarget="all"
+        onSearchTargetChange={() => {}}
+        selectionOnly={false}
+        onSelectionOnlyChange={() => {}}
+        hasSelection={false}
+        matches={[]}
+        currentMatchIndex={0}
+        onCurrentMatchIndexChange={() => {}}
+        onClose={() => {}}
+        {...overrides}
+      />,
+    );
+  });
+}
+
+describe("SearchResults enhanced options", () => {
+  it("keeps advanced options hidden until requested", () => {
+    renderSearchResults();
+
+    expect(container.textContent).toContain("詳細オプション");
+    expect(container.textContent).not.toContain("正規表現を使う");
+
+    const detailsButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("詳細オプション"),
+    );
+    act(() => detailsButton?.click());
+
+    expect(container.textContent).toContain("正規表現を使う");
+    expect(container.textContent).toContain("単語単位で一致");
+    expect(container.textContent).toContain("表記ゆれを吸収");
+  });
+
+  it("reports invalid regular expressions without throwing", () => {
+    renderSearchResults({ searchTerm: "(", regexSearch: true });
+    expect(container.textContent).toContain("正規表現が正しくありません");
+  });
+
+  it("forwards advanced option changes", () => {
+    const onRegexSearchChange = vi.fn();
+    renderSearchResults({ onRegexSearchChange });
+
+    const detailsButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("詳細オプション"),
+    );
+    act(() => detailsButton?.click());
+    const regexInput = container.querySelector(
+      'input[aria-label="正規表現を使う"]',
+    ) as HTMLInputElement;
+    act(() => regexInput.click());
+
+    expect(onRegexSearchChange).toHaveBeenCalledWith(true);
+  });
+
+  it("does not offer replacement for matches containing MDI structure", () => {
+    renderSearchResults({
+      matches: [
+        {
+          from: 1,
+          to: 2,
+          text: "東京",
+          source: "ruby-base",
+          replaceable: false,
+          paragraphNumber: 1,
+        },
+      ],
+    });
+
+    expect(container.textContent).toContain("構造を含むため置換できません");
+    expect(container.textContent).toContain("段落 1");
+  });
+
+  it("navigates to the previous and next match from the always-visible controls", () => {
+    const onCurrentMatchIndexChange = vi.fn();
+    renderSearchResults({
+      matches: [
+        { from: 1, to: 2, text: "a" },
+        { from: 3, to: 4, text: "a" },
+      ],
+      currentMatchIndex: 0,
+      onCurrentMatchIndexChange,
+    });
+
+    act(() => (container.querySelector('[aria-label="次の一致"]') as HTMLButtonElement).click());
+    expect(onCurrentMatchIndexChange).toHaveBeenLastCalledWith(1);
+
+    act(() => (container.querySelector('[aria-label="前の一致"]') as HTMLButtonElement).click());
+    expect(onCurrentMatchIndexChange).toHaveBeenLastCalledWith(1);
+  });
+
+  it("shows and forwards the comment exclusion filter", () => {
+    const onExcludeCommentsChange = vi.fn();
+    renderSearchResults({ onExcludeCommentsChange });
+    const detailsButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("詳細オプション"),
+    );
+    act(() => detailsButton?.click());
+
+    const comments = container.querySelector(
+      'input[aria-label="コメントを除外"]',
+    ) as HTMLInputElement;
+    expect(comments.checked).toBe(true);
+    act(() => comments.click());
+    expect(onExcludeCommentsChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/components/__tests__/SearchResults-project-navigation.test.tsx
+++ b/components/__tests__/SearchResults-project-navigation.test.tsx
@@ -86,7 +86,11 @@ describe("SearchResults project navigation", () => {
       );
     });
 
-    for (let attempt = 0; attempt < 20 && !container.textContent?.includes("second.mdi"); attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < 20 && !container.textContent?.includes("second.mdi");
+      attempt += 1
+    ) {
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 25));
       });
@@ -134,7 +138,11 @@ describe("SearchResults project navigation", () => {
       );
     });
 
-    for (let attempt = 0; attempt < 20 && !container.textContent?.includes("second.mdi"); attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt < 20 && !container.textContent?.includes("second.mdi");
+      attempt += 1
+    ) {
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 25));
       });

--- a/components/__tests__/SearchResults-project-navigation.test.tsx
+++ b/components/__tests__/SearchResults-project-navigation.test.tsx
@@ -1,0 +1,147 @@
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act } from "react";
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const projectVfs = vi.hoisted(() => ({
+  isRootOpen: vi.fn(() => true),
+  listDirectory: vi.fn(async () => [
+    { name: "first.mdi", path: "first.mdi", kind: "file" as const },
+    { name: "second.mdi", path: "second.mdi", kind: "file" as const },
+  ]),
+  readFile: vi.fn(async (path: string) => `${path} target`),
+}));
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => projectVfs,
+}));
+
+vi.mock("@/lib/editor-page/project-search-worker-client", () => ({
+  ProjectSearchWorkerClient: class {
+    matchDocument = async (content: string, _fileType: string, searchTerm: string) => {
+      const from = content.indexOf(searchTerm);
+      return {
+        content,
+        matches:
+          from < 0
+            ? []
+            : [
+                {
+                  from,
+                  to: from + searchTerm.length,
+                  rawFrom: from,
+                  rawTo: from + searchTerm.length,
+                  lineNumber: 1,
+                  text: searchTerm,
+                },
+              ],
+      };
+    };
+    dispose(): void {}
+  },
+}));
+
+import SearchResults from "../SearchResults";
+
+beforeEach(() => {
+  projectVfs.isRootOpen.mockReturnValue(true);
+  projectVfs.listDirectory.mockResolvedValue([
+    { name: "first.mdi", path: "first.mdi", kind: "file" as const },
+    { name: "second.mdi", path: "second.mdi", kind: "file" as const },
+  ]);
+  projectVfs.readFile.mockImplementation(async (path: string) => `${path} target`);
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.clearAllMocks();
+});
+
+describe("SearchResults project navigation", () => {
+  it("opens the exact file before jumping and navigates across files", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onOpenProjectFile = vi.fn(async () => {});
+    const onCurrentMatchIndexChange = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <SearchResults
+          editorView={null}
+          searchTerm="target"
+          onSearchTermChange={() => {}}
+          caseSensitive={false}
+          onCaseSensitiveChange={() => {}}
+          matches={[]}
+          currentMatchIndex={0}
+          onCurrentMatchIndexChange={onCurrentMatchIndexChange}
+          onClose={() => {}}
+          projectSearchEnabled
+          onOpenProjectFile={onOpenProjectFile}
+          onProjectBufferChange={() => {}}
+        />,
+      );
+    });
+
+    for (let attempt = 0; attempt < 20 && !container.textContent?.includes("second.mdi"); attempt += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+    }
+
+    expect(container.textContent).toContain("first.mdi");
+    expect(container.textContent).toContain("second.mdi");
+
+    await act(async () => {
+      (container.querySelector('[aria-label="次の一致"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+
+    expect(onOpenProjectFile).toHaveBeenCalledWith("second.mdi");
+    expect(onCurrentMatchIndexChange).toHaveBeenCalledWith(0);
+    expect(onOpenProjectFile.mock.invocationCallOrder[0]).toBeLessThan(
+      onCurrentMatchIndexChange.mock.invocationCallOrder[0],
+    );
+
+    act(() => root.unmount());
+  });
+
+  it("shows a file error while retaining successful results", async () => {
+    projectVfs.readFile.mockRejectedValueOnce(new Error("permission denied"));
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SearchResults
+          editorView={null}
+          searchTerm="target"
+          onSearchTermChange={() => {}}
+          caseSensitive={false}
+          onCaseSensitiveChange={() => {}}
+          matches={[]}
+          currentMatchIndex={0}
+          onCurrentMatchIndexChange={() => {}}
+          onClose={() => {}}
+          projectSearchEnabled
+          onOpenProjectFile={async () => {}}
+          onProjectBufferChange={() => {}}
+        />,
+      );
+    });
+
+    for (let attempt = 0; attempt < 20 && !container.textContent?.includes("second.mdi"); attempt += 1) {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      });
+    }
+
+    expect(container.textContent).toContain("second.mdi");
+    expect(container.textContent).toContain("first.mdi: permission denied");
+    act(() => root.unmount());
+  });
+});

--- a/components/__tests__/SearchResults-prop-sync.test.tsx
+++ b/components/__tests__/SearchResults-prop-sync.test.tsx
@@ -44,18 +44,28 @@ afterEach(() => {
  * Wrapper that simulates SidebarPanel's behavior: SearchResults is kept
  * mounted while its props change (the exact scenario from #1502).
  *
- * Note: SearchResults's public prop names are `searchTerm` / `matches`
- * (destructured internally as `initialSearchTerm` / `initialMatches`).
+ * SearchResults is now fully controlled — `searchTerm` / `matches` come
+ * straight from the shared search state in app/page.tsx.
  */
 function Wrapper({
-  searchTerm,
-  matches,
+  searchTerm = "",
+  matches = [],
 }: {
   searchTerm?: string;
   matches?: { from: number; to: number }[];
 }) {
   return (
-    <SearchResults editorView={null} onClose={() => {}} searchTerm={searchTerm} matches={matches} />
+    <SearchResults
+      editorView={null}
+      searchTerm={searchTerm}
+      onSearchTermChange={() => {}}
+      caseSensitive={false}
+      onCaseSensitiveChange={() => {}}
+      matches={matches}
+      currentMatchIndex={0}
+      onCurrentMatchIndexChange={() => {}}
+      onClose={() => {}}
+    />
   );
 }
 

--- a/components/__tests__/search-dialog-anchor-wire.test.tsx
+++ b/components/__tests__/search-dialog-anchor-wire.test.tsx
@@ -48,9 +48,15 @@ function Wrapper({ withAnchor, isOpen }: { withAnchor: boolean; isOpen: boolean 
   const ref = useRef<HTMLButtonElement | null>(anchorEl);
   return (
     <SearchDialog
-      editorView={null}
       isOpen={isOpen}
       onClose={() => {}}
+      searchTerm=""
+      onSearchTermChange={() => {}}
+      caseSensitive={false}
+      onCaseSensitiveChange={() => {}}
+      matches={[]}
+      currentMatchIndex={0}
+      onCurrentMatchIndexChange={() => {}}
       anchorRef={withAnchor ? ref : undefined}
     />
   );

--- a/components/__tests__/search-dialog-drag-cleanup.test.tsx
+++ b/components/__tests__/search-dialog-drag-cleanup.test.tsx
@@ -17,8 +17,8 @@ import { createRoot, type Root } from "react-dom/client";
 import { act } from "react";
 import SearchDialog from "../SearchDialog";
 
-// SearchDialog は editorView を触る effect を持つので、null を渡して decoration path を no-op にする。
-// (editorView == null 時は matches/decorations effect が早期 return する)
+// SearchDialog は controlled 化され、マッチ検出・ハイライトは親（useSearchHighlight）へ
+// 移譲済み。ここでは drag/portal ライフサイクルのみを検証するため、検索 props は静的に渡す。
 
 let root: Root;
 let anchorEl: HTMLDivElement;
@@ -58,7 +58,18 @@ function render(isOpen: boolean) {
   const anchorRef = { current: anchorEl };
   act(() => {
     root.render(
-      <SearchDialog editorView={null} isOpen={isOpen} onClose={() => {}} anchorRef={anchorRef} />,
+      <SearchDialog
+        isOpen={isOpen}
+        onClose={() => {}}
+        searchTerm=""
+        onSearchTermChange={() => {}}
+        caseSensitive={false}
+        onCaseSensitiveChange={() => {}}
+        matches={[]}
+        currentMatchIndex={0}
+        onCurrentMatchIndexChange={() => {}}
+        anchorRef={anchorRef}
+      />,
     );
   });
 }

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -382,7 +382,10 @@ export default function MilkdownEditor({
       });
   }, [editorViewInstance, lintingEnabled, lintingRuleRunner]);
 
-  // 縦書き時: マウスホイールの縦スクロールを横スクロールへ変換する
+  // 縦書き時: ホイール/トラックパッドの入力を横スクロールへ変換する。
+  // 縦書きはコンテナの overflowY が hidden で縦スクロールが無いため、縦スワイプも
+  // 横スワイプも scrollLeft に集約する（横スワイプを scrollTop に流すと「横に払うと
+  // 本文が横へ動かず上下に引っ張られる」体感になっていた, #1639）。
   useEffect(() => {
     const container = scrollContainerRef.current;
     if (!container || !isVertical) return;
@@ -404,18 +407,19 @@ export default function MilkdownEditor({
           container.scrollLeft += mouseHorizontalDelta;
           event.preventDefault();
         } else if (absX > 0) {
-          container.scrollTop += event.deltaX * sensitivity;
+          container.scrollLeft -= event.deltaX * sensitivity;
           event.preventDefault();
         }
         return;
       }
 
       if (isTrackpadInput) {
-        if (absY > 0) {
-          container.scrollLeft += event.deltaY * sensitivity;
-        }
-        if (absX > 0) {
-          container.scrollTop += event.deltaX * sensitivity;
+        // 縦書きは横スクロールのみ（overflowY hidden）。2本指パンは支配的な軸だけを
+        // 横スクロールへ写像し、対角・慣性入力で deltaX/deltaY が競合して引っかかるのを防ぐ。
+        // 横スワイプは指の向きに追従（-deltaX）、縦スワイプは読み進み方向（+deltaY）。
+        if (absX > 0 || absY > 0) {
+          const primaryDelta = absX >= absY ? -event.deltaX : event.deltaY;
+          container.scrollLeft += primaryDelta * sensitivity;
         }
         event.preventDefault();
         return;
@@ -427,7 +431,7 @@ export default function MilkdownEditor({
         container.scrollLeft += mouseHorizontalDelta;
         event.preventDefault();
       } else if (absX > 0) {
-        container.scrollTop += event.deltaX * sensitivity;
+        container.scrollLeft -= event.deltaX * sensitivity;
         event.preventDefault();
       }
     };
@@ -998,6 +1002,12 @@ export default function MilkdownEditor({
           <Milkdown />
         </div>
       </div>
+      {/* 縦書きの右端（文書の先頭側）の余白。スクロールコンテナの padding-right は
+          Chromium が scrollWidth に含めず実機 Electron で消えるため、scrollWidth に
+          確実に算入される in-flow なフレックススペーサーで右余白を作る（#1639）。 */}
+      {isVertical && (
+        <div aria-hidden="true" style={{ flex: "0 0 64px", minWidth: 64, alignSelf: "stretch" }} />
+      )}
     </div>
   );
 

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -14,6 +14,7 @@ import {
   wrapInOrderedListCommand,
 } from "@milkdown/preset-commonmark";
 import { gfm, toggleStrikethroughCommand } from "@milkdown/preset-gfm";
+import { clearFormatting } from "@/lib/editor-page/clear-formatting";
 import { listener, listenerCtx } from "@milkdown/plugin-listener";
 import { history } from "@milkdown/plugin-history";
 import { clipboard } from "@milkdown/plugin-clipboard";
@@ -619,6 +620,12 @@ export default function MilkdownEditor({
           break;
         case "code":
           execute(toggleInlineCodeCommand.key);
+          break;
+        case "clearFormatting":
+          // 選択範囲を標準本文（段落・装飾なし）に戻す
+          editor.action((ctx) => {
+            clearFormatting(ctx.get(editorViewCtx));
+          });
           break;
         default:
           break;

--- a/components/inspector/CorrectionsPanel.tsx
+++ b/components/inspector/CorrectionsPanel.tsx
@@ -21,7 +21,11 @@ import type { CorrectionModeId } from "@/lib/linting/correction-config";
 import { DEFAULT_POS_COLORS } from "@/packages/milkdown-plugin-japanese-novel/pos-highlight/pos-colors";
 import InfoTooltip from "./InfoTooltip";
 import IssueCard from "./IssueCard";
-import { useLintingSettings, usePosHighlightSettings } from "@/contexts/EditorSettingsContext";
+import {
+  useLintingSettings,
+  usePosHighlightSettings,
+  usePowerSettings,
+} from "@/contexts/EditorSettingsContext";
 
 import type { LintIssue, Severity } from "@/lib/linting";
 import type { SeverityFilter, EnrichedLintIssue } from "./types";
@@ -31,6 +35,7 @@ type SortMode = "position" | "severity" | "category";
 
 interface CorrectionsPanelProps {
   onOpenPosHighlightSettings?: () => void;
+  onOpenPowerSettings?: () => void;
   lintIssues: (LintIssue | EnrichedLintIssue)[];
   onNavigateToIssue?: (issue: LintIssue) => void;
   onApplyFix?: (issue: LintIssue) => void;
@@ -79,6 +84,7 @@ const POS_LEGEND_ITEMS = [
 /** Panel for displaying lint corrections and POS highlighting controls */
 export default function CorrectionsPanel({
   onOpenPosHighlightSettings,
+  onOpenPowerSettings,
   lintIssues,
   onNavigateToIssue,
   onApplyFix,
@@ -99,6 +105,7 @@ export default function CorrectionsPanel({
   } = usePosHighlightSettings();
   const { lintingEnabled, lintingRuleConfigs, onLintingEnabledChange, onLintingRuleConfigChange } =
     useLintingSettings();
+  const { powerSaveMode, onTemporarilyDisablePowerSave } = usePowerSettings();
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
   const [sortMode, setSortMode] = useState<SortMode>("category");
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -438,9 +445,34 @@ export default function CorrectionsPanel({
       </div>
 
       {!lintingEnabled ? (
-        <div className="pt-4 text-center">
-          <p className="text-sm text-foreground-tertiary">校正機能が無効です</p>
-        </div>
+        powerSaveMode ? (
+          <div className="bg-background-secondary mt-1 rounded-lg border border-border p-3 text-center">
+            <p className="text-sm text-foreground-secondary">省電力モードのため停止中です</p>
+            <p className="mt-1 text-xs text-foreground-tertiary">
+              バッテリー節約のため校正機能を一時停止しています。
+            </p>
+            <div className="mt-3 flex flex-col items-stretch gap-1.5">
+              <button
+                onClick={() => onTemporarilyDisablePowerSave?.()}
+                className="rounded-md bg-accent px-3 py-1.5 text-xs font-medium text-accent-foreground transition-colors hover:bg-accent-hover"
+              >
+                5分間だけ有効にする
+              </button>
+              {onOpenPowerSettings && (
+                <button
+                  onClick={onOpenPowerSettings}
+                  className="text-xs text-accent transition-colors hover:text-accent-hover hover:underline"
+                >
+                  省電力設定を開く
+                </button>
+              )}
+            </div>
+          </div>
+        ) : (
+          <div className="pt-4 text-center">
+            <p className="text-sm text-foreground-tertiary">校正機能が無効です</p>
+          </div>
+        )
       ) : (
         <>
           {/* Header: issue count + controls */}

--- a/components/inspector/GenjiWordInfoSection.tsx
+++ b/components/inspector/GenjiWordInfoSection.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type React from "react";
+
+import { useGenjiWordInfo } from "@/lib/utils/genji-word-info";
+
+interface GenjiWordInfoSectionProps {
+  /** 選択中の語（空またはnullのとき非表示） */
+  selectedWord: string | null | undefined;
+}
+
+/**
+ * 選択語の幻辞（Genji）辞書情報を表示するインスペクタセクション。
+ *
+ * - 幻辞が未インストール / オフライン / 該当語なし のときは何も表示しない。
+ * - 読み中はスケルトンローダーを表示し、品詞ハイライト本体の動作を一切変えない。
+ */
+export default function GenjiWordInfoSection({
+  selectedWord,
+}: GenjiWordInfoSectionProps): React.ReactElement | null {
+  const state = useGenjiWordInfo(selectedWord);
+
+  if (state.status === "idle" || state.status === "unavailable") {
+    return null;
+  }
+
+  return (
+    <div className="mt-4 border-t border-border pt-4">
+      <p className="text-xs font-medium text-foreground-tertiary uppercase tracking-wide mb-2">
+        選択語の辞書情報
+      </p>
+
+      {state.status === "loading" && (
+        <div className="space-y-1 animate-pulse">
+          <div className="h-3 bg-foreground-muted/20 rounded w-2/3" />
+          <div className="h-3 bg-foreground-muted/20 rounded w-1/2" />
+        </div>
+      )}
+
+      {state.status === "not-found" && (
+        <p className="text-xs text-foreground-tertiary">該当する辞書項目がありません</p>
+      )}
+
+      {state.status === "found" && (
+        <div className="space-y-2">
+          {/* 見出し・読み・品詞 */}
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="text-sm font-semibold text-foreground">{state.viewModel.word}</span>
+            {state.viewModel.reading && (
+              <span className="text-xs text-foreground-secondary">{state.viewModel.reading}</span>
+            )}
+            {state.viewModel.partOfSpeech && (
+              <span className="text-xs px-1.5 py-0.5 rounded bg-accent/10 text-accent font-medium">
+                {state.viewModel.partOfSpeech}
+              </span>
+            )}
+            {state.viewModel.register && (
+              <span className="text-xs px-1.5 py-0.5 rounded bg-foreground-muted/10 text-foreground-secondary">
+                {state.viewModel.register}
+              </span>
+            )}
+          </div>
+
+          {/* 語義 */}
+          {state.viewModel.glosses.length > 0 && (
+            <ol className="list-decimal list-inside space-y-0.5 pl-0.5">
+              {state.viewModel.glosses.map((gloss, i) => (
+                <li key={i} className="text-xs text-foreground-secondary leading-relaxed">
+                  {gloss}
+                </li>
+              ))}
+            </ol>
+          )}
+
+          {/* 類義語 */}
+          {state.viewModel.synonyms.length > 0 && (
+            <div className="flex items-center gap-1 flex-wrap">
+              <span className="text-xs text-foreground-tertiary shrink-0">類義語：</span>
+              {state.viewModel.synonyms.map((syn, i) => (
+                <span
+                  key={i}
+                  className="text-xs px-1.5 py-0.5 rounded bg-foreground-muted/10 text-foreground-secondary"
+                >
+                  {syn}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/inspector/GenjiWordInfoSection.tsx
+++ b/components/inspector/GenjiWordInfoSection.tsx
@@ -1,22 +1,27 @@
 "use client";
 
 import type React from "react";
+import clsx from "clsx";
 
 import { useGenjiWordInfo } from "@/lib/utils/genji-word-info";
 
 interface GenjiWordInfoSectionProps {
   /** 選択中の語（空またはnullのとき非表示） */
   selectedWord: string | null | undefined;
+  /** 余白を詰めた compact レイアウトにする（Inspector の compactMode 連動） */
+  compact?: boolean;
 }
 
 /**
  * 選択語の幻辞（Genji）辞書情報を表示するインスペクタセクション。
  *
- * - 幻辞が未インストール / オフライン / 該当語なし のときは何も表示しない。
+ * Inspector のタブバー直下に常駐し、どのタブでも語を選択すると表示される（#1639）。
+ * - 幻辞が未インストール / オフライン / 該当語なし のときは何も表示しない（null）。
  * - 読み中はスケルトンローダーを表示し、品詞ハイライト本体の動作を一切変えない。
  */
 export default function GenjiWordInfoSection({
   selectedWord,
+  compact = false,
 }: GenjiWordInfoSectionProps): React.ReactElement | null {
   const state = useGenjiWordInfo(selectedWord);
 
@@ -25,7 +30,12 @@ export default function GenjiWordInfoSection({
   }
 
   return (
-    <div className="mt-4 border-t border-border pt-4">
+    <div
+      className={clsx(
+        "flex-shrink-0 border-b border-border bg-background-secondary",
+        compact ? "px-3 py-2" : "px-4 py-3",
+      )}
+    >
       <p className="text-xs font-medium text-foreground-tertiary uppercase tracking-wide mb-2">
         選択語の辞書情報
       </p>

--- a/components/inspector/StatsPanel.tsx
+++ b/components/inspector/StatsPanel.tsx
@@ -44,6 +44,7 @@ interface StatsPanelProps {
       paragraphDensity: number;
     };
     hasMorphologicalAnalysis?: boolean;
+    hasDictAnalysis?: boolean;
   };
   previousDayStats?: PreviousDayStats | null;
 }
@@ -293,6 +294,12 @@ export default function StatsPanel({
                   {readabilityAnalysis.hasMorphologicalAnalysis === false && (
                     <span className="opacity-50 normal-case font-normal">(基本分析)</span>
                   )}
+                  {readabilityAnalysis.hasMorphologicalAnalysis === true &&
+                    readabilityAnalysis.hasDictAnalysis === false && (
+                      <span className="opacity-50 normal-case font-normal">
+                        (辞書未導入のため簡易判定)
+                      </span>
+                    )}
                 </p>
                 {(
                   [

--- a/components/inspector/StatsPanel.tsx
+++ b/components/inspector/StatsPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import InfoTooltip from "./InfoTooltip";
-import GenjiWordInfoSection from "./GenjiWordInfoSection";
 
 import type { PreviousDayStats } from "@/lib/editor-page/use-previous-day-stats";
 
@@ -48,8 +47,6 @@ interface StatsPanelProps {
     hasDictAnalysis?: boolean;
   };
   previousDayStats?: PreviousDayStats | null;
-  /** 選択中の語（品詞タブで幻辞情報を表示するために渡す） */
-  selectedWord?: string | null;
 }
 
 /** Format a diff value with sign prefix */
@@ -73,7 +70,6 @@ export default function StatsPanel({
   charUsageRates,
   readabilityAnalysis,
   previousDayStats,
-  selectedWord,
 }: StatsPanelProps) {
   const isSelection = selectedCharCount > 0;
   const activeCharCount = isSelection ? selectedCharCount : charCount;
@@ -680,9 +676,6 @@ export default function StatsPanel({
           </div>
         </div>
       </div>
-
-      {/* 選択語の幻辞情報（品詞ハイライト連携） */}
-      <GenjiWordInfoSection selectedWord={selectedWord} />
     </div>
   );
 }

--- a/components/inspector/StatsPanel.tsx
+++ b/components/inspector/StatsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import InfoTooltip from "./InfoTooltip";
+import GenjiWordInfoSection from "./GenjiWordInfoSection";
 
 import type { PreviousDayStats } from "@/lib/editor-page/use-previous-day-stats";
 
@@ -47,6 +48,8 @@ interface StatsPanelProps {
     hasDictAnalysis?: boolean;
   };
   previousDayStats?: PreviousDayStats | null;
+  /** 選択中の語（品詞タブで幻辞情報を表示するために渡す） */
+  selectedWord?: string | null;
 }
 
 /** Format a diff value with sign prefix */
@@ -70,6 +73,7 @@ export default function StatsPanel({
   charUsageRates,
   readabilityAnalysis,
   previousDayStats,
+  selectedWord,
 }: StatsPanelProps) {
   const isSelection = selectedCharCount > 0;
   const activeCharCount = isSelection ? selectedCharCount : charCount;
@@ -676,6 +680,9 @@ export default function StatsPanel({
           </div>
         </div>
       </div>
+
+      {/* 選択語の幻辞情報（品詞ハイライト連携） */}
+      <GenjiWordInfoSection selectedWord={selectedWord} />
     </div>
   );
 }

--- a/components/inspector/types.ts
+++ b/components/inspector/types.ts
@@ -104,4 +104,6 @@ export interface InspectorProps {
   switchToCorrectionsTrigger?: number;
   /** Previous day's stats for comparison display */
   previousDayStats?: PreviousDayStats | null;
+  /** 選択中の語（統計タブで幻辞情報を表示するために渡す） */
+  selectedWord?: string | null;
 }

--- a/components/inspector/types.ts
+++ b/components/inspector/types.ts
@@ -79,6 +79,7 @@ export interface InspectorProps {
     hasMorphologicalAnalysis?: boolean;
   };
   onOpenPosHighlightSettings?: () => void;
+  onOpenPowerSettings?: () => void;
   onHistoryRestore?: (content: string) => void;
   activeFileName?: string;
   activeFilePath?: string;

--- a/components/settings/DictSettingsTab.tsx
+++ b/components/settings/DictSettingsTab.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Download, RefreshCw, CheckCircle2, AlertCircle, Loader2 } from "lucide-react";
 import { useDictSettingsContext } from "@/contexts/EditorSettingsContext";
 import type { DictDownloadStatus } from "@/lib/dict/dict-types";
+import { getDictAccess } from "@/lib/dict/dict-access";
 import { SettingsField, SettingsSection, SettingsToggle } from "./primitives";
 
 interface UpdateInfo {
@@ -104,6 +105,8 @@ export default function DictSettingsTab() {
           onDictInstalledVersionChange(result.version);
         }
         setCheckResult(null);
+        // Drop cached "corrupt" health + negative lookups now the DB is fresh.
+        getDictAccess().invalidate();
       } else {
         setError(result.error ?? "ダウンロードに失敗しました");
         setDbStatus("error");
@@ -134,6 +137,7 @@ export default function DictSettingsTab() {
   };
 
   const isInstalled = dbStatus === "installed";
+  const isCorrupt = dbStatus === "corrupt";
   const updateAvailable = checkResult?.updateAvailable ?? false;
 
   return (
@@ -148,12 +152,25 @@ export default function DictSettingsTab() {
           {isInstalled ? (
             <CheckCircle2 className="w-4 h-4 text-success flex-shrink-0" />
           ) : (
-            <AlertCircle className="w-4 h-4 text-foreground-tertiary flex-shrink-0" />
+            <AlertCircle
+              className={`w-4 h-4 flex-shrink-0 ${isCorrupt ? "text-danger" : "text-foreground-tertiary"}`}
+            />
           )}
           <span className="text-sm text-foreground">
-            {isInstalled ? "インストール済み" : "未インストール"}
+            {isInstalled
+              ? "インストール済み"
+              : isCorrupt
+                ? "破損（再ダウンロードが必要）"
+                : "未インストール"}
           </span>
         </div>
+
+        {/* Corrupt notice */}
+        {isCorrupt && (
+          <div className="text-xs text-danger">
+            辞書データが破損しています。「再ダウンロード」で修復してください。
+          </div>
+        )}
 
         {/* Version */}
         {dictInstalledVersion && (
@@ -226,7 +243,7 @@ export default function DictSettingsTab() {
                 ) : (
                   <Download className="w-3 h-3" />
                 )}
-                {isInstalled ? "更新" : "ダウンロード"}
+                {isCorrupt ? "再ダウンロード" : isInstalled ? "更新" : "ダウンロード"}
               </button>
             )}
           </div>

--- a/contexts/EditorSettingsContext.tsx
+++ b/contexts/EditorSettingsContext.tsx
@@ -164,6 +164,7 @@ export function usePowerSettings() {
       powerSaveMode: settings.powerSaveMode,
       autoPowerSaveOnBattery: settings.autoPowerSaveOnBattery,
       onPowerSaveModeChange: handlers.handlePowerSaveModeChange,
+      onTemporarilyDisablePowerSave: handlers.temporarilyDisablePowerSave,
       onAutoPowerSaveOnBatteryChange: handlers.handleAutoPowerSaveOnBatteryChange,
     }),
     [settings, handlers],

--- a/electron/__tests__/dict-manager-access.test.ts
+++ b/electron/__tests__/dict-manager-access.test.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Backend tests for the analysis-access additions to DictManager (#1624):
+ *   - verify()      — fast integrity check (ok / not-installed / schema / malformed)
+ *   - lookupBatch() — exact-match lightweight projection
+ *   - getStatus()   — reports "corrupt" once the flag is tripped
+ *
+ * The real better-sqlite3 can't open here (the local copy is rebuilt for
+ * Electron's ABI) and vitest externalizes the native module so it can't be
+ * vi.mock'd. Instead we inject a fake DB through the manager's `_createDatabase`
+ * seam — the same override style as `_getDictDir` in dict-manager.test.ts —
+ * which still exercises the manager's projection / grouping / corruption logic.
+ */
+
+const { appGetPathMock } = vi.hoisted(() => ({
+  appGetPathMock: vi.fn(() => "/tmp/illusions-dict-access-test"),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: appGetPathMock },
+}));
+
+type DbMode = "healthy" | "no-table" | "malformed";
+
+class FakeStatement {
+  constructor(
+    private readonly sql: string,
+    private readonly rows: Array<{ entry: string; raw_json: string }>,
+    private readonly mode: DbMode,
+  ) {}
+  get(): unknown {
+    if (this.sql.includes("sqlite_master")) {
+      return this.mode === "no-table" ? undefined : { name: "entries" };
+    }
+    if (this.sql.includes("LIMIT 1")) {
+      return this.rows[0] ? { raw_json: this.rows[0].raw_json } : undefined;
+    }
+    return undefined;
+  }
+  all(...args: unknown[]): unknown[] {
+    if (this.sql.includes("WHERE entry IN")) {
+      const wanted = new Set(args as string[]);
+      return this.rows.filter((r) => wanted.has(r.entry)).map((r) => ({ ...r }));
+    }
+    return [];
+  }
+  run(): void {}
+}
+
+class FakeDatabase {
+  constructor(
+    private readonly rows: Array<{ entry: string; raw_json: string }>,
+    private readonly mode: DbMode,
+  ) {
+    if (mode === "malformed") throw new Error("file is not a database");
+  }
+  prepare(sql: string): FakeStatement {
+    return new FakeStatement(sql, this.rows, this.mode);
+  }
+  pragma(): void {}
+  exec(): void {}
+  close(): void {}
+}
+
+interface RawJsonInput {
+  entry: string;
+  reading: string;
+  pos?: string[];
+  register?: string;
+  freqRank?: number;
+}
+
+function rawJson(input: RawJsonInput): string {
+  return JSON.stringify({
+    uuid: `uuid-${input.entry}`,
+    entry: input.entry,
+    reading: { primary: input.reading, alternatives: [] },
+    grammar: { pos: input.pos ?? null },
+    definitions: input.register
+      ? [{ index: 0, gloss: "x", register: input.register }]
+      : [{ index: 0, gloss: "x" }],
+    relations: { homophones: [], synonyms: [], antonyms: [], related: [] },
+    meta: input.freqRank !== undefined ? { freq_rank: input.freqRank } : {},
+  });
+}
+
+interface TestableManager {
+  _getDictDir: () => string;
+  _createDatabase: (dbPath: string, opts?: unknown) => unknown;
+  verify: () => { ok: boolean; reason?: string };
+  lookupBatch: (terms: string[]) => Array<{
+    entry: string;
+    found: boolean;
+    reading?: string;
+    pos?: string;
+    register?: string;
+    freqRank?: number;
+  }>;
+  getStatus: () => { status: string; installedVersion?: string };
+}
+
+interface ManagerOptions {
+  rows?: RawJsonInput[];
+  mode?: DbMode;
+}
+
+async function freshManager(dictDir: string, opts: ManagerOptions = {}): Promise<TestableManager> {
+  const { rows = [], mode = "healthy" } = opts;
+  const fakeRows = rows.map((r) => ({ entry: r.entry, raw_json: rawJson(r) }));
+  const { getDictManager } = await import("../dict-manager.js");
+  const mgr = getDictManager() as unknown as TestableManager;
+  mgr._getDictDir = () => dictDir;
+  mgr._createDatabase = () => new FakeDatabase(fakeRows, mode);
+  return mgr;
+}
+
+describe("DictManager analysis access (#1624)", () => {
+  let tempDir: string;
+  let dictDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "illusions-dict-access-"));
+    dictDir = path.join(tempDir, "dict");
+    fs.mkdirSync(dictDir, { recursive: true });
+    dbPath = path.join(dictDir, "genji.db");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const LOOKUP_ROWS: RawJsonInput[] = [
+    { entry: "雪", reading: "ゆき", pos: ["名詞"], register: "文章語", freqRank: 1200 },
+    { entry: "走る", reading: "はしる", pos: ["動詞"], freqRank: 800 },
+  ];
+
+  describe("verify()", () => {
+    it("returns ok for a healthy DB with an entries table", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: [{ entry: "雪", reading: "ゆき" }] });
+      expect(mgr.verify()).toEqual({ ok: true });
+    });
+
+    it("returns not-installed when the DB file is absent", async () => {
+      const mgr = await freshManager(dictDir);
+      expect(mgr.verify()).toEqual({ ok: false, reason: "not-installed" });
+    });
+
+    it("returns schema when the entries table is missing", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { mode: "no-table" });
+      expect(mgr.verify()).toEqual({ ok: false, reason: "schema" });
+    });
+
+    it("returns malformed for a truncated / non-SQLite file", async () => {
+      fs.writeFileSync(dbPath, "this is not a sqlite database");
+      const mgr = await freshManager(dictDir, { mode: "malformed" });
+      expect(mgr.verify()).toEqual({ ok: false, reason: "malformed" });
+    });
+
+    it("flips getStatus() to corrupt after a malformed verify", async () => {
+      fs.writeFileSync(dbPath, "garbage");
+      const mgr = await freshManager(dictDir, { mode: "malformed" });
+      mgr.verify();
+      expect(mgr.getStatus().status).toBe("corrupt");
+    });
+  });
+
+  describe("lookupBatch()", () => {
+    it("projects reading / pos / register / freqRank for hits", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: LOOKUP_ROWS });
+      expect(mgr.lookupBatch(["雪"])).toEqual([
+        {
+          entry: "雪",
+          found: true,
+          reading: "ゆき",
+          pos: "名詞",
+          register: "文章語",
+          freqRank: 1200,
+        },
+      ]);
+    });
+
+    it("omits terms with no match and dedupes input", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: LOOKUP_ROWS });
+      const entries = mgr
+        .lookupBatch(["雪", "存在しない語", "走る", "雪"])
+        .map((r) => r.entry)
+        .sort();
+      expect(entries).toEqual(["走る", "雪"]);
+    });
+
+    it("returns [] for an empty request", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: LOOKUP_ROWS });
+      expect(mgr.lookupBatch([])).toEqual([]);
+      expect(mgr.lookupBatch(["", "  "].map((s) => s.trim()))).toEqual([]);
+    });
+  });
+});

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -76,6 +76,27 @@ class DictManager {
     this._latestAssetUrl = null;
     this._latestAssetDigest = null;
     this._latestVersion = null;
+    // Set when a DB open/query fails with a corruption-class error, so getStatus
+    // can report "corrupt" without re-running an integrity scan on every call.
+    this._corrupt = false;
+  }
+
+  /**
+   * Does this error look like SQLite database corruption (truncated download,
+   * bad header, encrypted/foreign file)? Used to flip the corrupt flag so the
+   * UI can prompt a re-download.
+   * @private
+   * @param {unknown} err
+   * @returns {boolean}
+   */
+  _isCorruptionError(err) {
+    const msg = String(err?.message ?? err ?? "").toLowerCase();
+    return (
+      msg.includes("malformed") ||
+      msg.includes("not a database") ||
+      msg.includes("file is encrypted") ||
+      msg.includes("disk image is malformed")
+    );
   }
 
   /**
@@ -127,6 +148,19 @@ class DictManager {
   // Database access
   // ---------------------------------------------------------------------------
 
+  /**
+   * Open a better-sqlite3 connection. Single seam for all three open sites
+   * (read handle, index writer, integrity probe) so tests can inject a fake DB
+   * without mocking the native module (which vitest externalizes).
+   * @private
+   * @param {string} dbPath
+   * @param {{ readonly?: boolean }} [opts]
+   */
+  _createDatabase(dbPath, opts) {
+    const Database = require("better-sqlite3");
+    return new Database(dbPath, opts);
+  }
+
   _openDb() {
     if (this._db) return this._db;
 
@@ -143,13 +177,14 @@ class DictManager {
     }
 
     try {
-      const Database = require("better-sqlite3");
-      const db = new Database(dbPath, { readonly: true });
+      const db = this._createDatabase(dbPath, { readonly: true });
       this._db = db;
+      this._corrupt = false;
       console.log("[DictManager] Database opened:", dbPath);
       return db;
     } catch (err) {
       console.error("[DictManager] Failed to open database:", err);
+      if (this._isCorruptionError(err)) this._corrupt = true;
       return null;
     }
   }
@@ -162,8 +197,7 @@ class DictManager {
   _ensureIndexes(dbPath) {
     let rwDb = null;
     try {
-      const Database = require("better-sqlite3");
-      rwDb = new Database(dbPath);
+      rwDb = this._createDatabase(dbPath);
 
       // Check if the entries table exists at all
       const tableCheck = rwDb
@@ -229,6 +263,7 @@ class DictManager {
       return rows.map((row) => this._rawJsonToEntry(row.raw_json)).filter(Boolean);
     } catch (err) {
       console.error("[DictManager] query error:", err);
+      if (this._isCorruptionError(err)) this._corrupt = true;
       return [];
     }
   }
@@ -258,7 +293,113 @@ class DictManager {
       return rows.map((row) => this._rawJsonToEntry(row.raw_json)).filter(Boolean);
     } catch (err) {
       console.error("[DictManager] queryByReading error:", err);
+      if (this._isCorruptionError(err)) this._corrupt = true;
       return [];
+    }
+  }
+
+  /**
+   * Exact-match batch lookup for analysis features (vocabulary stats,
+   * readability, ruby, lint rules). Returns a lightweight projection per term —
+   * never the full DictEntry — so hundreds of words cost one query + one small
+   * IPC payload. Terms with no match are simply absent from the result.
+   *
+   * @param {string[]} terms
+   * @returns {Array<{ entry: string } & import("../lib/dict/dict-types").DictLookup>}
+   */
+  lookupBatch(terms) {
+    if (this._downloadMutex.locked) return [];
+    if (!Array.isArray(terms)) return [];
+    const unique = [...new Set(terms.filter((t) => typeof t === "string" && t.length > 0))];
+    if (unique.length === 0) return [];
+
+    const db = this._openDb();
+    if (!db) return [];
+
+    try {
+      const placeholders = unique.map(() => "?").join(",");
+      const rows = db
+        .prepare(`SELECT entry, raw_json FROM entries WHERE entry IN (${placeholders})`)
+        .all(...unique);
+
+      const byEntry = new Map();
+      for (const row of rows) {
+        if (byEntry.has(row.entry)) continue; // first row wins for a given headword
+        const proj = this._rawJsonToLookup(row.raw_json);
+        if (proj) byEntry.set(row.entry, { entry: row.entry, ...proj });
+      }
+      return [...byEntry.values()];
+    } catch (err) {
+      console.error("[DictManager] lookupBatch error:", err);
+      if (this._isCorruptionError(err)) this._corrupt = true;
+      return [];
+    }
+  }
+
+  /**
+   * Project a raw_json string into the lightweight {@link DictLookup} shape
+   * (reading / pos / register / freqRank). Mirrors the analysis projection in
+   * lib/dict/providers/genji-api-backend.ts.
+   * @private
+   */
+  _rawJsonToLookup(rawJson) {
+    if (!rawJson) return null;
+    let raw;
+    try {
+      raw = typeof rawJson === "string" ? JSON.parse(rawJson) : rawJson;
+    } catch {
+      return null;
+    }
+    if (!raw) return null;
+
+    const register = (raw.definitions ?? []).find((d) => d?.register)?.register;
+    return {
+      found: true,
+      reading: raw.reading?.primary || undefined,
+      pos: raw.grammar?.pos?.join("・") || undefined,
+      register: register || undefined,
+      freqRank: typeof raw.meta?.freq_rank === "number" ? raw.meta.freq_rank : undefined,
+    };
+  }
+
+  /**
+   * Fast integrity check used to decide whether the installed DB is usable or
+   * needs re-downloading. Opens a short-lived read-only connection and runs a
+   * sentinel (schema + one row) rather than a full `PRAGMA integrity_check`,
+   * which would scan the whole ~500 MB file. Catches the realistic corruption
+   * modes: truncated download, bad header, missing `entries` table.
+   *
+   * @returns {{ ok: boolean, reason?: "not-installed" | "schema" | "malformed" }}
+   */
+  verify() {
+    const dbPath = this._getDbPath();
+    if (!fs.existsSync(dbPath)) return { ok: false, reason: "not-installed" };
+    // Mid-install: the file may be momentarily inconsistent; don't flag it.
+    if (this._downloadMutex.locked) return { ok: true };
+
+    let probe = null;
+    try {
+      probe = this._createDatabase(dbPath, { readonly: true });
+      const tbl = probe
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='entries'")
+        .get();
+      if (!tbl) {
+        this._corrupt = true;
+        return { ok: false, reason: "schema" };
+      }
+      probe.prepare("SELECT raw_json FROM entries LIMIT 1").get();
+      this._corrupt = false;
+      return { ok: true };
+    } catch (err) {
+      console.error("[DictManager] verify failed:", err);
+      this._corrupt = true;
+      return { ok: false, reason: "malformed" };
+    } finally {
+      if (probe) {
+        try {
+          probe.close();
+        } catch {}
+      }
     }
   }
 
@@ -340,6 +481,12 @@ class DictManager {
     try {
       installedVersion = fs.readFileSync(this._getVersionPath(), "utf8").trim();
     } catch {}
+
+    // A prior open/query tripped the corruption flag — surface it so the UI can
+    // prompt a re-download instead of silently returning empty results forever.
+    if (this._corrupt) {
+      return { status: "corrupt", installedVersion };
+    }
 
     return { status: "installed", installedVersion };
   }
@@ -519,6 +666,8 @@ class DictManager {
 
       onProgress?.(100);
       const version = this._latestVersion;
+      // Fresh install replaces any corrupt file — clear the flag.
+      this._corrupt = false;
       console.log("[DictManager] Download complete:", version);
 
       // Clear cached release info so next download fetches fresh data

--- a/electron/ipc/dict-ipc.js
+++ b/electron/ipc/dict-ipc.js
@@ -38,6 +38,35 @@ function registerDictHandlers() {
     }
   });
 
+  // Max headwords accepted in a single batch lookup. The renderer-side facade
+  // chunks larger sets; this is a defensive cap so a malformed payload can't
+  // build an unbounded SQL statement.
+  const MAX_BATCH_TERMS = 1000;
+
+  // Exact-match batch lookup (lightweight projection) for analysis features
+  ipcMain.handle(DICT_CHANNELS.invoke.lookupBatch, async (_event, { terms } = {}) => {
+    try {
+      if (!Array.isArray(terms)) return [];
+      const safe = terms
+        .filter((t) => typeof t === "string" && t.length > 0)
+        .slice(0, MAX_BATCH_TERMS);
+      return mgr.lookupBatch(safe);
+    } catch (err) {
+      console.error("[Dict IPC] dict:lookup-batch failed:", err);
+      return [];
+    }
+  });
+
+  // Fast integrity check (used to detect a corrupt DB and prompt re-download)
+  ipcMain.handle(DICT_CHANNELS.invoke.verify, async () => {
+    try {
+      return mgr.verify();
+    } catch (err) {
+      console.error("[Dict IPC] dict:verify failed:", err);
+      return { ok: false, reason: "malformed" };
+    }
+  });
+
   // Get installation status and installed version
   ipcMain.handle(DICT_CHANNELS.invoke.getStatus, async () => {
     try {

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -453,6 +453,7 @@ function registerFileHandlers() {
         verticalWriting,
         typesetting,
         googleFontFamily: opts.googleFontFamily,
+        fileType: opts.fileType,
       });
 
       const partition = `print-${Date.now()}`;

--- a/electron/ipc/shell-ipc.js
+++ b/electron/ipc/shell-ipc.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 // Shell and OS integration IPC handlers
 
-const { ipcMain, BrowserWindow, Menu, shell } = require("electron");
+const { ipcMain, BrowserWindow, Menu, shell, app } = require("electron");
 const path = require("path");
 const log = require("electron-log");
 const { SHELL_CHANNELS } = require("../lib/ipc-channels");
@@ -101,7 +101,14 @@ function registerShellHandlers() {
 
     popupWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
 
-    popupWindow.loadURL(url);
+    // Tag the popup browser's User-Agent so the dictionary site (dict.illusions.app)
+    // can identify in-app requests. Append a token to the default Chromium UA rather
+    // than replacing it, to keep compatibility with sites that sniff the browser.
+    const baseUserAgent = popupWindow.webContents.getUserAgent();
+    const appVersion = app.getVersion();
+    const userAgent = `${baseUserAgent} illusions/${appVersion}`;
+
+    popupWindow.loadURL(url, { userAgent });
     return true;
   });
 

--- a/electron/lib/__tests__/ipc-bridge.test.ts
+++ b/electron/lib/__tests__/ipc-bridge.test.ts
@@ -101,6 +101,8 @@ describe("ipc-channels: pinned channel names (public IPC contract)", () => {
     expect(DICT_CHANNELS.invoke).toEqual({
       query: "dict:query",
       queryReading: "dict:query-reading",
+      lookupBatch: "dict:lookup-batch",
+      verify: "dict:verify",
       getStatus: "dict:get-status",
       checkUpdate: "dict:check-update",
       download: "dict:download",

--- a/electron/lib/ipc-channels.js
+++ b/electron/lib/ipc-channels.js
@@ -52,6 +52,8 @@ const DICT_CHANNELS = Object.freeze({
   invoke: Object.freeze({
     query: "dict:query",
     queryReading: "dict:query-reading",
+    lookupBatch: "dict:lookup-batch",
+    verify: "dict:verify",
     getStatus: "dict:get-status",
     checkUpdate: "dict:check-update",
     download: "dict:download",

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -188,6 +188,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
       reading,
       limit,
     })),
+    lookupBatch: invokeChannel(DICT_CHANNELS.invoke.lookupBatch, (terms) => ({ terms })),
+    verify: invokeChannel(DICT_CHANNELS.invoke.verify, { arity: 0 }),
     getStatus: invokeChannel(DICT_CHANNELS.invoke.getStatus, { arity: 0 }),
     checkUpdate: invokeChannel(DICT_CHANNELS.invoke.checkUpdate, { arity: 0 }),
     download: invokeChannel(DICT_CHANNELS.invoke.download, { arity: 0 }),

--- a/lib/dict/__tests__/dict-access.test.ts
+++ b/lib/dict/__tests__/dict-access.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DictLookup } from "../dict-types";
+
+/**
+ * Tests for the DictAccess facade (#1624): health resolution, batch lookup with
+ * caching + negative caching, membership, web fallback, and invalidate().
+ */
+
+const mockLookupBatchRemote = vi.fn<(terms: string[]) => Promise<Map<string, DictLookup>>>();
+
+vi.mock("../providers/genji-api-backend", () => ({
+  lookupBatchRemote: (terms: string[]) => mockLookupBatchRemote(terms),
+}));
+
+interface DictApiMock {
+  lookupBatch: ReturnType<typeof vi.fn>;
+  verify: ReturnType<typeof vi.fn>;
+  getStatus: ReturnType<typeof vi.fn>;
+}
+
+function setElectronDict(dict: DictApiMock | null): void {
+  const w = window as unknown as { electronAPI?: unknown };
+  if (dict) {
+    w.electronAPI = { dict };
+  } else {
+    delete w.electronAPI;
+  }
+}
+
+async function importFresh() {
+  const mod = await import("../dict-access");
+  return mod.getDictAccess();
+}
+
+describe("DictAccess (#1624)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setElectronDict(null);
+  });
+
+  afterEach(() => {
+    setElectronDict(null);
+  });
+
+  describe("getHealth()", () => {
+    it("reports web-fallback when there is no Electron dict API", async () => {
+      const access = await importFresh();
+      const health = await access.getHealth();
+      expect(health.state).toBe("web-fallback");
+    });
+
+    it("reports not-installed", async () => {
+      setElectronDict({
+        getStatus: vi.fn().mockResolvedValue({ status: "not-installed" }),
+        verify: vi.fn(),
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      expect((await access.getHealth()).state).toBe("not-installed");
+    });
+
+    it("reports corrupt when getStatus is corrupt", async () => {
+      setElectronDict({
+        getStatus: vi.fn().mockResolvedValue({ status: "corrupt", installedVersion: "v1" }),
+        verify: vi.fn(),
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      const health = await access.getHealth();
+      expect(health.state).toBe("corrupt");
+      expect(health.installedVersion).toBe("v1");
+    });
+
+    it("reports ready when installed and verify passes", async () => {
+      const verify = vi.fn().mockResolvedValue({ ok: true });
+      setElectronDict({
+        getStatus: vi.fn().mockResolvedValue({ status: "installed", installedVersion: "v2" }),
+        verify,
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      const health = await access.getHealth();
+      expect(health.state).toBe("ready");
+      expect(verify).toHaveBeenCalledOnce();
+    });
+
+    it("reports corrupt when installed but verify fails", async () => {
+      setElectronDict({
+        getStatus: vi.fn().mockResolvedValue({ status: "installed", installedVersion: "v2" }),
+        verify: vi.fn().mockResolvedValue({ ok: false, reason: "malformed" }),
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      expect((await access.getHealth()).state).toBe("corrupt");
+    });
+
+    it("caches health within the TTL (one getStatus call across two reads)", async () => {
+      const getStatus = vi.fn().mockResolvedValue({ status: "installed" });
+      setElectronDict({
+        getStatus,
+        verify: vi.fn().mockResolvedValue({ ok: true }),
+        lookupBatch: vi.fn(),
+      });
+      const access = await importFresh();
+      await access.getHealth();
+      await access.getHealth();
+      expect(getStatus).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("lookupBatch() — local Electron path", () => {
+    it("projects hits, caches negatives, and returns an entry for every term", async () => {
+      const lookupBatch = vi
+        .fn()
+        .mockResolvedValue([{ entry: "雪", found: true, reading: "ゆき", freqRank: 1200 }]);
+      setElectronDict({
+        lookupBatch,
+        verify: vi.fn(),
+        getStatus: vi.fn(),
+      });
+      const access = await importFresh();
+
+      const result = await access.lookupBatch(["雪", "存在しない語"]);
+      expect(result.get("雪")).toEqual({ found: true, reading: "ゆき", freqRank: 1200 });
+      expect(result.get("存在しない語")).toEqual({ found: false });
+
+      // Second call for the same terms is fully cache-served (no extra IPC).
+      await access.lookupBatch(["雪", "存在しない語"]);
+      expect(lookupBatch).toHaveBeenCalledOnce();
+    });
+
+    it("dedupes and ignores empty terms", async () => {
+      const lookupBatch = vi.fn().mockResolvedValue([{ entry: "雪", found: true }]);
+      setElectronDict({ lookupBatch, verify: vi.fn(), getStatus: vi.fn() });
+      const access = await importFresh();
+
+      await access.lookupBatch(["雪", "雪", ""]);
+      expect(lookupBatch).toHaveBeenCalledWith(["雪"]);
+    });
+  });
+
+  describe("has()", () => {
+    it("returns true for a known headword and false for an unknown one", async () => {
+      setElectronDict({
+        lookupBatch: vi.fn().mockResolvedValue([{ entry: "雪", found: true }]),
+        verify: vi.fn(),
+        getStatus: vi.fn(),
+      });
+      const access = await importFresh();
+      expect(await access.has("雪")).toBe(true);
+      expect(await access.has("存在しない語")).toBe(false);
+      expect(await access.has("")).toBe(false);
+    });
+  });
+
+  describe("lookupBatch() — web fallback", () => {
+    it("uses the remote backend when there is no Electron dict", async () => {
+      mockLookupBatchRemote.mockResolvedValue(
+        new Map<string, DictLookup>([["雪", { found: true, reading: "ゆき" }]]),
+      );
+      const access = await importFresh();
+      const result = await access.lookupBatch(["雪"]);
+      expect(mockLookupBatchRemote).toHaveBeenCalledWith(["雪"]);
+      expect(result.get("雪")).toEqual({ found: true, reading: "ゆき" });
+    });
+  });
+
+  describe("invalidate()", () => {
+    it("clears cached lookups so the next call re-queries", async () => {
+      const lookupBatch = vi.fn().mockResolvedValue([{ entry: "雪", found: true }]);
+      setElectronDict({ lookupBatch, verify: vi.fn(), getStatus: vi.fn() });
+      const access = await importFresh();
+
+      await access.lookupBatch(["雪"]);
+      access.invalidate();
+      await access.lookupBatch(["雪"]);
+      expect(lookupBatch).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/lib/dict/dict-access.ts
+++ b/lib/dict/dict-access.ts
@@ -1,0 +1,233 @@
+/**
+ * DictAccess — consumer-facing facade over the Genji dictionary for analysis
+ * features (型態分析 / 語彙統計 / 読みやすさ / ルビ) and lint rules.
+ *
+ * Why this exists separately from {@link getDictService}:
+ *   `DictService.query()` returns full {@link DictEntry} objects by prefix match
+ *   — right for the lookup panel, wrong for bulk analysis (heavy payloads, one
+ *   round-trip per word, no freq_rank/register exposed). DictAccess adds the
+ *   three primitives analysis needs:
+ *     - getHealth()    — single source of truth for download presence + corruption
+ *     - has()          — exact-match membership (lint "辞書外語" rule)
+ *     - lookupBatch()  — many headwords in one IPC, lightweight projection, cached
+ *
+ * Graceful degradation: consumers should call getHealth() and only enrich when
+ * `state === "ready"` (local Electron DB). On web the remote API still answers
+ * single-word lookups (ruby), but bulk lookups are capped.
+ *
+ * Usage:
+ *   import { getDictAccess } from "@/lib/dict/dict-access";
+ *   const health = await getDictAccess().getHealth();
+ *   if (health.state === "ready") {
+ *     const map = await getDictAccess().lookupBatch(words);
+ *   }
+ */
+import type { DictLookup } from "./dict-types";
+import { LRUCache } from "@/lib/utils/lru-cache";
+import * as GenjiApiBackend from "./providers/genji-api-backend";
+
+export type GenjiHealthState = "ready" | "web-fallback" | "not-installed" | "corrupt" | "unknown";
+
+export interface GenjiHealth {
+  state: GenjiHealthState;
+  installedVersion?: string;
+  /** Japanese UI hint; populated for not-installed / corrupt / web-fallback. */
+  message?: string;
+}
+
+interface ElectronDictApi {
+  lookupBatch: (terms: string[]) => Promise<Array<{ entry: string } & DictLookup>>;
+  verify: () => Promise<{ ok: boolean; reason?: string }>;
+  getStatus: () => Promise<{ status: string; installedVersion?: string }>;
+}
+
+function getElectronDict(): ElectronDictApi | null {
+  if (typeof window === "undefined") return null;
+  return (
+    (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict ?? null
+  );
+}
+
+const CORRUPT_MESSAGE = "辞書データが破損しています。設定から再ダウンロードしてください。";
+
+const HEALTH_TTL_MS = 5000;
+const LOOKUP_CACHE_SIZE = 8000;
+/** SQLite bind-variable limit is 999; stay comfortably under it per query. */
+const LOCAL_BATCH_CHUNK = 400;
+/** Cap web bulk lookups so analysis can't fan out into hundreds of requests. */
+const REMOTE_MAX_TERMS = 300;
+
+const MISS: DictLookup = Object.freeze({ found: false });
+
+class DictAccess {
+  private readonly cache = new LRUCache<string, DictLookup>(LOOKUP_CACHE_SIZE);
+  private health: { value: GenjiHealth; at: number } | null = null;
+
+  /**
+   * Clear cached health + lookups. Call after a (re)download so newly installed
+   * data and previously-cached negatives are re-evaluated.
+   */
+  invalidate(): void {
+    this.health = null;
+    this.cache.clear();
+  }
+
+  /** Resolve dictionary availability/health, cached for a few seconds. */
+  async getHealth(): Promise<GenjiHealth> {
+    const now = Date.now();
+    if (this.health && now - this.health.at < HEALTH_TTL_MS) {
+      return this.health.value;
+    }
+    const value = await this.computeHealth();
+    this.health = { value, at: now };
+    return value;
+  }
+
+  private async computeHealth(): Promise<GenjiHealth> {
+    const dict = getElectronDict();
+    if (!dict) {
+      return {
+        state: "web-fallback",
+        message: "Web版ではオンライン辞典（幻辞API）を使用します。",
+      };
+    }
+    try {
+      const status = await dict.getStatus();
+      if (status.status === "not-installed") {
+        return { state: "not-installed", message: "辞書が未ダウンロードです。" };
+      }
+      if (status.status === "corrupt") {
+        return {
+          state: "corrupt",
+          installedVersion: status.installedVersion,
+          message: CORRUPT_MESSAGE,
+        };
+      }
+      if (status.status === "installed") {
+        // Proactively confirm integrity — catches a bad DB before the first query.
+        const v = await dict.verify();
+        if (!v.ok) {
+          return {
+            state: "corrupt",
+            installedVersion: status.installedVersion,
+            message: CORRUPT_MESSAGE,
+          };
+        }
+        return { state: "ready", installedVersion: status.installedVersion };
+      }
+      return { state: "unknown" };
+    } catch (err) {
+      console.warn("[dict-access] health check failed:", err);
+      return { state: "unknown" };
+    }
+  }
+
+  /** Exact-match membership check (for the future 辞書外語 lint rule). */
+  async has(term: string): Promise<boolean> {
+    if (!term) return false;
+    const result = await this.lookupBatch([term]);
+    return result.get(term)?.found ?? false;
+  }
+
+  /**
+   * Batch exact-match lookup. Returns a map keyed by every requested (deduped,
+   * non-empty) term; misses map to `{ found: false }`. Cached per-term.
+   */
+  async lookupBatch(terms: string[]): Promise<Map<string, DictLookup>> {
+    const out = new Map<string, DictLookup>();
+    const misses: string[] = [];
+    const seen = new Set<string>();
+
+    for (const t of terms) {
+      if (typeof t !== "string" || t.length === 0 || seen.has(t)) continue;
+      seen.add(t);
+      const cached = this.cache.get(t);
+      if (cached !== undefined) {
+        out.set(t, cached);
+      } else {
+        misses.push(t);
+      }
+    }
+    if (misses.length === 0) return out;
+
+    const dict = getElectronDict();
+    if (dict) {
+      await this.lookupLocal(dict, misses, out);
+    } else {
+      await this.lookupRemote(misses, out);
+    }
+    return out;
+  }
+
+  private async lookupLocal(
+    dict: ElectronDictApi,
+    misses: string[],
+    out: Map<string, DictLookup>,
+  ): Promise<void> {
+    for (let i = 0; i < misses.length; i += LOCAL_BATCH_CHUNK) {
+      const chunk = misses.slice(i, i + LOCAL_BATCH_CHUNK);
+      let rows: Array<{ entry: string } & DictLookup> = [];
+      try {
+        rows = await dict.lookupBatch(chunk);
+      } catch (err) {
+        console.warn("[dict-access] local lookupBatch failed:", err);
+        rows = [];
+      }
+
+      const found = new Set<string>();
+      for (const row of rows) {
+        const { entry, ...rest } = row;
+        const lookup: DictLookup = { ...rest, found: true };
+        this.cache.set(entry, lookup);
+        out.set(entry, lookup);
+        found.add(entry);
+      }
+      // Cache negatives so repeated analysis doesn't re-query absent words.
+      for (const t of chunk) {
+        if (!found.has(t)) {
+          this.cache.set(t, MISS);
+          out.set(t, MISS);
+        }
+      }
+    }
+  }
+
+  private async lookupRemote(misses: string[], out: Map<string, DictLookup>): Promise<void> {
+    const capped = misses.slice(0, REMOTE_MAX_TERMS);
+    if (capped.length < misses.length) {
+      console.warn(
+        `[dict-access] remote lookup capped at ${REMOTE_MAX_TERMS}/${misses.length} terms`,
+      );
+    }
+
+    let map: Map<string, DictLookup>;
+    try {
+      map = await GenjiApiBackend.lookupBatchRemote(capped);
+    } catch (err) {
+      console.warn("[dict-access] remote lookupBatch failed:", err);
+      map = new Map();
+    }
+
+    for (const t of capped) {
+      const lookup = map.get(t) ?? MISS;
+      this.cache.set(t, lookup);
+      out.set(t, lookup);
+    }
+    // Terms beyond the cap: report as not-found WITHOUT caching, so a later
+    // smaller request can still resolve them.
+    for (const t of misses.slice(REMOTE_MAX_TERMS)) {
+      if (!out.has(t)) out.set(t, MISS);
+    }
+  }
+}
+
+let _instance: DictAccess | null = null;
+
+export function getDictAccess(): DictAccess {
+  if (!_instance) {
+    _instance = new DictAccess();
+  }
+  return _instance;
+}
+
+export type { DictAccess };

--- a/lib/dict/dict-types.ts
+++ b/lib/dict/dict-types.ts
@@ -88,6 +88,9 @@ export type DictDownloadStatus =
   | "downloading"
   | "installing"
   | "installed"
+  /** DB file exists but failed an integrity check (truncated download, bad
+   * header, missing table). The user should re-download. */
+  | "corrupt"
   | "error";
 
 export interface DictDownloadState {
@@ -121,4 +124,27 @@ export interface DictQueryResult {
   noResults: boolean;
   /** True when the provider is not installed / not available */
   providerUnavailable: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Lightweight analysis projection
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal per-term projection returned by batch lookups for analysis features
+ * (vocabulary stats, readability, ruby, lint rules). Deliberately small so it
+ * is cheap to ship across IPC for hundreds of words at once — never the full
+ * {@link DictEntry} (definitions/examples/relations) which the lookup panel uses.
+ */
+export interface DictLookup {
+  /** Whether the headword exists in the dictionary (exact match). */
+  found: boolean;
+  /** Primary kana reading (読み) — used for ruby suggestions. */
+  reading?: string;
+  /** Part(s) of speech, joined with "・". */
+  pos?: string;
+  /** Register label (口語/文章語/雅語 …) from the first definition that has one. */
+  register?: string;
+  /** Frequency rank (smaller = more common) — used for vocabulary difficulty. */
+  freqRank?: number;
 }

--- a/lib/dict/providers/genji-api-backend.ts
+++ b/lib/dict/providers/genji-api-backend.ts
@@ -11,6 +11,7 @@ import type {
   DictExample,
   DictRelationships,
   DictReading,
+  DictLookup,
 } from "../dict-types";
 
 const GENJI_API_BASE = "https://api.dict.illusions.app";
@@ -185,6 +186,52 @@ export async function queryByEntry(term: string, limit: number): Promise<DictEnt
     limit: String(limit),
   });
   return raws.map(mapRawJsonToDictEntry);
+}
+
+/** Project a raw_json row into the lightweight analysis shape. */
+function rawJsonToLookup(raw: RawJson): DictLookup {
+  const register = raw.definitions?.find((d) => d.register)?.register;
+  return {
+    found: true,
+    reading: raw.reading?.primary || undefined,
+    pos: raw.grammar?.pos?.join("・") || undefined,
+    register: register || undefined,
+    freqRank: typeof raw.meta?.freq_rank === "number" ? raw.meta.freq_rank : undefined,
+  };
+}
+
+/** Headwords per remote chunk — keeps each Datasette URL well under length limits. */
+const REMOTE_BATCH_CHUNK = 50;
+
+/**
+ * Exact-match batch lookup over the remote Genji API (web fallback). Issues one
+ * parameterized `entry IN (...)` query per chunk. Returns a map keyed by the
+ * requested term; misses map to `{ found: false }`. Slower than the local
+ * Electron path, so callers doing bulk analysis should gate on dictionary
+ * health and prefer the local DB.
+ */
+export async function lookupBatchRemote(terms: string[]): Promise<Map<string, DictLookup>> {
+  const result = new Map<string, DictLookup>();
+  const unique = [...new Set(terms.filter((t) => typeof t === "string" && t.length > 0))];
+
+  for (let i = 0; i < unique.length; i += REMOTE_BATCH_CHUNK) {
+    const chunk = unique.slice(i, i + REMOTE_BATCH_CHUNK);
+    const params: Record<string, string> = {};
+    const names = chunk.map((t, j) => {
+      params[`p${j}`] = t;
+      return `:p${j}`;
+    });
+    const sql = `SELECT raw_json FROM entries WHERE entry IN (${names.join(",")})`;
+    const raws = await executeSql(sql, params);
+    for (const raw of raws) {
+      if (!result.has(raw.entry)) result.set(raw.entry, rawJsonToLookup(raw));
+    }
+  }
+
+  for (const t of unique) {
+    if (!result.has(t)) result.set(t, { found: false });
+  }
+  return result;
 }
 
 /**

--- a/lib/editor-page/__tests__/center-editor-position-vertical.test.ts
+++ b/lib/editor-page/__tests__/center-editor-position-vertical.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import type { EditorView } from "@milkdown/prose/view";
+
+import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
+
+describe("centerEditorPosition in vertical writing", () => {
+  it("centers the current match on the horizontal scroll axis", () => {
+    const scrollTo = vi.fn();
+    const container = document.createElement("div");
+    container.style.overflowX = "auto";
+    Object.assign(container, { scrollLeft: 200, scrollTop: 30, scrollTo });
+    container.getBoundingClientRect = () =>
+      ({ left: 10, right: 510, top: 20, bottom: 420, width: 500, height: 400 }) as DOMRect;
+    container.className = "editor-scroll-container";
+    const editorDom = document.createElement("div");
+    container.appendChild(editorDom);
+    document.body.appendChild(container);
+
+    const view = {
+      dom: editorDom,
+      coordsAtPos: () => ({ left: 1000, right: 1020, top: 100, bottom: 120 }),
+    } as unknown as EditorView;
+
+    expect(centerEditorPosition(view, 5, "auto")).toBe(true);
+    expect(scrollTo).toHaveBeenCalledWith({ left: 950, top: -80, behavior: "auto" });
+
+    container.remove();
+  });
+});

--- a/lib/editor-page/__tests__/clear-formatting.test.ts
+++ b/lib/editor-page/__tests__/clear-formatting.test.ts
@@ -1,0 +1,91 @@
+/**
+ * clearFormatting: 選択範囲を標準本文（段落・装飾なし）へ戻す。
+ * 見出し・太字・取り消し線・引用・リスト・コードブロックが
+ * すべて素の段落テキストになることを検証する。
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { Editor, rootCtx, defaultValueCtx, editorViewCtx } from "@milkdown/core";
+import { commonmark } from "@milkdown/preset-commonmark";
+import { gfm } from "@milkdown/preset-gfm";
+import { TextSelection } from "@milkdown/prose/state";
+import type { EditorView } from "@milkdown/prose/view";
+import { clearFormatting } from "../clear-formatting";
+
+const mountedRoots: HTMLElement[] = [];
+afterEach(() => {
+  mountedRoots.forEach((r) => r.remove());
+  mountedRoots.length = 0;
+});
+
+async function makeView(markdown: string): Promise<{ editor: Editor; view: EditorView }> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  mountedRoots.push(root);
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, markdown);
+    })
+    .use(commonmark)
+    .use(gfm)
+    .create();
+  let view!: EditorView;
+  editor.action((ctx) => {
+    view = ctx.get(editorViewCtx);
+  });
+  return { editor, view };
+}
+
+/** 文書全体を選択して書式解除を実行する。 */
+function selectAllAndClear(view: EditorView): void {
+  const { doc } = view.state;
+  const sel = TextSelection.create(doc, 1, doc.content.size - 1);
+  view.dispatch(view.state.tr.setSelection(sel));
+  clearFormatting(view);
+}
+
+describe("clearFormatting", () => {
+  it("見出しを標準段落に戻す", async () => {
+    const { view } = await makeView("# 花様年華");
+    selectAllAndClear(view);
+    const top = view.state.doc.firstChild;
+    expect(top?.type.name).toBe("paragraph");
+    expect(view.state.doc.textContent).toBe("花様年華");
+  });
+
+  it("太字・斜体・取り消し線などのインラインマークを除去する", async () => {
+    const { view } = await makeView("**太字** *斜体* ~~取り消し~~");
+    selectAllAndClear(view);
+    let markCount = 0;
+    view.state.doc.descendants((node) => {
+      markCount += node.marks.length;
+    });
+    expect(markCount).toBe(0);
+    expect(view.state.doc.firstChild?.type.name).toBe("paragraph");
+  });
+
+  it("引用ブロックを解除して段落に戻す", async () => {
+    const { view } = await makeView("> 引用文です");
+    selectAllAndClear(view);
+    expect(view.state.doc.firstChild?.type.name).toBe("paragraph");
+    expect(view.state.doc.textContent).toBe("引用文です");
+  });
+
+  it("リスト項目を解除して段落に戻す", async () => {
+    const { view } = await makeView("- 項目一\n- 項目二");
+    selectAllAndClear(view);
+    view.state.doc.forEach((node) => {
+      expect(node.type.name).toBe("paragraph");
+    });
+  });
+
+  it("選択が空のときは何も変更しない", async () => {
+    const { view } = await makeView("# 見出し");
+    const before = view.state.doc.toJSON();
+    // カーソルのみ（空選択）
+    const sel = TextSelection.create(view.state.doc, 1, 1);
+    view.dispatch(view.state.tr.setSelection(sel));
+    clearFormatting(view);
+    expect(view.state.doc.toJSON()).toEqual(before);
+  });
+});

--- a/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
+++ b/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from "vitest";
+import { Schema, type Node } from "prosemirror-model";
+
+import {
+  buildReplacementText,
+  createReplacementSteps,
+  findSearchMatches,
+  getSearchPatternError,
+} from "@/lib/editor-page/find-search-matches";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    heading: {
+      group: "block",
+      content: "inline*",
+      attrs: { level: { default: 1 } },
+      toDOM: () => ["h1", 0] as [string, number],
+    },
+    paragraph: {
+      group: "block",
+      content: "inline*",
+      toDOM: () => ["p", 0] as [string, number],
+    },
+    blankParagraph: {
+      group: "block",
+      atom: true,
+      toDOM: () => ["p"],
+    },
+    text: { group: "inline" },
+    hardbreak: {
+      group: "inline",
+      inline: true,
+      selectable: false,
+      leafText: () => "\n",
+      toDOM: () => ["br"],
+    },
+    ruby: atomNode({ base: { default: "" }, text: { default: "" } }, "ruby"),
+    tcy: atomNode({ value: { default: "" } }, "span"),
+    nobreak: atomNode({ text: { default: "" } }, "span"),
+    kern: atomNode({ amount: { default: "" }, text: { default: "" } }, "span"),
+    mdibreak: atomNode({}, "br"),
+  },
+  marks: {},
+});
+
+function atomNode(attrs: Record<string, { default: string }>, tag: string) {
+  return {
+    group: "inline",
+    inline: true,
+    atom: true,
+    attrs,
+    toDOM: () => [tag] as [string],
+  };
+}
+
+function paragraph(...children: Node[]): Node {
+  return schema.node("paragraph", null, children);
+}
+
+function doc(...children: Node[]): Node {
+  return schema.node("doc", null, children);
+}
+
+describe("findSearchMatches enhanced search", () => {
+  it("supports regular expressions, captures, and case sensitivity", () => {
+    const source = doc(paragraph(schema.text("Alpha-12 alpha-34")));
+
+    const matches = findSearchMatches(source, "(alpha)-(\\d+)", {
+      regex: true,
+      caseSensitive: false,
+    });
+
+    expect(matches.map((match) => match.text)).toEqual(["Alpha-12", "alpha-34"]);
+    expect(matches.map((match) => match.captures)).toEqual([
+      ["Alpha", "12"],
+      ["alpha", "34"],
+    ]);
+  });
+
+  it("keeps JavaScript greedy regular expression semantics", () => {
+    const source = doc(paragraph(schema.text("a1b a2b")));
+
+    expect(findSearchMatches(source, "a.*b", { regex: true })).toMatchObject([
+      { text: "a1b a2b" },
+    ]);
+  });
+
+  it("reports invalid patterns and ignores zero-width matches", () => {
+    const source = doc(paragraph(schema.text("abc")));
+
+    expect(getSearchPatternError("(", { regex: true })).toBe("正規表現が正しくありません");
+    expect(findSearchMatches(source, "(?=a)", { regex: true })).toEqual([]);
+  });
+
+  it("matches whole Unicode words without matching inside longer words", () => {
+    const source = doc(paragraph(schema.text("cat scatter cat2 cat 猫 猫舌")));
+
+    expect(findSearchMatches(source, "cat", { wholeWord: true })).toHaveLength(2);
+    expect(findSearchMatches(source, "猫", { wholeWord: true })).toHaveLength(1);
+  });
+
+  it("normalizes kana, width, and old character forms while preserving source positions", () => {
+    const source = doc(paragraph(schema.text("カタカナ ｶﾞ ＡＢＣ 舊體 ㍻")));
+
+    const kana = findSearchMatches(source, "かたかな", { normalizeVariants: true });
+    const width = findSearchMatches(source, "ABC", { normalizeVariants: true });
+    const halfWidthKana = findSearchMatches(source, "が", { normalizeVariants: true });
+    const oldForm = findSearchMatches(source, "旧体", { normalizeVariants: true });
+    const expanded = findSearchMatches(source, "平成", { normalizeVariants: true });
+
+    expect(kana[0].text).toBe("カタカナ");
+    expect(width[0].text).toBe("ＡＢＣ");
+    expect(halfWidthKana[0].text).toBe("ｶﾞ");
+    expect(oldForm[0].text).toBe("舊體");
+    expect(expanded[0].text).toBe("㍻");
+    expect(expanded[0].to - expanded[0].from).toBe(1);
+  });
+
+  it("searches ruby base and reading without making either directly replaceable", () => {
+    const source = doc(
+      paragraph(
+        schema.text("前"),
+        schema.node("ruby", { base: "東京", text: "とう.きょう" }),
+        schema.text("後"),
+      ),
+    );
+
+    const base = findSearchMatches(source, "東京", { searchTarget: "all" });
+    const reading = findSearchMatches(source, "とうきょう", { searchTarget: "ruby" });
+
+    expect(base).toMatchObject([{ source: "ruby-base", replaceable: false }]);
+    expect(reading).toMatchObject([{ source: "ruby-text", replaceable: false }]);
+    expect(findSearchMatches(source, "東京", { searchTarget: "ruby" })).toEqual([]);
+    expect(findSearchMatches(source, "とうきょう", { searchTarget: "body" })).toEqual([]);
+  });
+
+  it("searches displayed MDI atom text but never macro metadata", () => {
+    const source = doc(
+      paragraph(
+        schema.node("kern", { amount: "0.5em", text: "本文" }),
+        schema.node("nobreak", { text: "禁則" }),
+        schema.node("tcy", { value: "12" }),
+      ),
+      schema.node("blankParagraph"),
+    );
+
+    expect(findSearchMatches(source, "本文", {})).toMatchObject([
+      { source: "kern", replaceable: false },
+    ]);
+    expect(findSearchMatches(source, "禁則", {})).toHaveLength(1);
+    expect(findSearchMatches(source, "12", {})).toHaveLength(1);
+    expect(findSearchMatches(source, "0.5em", {})).toEqual([]);
+    expect(findSearchMatches(source, "blank", {})).toEqual([]);
+  });
+
+  it("finds text spanning an atom with exact ProseMirror bounds and blocks replacement", () => {
+    const source = doc(
+      paragraph(
+        schema.text("前"),
+        schema.node("ruby", { base: "東京", text: "とうきょう" }),
+        schema.text("後"),
+      ),
+    );
+
+    const matches = findSearchMatches(source, "前東京後", {});
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({ text: "前東京後", replaceable: false });
+    expect(matches[0].to - matches[0].from).toBe(3);
+  });
+
+  it("limits matches to a selected ProseMirror range", () => {
+    const source = doc(paragraph(schema.text("one two one")));
+
+    expect(findSearchMatches(source, "one", { range: { from: 5, to: 12 } })).toMatchObject([
+      { from: 9, to: 12 },
+    ]);
+  });
+
+  it("handles empty, single-character, and whole-document searches", () => {
+    const source = doc(paragraph(schema.text("abc")));
+
+    expect(findSearchMatches(source, "", {})).toEqual([]);
+    expect(findSearchMatches(source, "a", {})).toMatchObject([{ text: "a" }]);
+    expect(findSearchMatches(source, "abc", {})).toMatchObject([{ text: "abc" }]);
+    expect(findSearchMatches(source, "missing", {})).toEqual([]);
+  });
+
+  it("adds heading and paragraph metadata for grouped results", () => {
+    const source = doc(
+      schema.node("heading", { level: 1 }, schema.text("第一章")),
+      paragraph(schema.text("対象")),
+      paragraph(schema.text("対象")),
+    );
+
+    expect(findSearchMatches(source, "対象", {})).toMatchObject([
+      { heading: "第一章", paragraphNumber: 1 },
+      { heading: "第一章", paragraphNumber: 2 },
+    ]);
+  });
+});
+
+describe("search replacement helpers", () => {
+  it("expands capture references, the full match, and escaped dollars", () => {
+    const match = {
+      from: 3,
+      to: 11,
+      text: "Alpha-12",
+      captures: ["Alpha", "12"],
+    };
+
+    expect(buildReplacementText(match, "$2:$1:$&:$$", { regex: true })).toBe("12:Alpha:Alpha-12:$");
+  });
+
+  it("creates only safe replacement steps in descending position order", () => {
+    const steps = createReplacementSteps(
+      [
+        { from: 1, to: 4, text: "one", replaceable: true },
+        { from: 5, to: 6, text: "東京", replaceable: false, source: "ruby-base" },
+        { from: 7, to: 10, text: "two", replaceable: true },
+      ],
+      "replacement",
+      {},
+    );
+
+    expect(steps).toEqual([
+      { from: 7, to: 10, text: "replacement" },
+      { from: 1, to: 4, text: "replacement" },
+    ]);
+  });
+
+  it("creates replacement steps only for matches inside the selected range", () => {
+    const source = doc(paragraph(schema.text("one two one")));
+    const matches = findSearchMatches(source, "one", { range: { from: 5, to: 12 } });
+
+    expect(createReplacementSteps(matches, "three", {})).toEqual([
+      { from: 9, to: 12, text: "three" },
+    ]);
+  });
+});

--- a/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
+++ b/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
@@ -81,9 +81,7 @@ describe("findSearchMatches enhanced search", () => {
   it("keeps JavaScript greedy regular expression semantics", () => {
     const source = doc(paragraph(schema.text("a1b a2b")));
 
-    expect(findSearchMatches(source, "a.*b", { regex: true })).toMatchObject([
-      { text: "a1b a2b" },
-    ]);
+    expect(findSearchMatches(source, "a.*b", { regex: true })).toMatchObject([{ text: "a1b a2b" }]);
   });
 
   it("reports invalid patterns and ignores zero-width matches", () => {

--- a/lib/editor-page/__tests__/pos-highlight-activation.test.tsx
+++ b/lib/editor-page/__tests__/pos-highlight-activation.test.tsx
@@ -140,13 +140,15 @@ describe("#1466 — effective POS highlight follows window activity", () => {
     expect(lastAppliedEnabled()).toBe(false);
   });
 
-  it("stays false in power-save mode even in the foreground", async () => {
+  it("stays enabled in power-save mode while in the foreground (power-save no longer gates POS)", async () => {
     await mountHook(makeParams({ powerSaveMode: true }));
-    expect(lastAppliedEnabled()).toBe(false);
+    expect(lastAppliedEnabled()).toBe(true);
 
+    // Background still suspends it; focus restores it even under power-save.
     await dispatchActivity("blur");
-    await dispatchActivity("focus");
     expect(lastAppliedEnabled()).toBe(false);
+    await dispatchActivity("focus");
+    expect(lastAppliedEnabled()).toBe(true);
   });
 
   it("passes colors/disabledTypes through and applies to the given view only", async () => {

--- a/lib/editor-page/__tests__/power-policy.test.ts
+++ b/lib/editor-page/__tests__/power-policy.test.ts
@@ -62,9 +62,21 @@ describe("shouldEnablePosHighlight", () => {
     ).toBe(false);
   });
 
-  it("disables highlighting in power-save mode even in the foreground", () => {
+  it("keeps highlighting in power-save mode while in the foreground (power-save no longer gates POS)", () => {
+    // The morphology already runs for the vocabulary panel; gating POS off in
+    // power-save only produced a toggle that read ON while nothing was colored.
     expect(
       shouldEnablePosHighlight(foreground, { posHighlightEnabled: true, powerSaveMode: true }),
+    ).toBe(true);
+    // The user's own toggle is still respected.
+    expect(
+      shouldEnablePosHighlight(foreground, { posHighlightEnabled: false, powerSaveMode: true }),
+    ).toBe(false);
+  });
+
+  it("still suspends highlighting while backgrounded even in power-save mode", () => {
+    expect(
+      shouldEnablePosHighlight(background, { posHighlightEnabled: true, powerSaveMode: true }),
     ).toBe(false);
   });
 

--- a/lib/editor-page/__tests__/project-search-vfs-integration.test.ts
+++ b/lib/editor-page/__tests__/project-search-vfs-integration.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { searchProjectFiles } from "@/lib/editor-page/project-search";
+import { ElectronVFS } from "@/lib/vfs/electron-vfs";
+import { WebVFS } from "@/lib/vfs/web-vfs";
+
+interface FakeNativeEntry {
+  name: string;
+  kind: "file" | "directory";
+}
+
+function fileHandle(name: string, content: string): FileSystemFileHandle {
+  return {
+    name,
+    kind: "file",
+    getFile: async () => new File([content], name),
+  } as unknown as FileSystemFileHandle;
+}
+
+function directoryHandle(
+  name: string,
+  entries: ReadonlyMap<string, FileSystemHandle>,
+  getDirectoryHandle = vi.fn(async (entryName: string) => {
+    const entry = entries.get(entryName);
+    if (!entry || entry.kind !== "directory") throw new DOMException("not found", "NotFoundError");
+    return entry as FileSystemDirectoryHandle;
+  }),
+): FileSystemDirectoryHandle {
+  return {
+    name,
+    kind: "directory",
+    getDirectoryHandle,
+    getFileHandle: async (entryName: string) => {
+      const entry = entries.get(entryName);
+      if (!entry || entry.kind !== "file") throw new DOMException("not found", "NotFoundError");
+      return entry as FileSystemFileHandle;
+    },
+    async *[Symbol.asyncIterator]() {
+      for (const item of entries) yield item;
+    },
+  } as unknown as FileSystemDirectoryHandle;
+}
+
+const originalElectronApi = window.electronAPI;
+
+afterEach(() => {
+  Object.defineProperty(window, "electronAPI", {
+    configurable: true,
+    writable: true,
+    value: originalElectronApi,
+  });
+});
+
+describe("project search VFS integration", () => {
+  it("uses WebVFS without entering dot-prefixed directories", async () => {
+    const hiddenDirectory = directoryHandle(".illusions", new Map());
+    const hiddenLookup = vi.fn(async () => hiddenDirectory);
+    const root = directoryHandle(
+      "project",
+      new Map<string, FileSystemHandle>([
+        [".illusions", hiddenDirectory],
+        [".draft.mdi", fileHandle(".draft.mdi", "target")],
+        ["chapter.mdi", fileHandle("chapter.mdi", "target")],
+      ]),
+      hiddenLookup,
+    );
+    const vfs = new WebVFS();
+    vfs.setRootHandle(root);
+
+    const results = await searchProjectFiles({ vfs, searchTerm: "target", options: {} });
+
+    expect(results.map((result) => result.path)).toEqual(["/chapter.mdi"]);
+    expect(hiddenLookup).not.toHaveBeenCalled();
+  });
+
+  it("uses ElectronVFS without issuing IPC reads for dot-prefixed paths", async () => {
+    const readFile = vi.fn(async () => "target");
+    const readDirectory = vi.fn(async (path: string): Promise<FakeNativeEntry[]> => {
+      if (path === "/project") {
+        return [
+          { name: ".illusions", kind: "directory" },
+          { name: ".draft.mdi", kind: "file" },
+          { name: "chapter.mdi", kind: "file" },
+        ];
+      }
+      throw new Error(`Unexpected directory read: ${path}`);
+    });
+    Object.defineProperty(window, "electronAPI", {
+      configurable: true,
+      writable: true,
+      value: { vfs: { readDirectory, readFile } },
+    });
+    const vfs = new ElectronVFS();
+    await vfs.setRootPath("/project");
+
+    const results = await searchProjectFiles({ vfs, searchTerm: "target", options: {} });
+
+    expect(results.map((result) => result.path)).toEqual(["chapter.mdi"]);
+    expect(readDirectory).toHaveBeenCalledTimes(1);
+    expect(readFile).toHaveBeenCalledWith("/project/chapter.mdi");
+    expect(readFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/editor-page/__tests__/project-search-worker-client.test.ts
+++ b/lib/editor-page/__tests__/project-search-worker-client.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ProjectSearchWorkerClient,
+  type ProjectSearchWorkerRequest,
+  type ProjectSearchWorkerResponse,
+} from "@/lib/editor-page/project-search-worker-client";
+
+class FakeWorker {
+  onmessage: ((event: MessageEvent<ProjectSearchWorkerResponse>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  readonly received: ProjectSearchWorkerRequest[] = [];
+  terminated = false;
+
+  postMessage(message: ProjectSearchWorkerRequest): void {
+    this.received.push(message);
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  emit(message: ProjectSearchWorkerResponse): void {
+    this.onmessage?.(new MessageEvent("message", { data: message }));
+  }
+}
+
+describe("ProjectSearchWorkerClient", () => {
+  it("matches a document through a worker round trip", async () => {
+    const worker = new FakeWorker();
+    const client = new ProjectSearchWorkerClient(() => worker as unknown as Worker);
+
+    const pending = client.matchDocument("target", ".mdi", "target", {});
+    expect(worker.received).toMatchObject([
+      { type: "MATCH_DOCUMENT", id: 1, content: "target", fileType: ".mdi" },
+    ]);
+
+    worker.emit({
+      type: "MATCH_RESULT",
+      id: 1,
+      result: {
+        content: "target",
+        matches: [{ from: 0, to: 6, rawFrom: 0, rawTo: 6, lineNumber: 1 }],
+      },
+    });
+
+    await expect(pending).resolves.toMatchObject({ matches: [{ rawFrom: 0, rawTo: 6 }] });
+    client.dispose();
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("rejects pending work when disposed", async () => {
+    const worker = new FakeWorker();
+    const client = new ProjectSearchWorkerClient(() => worker as unknown as Worker);
+    const pending = client.matchDocument("target", ".mdi", "target", {});
+
+    client.dispose();
+
+    await expect(pending).rejects.toThrow("disposed");
+  });
+
+  it("poisons the client after a worker crash", async () => {
+    const worker = new FakeWorker();
+    const client = new ProjectSearchWorkerClient(() => worker as unknown as Worker);
+    const pending = client.matchDocument("first", ".mdi", "first", {});
+
+    worker.onerror?.(new ErrorEvent("error", { message: "worker crashed" }));
+
+    await expect(pending).rejects.toThrow("worker crashed");
+    const afterCrash = client.matchDocument("second", ".mdi", "second", {});
+    expect(worker.received).toHaveLength(1);
+    await expect(afterCrash).rejects.toThrow("worker crashed");
+    expect(worker.terminated).toBe(true);
+  });
+});

--- a/lib/editor-page/__tests__/project-search.test.ts
+++ b/lib/editor-page/__tests__/project-search.test.ts
@@ -232,21 +232,27 @@ describe("project-wide replacement", () => {
   it.each([
     ["a a", "longer", "longer longer"],
     ["target target", "x", "x x"],
-  ])("handles replacement length changes without offset drift", async (content, replacement, expected) => {
-    const searchTerm = content.startsWith("a") ? "a" : "target";
-    const searched = findRawDocumentMatches(content, ".mdi", searchTerm, {});
-    const writeFile = vi.fn(async () => {});
-    const vfs = { readFile: vi.fn(async () => content), writeFile } as unknown as VirtualFileSystem;
+  ])(
+    "handles replacement length changes without offset drift",
+    async (content, replacement, expected) => {
+      const searchTerm = content.startsWith("a") ? "a" : "target";
+      const searched = findRawDocumentMatches(content, ".mdi", searchTerm, {});
+      const writeFile = vi.fn(async () => {});
+      const vfs = {
+        readFile: vi.fn(async () => content),
+        writeFile,
+      } as unknown as VirtualFileSystem;
 
-    await replaceProjectFiles({
-      vfs,
-      results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
-      replacement,
-      options: {},
-    });
+      await replaceProjectFiles({
+        vfs,
+        results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
+        replacement,
+        options: {},
+      });
 
-    expect(writeFile).toHaveBeenCalledWith("chapter.mdi", expected);
-  });
+      expect(writeFile).toHaveBeenCalledWith("chapter.mdi", expected);
+    },
+  );
 
   it("updates open buffers without writing them to disk", async () => {
     const open = findRawDocumentMatches("target", ".mdi", "target", {});

--- a/lib/editor-page/__tests__/project-search.test.ts
+++ b/lib/editor-page/__tests__/project-search.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  findRawDocumentMatches,
+  isSearchableProjectPath,
+  replaceProjectFiles,
+  undoProjectReplacement,
+  searchProjectFiles,
+} from "@/lib/editor-page/project-search";
+import type { VirtualFileSystem, VFSEntry } from "@/lib/vfs/types";
+
+function entry(path: string, kind: VFSEntry["kind"]): VFSEntry {
+  return { name: path.split("/").at(-1) ?? path, path, kind };
+}
+
+describe("project search path filtering", () => {
+  it("returns no results for an empty project", async () => {
+    const vfs = {
+      listDirectory: vi.fn(async () => []),
+    } as unknown as VirtualFileSystem;
+
+    await expect(searchProjectFiles({ vfs, searchTerm: "target", options: {} })).resolves.toEqual(
+      [],
+    );
+  });
+
+  it("excludes every dot-prefixed path segment and unsupported file", () => {
+    expect(isSearchableProjectPath("chapter/one.mdi")).toBe(true);
+    expect(isSearchableProjectPath(".illusions/history/one.mdi")).toBe(false);
+    expect(isSearchableProjectPath("chapter/.vscode/settings.mdi")).toBe(false);
+    expect(isSearchableProjectPath("chapter/.draft.mdi")).toBe(false);
+    expect(isSearchableProjectPath("chapter/cover.png")).toBe(false);
+  });
+
+  it("never descends into hidden directories or reads hidden files", async () => {
+    const directories: Record<string, VFSEntry[]> = {
+      "": [
+        entry(".illusions", "directory"),
+        entry(".vscode", "directory"),
+        entry("chapters", "directory"),
+        entry(".secret.mdi", "file"),
+        entry("root.mdi", "file"),
+      ],
+      chapters: [entry("chapters/one.mdi", "file"), entry("chapters/notes.json", "file")],
+    };
+    const listDirectory = vi.fn(async (path: string) => directories[path] ?? []);
+    const readFile = vi.fn(async (path: string) => `target in ${path}`);
+    const vfs = { listDirectory, readFile } as unknown as VirtualFileSystem;
+
+    const results = await searchProjectFiles({ vfs, searchTerm: "target", options: {} });
+
+    expect(results.map((result) => result.path)).toEqual(["chapters/one.mdi", "root.mdi"]);
+    expect(listDirectory).toHaveBeenCalledTimes(2);
+    expect(listDirectory).not.toHaveBeenCalledWith(".illusions");
+    expect(listDirectory).not.toHaveBeenCalledWith(".vscode");
+    expect(readFile).not.toHaveBeenCalledWith(".secret.mdi");
+  });
+
+  it("does not list a hidden directory selected as the search root", async () => {
+    const listDirectory = vi.fn(async () => [entry(".illusions/history.mdi", "file")]);
+    const vfs = { listDirectory } as unknown as VirtualFileSystem;
+
+    const results = await searchProjectFiles({
+      vfs,
+      searchTerm: "target",
+      options: {},
+      rootPath: ".illusions",
+    });
+
+    expect(results).toEqual([]);
+    expect(listDirectory).not.toHaveBeenCalled();
+  });
+
+  it("stops before reading files when the search is aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const readFile = vi.fn(async () => "target");
+    const vfs = {
+      listDirectory: vi.fn(async () => [entry("chapter.mdi", "file")]),
+      readFile,
+    } as unknown as VirtualFileSystem;
+
+    await expect(
+      searchProjectFiles({
+        vfs,
+        searchTerm: "target",
+        options: {},
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(readFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("raw project document matching", () => {
+  it("searches displayed MDI text without exposing macro names or metadata", () => {
+    const content = [
+      "前{東京|とう.きょう}後",
+      "[[kern:0.5em:本文]]",
+      "[[no-break:禁則]]",
+      "[[blank]]",
+    ].join("\n");
+
+    expect(findRawDocumentMatches(content, ".mdi", "東京", {}).matches).toMatchObject([
+      { text: "東京", source: "ruby-base", replaceable: false },
+    ]);
+    expect(findRawDocumentMatches(content, ".mdi", "とうきょう", {}).matches).toMatchObject([
+      { text: "とうきょう", source: "ruby-text", replaceable: false },
+    ]);
+    expect(findRawDocumentMatches(content, ".mdi", "本文", {}).matches).toMatchObject([
+      { text: "本文", source: "kern", replaceable: false },
+    ]);
+    expect(findRawDocumentMatches(content, ".mdi", "0.5em", {}).matches).toEqual([]);
+    expect(findRawDocumentMatches(content, ".mdi", "blank", {}).matches).toEqual([]);
+  });
+
+  it("returns raw offsets only for plain-text replacements and preserves macros", () => {
+    const content = "対象{対象|たいしょう}対象";
+    const result = findRawDocumentMatches(content, ".mdi", "対象", {});
+
+    expect(result.matches).toMatchObject([
+      { rawFrom: 0, rawTo: 2, replaceable: true },
+      { source: "ruby-base", replaceable: false },
+      { rawFrom: 12, rawTo: 14, replaceable: true },
+    ]);
+  });
+
+  it("uses an unsaved buffer instead of stale VFS content", async () => {
+    const vfs = {
+      listDirectory: vi.fn(async () => [entry("chapter.mdi", "file")]),
+      readFile: vi.fn(async () => "old text"),
+    } as unknown as VirtualFileSystem;
+
+    const results = await searchProjectFiles({
+      vfs,
+      searchTerm: "new text",
+      options: {},
+      openBuffers: new Map([["chapter.mdi", "new text"]]),
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].matches).toHaveLength(1);
+    expect(vfs.readFile).not.toHaveBeenCalled();
+  });
+
+  it("excludes HTML comments by default and can include them as non-replaceable results", () => {
+    const content = "target <!-- target -->";
+
+    expect(findRawDocumentMatches(content, ".mdi", "target", {}).matches).toHaveLength(1);
+    expect(
+      findRawDocumentMatches(content, ".mdi", "target", { excludeComments: false }).matches,
+    ).toMatchObject([
+      { source: "text", replaceable: true },
+      { source: "comment", replaceable: false },
+    ]);
+  });
+
+  it("applies comment filtering to Markdown files", () => {
+    const content = "target <!-- target -->";
+
+    expect(findRawDocumentMatches(content, ".md", "target", {}).matches).toHaveLength(1);
+    expect(
+      findRawDocumentMatches(content, ".md", "target", { excludeComments: false }).matches,
+    ).toMatchObject([
+      { source: "text", replaceable: true },
+      { source: "comment", replaceable: false },
+    ]);
+  });
+
+  it("reports file results incrementally across a large project", async () => {
+    const files = Array.from({ length: 64 }, (_, index) => entry(`chapter-${index}.mdi`, "file"));
+    const vfs = {
+      listDirectory: vi.fn(async () => files),
+      readFile: vi.fn(async (path: string) => `target ${path}`),
+    } as unknown as VirtualFileSystem;
+    const onFileResult = vi.fn();
+    const onProgress = vi.fn();
+
+    const results = await searchProjectFiles({
+      vfs,
+      searchTerm: "target",
+      options: {},
+      onFileResult,
+      onProgress,
+    });
+
+    expect(results).toHaveLength(64);
+    expect(onFileResult).toHaveBeenCalledTimes(64);
+    expect(onProgress).toHaveBeenLastCalledWith(64, 64);
+  });
+
+  it("delegates huge-file matching to the supplied asynchronous matcher", async () => {
+    const content = `${"x".repeat(2_000_000)}target`;
+    const vfs = {
+      listDirectory: vi.fn(async () => [entry("huge.mdi", "file")]),
+      readFile: vi.fn(async () => content),
+    } as unknown as VirtualFileSystem;
+    const matchDocument = vi.fn(async (...args: Parameters<typeof findRawDocumentMatches>) =>
+      findRawDocumentMatches(...args),
+    );
+
+    const results = await searchProjectFiles({
+      vfs,
+      searchTerm: "target",
+      options: {},
+      matchDocument,
+    });
+
+    expect(matchDocument).toHaveBeenCalledTimes(1);
+    expect(results[0].matches[0].rawFrom).toBe(2_000_000);
+  });
+});
+
+describe("project-wide replacement", () => {
+  it("replaces only plain text and preserves MDI atoms", async () => {
+    const content = "対象{対象|たいしょう}対象";
+    const searched = findRawDocumentMatches(content, ".mdi", "対象", {});
+    const writeFile = vi.fn(async () => {});
+    const vfs = { readFile: vi.fn(async () => content), writeFile } as unknown as VirtualFileSystem;
+
+    const changes = await replaceProjectFiles({
+      vfs,
+      results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
+      replacement: "変更",
+      options: {},
+    });
+
+    expect(writeFile).toHaveBeenCalledWith("chapter.mdi", "変更{対象|たいしょう}変更");
+    expect(changes).toMatchObject([{ path: "chapter.mdi", replacementCount: 2 }]);
+  });
+
+  it.each([
+    ["a a", "longer", "longer longer"],
+    ["target target", "x", "x x"],
+  ])("handles replacement length changes without offset drift", async (content, replacement, expected) => {
+    const searchTerm = content.startsWith("a") ? "a" : "target";
+    const searched = findRawDocumentMatches(content, ".mdi", searchTerm, {});
+    const writeFile = vi.fn(async () => {});
+    const vfs = { readFile: vi.fn(async () => content), writeFile } as unknown as VirtualFileSystem;
+
+    await replaceProjectFiles({
+      vfs,
+      results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
+      replacement,
+      options: {},
+    });
+
+    expect(writeFile).toHaveBeenCalledWith("chapter.mdi", expected);
+  });
+
+  it("updates open buffers without writing them to disk", async () => {
+    const open = findRawDocumentMatches("target", ".mdi", "target", {});
+    const closed = findRawDocumentMatches("target", ".mdi", "target", {});
+    const writeFile = vi.fn(async () => {});
+    const onOpenBufferChange = vi.fn(async () => {});
+    const vfs = {
+      readFile: vi.fn(async () => "target"),
+      writeFile,
+    } as unknown as VirtualFileSystem;
+
+    const changes = await replaceProjectFiles({
+      vfs,
+      results: [
+        { ...open, path: "open.mdi", fileName: "open.mdi" },
+        { ...closed, path: "closed.mdi", fileName: "closed.mdi" },
+      ],
+      replacement: "changed",
+      options: {},
+      openBuffers: new Map([["open.mdi", "target"]]),
+      onOpenBufferChange,
+    });
+
+    expect(onOpenBufferChange).toHaveBeenCalledWith("open.mdi", "changed");
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    expect(writeFile).toHaveBeenCalledWith("closed.mdi", "changed");
+    expect(changes).toHaveLength(2);
+  });
+
+  it("aborts before writing when a file changed after the search", async () => {
+    const searched = findRawDocumentMatches("target", ".mdi", "target", {});
+    const writeFile = vi.fn(async () => {});
+    const vfs = {
+      readFile: vi.fn(async () => "newer content"),
+      writeFile,
+    } as unknown as VirtualFileSystem;
+
+    await expect(
+      replaceProjectFiles({
+        vfs,
+        results: [{ ...searched, path: "chapter.mdi", fileName: "chapter.mdi" }],
+        replacement: "changed",
+        options: {},
+      }),
+    ).rejects.toThrow("検索後に内容が変更されました");
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it("restores both VFS files and open buffers from the operation log", async () => {
+    const writeFile = vi.fn(async () => {});
+    const onOpenBufferChange = vi.fn(async () => {});
+    const vfs = {
+      readFile: vi.fn(async () => "after-closed"),
+      writeFile,
+    } as unknown as VirtualFileSystem;
+    const changes = [
+      {
+        path: "open.mdi",
+        before: "before-open",
+        after: "after-open",
+        replacementCount: 1,
+        openBuffer: true,
+      },
+      {
+        path: "closed.mdi",
+        before: "before-closed",
+        after: "after-closed",
+        replacementCount: 1,
+        openBuffer: false,
+      },
+    ];
+
+    await undoProjectReplacement({
+      vfs,
+      changes,
+      openBuffers: new Map([["open.mdi", "after-open"]]),
+      onOpenBufferChange,
+    });
+
+    expect(onOpenBufferChange).toHaveBeenCalledWith("open.mdi", "before-open");
+    expect(writeFile).toHaveBeenCalledWith("closed.mdi", "before-closed");
+  });
+
+  it("does not undo over content edited after replacement", async () => {
+    const writeFile = vi.fn(async () => {});
+    const vfs = {
+      readFile: vi.fn(async () => "edited-again"),
+      writeFile,
+    } as unknown as VirtualFileSystem;
+
+    await expect(
+      undoProjectReplacement({
+        vfs,
+        changes: [
+          {
+            path: "chapter.mdi",
+            before: "before",
+            after: "after",
+            replacementCount: 1,
+            openBuffer: false,
+          },
+        ],
+      }),
+    ).rejects.toThrow("置換後に内容が変更されました");
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});

--- a/lib/editor-page/__tests__/search-history.test.ts
+++ b/lib/editor-page/__tests__/search-history.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { addSearchHistoryEntry, loadSearchHistory } from "@/lib/editor-page/search-history";
+
+describe("search history", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("stores unique non-empty terms with the newest first", () => {
+    addSearchHistoryEntry(" first ");
+    addSearchHistoryEntry("second");
+    addSearchHistoryEntry("first");
+    addSearchHistoryEntry("   ");
+
+    expect(loadSearchHistory()).toEqual(["first", "second"]);
+  });
+
+  it("keeps only the ten most recent terms", () => {
+    for (let index = 0; index < 12; index += 1) addSearchHistoryEntry(`term-${index}`);
+
+    expect(loadSearchHistory()).toHaveLength(10);
+    expect(loadSearchHistory()[0]).toBe("term-11");
+    expect(loadSearchHistory().at(-1)).toBe("term-2");
+  });
+
+  it("recovers from malformed persisted data", () => {
+    localStorage.setItem("illusions:search-history", "not-json");
+    expect(loadSearchHistory()).toEqual([]);
+  });
+});

--- a/lib/editor-page/__tests__/selection-search-range.test.ts
+++ b/lib/editor-page/__tests__/selection-search-range.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { getEditorSelectionSearchRange } from "@/lib/editor-page/use-selection-tracking";
+
+describe("getEditorSelectionSearchRange", () => {
+  it("tracks a moved selection even when its length is unchanged", () => {
+    expect(getEditorSelectionSearchRange({ empty: false, from: 2, to: 5 })).toEqual({
+      from: 2,
+      to: 5,
+    });
+    expect(getEditorSelectionSearchRange({ empty: false, from: 8, to: 11 })).toEqual({
+      from: 8,
+      to: 11,
+    });
+  });
+
+  it("uses the editor selection even after DOM focus leaves the editor", () => {
+    expect(getEditorSelectionSearchRange({ empty: false, from: 4, to: 9 })).toEqual({
+      from: 4,
+      to: 9,
+    });
+    expect(getEditorSelectionSearchRange({ empty: true, from: 4, to: 4 })).toBeNull();
+  });
+});

--- a/lib/editor-page/__tests__/text-statistics.test.ts
+++ b/lib/editor-page/__tests__/text-statistics.test.ts
@@ -33,6 +33,14 @@ describe("extractVisibleText", () => {
     expect(extractVisibleText("[[kern:-0.1em:確実]]")).toBe("確実");
   });
 
+  it("MDI 空行マーカー [[blank]] を行ごと削除する", () => {
+    expect(extractVisibleText("前の文。\n[[blank]]\n次の文。")).toBe("前の文。\n\n次の文。");
+  });
+
+  it("serializer エスケープ形 \\[\\[blank]] も行ごと削除する（可視文字に計上しない）", () => {
+    expect(extractVisibleText("前の文。\n\\[\\[blank]]\n次の文。")).toBe("前の文。\n\n次の文。");
+  });
+
   it("HTML タグを除去して内容を残す", () => {
     expect(extractVisibleText("<b>太字</b>")).toBe("太字");
   });
@@ -234,6 +242,12 @@ describe("computeTextStatistics", () => {
     expect(stats.visibleTextCharCount).toBe(2);
     expect(stats.manuscriptCellCount).toBe(20);
     expect(stats.manuscriptPages).toBe(1);
+  });
+
+  it("[[blank]] マーカー（エスケープ形含む）は可視文字数に計上しない", () => {
+    // 「あ」2文字のみが可視。マーカー \[\[blank]] の記号類は数えない。
+    const stats = computeTextStatistics("あ\n\\[\\[blank]]\nあ");
+    expect(stats.visibleTextCharCount).toBe(2);
   });
 
   it("400字 → 1ページ", () => {

--- a/lib/editor-page/__tests__/use-panel-state-search-options.test.tsx
+++ b/lib/editor-page/__tests__/use-panel-state-search-options.test.tsx
@@ -1,0 +1,70 @@
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { act, useEffect } from "react";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { usePanelState } from "@/lib/editor-page/use-panel-state";
+
+type PanelStateResult = ReturnType<typeof usePanelState>;
+
+let container: HTMLDivElement;
+let root: Root;
+let current: PanelStateResult | undefined;
+
+function Harness({ onValue }: { onValue: (value: PanelStateResult) => void }) {
+  const value = usePanelState({ setShowSettingsModal: () => {} });
+  useEffect(() => onValue(value), [onValue, value]);
+  return null;
+}
+
+const captureValue = (value: PanelStateResult) => {
+  current = value;
+};
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root.render(<Harness onValue={captureValue} />));
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  current = undefined;
+});
+
+describe("usePanelState search options", () => {
+  it("exposes conservative defaults", () => {
+    expect(current?.state).toMatchObject({
+      regexSearch: false,
+      wholeWordSearch: false,
+      normalizeVariants: false,
+      excludeComments: true,
+      searchTarget: "all",
+      selectionOnly: false,
+    });
+  });
+
+  it("updates every enhanced search option", () => {
+    act(() => {
+      current?.handlers.setRegexSearch(true);
+      current?.handlers.setWholeWordSearch(true);
+      current?.handlers.setNormalizeVariants(true);
+      current?.handlers.setExcludeComments(false);
+      current?.handlers.setSearchTarget("ruby");
+      current?.handlers.setSelectionOnly(true);
+    });
+
+    expect(current?.state).toMatchObject({
+      regexSearch: true,
+      wholeWordSearch: true,
+      normalizeVariants: true,
+      excludeComments: false,
+      searchTarget: "ruby",
+      selectionOnly: true,
+    });
+  });
+});

--- a/lib/editor-page/__tests__/use-power-saving.test.tsx
+++ b/lib/editor-page/__tests__/use-power-saving.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Tests for usePowerSaving (#1402 follow-up).
+ *
+ * The previous implementation FORCED power-save ON whenever it saw "battery",
+ * and re-ran on every effect re-subscription — which made power-save
+ * impossible to turn off on battery. The new design:
+ *
+ * 1. SUGGESTS power-save on AC→battery (never forces),
+ * 2. auto-disables power-save on battery→AC,
+ * 3. only reacts to genuine state TRANSITIONS (repeated same-state is a no-op),
+ * 4. never suggests when already in power-save or when the setting is off.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { usePowerSaving } from "../use-power-saving";
+
+type PowerState = "ac" | "battery";
+
+// ---------------------------------------------------------------------------
+// Fake Electron power API
+// ---------------------------------------------------------------------------
+
+let initialState: PowerState = "ac";
+let stateListener: ((state: PowerState) => void) | null = null;
+let resolveInitial: () => void;
+let initialApplied: Promise<void>;
+
+function installPowerApi(): void {
+  initialApplied = new Promise<void>((resolve) => {
+    resolveInitial = resolve;
+  });
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    power: {
+      getPowerState: () =>
+        Promise.resolve(initialState).then((s) => {
+          // Let tests await the mount-time application.
+          queueMicrotask(resolveInitial);
+          return s;
+        }),
+      onPowerStateChange: (cb: (state: PowerState) => void) => {
+        stateListener = cb;
+        return () => {
+          stateListener = null;
+        };
+      },
+    },
+  };
+}
+
+function emit(state: PowerState): Promise<void> {
+  return act(async () => {
+    stateListener?.(state);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface HostProps {
+  powerSaveMode: boolean;
+  autoPowerSaveOnBattery: boolean;
+  onPowerSaveModeChange: (enabled: boolean) => void;
+  onSuggestPowerSave: () => void;
+}
+
+function HookHost(props: HostProps): null {
+  usePowerSaving(props);
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+async function mountHook(props: HostProps): Promise<void> {
+  await act(async () => {
+    root.render(<HookHost {...props} />);
+  });
+  await act(async () => {
+    await initialApplied;
+  });
+}
+
+beforeEach(() => {
+  initialState = "ac";
+  stateListener = null;
+  installPowerApi();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+function makeProps(overrides: Partial<HostProps> = {}): HostProps {
+  return {
+    powerSaveMode: false,
+    autoPowerSaveOnBattery: true,
+    onPowerSaveModeChange: vi.fn(),
+    onSuggestPowerSave: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("usePowerSaving", () => {
+  it("suggests (never forces) power-save when switching to battery", async () => {
+    const props = makeProps();
+    await mountHook(props); // mounts on AC
+    await emit("battery");
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
+    // Crucially, it never FORCES power-save on.
+    expect(props.onPowerSaveModeChange).not.toHaveBeenCalledWith(true);
+  });
+
+  it("auto-disables power-save when AC is restored", async () => {
+    const props = makeProps({ powerSaveMode: true });
+    initialState = "battery";
+    await mountHook(props); // mounts on battery (suggestion skipped: already on)
+    await emit("ac");
+
+    expect(props.onPowerSaveModeChange).toHaveBeenCalledWith(false);
+    // Mounting on battery while already in power-save must not force or suggest.
+    expect(props.onSuggestPowerSave).not.toHaveBeenCalled();
+  });
+
+  it("does not re-suggest on repeated battery readings (no transition)", async () => {
+    const props = makeProps();
+    await mountHook(props); // AC
+    await emit("battery");
+    await emit("battery");
+    await emit("battery");
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not suggest while power-save is already enabled", async () => {
+    const props = makeProps({ powerSaveMode: true });
+    await mountHook(props); // AC
+    await emit("battery");
+
+    expect(props.onSuggestPowerSave).not.toHaveBeenCalled();
+  });
+
+  it("does not suggest when the auto-suggest setting is off", async () => {
+    const props = makeProps({ autoPowerSaveOnBattery: false });
+    await mountHook(props); // AC
+    await emit("battery");
+
+    expect(props.onSuggestPowerSave).not.toHaveBeenCalled();
+  });
+
+  it("suggests on mount when already on battery", async () => {
+    const props = makeProps();
+    initialState = "battery";
+    await mountHook(props);
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT auto-disable on the initial AC reading (mount must not race the restore path)", async () => {
+    const props = makeProps({ powerSaveMode: true });
+    initialState = "ac";
+    await mountHook(props);
+
+    // The initial reading only records state; auto-disable is reserved for a
+    // real battery→AC transition so it can't clear prePowerSaveState at boot.
+    expect(props.onPowerSaveModeChange).not.toHaveBeenCalled();
+  });
+
+  it("throttles repeated suggestions across rapid AC/battery bounce", async () => {
+    const props = makeProps();
+    await mountHook(props); // AC
+    await emit("battery"); // suggestion #1
+    await emit("ac");
+    await emit("battery"); // within the throttle window → suppressed
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/editor-page/__tests__/use-power-saving.test.tsx
+++ b/lib/editor-page/__tests__/use-power-saving.test.tsx
@@ -18,7 +18,7 @@ import { act } from "react";
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
-import { usePowerSaving } from "../use-power-saving";
+import { usePowerSaving, __resetSuggestThrottleForTest } from "../use-power-saving";
 
 type PowerState = "ac" | "battery";
 
@@ -88,6 +88,7 @@ async function mountHook(props: HostProps): Promise<void> {
 }
 
 beforeEach(() => {
+  __resetSuggestThrottleForTest();
   initialState = "ac";
   stateListener = null;
   installPowerApi();
@@ -180,6 +181,23 @@ describe("usePowerSaving", () => {
     // The initial reading only records state; auto-disable is reserved for a
     // real battery→AC transition so it can't clear prePowerSaveState at boot.
     expect(props.onPowerSaveModeChange).not.toHaveBeenCalled();
+  });
+
+  it("does not suggest twice when the consumer remounts on battery (module-scoped throttle)", async () => {
+    // Reproduces the duplicate-toast bug: the editor page remounting during
+    // startup created a second hook instance whose per-instance throttle was
+    // reset to 0, firing a second identical toast.
+    const props = makeProps();
+    initialState = "battery";
+    await mountHook(props); // first mount → suggestion #1
+
+    // Remount a fresh instance (new fiber → fresh per-instance refs).
+    await act(async () => root.unmount());
+    installPowerApi();
+    root = createRoot(container);
+    await mountHook(props); // second mount must be throttled
+
+    expect(props.onSuggestPowerSave).toHaveBeenCalledTimes(1);
   });
 
   it("throttles repeated suggestions across rapid AC/battery bounce", async () => {

--- a/lib/editor-page/__tests__/use-search-highlight.test.tsx
+++ b/lib/editor-page/__tests__/use-search-highlight.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for useSearchHighlight — the single source of search-highlight dispatch.
+ *
+ * Covers the two behaviors introduced when SearchDialog / SearchResults were
+ * made controlled and stopped writing `searchDecorations` themselves:
+ *  1. Visibility gate: when no search UI is visible (or the term is empty /
+ *     there are no matches), decorations are cleared (empty dispatch).
+ *  2. Active highlight: when a search UI is visible with matches, the full set
+ *     is dispatched, current match emphasized.
+ *  3. #1507: a destroyed EditorView never throws.
+ */
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import type { EditorView } from "@milkdown/prose/view";
+
+// centerEditorPosition / TextSelection touch real ProseMirror layout — stub them.
+vi.mock("@/lib/editor-page/center-editor-position", () => ({
+  centerEditorPosition: vi.fn(),
+}));
+vi.mock("@milkdown/prose/state", () => ({
+  TextSelection: { create: vi.fn(() => ({})) },
+}));
+
+import { useSearchHighlight } from "../use-search-highlight";
+import type { SearchMatch } from "../find-search-matches";
+
+interface DispatchedMeta {
+  key: string;
+  value: unknown;
+}
+
+function makeView(alive: boolean): { view: EditorView; metas: DispatchedMeta[] } {
+  const metas: DispatchedMeta[] = [];
+  const tr = {
+    setMeta(key: string, value: unknown) {
+      metas.push({ key, value });
+      return tr;
+    },
+    setSelection() {
+      return tr;
+    },
+  };
+  const view = {
+    docView: alive ? {} : null,
+    state: { tr, doc: {} },
+    dispatch: vi.fn(),
+    focus: vi.fn(),
+  } as unknown as EditorView;
+  return { view, metas };
+}
+
+function decorationsDispatched(metas: DispatchedMeta[]): unknown[] | undefined {
+  const entry = metas.filter((m) => m.key === "searchDecorations").pop();
+  return entry?.value as unknown[] | undefined;
+}
+
+function Harness(props: {
+  view: EditorView | null;
+  matches: SearchMatch[];
+  currentMatchIndex: number;
+  searchTerm: string;
+  isSearchVisible: boolean;
+}) {
+  useSearchHighlight({
+    editorView: props.view,
+    matches: props.matches,
+    currentMatchIndex: props.currentMatchIndex,
+    searchTerm: props.searchTerm,
+    isSearchVisible: props.isSearchVisible,
+  });
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("useSearchHighlight – visibility gate (要求2)", () => {
+  it("clears decorations (empty dispatch) when no search UI is visible", () => {
+    const { view, metas } = makeView(true);
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={[{ from: 1, to: 2 }]}
+          currentMatchIndex={0}
+          searchTerm="foo"
+          isSearchVisible={false}
+        />,
+      );
+    });
+    expect(decorationsDispatched(metas)).toEqual([]);
+  });
+
+  it("clears decorations when the term is empty even if visible", () => {
+    const { view, metas } = makeView(true);
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={[]}
+          currentMatchIndex={0}
+          searchTerm=""
+          isSearchVisible={true}
+        />,
+      );
+    });
+    expect(decorationsDispatched(metas)).toEqual([]);
+  });
+
+  it("dispatches the full match set when visible with matches", () => {
+    const { view, metas } = makeView(true);
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={[
+            { from: 1, to: 2 },
+            { from: 5, to: 6 },
+          ]}
+          currentMatchIndex={1}
+          searchTerm="foo"
+          isSearchVisible={true}
+        />,
+      );
+    });
+    const dispatched = decorationsDispatched(metas);
+    expect(dispatched).toHaveLength(2);
+  });
+});
+
+describe("useSearchHighlight – destroyed view (#1507)", () => {
+  it("does not throw when the editorView is destroyed", () => {
+    const { view } = makeView(false /* docView = null */);
+    expect(() => {
+      act(() => {
+        root.render(
+          <Harness
+            view={view}
+            matches={[{ from: 1, to: 2 }]}
+            currentMatchIndex={0}
+            searchTerm="foo"
+            isSearchVisible={true}
+          />,
+        );
+      });
+    }).not.toThrow();
+  });
+});

--- a/lib/editor-page/clear-formatting.ts
+++ b/lib/editor-page/clear-formatting.ts
@@ -1,0 +1,49 @@
+import { setBlockType, lift } from "@milkdown/prose/commands";
+import { liftListItem } from "@milkdown/prose/schema-list";
+import type { EditorView } from "@milkdown/prose/view";
+
+/** lift 系コマンドを変化が無くなるまで反復実行する（多重ネスト対策）。上限付き。 */
+function repeat(
+  view: EditorView,
+  command: (state: EditorView["state"], dispatch: EditorView["dispatch"]) => boolean,
+): void {
+  for (let i = 0; i < 16; i += 1) {
+    if (!command(view.state, view.dispatch)) break;
+  }
+}
+
+/**
+ * 選択範囲を標準本文（段落・装飾なし）に戻す。
+ *
+ * Milkdown には単一の「書式解除」コマンドが無いため、ProseMirror を直接操作する。
+ * 1) インラインマーク（太字・斜体・取り消し線・コード等）をすべて除去
+ * 2) 見出し・コードブロック等のテキストブロックを標準段落へ変換
+ * 3) リスト項目を段落へ引き上げ（list_item は generic lift では解除できないため専用コマンド）
+ * 4) 引用などの残りのラッパーから段落を引き上げる
+ *
+ * 選択が空の場合は何もしない。
+ */
+export function clearFormatting(view: EditorView): void {
+  if (view.state.selection.empty) return;
+
+  // 1) インラインマークをすべて除去
+  const { from, to } = view.state.selection;
+  view.dispatch(view.state.tr.removeMark(from, to));
+
+  // 2) テキストブロックを標準段落へ変換
+  const paragraph = view.state.schema.nodes.paragraph;
+  if (paragraph) {
+    setBlockType(paragraph)(view.state, view.dispatch);
+  }
+
+  // 3) リスト項目を引き上げてリストから抜ける
+  const listItem = view.state.schema.nodes.list_item;
+  if (listItem) {
+    repeat(view, liftListItem(listItem));
+  }
+
+  // 4) 引用などの残りのラッパーを解除
+  repeat(view, lift);
+
+  view.focus();
+}

--- a/lib/editor-page/find-search-matches.ts
+++ b/lib/editor-page/find-search-matches.ts
@@ -1,69 +1,454 @@
 import type { Node } from "@milkdown/prose/model";
 
-export interface SearchMatch {
+import { normalizeJapaneseSearchVariants } from "./japanese-variant-normalization";
+
+export type SearchMatchSource =
+  | "text"
+  | "ruby-base"
+  | "ruby-text"
+  | "tcy"
+  | "nobreak"
+  | "kern"
+  | "hardbreak"
+  | "mdibreak"
+  | "comment"
+  | "mixed";
+
+export type SearchTarget = "all" | "body" | "ruby";
+
+export interface SearchRange {
   from: number;
   to: number;
 }
 
+export interface SearchOptions {
+  caseSensitive?: boolean;
+  regex?: boolean;
+  wholeWord?: boolean;
+  normalizeVariants?: boolean;
+  excludeComments?: boolean;
+  searchTarget?: SearchTarget;
+  range?: SearchRange;
+}
+
+export interface SearchMatch {
+  from: number;
+  to: number;
+  text?: string;
+  source?: SearchMatchSource;
+  replaceable?: boolean;
+  captures?: string[];
+  heading?: string;
+  paragraphNumber?: number;
+}
+
+export interface ReplacementStep {
+  from: number;
+  to: number;
+  text: string;
+}
+
+type ResolvedSearchOptions = Required<Omit<SearchOptions, "range">> & {
+  range?: SearchRange;
+};
+
+export interface SearchTextSegment {
+  text: string;
+  displayFrom: number;
+  displayTo: number;
+  from: number;
+  to: number;
+  source: SearchMatchSource;
+  replaceable: boolean;
+}
+
+export interface SearchTextProjection {
+  text: string;
+  segments: SearchTextSegment[];
+}
+
+interface NormalizedProjection {
+  text: string;
+  sourceFrom: number[];
+  sourceTo: number[];
+}
+
+interface RawMatch {
+  from: number;
+  to: number;
+  captures?: string[];
+}
+
+const DEFAULT_OPTIONS: ResolvedSearchOptions = {
+  caseSensitive: false,
+  regex: false,
+  wholeWord: false,
+  normalizeVariants: false,
+  excludeComments: true,
+  searchTarget: "all",
+};
+
+const WORD_CHAR_RE = /[\p{L}\p{N}_]/u;
+const JAPANESE_GRAPHEME_SEGMENTER = new Intl.Segmenter("ja", { granularity: "grapheme" });
+
 /**
- * Find every occurrence of `searchTerm` in a ProseMirror document and return
- * their positions in ProseMirror coordinates.
- *
- * Why this walks the document with `doc.descendants` instead of searching
- * `doc.textContent`:
- *
- *   `doc.textContent` flattens the document to a plain string, but that string
- *   is NOT aligned 1:1 with ProseMirror positions. Nodes that are not text but
- *   define a `leafText` spec (most importantly Milkdown's `hardbreak`, whose
- *   spec is `leafText: () => "\n"`) contribute characters to `textContent`
- *   while occupying a position that a naive text-offset → position mapping
- *   never accounts for. The result is that every match after a hardbreak (or
- *   any other leafText node) drifts forward by the number of such nodes before
- *   it, so the highlight lands on the wrong character.
- *
- * By visiting each text node directly we use its real `pos`, so the returned
- * positions are always correct regardless of hardbreaks, ruby atoms, or other
- * inline leaf nodes.
- *
- * Ruby (`atom: true`) nodes are not recursed into by `descendants`, so their
- * `base` text is matched explicitly and the whole atom is highlighted.
+ * Search displayed editor text while retaining exact ProseMirror positions.
+ * MDI syntax is represented by atom nodes and is never exposed as raw markup.
  */
 export function findSearchMatches(
   doc: Node,
   searchTerm: string,
-  caseSensitive: boolean,
+  caseSensitiveOrOptions: boolean | SearchOptions,
 ): SearchMatch[] {
-  const foundMatches: SearchMatch[] = [];
-  if (!searchTerm) return foundMatches;
+  if (!searchTerm) return [];
 
-  const searchStr = caseSensitive ? searchTerm : searchTerm.toLowerCase();
+  const options = resolveOptions(caseSensitiveOrOptions);
+  if (options.regex && !compilePattern(searchTerm, options)) return [];
+
+  const matches: SearchMatch[] = [];
+  let currentHeading: string | undefined;
+  let paragraphNumber = 0;
 
   doc.descendants((node, pos) => {
-    if (node.isText && node.text) {
-      const nodeText = caseSensitive ? node.text : node.text.toLowerCase();
-      let searchIndex = 0;
-      while (searchIndex < nodeText.length) {
-        const matchIndex = nodeText.indexOf(searchStr, searchIndex);
-        if (matchIndex === -1) break;
-        foundMatches.push({
-          from: pos + matchIndex,
-          to: pos + matchIndex + searchTerm.length,
-        });
-        searchIndex = matchIndex + 1;
+    if (!node.isTextblock) return;
+
+    const isHeading = node.type.name === "heading";
+    if (!isHeading) paragraphNumber += 1;
+
+    const bodyProjection = createBodyProjection(node, pos + 1, options.excludeComments);
+    const metadata = {
+      heading: isHeading ? bodyProjection.text || currentHeading : currentHeading,
+      paragraphNumber: isHeading ? undefined : paragraphNumber,
+    };
+
+    if (options.searchTarget !== "ruby") {
+      matches.push(...searchProjection(bodyProjection, searchTerm, options, metadata));
+    }
+
+    if (options.searchTarget !== "body") {
+      for (const rubyProjection of createRubyReadingProjections(node, pos + 1)) {
+        matches.push(...searchProjection(rubyProjection, searchTerm, options, metadata));
+      }
+    }
+
+    if (isHeading && bodyProjection.text) currentHeading = bodyProjection.text;
+    return false;
+  });
+
+  return matches.sort((left, right) => left.from - right.from || left.to - right.to);
+}
+
+export function getSearchPatternError(
+  searchTerm: string,
+  caseSensitiveOrOptions: boolean | SearchOptions,
+): string | null {
+  if (!searchTerm) return null;
+  const options = resolveOptions(caseSensitiveOrOptions);
+  if (!options.regex) return null;
+  return compilePattern(searchTerm, options) ? null : "正規表現が正しくありません";
+}
+
+export function findSearchMatchesInProjection(
+  projection: SearchTextProjection,
+  searchTerm: string,
+  caseSensitiveOrOptions: boolean | SearchOptions,
+  metadata: Pick<SearchMatch, "heading" | "paragraphNumber"> = {},
+): SearchMatch[] {
+  if (!searchTerm) return [];
+  return searchProjection(projection, searchTerm, resolveOptions(caseSensitiveOrOptions), metadata);
+}
+
+export function isSearchMatchReplaceable(match: SearchMatch): boolean {
+  return match.replaceable !== false && match.from < match.to;
+}
+
+export function buildReplacementText(
+  match: SearchMatch,
+  replacement: string,
+  caseSensitiveOrOptions: boolean | SearchOptions,
+): string {
+  if (!resolveOptions(caseSensitiveOrOptions).regex) return replacement;
+
+  return replacement.replace(/\$(\$|&|[1-9][0-9]?)/g, (token, reference: string) => {
+    if (reference === "$") return "$";
+    if (reference === "&") return match.text ?? "";
+
+    const captureIndex = Number(reference) - 1;
+    if (!match.captures || captureIndex < 0 || captureIndex >= match.captures.length) return token;
+    return match.captures[captureIndex] ?? "";
+  });
+}
+
+export function createReplacementSteps(
+  matches: readonly SearchMatch[],
+  replacement: string,
+  caseSensitiveOrOptions: boolean | SearchOptions,
+): ReplacementStep[] {
+  const seen = new Set<string>();
+
+  return matches
+    .filter(isSearchMatchReplaceable)
+    .map((match) => ({
+      from: match.from,
+      to: match.to,
+      text: buildReplacementText(match, replacement, caseSensitiveOrOptions),
+    }))
+    .filter((step) => {
+      const key = `${step.from}:${step.to}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .sort((left, right) => right.from - left.from || right.to - left.to);
+}
+
+function resolveOptions(value: boolean | SearchOptions): ResolvedSearchOptions {
+  if (typeof value === "boolean") return { ...DEFAULT_OPTIONS, caseSensitive: value };
+  return { ...DEFAULT_OPTIONS, ...value };
+}
+
+function createBodyProjection(
+  block: Node,
+  blockContentStart: number,
+  excludeComments: boolean,
+): SearchTextProjection {
+  const projection: SearchTextProjection = { text: "", segments: [] };
+
+  block.forEach((child, offset) => {
+    const from = blockContentStart + offset;
+    if (child.isText && child.text) {
+      appendSegment(projection, child.text, from, from + child.nodeSize, "text", true);
+      return;
+    }
+
+    const comment = getCommentText(child);
+    if (comment !== null) {
+      if (!excludeComments) {
+        appendSegment(projection, comment, from, from + child.nodeSize, "comment", false);
       }
       return;
     }
-    if (node.type.name === "ruby") {
-      const baseRaw = (node.attrs.base as string) ?? "";
-      const baseText = caseSensitive ? baseRaw : baseRaw.toLowerCase();
-      let i = 0;
-      while ((i = baseText.indexOf(searchStr, i)) !== -1) {
-        foundMatches.push({ from: pos, to: pos + node.nodeSize });
-        i += searchStr.length; // advance past matched chars to avoid spurious overlapping matches
-      }
-      return false; // atom — do not recurse into ruby internals
+
+    const atom = getDisplayedAtomText(child);
+    if (atom) {
+      appendSegment(projection, atom.text, from, from + child.nodeSize, atom.source, false);
     }
   });
 
-  return foundMatches;
+  return projection;
+}
+
+function getCommentText(node: Node): string | null {
+  if (node.type.name !== "comment" && node.type.name !== "htmlComment") return null;
+  const value = node.attrs.value ?? node.attrs.text ?? node.textContent;
+  return typeof value === "string" ? value.replace(/^<!--\s*|\s*-->$/g, "") : "";
+}
+
+function createRubyReadingProjections(
+  block: Node,
+  blockContentStart: number,
+): SearchTextProjection[] {
+  const projections: SearchTextProjection[] = [];
+
+  block.forEach((child, offset) => {
+    if (child.type.name !== "ruby") return;
+    const text = ((child.attrs.text as string) ?? "").replace(/\./g, "");
+    if (!text) return;
+
+    const from = blockContentStart + offset;
+    const projection: SearchTextProjection = { text: "", segments: [] };
+    appendSegment(projection, text, from, from + child.nodeSize, "ruby-text", false);
+    projections.push(projection);
+  });
+
+  return projections;
+}
+
+function appendSegment(
+  projection: SearchTextProjection,
+  text: string,
+  from: number,
+  to: number,
+  source: SearchMatchSource,
+  replaceable: boolean,
+): void {
+  if (!text) return;
+  const displayFrom = projection.text.length;
+  projection.text += text;
+  projection.segments.push({
+    text,
+    displayFrom,
+    displayTo: projection.text.length,
+    from,
+    to,
+    source,
+    replaceable,
+  });
+}
+
+function getDisplayedAtomText(node: Node): { text: string; source: SearchMatchSource } | null {
+  switch (node.type.name) {
+    case "ruby":
+      return { text: (node.attrs.base as string) ?? "", source: "ruby-base" };
+    case "tcy":
+      return { text: (node.attrs.value as string) ?? "", source: "tcy" };
+    case "nobreak":
+      return { text: (node.attrs.text as string) ?? "", source: "nobreak" };
+    case "kern":
+      return { text: (node.attrs.text as string) ?? "", source: "kern" };
+    case "hardbreak":
+      return { text: "\n", source: "hardbreak" };
+    case "mdibreak":
+      return { text: "\n", source: "mdibreak" };
+    default:
+      return null;
+  }
+}
+
+function searchProjection(
+  projection: SearchTextProjection,
+  searchTerm: string,
+  options: ResolvedSearchOptions,
+  metadata: Pick<SearchMatch, "heading" | "paragraphNumber">,
+): SearchMatch[] {
+  if (!projection.text || projection.segments.length === 0) return [];
+
+  const normalized = normalizeProjection(projection.text, options.normalizeVariants);
+  const normalizedTerm = options.normalizeVariants
+    ? normalizeJapaneseSearchVariants(searchTerm)
+    : searchTerm;
+  const pattern = compilePattern(normalizedTerm, options);
+  if (!pattern) return [];
+
+  const rawMatches = executePattern(normalized.text, normalizedTerm, pattern, options);
+  const matches: SearchMatch[] = [];
+
+  for (const rawMatch of rawMatches) {
+    const sourceFrom = normalized.sourceFrom[rawMatch.from];
+    const sourceTo = normalized.sourceTo[rawMatch.to - 1];
+    if (sourceFrom === undefined || sourceTo === undefined) continue;
+
+    const match = mapProjectionMatch(projection, sourceFrom, sourceTo, rawMatch.captures);
+    if (!match) continue;
+    if (options.range && (match.from < options.range.from || match.to > options.range.to)) continue;
+    matches.push({ ...match, ...metadata });
+  }
+
+  return matches;
+}
+
+function compilePattern(searchTerm: string, options: ResolvedSearchOptions): RegExp | null {
+  try {
+    const source = options.regex ? searchTerm : escapeRegExp(searchTerm);
+    return new RegExp(source, options.caseSensitive ? "gu" : "giu");
+  } catch {
+    return null;
+  }
+}
+
+function executePattern(
+  text: string,
+  searchTerm: string,
+  pattern: RegExp,
+  options: ResolvedSearchOptions,
+): RawMatch[] {
+  if (!searchTerm) return [];
+  const matches: RawMatch[] = [];
+  pattern.lastIndex = 0;
+
+  while (pattern.lastIndex <= text.length) {
+    const match = pattern.exec(text);
+    if (!match) break;
+
+    const matchedText = match[0] ?? "";
+    if (!matchedText) {
+      pattern.lastIndex = advanceCodePoint(text, match.index);
+      continue;
+    }
+
+    const to = match.index + matchedText.length;
+    if (!options.wholeWord || hasWordBoundaries(text, match.index, to)) {
+      matches.push({
+        from: match.index,
+        to,
+        captures: match.slice(1).map((capture) => capture ?? ""),
+      });
+    }
+  }
+
+  return matches;
+}
+
+function mapProjectionMatch(
+  projection: SearchTextProjection,
+  displayFrom: number,
+  displayTo: number,
+  captures: string[] | undefined,
+): SearchMatch | null {
+  const segments = projection.segments.filter(
+    (segment) => segment.displayFrom < displayTo && segment.displayTo > displayFrom,
+  );
+  const first = segments[0];
+  const last = segments.at(-1);
+  if (!first || !last) return null;
+
+  const from = first.replaceable
+    ? first.from + Math.max(0, displayFrom - first.displayFrom)
+    : first.from;
+  const to = last.replaceable
+    ? last.from + Math.min(last.text.length, displayTo - last.displayFrom)
+    : last.to;
+  const sources = new Set(segments.map((segment) => segment.source));
+
+  return {
+    from,
+    to,
+    text: projection.text.slice(displayFrom, displayTo),
+    source: sources.size === 1 ? first.source : "mixed",
+    replaceable: segments.every((segment) => segment.replaceable) && from < to,
+    captures,
+  };
+}
+
+function normalizeProjection(text: string, normalizeVariants: boolean): NormalizedProjection {
+  const projection: NormalizedProjection = { text: "", sourceFrom: [], sourceTo: [] };
+
+  for (const { segment, index: sourceIndex } of JAPANESE_GRAPHEME_SEGMENTER.segment(text)) {
+    const normalizedSegment = normalizeVariants
+      ? normalizeJapaneseSearchVariants(segment)
+      : segment;
+    projection.text += normalizedSegment;
+    for (let index = 0; index < normalizedSegment.length; index += 1) {
+      projection.sourceFrom.push(sourceIndex);
+      projection.sourceTo.push(sourceIndex + segment.length);
+    }
+  }
+
+  return projection;
+}
+
+function hasWordBoundaries(text: string, from: number, to: number): boolean {
+  return !isWordCharacter(codePointBefore(text, from)) && !isWordCharacter(codePointAt(text, to));
+}
+
+function isWordCharacter(value: string): boolean {
+  return value !== "" && WORD_CHAR_RE.test(value);
+}
+
+function codePointBefore(text: string, index: number): string {
+  return Array.from(text.slice(0, index)).at(-1) ?? "";
+}
+
+function codePointAt(text: string, index: number): string {
+  return Array.from(text.slice(index))[0] ?? "";
+}
+
+function advanceCodePoint(text: string, index: number): number {
+  if (index >= text.length) return text.length + 1;
+  const codePoint = text.codePointAt(index);
+  return index + (codePoint !== undefined && codePoint > 0xffff ? 2 : 1);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/lib/editor-page/japanese-variant-normalization.ts
+++ b/lib/editor-page/japanese-variant-normalization.ts
@@ -1,0 +1,31 @@
+import kyujitaiData from "kyujitai/data/kyujitai.json";
+
+interface KyujitaiData {
+  kyuji: Array<[shinjitai: string, kyujitai: string, variationSelector?: string]>;
+}
+
+const SHINJITAI_BY_KYUJITAI = new Map(
+  (kyujitaiData as unknown as KyujitaiData).kyuji
+    .filter(([shinjitai, kyujitai]) => shinjitai !== kyujitai)
+    .map(([shinjitai, kyujitai]) => [kyujitai, shinjitai] as const),
+);
+
+/**
+ * Normalizes width, kana script, and old character forms for search comparison.
+ * The kyujitai table is maintained by the `kyujitai` package rather than in
+ * search logic, so data changes remain independently reviewable.
+ */
+export function normalizeJapaneseSearchVariants(text: string): string {
+  let normalized = "";
+
+  for (const character of text.normalize("NFKC")) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const kana =
+      codePoint >= 0x30a1 && codePoint <= 0x30f6
+        ? String.fromCodePoint(codePoint - 0x60)
+        : character;
+    normalized += SHINJITAI_BY_KYUJITAI.get(kana) ?? kana;
+  }
+
+  return normalized;
+}

--- a/lib/editor-page/power-policy.ts
+++ b/lib/editor-page/power-policy.ts
@@ -103,26 +103,34 @@ export function getAutoSaveIntervalMs(
  *
  * Focus-dependent (#1466, restoring the PR #1427 CPU-saving requirement):
  * the expensive morphological highlighting is suspended while the window
- * is backgrounded or power-save mode is on, and resumes when the user
- * setting allows it. This is safe with respect to #1445 because the sole
- * consumer (use-pos-highlight-activation.ts) subscribes to the
- * framework-free window-activity service — no React re-render on focus
- * switches — and applies the decision via `updatePosHighlightSettings`,
- * which dispatches a meta-only transaction: decorations toggle, the
- * document, selection, and scroll are never touched.
+ * is backgrounded, and resumes when the user setting allows it. This is
+ * safe with respect to #1445 because the sole consumer
+ * (use-pos-highlight-activation.ts) subscribes to the framework-free
+ * window-activity service — no React re-render on focus switches — and
+ * applies the decision via `updatePosHighlightSettings`, which dispatches
+ * a meta-only transaction: decorations toggle, the document, selection,
+ * and scroll are never touched.
+ *
+ * NOTE: power-save mode no longer suspends POS highlighting. POS highlight
+ * decorations are cheap to keep once tokenized (the morphology runs for the
+ * vocabulary panel regardless), so gating them off in power-save only
+ * surprised users — a toggle that read ON while nothing was colored. Only
+ * the focus/background gate remains. `powerSaveMode` is intentionally not
+ * read here; it is still accepted in `settings` so callers can pass the
+ * shared `PowerPolicySettings` object unchanged.
  *
  * The user setting itself is never mutated; this returns an EFFECTIVE
  * value, so regaining focus restores exactly the user's choice.
  *
- * 品詞ハイライトを有効にすべきかどうか（#1466）。バックグラウンド中
- * または省電力モード中は重い形態素ハイライトを一時停止し、フォーカス
- * 復帰時にユーザー設定どおりの状態へ戻す。判断の適用は meta 専用
- * transaction による装飾の付け外しのみで、本文・選択・スクロールには
- * 一切触れない（#1445 ガード）。ユーザー設定自体は変更しない。
+ * 品詞ハイライトを有効にすべきかどうか（#1466）。バックグラウンド中は
+ * 重い形態素ハイライトを一時停止し、フォーカス復帰でユーザー設定どおりへ
+ * 戻す。省電力モードでは停止しない（トグル ON なのに無色になる UX を回避）。
+ * 判断の適用は meta 専用 transaction による装飾の付け外しのみで、本文・
+ * 選択・スクロールには一切触れない（#1445 ガード）。設定自体は変更しない。
  */
 export function shouldEnablePosHighlight(
   activity: WindowActivityState,
   settings: PowerPolicySettings & { posHighlightEnabled: boolean },
 ): boolean {
-  return settings.posHighlightEnabled && !settings.powerSaveMode && !isBackground(activity);
+  return settings.posHighlightEnabled && !isBackground(activity);
 }

--- a/lib/editor-page/project-search-worker-client.ts
+++ b/lib/editor-page/project-search-worker-client.ts
@@ -1,0 +1,102 @@
+import type { SearchOptions } from "./find-search-matches";
+import type { ProjectDocumentMatcher, RawDocumentSearchResult } from "./project-search";
+
+export interface ProjectSearchWorkerRequest {
+  type: "MATCH_DOCUMENT";
+  id: number;
+  content: string;
+  fileType: string;
+  searchTerm: string;
+  options: SearchOptions;
+}
+
+export type ProjectSearchWorkerResponse =
+  | {
+      type: "MATCH_RESULT";
+      id: number;
+      result: RawDocumentSearchResult;
+    }
+  | {
+      type: "MATCH_ERROR";
+      id: number;
+      error: { name: string; message: string };
+    };
+
+export type ProjectSearchWorkerFactory = () => Worker;
+
+const defaultWorkerFactory: ProjectSearchWorkerFactory = () =>
+  new Worker(new URL("./project-search.worker.ts", import.meta.url), { type: "module" });
+
+interface PendingMatch {
+  resolve: (result: RawDocumentSearchResult) => void;
+  reject: (error: Error) => void;
+}
+
+export class ProjectSearchWorkerClient {
+  private readonly worker: Worker;
+  private readonly pending = new Map<number, PendingMatch>();
+  private nextId = 1;
+  private disposed = false;
+  private fatalError: Error | null = null;
+
+  readonly matchDocument: ProjectDocumentMatcher = (content, fileType, searchTerm, options) => {
+    if (this.fatalError) return Promise.reject(this.fatalError);
+    if (this.disposed) return Promise.reject(new Error("Project search worker is disposed"));
+
+    const id = this.nextId++;
+    const result = new Promise<RawDocumentSearchResult>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+    this.worker.postMessage({
+      type: "MATCH_DOCUMENT",
+      id,
+      content,
+      fileType,
+      searchTerm,
+      options,
+    } satisfies ProjectSearchWorkerRequest);
+    return result;
+  };
+
+  constructor(factory: ProjectSearchWorkerFactory = defaultWorkerFactory) {
+    this.worker = factory();
+    this.worker.onmessage = (event: MessageEvent<ProjectSearchWorkerResponse>) => {
+      const message = event.data;
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+
+      if (message.type === "MATCH_RESULT") {
+        pending.resolve(message.result);
+        return;
+      }
+
+      const error = new Error(message.error.message);
+      error.name = message.error.name;
+      pending.reject(error);
+    };
+    this.worker.onerror = (event) => {
+      this.poison(new Error(event.message || "Project search worker failed"));
+    };
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.rejectAll(new Error("Project search worker is disposed"));
+    this.worker.terminate();
+  }
+
+  private rejectAll(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+
+  private poison(error: Error): void {
+    if (this.fatalError) return;
+    this.fatalError = error;
+    this.disposed = true;
+    this.rejectAll(error);
+    this.worker.terminate();
+  }
+}

--- a/lib/editor-page/project-search.ts
+++ b/lib/editor-page/project-search.ts
@@ -294,10 +294,7 @@ function createPlainProjection(content: string): SearchTextProjection {
   };
 }
 
-function createMarkdownProjection(
-  content: string,
-  excludeComments: boolean,
-): SearchTextProjection {
+function createMarkdownProjection(content: string, excludeComments: boolean): SearchTextProjection {
   const projection: SearchTextProjection = { text: "", segments: [] };
   const commentPattern = /<!--[\s\S]*?-->/g;
   let cursor = 0;
@@ -360,14 +357,7 @@ function createMdiProjections(
       appendProjectionSegment(body, content.slice(cursor, rawFrom), cursor, rawFrom, "text", true);
     }
 
-    appendMdiToken(
-      body,
-      rubyReadings,
-      token,
-      rawFrom,
-      rawFrom + token.length,
-      excludeComments,
-    );
+    appendMdiToken(body, rubyReadings, token, rawFrom, rawFrom + token.length, excludeComments);
     cursor = rawFrom + token.length;
   }
 

--- a/lib/editor-page/project-search.ts
+++ b/lib/editor-page/project-search.ts
@@ -1,0 +1,531 @@
+import {
+  createReplacementSteps,
+  findSearchMatchesInProjection,
+  type SearchMatch,
+  type SearchMatchSource,
+  type SearchOptions,
+  type SearchTextProjection,
+} from "./find-search-matches";
+import type { VirtualFileSystem } from "@/lib/vfs/types";
+
+export interface RawDocumentSearchMatch extends SearchMatch {
+  rawFrom: number;
+  rawTo: number;
+  lineNumber: number;
+}
+
+export interface RawDocumentSearchResult {
+  matches: RawDocumentSearchMatch[];
+  content: string;
+}
+
+export interface ProjectSearchFileResult extends RawDocumentSearchResult {
+  path: string;
+  fileName: string;
+}
+
+export interface SearchProjectFilesParams {
+  vfs: VirtualFileSystem;
+  searchTerm: string;
+  options: SearchOptions;
+  rootPath?: string;
+  openBuffers?: ReadonlyMap<string, string>;
+  signal?: AbortSignal;
+  onProgress?: (searchedFiles: number, totalFiles: number) => void;
+  onFileResult?: (result: ProjectSearchFileResult) => void;
+  onFileError?: (path: string, error: unknown) => void;
+  matchDocument?: ProjectDocumentMatcher;
+}
+
+export type ProjectDocumentMatcher = (
+  content: string,
+  fileType: string,
+  searchTerm: string,
+  options: SearchOptions,
+) => RawDocumentSearchResult | Promise<RawDocumentSearchResult>;
+
+export interface ProjectReplacementChange {
+  path: string;
+  before: string;
+  after: string;
+  replacementCount: number;
+  openBuffer: boolean;
+}
+
+interface ReplaceProjectFilesParams {
+  vfs: VirtualFileSystem;
+  results: readonly ProjectSearchFileResult[];
+  replacement: string;
+  options: SearchOptions;
+  openBuffers?: ReadonlyMap<string, string>;
+  onOpenBufferChange?: (path: string, content: string) => void | Promise<void>;
+}
+
+interface UndoProjectReplacementParams {
+  vfs: VirtualFileSystem;
+  changes: readonly ProjectReplacementChange[];
+  openBuffers?: ReadonlyMap<string, string>;
+  onOpenBufferChange?: (path: string, content: string) => void | Promise<void>;
+}
+
+const SEARCHABLE_EXTENSIONS = new Set([".mdi", ".md", ".txt"]);
+const PROJECT_SEARCH_YIELD_INTERVAL = 8;
+const MDI_TOKEN_RE =
+  /<!--[\s\S]*?-->|\{[^{}|\n]+\|[^{}\n]+\}|\^[^^\n]+\^|\[\[(?:blank|br|no-break:[^\]\n]*|kern:[^:\]\n]+:[^\]\n]*)\]\]/g;
+
+export function isSearchableProjectPath(path: string): boolean {
+  if (hasHiddenPathSegment(path)) return false;
+  const fileName = normalizePath(path).split("/").at(-1) ?? "";
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex < 0) return false;
+  return SEARCHABLE_EXTENSIONS.has(fileName.slice(dotIndex).toLowerCase());
+}
+
+export async function searchProjectFiles({
+  vfs,
+  searchTerm,
+  options,
+  rootPath = "",
+  openBuffers = new Map(),
+  signal,
+  onProgress,
+  onFileResult,
+  onFileError,
+  matchDocument = findRawDocumentMatches,
+}: SearchProjectFilesParams): Promise<ProjectSearchFileResult[]> {
+  if (!searchTerm) return [];
+
+  const paths = await collectSearchablePaths(vfs, rootPath, signal);
+  const results: ProjectSearchFileResult[] = [];
+
+  for (let index = 0; index < paths.length; index += 1) {
+    throwIfAborted(signal);
+    const path = paths[index];
+
+    try {
+      const content = openBuffers.get(path) ?? (await vfs.readFile(path));
+      const fileType = getFileExtension(path);
+      const result = await matchDocument(content, fileType, searchTerm, options);
+      if (result.matches.length > 0) {
+        const fileResult = {
+          ...result,
+          path,
+          fileName: path.split("/").at(-1) ?? path,
+        };
+        results.push(fileResult);
+        onFileResult?.(fileResult);
+      }
+    } catch (error) {
+      onFileError?.(path, error);
+    }
+
+    onProgress?.(index + 1, paths.length);
+    if ((index + 1) % PROJECT_SEARCH_YIELD_INTERVAL === 0) await yieldToMainThread();
+  }
+
+  return results;
+}
+
+export function findRawDocumentMatches(
+  content: string,
+  fileType: string,
+  searchTerm: string,
+  options: SearchOptions,
+): RawDocumentSearchResult {
+  if (!searchTerm) return { content, matches: [] };
+
+  const normalizedFileType = fileType.toLowerCase();
+  const { body, rubyReadings } =
+    normalizedFileType === ".mdi"
+      ? createMdiProjections(content, options.excludeComments ?? true)
+      : {
+          body:
+            normalizedFileType === ".md"
+              ? createMarkdownProjection(content, options.excludeComments ?? true)
+              : createPlainProjection(content),
+          rubyReadings: [],
+        };
+  const target = options.searchTarget ?? "all";
+  const matches: SearchMatch[] = [];
+
+  if (target !== "ruby") {
+    matches.push(...findSearchMatchesInProjection(body, searchTerm, options));
+  }
+  if (target !== "body") {
+    for (const reading of rubyReadings) {
+      matches.push(...findSearchMatchesInProjection(reading, searchTerm, options));
+    }
+  }
+
+  return {
+    content,
+    matches: matches
+      .map((match) => addRawMatchMetadata(content, match))
+      .sort((left, right) => left.rawFrom - right.rawFrom || left.rawTo - right.rawTo),
+  };
+}
+
+export async function replaceProjectFiles({
+  vfs,
+  results,
+  replacement,
+  options,
+  openBuffers = new Map(),
+  onOpenBufferChange,
+}: ReplaceProjectFilesParams): Promise<ProjectReplacementChange[]> {
+  const plans: Array<{
+    result: ProjectSearchFileResult;
+    nextContent: string;
+    replacementCount: number;
+    openBuffer: boolean;
+  }> = [];
+  const changes: ProjectReplacementChange[] = [];
+
+  for (const result of results) {
+    if (!isSearchableProjectPath(result.path)) continue;
+    const steps = createReplacementSteps(result.matches, replacement, options);
+    if (steps.length === 0) continue;
+
+    const openBuffer = openBuffers.has(result.path);
+    const currentContent = openBuffer
+      ? (openBuffers.get(result.path) ?? "")
+      : await vfs.readFile(result.path);
+    if (currentContent !== result.content) {
+      throw new Error(`${result.path} は検索後に内容が変更されました`);
+    }
+
+    let nextContent = result.content;
+    for (const step of steps) {
+      nextContent = nextContent.slice(0, step.from) + step.text + nextContent.slice(step.to);
+    }
+    plans.push({ result, nextContent, replacementCount: steps.length, openBuffer });
+  }
+
+  try {
+    for (const plan of plans) {
+      const { result, nextContent, replacementCount, openBuffer } = plan;
+      if (openBuffer) {
+        if (!onOpenBufferChange) {
+          throw new Error(`Open buffer update handler is missing for ${result.path}`);
+        }
+        await onOpenBufferChange(result.path, nextContent);
+      } else {
+        await vfs.writeFile(result.path, nextContent);
+      }
+
+      changes.push({
+        path: result.path,
+        before: result.content,
+        after: nextContent,
+        replacementCount,
+        openBuffer,
+      });
+    }
+  } catch (error) {
+    await restoreProjectChanges(vfs, changes, onOpenBufferChange);
+    throw error;
+  }
+
+  return changes;
+}
+
+export async function undoProjectReplacement({
+  vfs,
+  changes,
+  openBuffers = new Map(),
+  onOpenBufferChange,
+}: UndoProjectReplacementParams): Promise<void> {
+  for (const change of changes) {
+    const currentContent = change.openBuffer
+      ? openBuffers.get(change.path)
+      : await vfs.readFile(change.path);
+    if (currentContent !== change.after) {
+      throw new Error(`${change.path} は置換後に内容が変更されました`);
+    }
+  }
+  await restoreProjectChanges(vfs, [...changes].reverse(), onOpenBufferChange);
+}
+
+async function collectSearchablePaths(
+  vfs: VirtualFileSystem,
+  rootPath: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  if (rootPath && hasHiddenPathSegment(rootPath)) return [];
+  const paths: string[] = [];
+
+  async function visit(directoryPath: string): Promise<void> {
+    throwIfAborted(signal);
+    const entries = [...(await vfs.listDirectory(directoryPath))].sort((left, right) =>
+      left.path.localeCompare(right.path),
+    );
+
+    for (const entry of entries) {
+      throwIfAborted(signal);
+      if (hasHiddenPathSegment(entry.path)) continue;
+      if (entry.kind === "directory") {
+        await visit(entry.path);
+      } else if (isSearchableProjectPath(entry.path)) {
+        paths.push(entry.path);
+      }
+    }
+  }
+
+  await visit(rootPath);
+  return paths;
+}
+
+function createPlainProjection(content: string): SearchTextProjection {
+  return {
+    text: content,
+    segments: content
+      ? [
+          {
+            text: content,
+            displayFrom: 0,
+            displayTo: content.length,
+            from: 0,
+            to: content.length,
+            source: "text",
+            replaceable: true,
+          },
+        ]
+      : [],
+  };
+}
+
+function createMarkdownProjection(
+  content: string,
+  excludeComments: boolean,
+): SearchTextProjection {
+  const projection: SearchTextProjection = { text: "", segments: [] };
+  const commentPattern = /<!--[\s\S]*?-->/g;
+  let cursor = 0;
+
+  for (const match of content.matchAll(commentPattern)) {
+    const rawFrom = match.index;
+    if (rawFrom > cursor) {
+      appendProjectionSegment(
+        projection,
+        content.slice(cursor, rawFrom),
+        cursor,
+        rawFrom,
+        "text",
+        true,
+      );
+    }
+    if (!excludeComments) {
+      appendProjectionSegment(
+        projection,
+        match[0].replace(/^<!--\s*|\s*-->$/g, ""),
+        rawFrom,
+        rawFrom + match[0].length,
+        "comment",
+        false,
+      );
+    }
+    cursor = rawFrom + match[0].length;
+  }
+
+  if (cursor < content.length) {
+    appendProjectionSegment(
+      projection,
+      content.slice(cursor),
+      cursor,
+      content.length,
+      "text",
+      true,
+    );
+  }
+
+  return projection;
+}
+
+function createMdiProjections(
+  content: string,
+  excludeComments: boolean,
+): {
+  body: SearchTextProjection;
+  rubyReadings: SearchTextProjection[];
+} {
+  const body: SearchTextProjection = { text: "", segments: [] };
+  const rubyReadings: SearchTextProjection[] = [];
+  let cursor = 0;
+
+  MDI_TOKEN_RE.lastIndex = 0;
+  for (const tokenMatch of content.matchAll(MDI_TOKEN_RE)) {
+    const rawFrom = tokenMatch.index;
+    const token = tokenMatch[0];
+    if (rawFrom > cursor) {
+      appendProjectionSegment(body, content.slice(cursor, rawFrom), cursor, rawFrom, "text", true);
+    }
+
+    appendMdiToken(
+      body,
+      rubyReadings,
+      token,
+      rawFrom,
+      rawFrom + token.length,
+      excludeComments,
+    );
+    cursor = rawFrom + token.length;
+  }
+
+  if (cursor < content.length) {
+    appendProjectionSegment(body, content.slice(cursor), cursor, content.length, "text", true);
+  }
+
+  return { body, rubyReadings };
+}
+
+function appendMdiToken(
+  body: SearchTextProjection,
+  rubyReadings: SearchTextProjection[],
+  token: string,
+  rawFrom: number,
+  rawTo: number,
+  excludeComments: boolean,
+): void {
+  if (token.startsWith("<!--")) {
+    if (!excludeComments) {
+      appendProjectionSegment(
+        body,
+        token.replace(/^<!--\s*|\s*-->$/g, ""),
+        rawFrom,
+        rawTo,
+        "comment",
+        false,
+      );
+    }
+    return;
+  }
+
+  const ruby = /^\{([^{}|\n]+)\|([^{}\n]+)\}$/.exec(token);
+  if (ruby) {
+    appendProjectionSegment(body, ruby[1], rawFrom, rawTo, "ruby-base", false);
+    const reading: SearchTextProjection = { text: "", segments: [] };
+    appendProjectionSegment(
+      reading,
+      ruby[2].replace(/\./g, ""),
+      rawFrom,
+      rawTo,
+      "ruby-text",
+      false,
+    );
+    rubyReadings.push(reading);
+    return;
+  }
+
+  const tcy = /^\^([^^\n]+)\^$/.exec(token);
+  if (tcy) {
+    appendProjectionSegment(body, tcy[1], rawFrom, rawTo, "tcy", false);
+    return;
+  }
+
+  const noBreak = /^\[\[no-break:([^\]\n]*)\]\]$/.exec(token);
+  if (noBreak) {
+    appendProjectionSegment(body, noBreak[1], rawFrom, rawTo, "nobreak", false);
+    return;
+  }
+
+  const kern = /^\[\[kern:[^:\]\n]+:([^\]\n]*)\]\]$/.exec(token);
+  if (kern) {
+    appendProjectionSegment(body, kern[1], rawFrom, rawTo, "kern", false);
+    return;
+  }
+
+  if (token === "[[blank]]" || token === "[[br]]") {
+    appendProjectionSegment(body, "\n", rawFrom, rawTo, "mdibreak", false);
+  }
+}
+
+function appendProjectionSegment(
+  projection: SearchTextProjection,
+  text: string,
+  from: number,
+  to: number,
+  source: SearchMatchSource,
+  replaceable: boolean,
+): void {
+  if (!text) return;
+  const displayFrom = projection.text.length;
+  projection.text += text;
+  projection.segments.push({
+    text,
+    displayFrom,
+    displayTo: projection.text.length,
+    from,
+    to,
+    source,
+    replaceable,
+  });
+}
+
+function addRawMatchMetadata(content: string, match: SearchMatch): RawDocumentSearchMatch {
+  const rawFrom = match.from;
+  const rawTo = match.to;
+  const before = content.slice(0, rawFrom);
+  const lineNumber = before.split("\n").length;
+  const heading = findPreviousHeading(before);
+
+  return {
+    ...match,
+    rawFrom,
+    rawTo,
+    lineNumber,
+    paragraphNumber: lineNumber,
+    heading,
+  };
+}
+
+function findPreviousHeading(content: string): string | undefined {
+  const lines = content.split("\n");
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const heading = /^#{1,6}\s+(.+?)\s*$/.exec(lines[index]);
+    if (heading) return heading[1];
+  }
+  return undefined;
+}
+
+function hasHiddenPathSegment(path: string): boolean {
+  return normalizePath(path)
+    .split("/")
+    .filter(Boolean)
+    .some((segment) => segment.startsWith("."));
+}
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
+function getFileExtension(path: string): string {
+  const fileName = normalizePath(path).split("/").at(-1) ?? "";
+  const dotIndex = fileName.lastIndexOf(".");
+  return dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : "";
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  throw new DOMException("Project search was cancelled", "AbortError");
+}
+
+function yieldToMainThread(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function restoreProjectChanges(
+  vfs: VirtualFileSystem,
+  changes: readonly ProjectReplacementChange[],
+  onOpenBufferChange?: (path: string, content: string) => void | Promise<void>,
+): Promise<void> {
+  for (const change of changes) {
+    if (change.openBuffer) {
+      if (!onOpenBufferChange) {
+        throw new Error(`Open buffer update handler is missing for ${change.path}`);
+      }
+      await onOpenBufferChange(change.path, change.before);
+    } else {
+      await vfs.writeFile(change.path, change.before);
+    }
+  }
+}

--- a/lib/editor-page/project-search.worker.ts
+++ b/lib/editor-page/project-search.worker.ts
@@ -1,0 +1,36 @@
+/// <reference lib="webworker" />
+
+import { findRawDocumentMatches } from "./project-search";
+import type {
+  ProjectSearchWorkerRequest,
+  ProjectSearchWorkerResponse,
+} from "./project-search-worker-client";
+
+declare const self: DedicatedWorkerGlobalScope;
+
+function post(message: ProjectSearchWorkerResponse): void {
+  self.postMessage(message);
+}
+
+self.onmessage = (event: MessageEvent<ProjectSearchWorkerRequest>) => {
+  const message = event.data;
+  try {
+    post({
+      type: "MATCH_RESULT",
+      id: message.id,
+      result: findRawDocumentMatches(
+        message.content,
+        message.fileType,
+        message.searchTerm,
+        message.options,
+      ),
+    });
+  } catch (error) {
+    const cause = error instanceof Error ? error : new Error(String(error));
+    post({
+      type: "MATCH_ERROR",
+      id: message.id,
+      error: { name: cause.name, message: cause.message },
+    });
+  }
+};

--- a/lib/editor-page/search-history.ts
+++ b/lib/editor-page/search-history.ts
@@ -1,0 +1,20 @@
+import { localPreferences } from "@/lib/storage/local-preferences";
+
+const SEARCH_HISTORY_LIMIT = 10;
+
+export function loadSearchHistory(): string[] {
+  return localPreferences.getSearchHistory().slice(0, SEARCH_HISTORY_LIMIT);
+}
+
+export function addSearchHistoryEntry(searchTerm: string): string[] {
+  const normalizedTerm = searchTerm.trim();
+  if (!normalizedTerm) return loadSearchHistory();
+
+  const next = [
+    normalizedTerm,
+    ...loadSearchHistory().filter((entry) => entry !== normalizedTerm),
+  ].slice(0, SEARCH_HISTORY_LIMIT);
+
+  localPreferences.setSearchHistory(next);
+  return next;
+}

--- a/lib/editor-page/text-statistics.ts
+++ b/lib/editor-page/text-statistics.ts
@@ -60,10 +60,11 @@ const LINE_END_PROHIBITED = new Set("（〔［｛〈《「『【".split(""));
  *  6. MDI 縦中横 (`^内容^`) → 内容のみ
  *  7. MDI no-break (`[[no-break:文字列]]`) → 文字列のみ
  *  8. MDI kern (`[[kern:量:文字列]]`) → 文字列のみ
- *  9. HTML タグ (`<tag>`) → タグ記号のみ除去、内容は残す
- * 10. Markdown 見出し記号（行頭の `#+ `）→ 除去（本文は残す）
- * 11. 強調記号 (`**...**`, `__...__`, `*...*`, `_..._`, `~~...~~`) → 内容は残す
- * 12. バックスラッシュエスケープ (`\X`) → バックスラッシュのみ除去
+ *  9. MDI 空行マーカー (`[[blank]]` / serializer エスケープ形 `\[\[blank]]`) → 行ごと削除
+ * 10. HTML タグ (`<tag>`) → タグ記号のみ除去、内容は残す
+ * 11. Markdown 見出し記号（行頭の `#+ `）→ 除去（本文は残す）
+ * 12. 強調記号 (`**...**`, `__...__`, `*...*`, `_..._`, `~~...~~`) → 内容は残す
+ * 13. バックスラッシュエスケープ (`\X`) → バックスラッシュのみ除去
  */
 export function extractVisibleText(rawContent: string): string {
   let text = rawContent;
@@ -92,13 +93,18 @@ export function extractVisibleText(rawContent: string): string {
   // 8. MDI kern [[kern:量:文字列]] → 文字列のみ
   text = text.replace(/\[\[kern:[^\]]*?:([^\]]*)\]\]/g, "$1");
 
-  // 9. HTML タグ → タグ記号を除去、内容は残す
+  // 9. MDI 空行マーカー [[blank]] → 行ごと削除（可視文字としてカウントしない）。
+  // ライブ編集中の content は serializer が `[` をエスケープするため `\[\[blank]]`
+  // となる。各ブラケット前の `\` を任意マッチさせ、クリーン形・エスケープ形の双方を除去する。
+  text = text.replace(/^[ \t]*\\?\[\\?\[blank\\?\]\\?\][ \t]*$/gm, "");
+
+  // 10. HTML タグ → タグ記号を除去、内容は残す
   text = text.replace(/<[^>]*>/g, "");
 
-  // 10. Markdown 見出し記号（行頭の # 記号と直後のスペース）
+  // 11. Markdown 見出し記号（行頭の # 記号と直後のスペース）
   text = text.replace(/^#{1,6} /gm, "");
 
-  // 11. 強調記号のみ除去（内容は残す）
+  // 12. 強調記号のみ除去（内容は残す）
   // ** と __ を先に処理してから単体 * と _ を処理する順番を守ること。
   text = text.replace(/~~([^~]*)~~/g, "$1");
   text = text.replace(/\*\*([^*]*)\*\*/g, "$1");
@@ -108,7 +114,7 @@ export function extractVisibleText(rawContent: string): string {
   text = text.replace(/(?<!\*)\*(?!\*)([^*\n]+?)(?<!\*)\*(?!\*)/g, "$1");
   text = text.replace(/(?<!\w)_(?!_)([^_\n]+?)_(?!\w)(?!_)/g, "$1");
 
-  // 12. バックスラッシュエスケープ（バックスラッシュのみ除去）
+  // 13. バックスラッシュエスケープ（バックスラッシュのみ除去）
   text = text.replace(/\\(.)/g, "$1");
 
   return text;

--- a/lib/editor-page/use-ai-settings.ts
+++ b/lib/editor-page/use-ai-settings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { fetchAppState, persistAppState } from "@/lib/storage/app-state-manager";
 import { configureAiClient, resetAiClient } from "@/lib/ai/ai-client";
@@ -39,6 +39,8 @@ export interface AiSettingsHandlers {
   handleCharacterExtractionBatchSizeChange: (value: number) => void;
   handleCharacterExtractionConcurrencyChange: (value: number) => void;
   handlePowerSaveModeChange: (enabled: boolean) => Promise<void>;
+  /** Lift power-save mode for a few minutes, then restore it (default 5 min). */
+  temporarilyDisablePowerSave: (durationMs?: number) => void;
   handleAutoPowerSaveOnBatteryChange: (enabled: boolean) => void;
   handleCorrectionConfigChange: (partial: Partial<CorrectionConfig>) => void;
   handleAiApiKeyChange: (apiKey: string) => void;
@@ -78,6 +80,20 @@ export function useAiSettings(): UseAiSettingsResult {
   const [correctionGuidelines, setCorrectionGuidelines] = useState<GuidelineId[]>(
     DEFAULT_CORRECTION_CONFIG.guidelines,
   );
+
+  // Latest-value refs so power-save handlers can stay identity-stable
+  // (deps: []). Without this, `handlePowerSaveModeChange` was re-created on
+  // every `lintingEnabled` change, which re-subscribed `usePowerSaving` and
+  // re-fired the battery auto-trigger — the loop that made power-save
+  // impossible to turn off on battery and clobbered `prePowerSaveState`.
+  const lintingEnabledRef = useRef(lintingEnabled);
+  lintingEnabledRef.current = lintingEnabled;
+  const lintingRuleConfigsRef = useRef(lintingRuleConfigs);
+  lintingRuleConfigsRef.current = lintingRuleConfigs;
+  const powerSaveModeRef = useRef(powerSaveMode);
+  powerSaveModeRef.current = powerSaveMode;
+  /** Pending timer for "temporarily disable power-save for N minutes". */
+  const tempPowerSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const applyPersistedAiSettings = useCallback((appState: Record<string, unknown>) => {
     if (typeof appState.lintingEnabled === "boolean") setLintingEnabled(appState.lintingEnabled);
@@ -227,10 +243,28 @@ export function useAiSettings(): UseAiSettingsResult {
     [],
   );
 
+  const clearTempPowerSaveTimer = useCallback(() => {
+    if (tempPowerSaveTimerRef.current !== null) {
+      clearTimeout(tempPowerSaveTimerRef.current);
+      tempPowerSaveTimerRef.current = null;
+    }
+  }, []);
+
   const handlePowerSaveModeChange = useCallback(
     async (enabled: boolean) => {
+      // Any explicit power-save change cancels a pending "5-minute" re-enable
+      // (e.g. the user plugged into AC, which auto-disables power-save).
+      clearTempPowerSaveTimer();
       if (enabled) {
-        const snapshot = { lintingEnabled, lintingRuleConfigs };
+        // Clobber guard: only snapshot the linting state on the OFF -> ON
+        // transition. Re-entering while already ON would overwrite
+        // `prePowerSaveState` with the already-suppressed `lintingEnabled:false`,
+        // permanently losing the user's real setting.
+        if (powerSaveModeRef.current) return;
+        const snapshot = {
+          lintingEnabled: lintingEnabledRef.current,
+          lintingRuleConfigs: lintingRuleConfigsRef.current,
+        };
         await persistAppState({
           powerSaveMode: true,
           prePowerSaveState: snapshot,
@@ -239,6 +273,12 @@ export function useAiSettings(): UseAiSettingsResult {
         setPowerSaveMode(true);
         setLintingEnabled(false);
       } else {
+        if (!powerSaveModeRef.current) {
+          // Already off — just make sure the persisted flag is clean.
+          await persistAppState({ powerSaveMode: false, prePowerSaveState: null });
+          setPowerSaveMode(false);
+          return;
+        }
         const stored = await fetchAppState();
         const prev = stored?.prePowerSaveState;
         if (prev) {
@@ -256,8 +296,33 @@ export function useAiSettings(): UseAiSettingsResult {
         setPowerSaveMode(false);
       }
     },
-    [lintingEnabled, lintingRuleConfigs],
+    [clearTempPowerSaveTimer],
   );
+
+  /**
+   * Temporarily lift power-save mode for `durationMs`, then restore it.
+   * Lets the user run the proofreader for a few minutes without permanently
+   * turning off battery saving. Restoring re-snapshots the (now restored)
+   * linting state, so the round-trip is lossless.
+   */
+  const temporarilyDisablePowerSave = useCallback(
+    (durationMs: number = 5 * 60 * 1000) => {
+      // Await the OFF transition (which also clears any existing timer) before
+      // scheduling the re-enable, so the OFF state is committed first and the
+      // re-enable's clobber guard never sees a stale "still on" ref.
+      void (async () => {
+        await handlePowerSaveModeChange(false);
+        tempPowerSaveTimerRef.current = setTimeout(() => {
+          tempPowerSaveTimerRef.current = null;
+          void handlePowerSaveModeChange(true);
+        }, durationMs);
+      })();
+    },
+    [handlePowerSaveModeChange],
+  );
+
+  // Clear the pending re-enable timer on unmount.
+  useEffect(() => clearTempPowerSaveTimer, [clearTempPowerSaveTimer]);
 
   const handleAutoPowerSaveOnBatteryChange = useCallback((enabled: boolean) => {
     setAutoPowerSaveOnBattery(enabled);
@@ -303,6 +368,7 @@ export function useAiSettings(): UseAiSettingsResult {
       handleCharacterExtractionBatchSizeChange,
       handleCharacterExtractionConcurrencyChange,
       handlePowerSaveModeChange,
+      temporarilyDisablePowerSave,
       handleAutoPowerSaveOnBatteryChange,
       handleCorrectionConfigChange,
       handleAiApiKeyChange,

--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -108,6 +108,7 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
     handleCharacterExtractionConcurrencyChange:
       aiHandlers.handleCharacterExtractionConcurrencyChange,
     handlePowerSaveModeChange: aiHandlers.handlePowerSaveModeChange,
+    temporarilyDisablePowerSave: aiHandlers.temporarilyDisablePowerSave,
     handleAutoPowerSaveOnBatteryChange: aiHandlers.handleAutoPowerSaveOnBatteryChange,
     handleCorrectionConfigChange: aiHandlers.handleCorrectionConfigChange,
     handleDictAutoCheckUpdatesChange: dictHandlers.handleDictAutoCheckUpdatesChange,

--- a/lib/editor-page/use-panel-state.ts
+++ b/lib/editor-page/use-panel-state.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from "react";
 import type { ActivityBarView } from "@/components/ActivityBar";
 import { isBottomView } from "@/components/ActivityBar";
 import type { SettingsCategory } from "@/components/SettingsModal";
+import type { SearchTarget } from "./find-search-matches";
 
 export interface PanelState {
   topView: ActivityBarView;
@@ -12,6 +13,12 @@ export interface PanelState {
    *  （サイドパネル）の両方がこれを共有し、内容のズレを防ぐ。 */
   searchTerm: string;
   caseSensitive: boolean;
+  regexSearch: boolean;
+  wholeWordSearch: boolean;
+  normalizeVariants: boolean;
+  excludeComments: boolean;
+  searchTarget: SearchTarget;
+  selectionOnly: boolean;
   /** 現在フォーカス中のマッチ index。両 UI のナビ／クリックで共有更新する。 */
   currentMatchIndex: number;
   isRightPanelCollapsed: boolean;
@@ -36,6 +43,12 @@ export interface PanelHandlers {
   handleOpenDictionary: (searchTerm?: string) => void;
   setSearchTerm: (term: string) => void;
   setCaseSensitive: Dispatch<SetStateAction<boolean>>;
+  setRegexSearch: Dispatch<SetStateAction<boolean>>;
+  setWholeWordSearch: Dispatch<SetStateAction<boolean>>;
+  setNormalizeVariants: Dispatch<SetStateAction<boolean>>;
+  setExcludeComments: Dispatch<SetStateAction<boolean>>;
+  setSearchTarget: Dispatch<SetStateAction<SearchTarget>>;
+  setSelectionOnly: Dispatch<SetStateAction<boolean>>;
   setCurrentMatchIndex: Dispatch<SetStateAction<number>>;
   /** サイドバー検索パネルを開く（共有 searchTerm をそのまま表示）。 */
   handleShowAllSearchResults: () => void;
@@ -61,6 +74,12 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
   const [bottomView, setBottomView] = useState<ActivityBarView>("none");
   const [searchTerm, setSearchTermRaw] = useState("");
   const [caseSensitive, setCaseSensitive] = useState(false);
+  const [regexSearch, setRegexSearch] = useState(false);
+  const [wholeWordSearch, setWholeWordSearch] = useState(false);
+  const [normalizeVariants, setNormalizeVariants] = useState(false);
+  const [excludeComments, setExcludeComments] = useState(true);
+  const [searchTarget, setSearchTarget] = useState<SearchTarget>("all");
+  const [selectionOnly, setSelectionOnly] = useState(false);
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
   const [isRightPanelCollapsed, setIsRightPanelCollapsed] = useState(false);
   const [dictionarySearchTrigger, setDictionarySearchTrigger] = useState<{
@@ -136,6 +155,12 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
       bottomView,
       searchTerm,
       caseSensitive,
+      regexSearch,
+      wholeWordSearch,
+      normalizeVariants,
+      excludeComments,
+      searchTarget,
+      selectionOnly,
       currentMatchIndex,
       isRightPanelCollapsed,
       dictionarySearchTrigger,
@@ -156,6 +181,12 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
       handleOpenDictionary,
       setSearchTerm,
       setCaseSensitive,
+      setRegexSearch,
+      setWholeWordSearch,
+      setNormalizeVariants,
+      setExcludeComments,
+      setSearchTarget,
+      setSelectionOnly,
       setCurrentMatchIndex,
       handleShowAllSearchResults,
       handleCloseSearchResults,

--- a/lib/editor-page/use-panel-state.ts
+++ b/lib/editor-page/use-panel-state.ts
@@ -8,7 +8,12 @@ import type { SettingsCategory } from "@/components/SettingsModal";
 export interface PanelState {
   topView: ActivityBarView;
   bottomView: ActivityBarView;
-  searchResults: { matches: { from: number; to: number }[]; searchTerm: string } | null;
+  /** 単一の検索 source of truth。SearchDialog（フローティング窓）と SearchResults
+   *  （サイドパネル）の両方がこれを共有し、内容のズレを防ぐ。 */
+  searchTerm: string;
+  caseSensitive: boolean;
+  /** 現在フォーカス中のマッチ index。両 UI のナビ／クリックで共有更新する。 */
+  currentMatchIndex: number;
   isRightPanelCollapsed: boolean;
   dictionarySearchTrigger: { term: string; id: number };
   settingsInitialCategory: SettingsCategory | undefined;
@@ -29,7 +34,11 @@ export interface PanelHandlers {
     diff: { snapshotContent: string; currentContent: string; label: string } | null,
   ) => void;
   handleOpenDictionary: (searchTerm?: string) => void;
-  handleShowAllSearchResults: (matches: { from: number; to: number }[], searchTerm: string) => void;
+  setSearchTerm: (term: string) => void;
+  setCaseSensitive: Dispatch<SetStateAction<boolean>>;
+  setCurrentMatchIndex: Dispatch<SetStateAction<number>>;
+  /** サイドバー検索パネルを開く（共有 searchTerm をそのまま表示）。 */
+  handleShowAllSearchResults: () => void;
   handleCloseSearchResults: () => void;
   handleOpenLintingSettings: () => void;
   handleOpenPosHighlightSettings: () => void;
@@ -50,10 +59,9 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
 } {
   const [topView, setTopView] = useState<ActivityBarView>("explorer");
   const [bottomView, setBottomView] = useState<ActivityBarView>("none");
-  const [searchResults, setSearchResults] = useState<{
-    matches: { from: number; to: number }[];
-    searchTerm: string;
-  } | null>(null);
+  const [searchTerm, setSearchTermRaw] = useState("");
+  const [caseSensitive, setCaseSensitive] = useState(false);
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
   const [isRightPanelCollapsed, setIsRightPanelCollapsed] = useState(false);
   const [dictionarySearchTrigger, setDictionarySearchTrigger] = useState<{
     term: string;
@@ -89,16 +97,17 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
     });
   }, []);
 
-  const handleShowAllSearchResults = useCallback(
-    (matches: { from: number; to: number }[], searchTerm: string) => {
-      setSearchResults({ matches, searchTerm });
-      setTopView("search");
-    },
-    [],
-  );
+  // 検索語変更時は現在マッチ index を先頭へリセットする。
+  const setSearchTerm = useCallback((term: string) => {
+    setSearchTermRaw(term);
+    setCurrentMatchIndex(0);
+  }, []);
+
+  const handleShowAllSearchResults = useCallback(() => {
+    setTopView("search");
+  }, []);
 
   const handleCloseSearchResults = useCallback(() => {
-    setSearchResults(null);
     setTopView("explorer");
   }, []);
 
@@ -125,7 +134,9 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
     state: {
       topView,
       bottomView,
-      searchResults,
+      searchTerm,
+      caseSensitive,
+      currentMatchIndex,
       isRightPanelCollapsed,
       dictionarySearchTrigger,
       settingsInitialCategory,
@@ -143,6 +154,9 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
       setRubySelectedText,
       setEditorDiff,
       handleOpenDictionary,
+      setSearchTerm,
+      setCaseSensitive,
+      setCurrentMatchIndex,
       handleShowAllSearchResults,
       handleCloseSearchResults,
       handleOpenLintingSettings,

--- a/lib/editor-page/use-panel-state.ts
+++ b/lib/editor-page/use-panel-state.ts
@@ -33,6 +33,7 @@ export interface PanelHandlers {
   handleCloseSearchResults: () => void;
   handleOpenLintingSettings: () => void;
   handleOpenPosHighlightSettings: () => void;
+  handleOpenPowerSettings: () => void;
   triggerSwitchToCorrections: () => void;
 }
 
@@ -111,6 +112,11 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
     setShowSettingsModal(true);
   }, [setShowSettingsModal]);
 
+  const handleOpenPowerSettings = useCallback(() => {
+    setSettingsInitialCategory("power");
+    setShowSettingsModal(true);
+  }, [setShowSettingsModal]);
+
   const triggerSwitchToCorrections = useCallback(() => {
     setSwitchToCorrectionsTrigger((n) => n + 1);
   }, []);
@@ -141,6 +147,7 @@ export function usePanelState({ setShowSettingsModal }: UsePanelStateParams): {
       handleCloseSearchResults,
       handleOpenLintingSettings,
       handleOpenPosHighlightSettings,
+      handleOpenPowerSettings,
       triggerSwitchToCorrections,
     },
   };

--- a/lib/editor-page/use-power-saving.ts
+++ b/lib/editor-page/use-power-saving.ts
@@ -1,51 +1,116 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+
+type PowerState = "ac" | "battery";
+
+/** Minimum gap between battery suggestions, to absorb rapid power bounce. */
+const SUGGEST_THROTTLE_MS = 60_000;
 
 interface UsePowerSavingOptions {
+  /** Current power-save mode, so we never re-suggest while already enabled. */
   powerSaveMode: boolean;
+  /** Whether to surface the battery suggestion at all. */
   autoPowerSaveOnBattery: boolean;
+  /** Apply a concrete power-save change (used to auto-disable on AC). */
   onPowerSaveModeChange: (enabled: boolean) => void;
+  /** Surface a non-forcing "switch to power-save?" suggestion to the user. */
+  onSuggestPowerSave: () => void;
 }
 
 /**
- * Listens for Electron power state changes and auto-switches power saving mode.
+ * Reacts to Electron power-state transitions.
  *
- * - When on battery and `autoPowerSaveOnBattery` is enabled, power saving is turned on.
- * - When AC power is restored, power saving is turned off.
- * - Does nothing on web (no `window.electronAPI?.power`).
+ * Design (#1402 follow-up): the previous implementation *forced* power-save
+ * mode ON whenever it saw `battery`, and did so on every effect re-run — not
+ * just on real transitions. Because the apply callback's identity changed
+ * whenever linting state changed, the effect re-subscribed and re-fired,
+ * instantly re-enabling power-save the moment the user turned it off. That
+ * made power-save impossible to disable on battery.
+ *
+ * Now:
+ * - We only act on genuine power-state TRANSITIONS (tracked via a ref), so an
+ *   effect re-run with the same state is a no-op.
+ * - On AC→battery we SUGGEST power-save via a toast (`onSuggestPowerSave`)
+ *   instead of forcing it. The user stays in control — matching the setting's
+ *   wording, "バッテリー駆動時に自動で省電力モードを提案する".
+ * - On battery→AC we auto-disable power-save (this direction never traps the
+ *   user and restores full functionality).
+ * - All callbacks/flags are read through refs so the effect mounts once and
+ *   never re-subscribes; identity churn can no longer cause spurious toggles.
+ *
+ * Does nothing on web (no `window.electronAPI?.power`).
  */
 export function usePowerSaving({
+  powerSaveMode,
   autoPowerSaveOnBattery,
   onPowerSaveModeChange,
+  onSuggestPowerSave,
 }: UsePowerSavingOptions): void {
+  const powerSaveModeRef = useRef(powerSaveMode);
+  powerSaveModeRef.current = powerSaveMode;
+  const autoOnBatteryRef = useRef(autoPowerSaveOnBattery);
+  autoOnBatteryRef.current = autoPowerSaveOnBattery;
+  const onChangeRef = useRef(onPowerSaveModeChange);
+  onChangeRef.current = onPowerSaveModeChange;
+  const onSuggestRef = useRef(onSuggestPowerSave);
+  onSuggestRef.current = onSuggestPowerSave;
+
+  /** Last power state we acted on; null until the first reading. */
+  const lastStateRef = useRef<PowerState | null>(null);
+  /** Epoch ms of the last suggestion, to throttle rapid AC/battery bounce. */
+  const lastSuggestAtRef = useRef(0);
+
   useEffect(() => {
     const powerAPI = window.electronAPI?.power;
     if (!powerAPI) {
       return;
     }
 
-    // Apply the current state immediately on mount.
-    powerAPI.getPowerState().then((state) => {
-      if (state === "battery" && autoPowerSaveOnBattery) {
-        onPowerSaveModeChange(true);
-      } else if (state === "ac") {
-        onPowerSaveModeChange(false);
-      }
-    });
+    let disposed = false;
 
-    // Subscribe to future state changes.
-    const unsubscribe = powerAPI.onPowerStateChange((state) => {
-      if (state === "battery" && autoPowerSaveOnBattery) {
-        onPowerSaveModeChange(true);
-      } else if (state === "ac") {
-        onPowerSaveModeChange(false);
+    const handleTransition = (state: PowerState): void => {
+      if (disposed) return;
+      // Only react to genuine transitions; ignore repeated same-state reads.
+      if (lastStateRef.current === state) return;
+      const prev = lastStateRef.current;
+      lastStateRef.current = state;
+
+      if (state === "battery") {
+        // Suggest, never force. Skip if power-save is already on, the user
+        // opted out, or we suggested very recently (debounce bounce).
+        const now = Date.now();
+        if (
+          autoOnBatteryRef.current &&
+          !powerSaveModeRef.current &&
+          now - lastSuggestAtRef.current > SUGGEST_THROTTLE_MS
+        ) {
+          lastSuggestAtRef.current = now;
+          onSuggestRef.current();
+        }
+      } else if (prev !== null) {
+        // Auto-disable only on a REAL battery→AC transition. We must NOT act on
+        // the initial mount reading (prev === null): at startup the persisted
+        // powerSaveMode is still hydrating, and disabling here races with the
+        // restore path — it would clear prePowerSaveState and strand linting
+        // off. On mount we respect the persisted/hydrated value instead.
+        onChangeRef.current(false);
       }
+    };
+
+    // Subscribe FIRST so a transition during the initial async read is not
+    // missed, then apply the initial reading only if nothing was observed yet
+    // (guards against an out-of-order initial result overwriting a real
+    // transition that already arrived).
+    const unsubscribe = powerAPI.onPowerStateChange(handleTransition);
+    powerAPI.getPowerState().then((state) => {
+      if (disposed) return;
+      if (lastStateRef.current === null) handleTransition(state);
     });
 
     return () => {
+      disposed = true;
       unsubscribe();
     };
-    // Re-run when autoPowerSaveOnBattery changes or when the callback identity
-    // changes (i.e. when the caller's useCallback deps — lintingEnabled,
-    // lintingRuleConfigs — are updated).
-  }, [autoPowerSaveOnBattery, onPowerSaveModeChange]);
+    // Mount once: all inputs are read through refs, so the subscription is
+    // never torn down and re-created by unrelated re-renders.
+  }, []);
 }

--- a/lib/editor-page/use-power-saving.ts
+++ b/lib/editor-page/use-power-saving.ts
@@ -5,6 +5,19 @@ type PowerState = "ac" | "battery";
 /** Minimum gap between battery suggestions, to absorb rapid power bounce. */
 const SUGGEST_THROTTLE_MS = 60_000;
 
+/**
+ * Last suggestion time, MODULE-scoped on purpose: the notification is a global
+ * singleton, so the throttle must be too. A per-hook ref would reset to 0 when
+ * the consumer (the editor page) remounts during startup — producing a second,
+ * duplicate toast from the fresh instance. Module scope dedupes across mounts.
+ */
+let lastSuggestAt = 0;
+
+/** @internal test-only: reset the module-scoped suggestion throttle. */
+export function __resetSuggestThrottleForTest(): void {
+  lastSuggestAt = 0;
+}
+
 interface UsePowerSavingOptions {
   /** Current power-save mode, so we never re-suggest while already enabled. */
   powerSaveMode: boolean;
@@ -56,8 +69,6 @@ export function usePowerSaving({
 
   /** Last power state we acted on; null until the first reading. */
   const lastStateRef = useRef<PowerState | null>(null);
-  /** Epoch ms of the last suggestion, to throttle rapid AC/battery bounce. */
-  const lastSuggestAtRef = useRef(0);
 
   useEffect(() => {
     const powerAPI = window.electronAPI?.power;
@@ -81,9 +92,9 @@ export function usePowerSaving({
         if (
           autoOnBatteryRef.current &&
           !powerSaveModeRef.current &&
-          now - lastSuggestAtRef.current > SUGGEST_THROTTLE_MS
+          now - lastSuggestAt > SUGGEST_THROTTLE_MS
         ) {
-          lastSuggestAtRef.current = now;
+          lastSuggestAt = now;
           onSuggestRef.current();
         }
       } else if (prev !== null) {

--- a/lib/editor-page/use-search-highlight.ts
+++ b/lib/editor-page/use-search-highlight.ts
@@ -1,0 +1,89 @@
+import { useEffect } from "react";
+import { Decoration, type EditorView } from "@milkdown/prose/view";
+import { TextSelection } from "@milkdown/prose/state";
+import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
+import type { SearchMatch } from "@/lib/editor-page/find-search-matches";
+
+/**
+ * #1507: After a tab switch the parent's editorView reference may briefly point
+ * at a destroyed EditorView (ProseMirror sets `docView` to null on destroy).
+ * Dispatching on it routes through torn-down Milkdown plugins and throws
+ * "Context editorState not found". This guard is the single chokepoint for that
+ * check now that highlight dispatch is centralized here.
+ */
+export function isEditorViewAlive(view: EditorView | null): view is EditorView {
+  return view !== null && (view as unknown as { docView: unknown }).docView !== null;
+}
+
+interface UseSearchHighlightParams {
+  editorView: EditorView | null;
+  matches: SearchMatch[];
+  /** 強調表示する現在のマッチ index。範囲外なら現在強調なし。 */
+  currentMatchIndex: number;
+  searchTerm: string;
+  /** いずれかの検索 UI（フローティング窓 or サイドパネル）が表示中か。
+   *  false になったら（＝両方とも非表示）ハイライトを消す。 */
+  isSearchVisible: boolean;
+}
+
+/**
+ * 検索ハイライト適用の唯一の場所。SearchDialog と SearchResults が各自で
+ * `searchDecorations` を dispatch していた double-writer 衝突を解消するため、
+ * 両 UI から dispatch ロジックを引き上げてここへ集約する。
+ *
+ * 責務:
+ *  1. `isEditorViewAlive` で破棄済み view をガード（#1507）
+ *  2. 検索 UI が非表示 or 検索語が空 → decorations を空 dispatch してクリア
+ *  3. それ以外 → 全マッチをハイライト（current は強調クラス）＋現在マッチへスクロール
+ */
+export function useSearchHighlight({
+  editorView,
+  matches,
+  currentMatchIndex,
+  searchTerm,
+  isSearchVisible,
+}: UseSearchHighlightParams): void {
+  useEffect(() => {
+    if (!isEditorViewAlive(editorView)) return;
+    const { state, dispatch } = editorView;
+
+    // 非表示時・検索語空時はハイライトを消す（要求2: 検索窓を閉じた／
+    // 検索パネル非表示でハイライト除去）。
+    if (!isSearchVisible || !searchTerm || matches.length === 0) {
+      try {
+        dispatch(state.tr.setMeta("searchDecorations", []));
+      } catch {
+        // view が dispatch 途中で破棄された場合のベストエフォート
+      }
+      return;
+    }
+
+    const decorations = matches.map((match, index) =>
+      Decoration.inline(match.from, match.to, {
+        class: index === currentMatchIndex ? "search-result-current" : "search-result",
+      }),
+    );
+
+    try {
+      dispatch(state.tr.setMeta("searchDecorations", decorations));
+    } catch {
+      // #1507: view が検索中に破棄された — decorations も一緒に消える
+    }
+
+    // 現在のマッチを画面中央へ。選択も移動して連続ナビを自然にする。
+    const current = matches[currentMatchIndex];
+    if (current) {
+      try {
+        const view = editorView;
+        view.dispatch(
+          view.state.tr.setSelection(
+            TextSelection.create(view.state.doc, current.from, current.from),
+          ),
+        );
+        centerEditorPosition(view, current.from);
+      } catch {
+        // 破棄済み view ではスクロール不要
+      }
+    }
+  }, [editorView, matches, currentMatchIndex, searchTerm, isSearchVisible]);
+}

--- a/lib/editor-page/use-selection-tracking.ts
+++ b/lib/editor-page/use-selection-tracking.ts
@@ -29,10 +29,16 @@ export interface EditorSelectionState {
   pointerClientY: number | null;
 }
 
+export interface SelectionSearchRange {
+  from: number;
+  to: number;
+}
+
 interface UseSelectionTrackingOptions {
   editorViewInstance: EditorView | null;
   scrollContainerRef: RefObject<HTMLDivElement | null>;
   onSelectionChange?: (charCount: number, manuscriptCells: number, manuscriptPages: number) => void;
+  onSelectionRangeChange?: (range: SelectionSearchRange | null) => void;
 }
 
 const EMPTY_SELECTION_STATE: EditorSelectionState = {
@@ -81,6 +87,14 @@ function sameSelectionState(a: EditorSelectionState, b: EditorSelectionState): b
   );
 }
 
+export function getEditorSelectionSearchRange(
+  selection: { empty: boolean; from: number; to: number },
+): SelectionSearchRange | null {
+  return !selection.empty && selection.from < selection.to
+    ? { from: selection.from, to: selection.to }
+    : null;
+}
+
 function safeCoordsAtPos(editorViewInstance: EditorView, pos: number): ViewportRect | null {
   try {
     return toViewportRect(editorViewInstance.coordsAtPos(pos));
@@ -101,10 +115,13 @@ export function useSelectionTracking({
   editorViewInstance,
   scrollContainerRef,
   onSelectionChange,
+  onSelectionRangeChange,
 }: UseSelectionTrackingOptions): EditorSelectionState {
   const [selectionState, setSelectionState] = useState<EditorSelectionState>(EMPTY_SELECTION_STATE);
   const selectionStateRef = useRef(selectionState);
   const onSelectionChangeRef = useRef(onSelectionChange);
+  const onSelectionRangeChangeRef = useRef(onSelectionRangeChange);
+  const lastReportedRangeRef = useRef<SelectionSearchRange | null>(null);
   const lastPointerYRef = useRef<number | null>(null);
   const lastReportedCountRef = useRef(0);
   // 原稿用紙マス数も保持する。可視文字数が同じでも禁則処理でマス数は変わり得るため、
@@ -120,6 +137,21 @@ export function useSelectionTracking({
     onSelectionChangeRef.current = onSelectionChange;
   }, [onSelectionChange]);
 
+  useEffect(() => {
+    onSelectionRangeChangeRef.current = onSelectionRangeChange;
+  }, [onSelectionRangeChange]);
+
+  const reportSelectionRange = useCallback(
+    (selection: { empty: boolean; from: number; to: number }) => {
+      const range = getEditorSelectionSearchRange(selection);
+      const previous = lastReportedRangeRef.current;
+      if (previous?.from === range?.from && previous?.to === range?.to) return;
+      lastReportedRangeRef.current = range;
+      onSelectionRangeChangeRef.current?.(range);
+    },
+    [],
+  );
+
   const updateSelectionState = useCallback(() => {
     if (!editorViewInstance) {
       if (lastReportedCountRef.current !== 0 || lastReportedCellsRef.current !== 0) {
@@ -130,6 +162,7 @@ export function useSelectionTracking({
       setSelectionState((prev) =>
         sameSelectionState(prev, EMPTY_SELECTION_STATE) ? prev : EMPTY_SELECTION_STATE,
       );
+      reportSelectionRange({ empty: true, from: 0, to: 0 });
       return;
     }
 
@@ -188,8 +221,9 @@ export function useSelectionTracking({
       onSelectionChangeRef.current?.(0, 0, 0);
     }
 
+    reportSelectionRange(selection);
     setSelectionState((prev) => (sameSelectionState(prev, nextState) ? prev : nextState));
-  }, [editorViewInstance]);
+  }, [editorViewInstance, reportSelectionRange]);
 
   const scheduleUpdate = useCallback(
     (pointerClientY?: number | null) => {

--- a/lib/editor-page/use-selection-tracking.ts
+++ b/lib/editor-page/use-selection-tracking.ts
@@ -87,9 +87,11 @@ function sameSelectionState(a: EditorSelectionState, b: EditorSelectionState): b
   );
 }
 
-export function getEditorSelectionSearchRange(
-  selection: { empty: boolean; from: number; to: number },
-): SelectionSearchRange | null {
+export function getEditorSelectionSearchRange(selection: {
+  empty: boolean;
+  from: number;
+  to: number;
+}): SelectionSearchRange | null {
   return !selection.empty && selection.from < selection.to
     ? { from: selection.from, to: selection.to }
     : null;

--- a/lib/editor-page/use-startup-checks.ts
+++ b/lib/editor-page/use-startup-checks.ts
@@ -5,8 +5,11 @@
 import { useEffect, useRef } from "react";
 import { startupCheckQueue } from "@/lib/services/startup-check-queue";
 import { dictUpdateCheck } from "@/lib/services/startup-checks/dict-update-check";
+import { dictCorruptCheck } from "@/lib/services/startup-checks/dict-corrupt-check";
 
 // Register built-in checks once at module load. register() is idempotent per id.
+// Corrupt is checked before update: a corrupt DB needs re-download regardless of version.
+startupCheckQueue.register(dictCorruptCheck);
 startupCheckQueue.register(dictUpdateCheck);
 
 export function useStartupChecks(): void {

--- a/lib/editor-page/use-text-statistics.ts
+++ b/lib/editor-page/use-text-statistics.ts
@@ -7,6 +7,7 @@ import {
   cleanMarkdown,
   analyzeReadability,
   enrichReadabilityWithMorphology,
+  enrichReadabilityWithDict,
 } from "@/lib/utils";
 
 import type {
@@ -16,6 +17,8 @@ import type {
 } from "@/lib/utils";
 
 import { getNlpClient } from "@/lib/nlp-client/nlp-client";
+import { getDictAccess } from "@/lib/dict/dict-access";
+import type { Token } from "@/lib/nlp-client/types";
 import { computeTextStatistics } from "./text-statistics";
 import type { TextStatistics } from "./text-statistics";
 
@@ -37,10 +40,12 @@ export interface TextStatisticsResult extends TextStatistics {
  * All values are memoized and only recomputed when content changes.
  *
  * 原稿用紙換算統計を含む統合統計を返す。
- * Readability is computed in two phases:
+ * Readability is computed in three phases:
  *   Phase 1 (sync):  surface-level analysis via analyzeReadability()
  *   Phase 2 (async): morphological enrichment via enrichReadabilityWithMorphology()
  *                    using kuromoji through INlpClient
+ *   Phase 3 (async): dictionary enrichment via enrichReadabilityWithDict()
+ *                    using Genji freq_rank via DictAccess — only when state === "ready"
  */
 export function useTextStatistics(content: string): TextStatisticsResult {
   const manuscriptStats = useMemo(() => computeTextStatistics(content), [content]);
@@ -57,7 +62,7 @@ export function useTextStatistics(content: string): TextStatisticsResult {
   // Phase 1: synchronous surface analysis（即時）
   const surfaceAnalysis = useMemo(() => analyzeReadability(cleanedContent), [cleanedContent]);
 
-  // Phase 2: async morphological enrichment（NLP完了後に更新）
+  // Phase 2 + 3: async enrichment（NLP完了後 → 辞書補強）
   const [readabilityAnalysis, setReadabilityAnalysis] =
     useState<EnhancedReadabilityAnalysis>(surfaceAnalysis);
 
@@ -69,15 +74,52 @@ export function useTextStatistics(content: string): TextStatisticsResult {
     if (cleanedContent.length < 50) return;
 
     let cancelled = false;
-    getNlpClient()
-      .tokenizeParagraph(cleanedContent)
-      .then((tokens) => {
+
+    const run = async (): Promise<void> => {
+      // Phase 2: kuromoji 形態素解析
+      let morphResult = surfaceAnalysis;
+      let tokens: Token[] = [];
+      try {
+        tokens = await getNlpClient().tokenizeParagraph(cleanedContent);
         if (cancelled) return;
-        setReadabilityAnalysis(enrichReadabilityWithMorphology(surfaceAnalysis, tokens));
-      })
-      .catch(() => {
+        morphResult = enrichReadabilityWithMorphology(surfaceAnalysis, tokens);
+        setReadabilityAnalysis(morphResult);
+      } catch {
         // NLP失敗時は表層結果のまま維持（silent fallback）
-      });
+        if (cancelled) return;
+      }
+
+      // Phase 3: 幻辞辞書補強（state === "ready" のときのみ実行）
+      // Web では重い一括照合をしないためヘルスチェックで必ず確認する
+      try {
+        const access = getDictAccess();
+        const health = await access.getHealth();
+        if (cancelled) return;
+        if (health.state !== "ready") return; // graceful degradation
+
+        // 内容語（名詞/動詞/形容詞/副詞）の basic_form を収集してバッチ照合
+        const contentForms = [
+          ...new Set(
+            tokens
+              .filter((t) => ["名詞", "動詞", "形容詞", "副詞"].includes(t.pos))
+              .map((t) => t.basic_form ?? t.surface)
+              .filter((f): f is string => typeof f === "string" && f.length > 0),
+          ),
+        ];
+
+        if (contentForms.length === 0) return;
+
+        const lookupMap = await access.lookupBatch(contentForms);
+        if (cancelled) return;
+
+        const dictResult = enrichReadabilityWithDict(morphResult, tokens, lookupMap);
+        setReadabilityAnalysis(dictResult);
+      } catch {
+        // 辞書補強失敗時は Tier 2 結果のまま維持（silent fallback）
+      }
+    };
+
+    void run();
 
     return () => {
       cancelled = true;

--- a/lib/export/__tests__/blank-paragraph-export.test.ts
+++ b/lib/export/__tests__/blank-paragraph-export.test.ts
@@ -3,6 +3,7 @@ import { unzipSync, strFromU8 } from "fflate";
 import { mdiToHtml } from "@/lib/export/mdi-to-html";
 import { mdiToPlainText } from "@/lib/export/txt-exporter";
 import { generateDocxBlob } from "@/lib/export/docx-exporter";
+import { buildEpubFiles } from "@/lib/export/epub-shared";
 
 describe("html exporter — [[blank]] paragraph handling", () => {
   it("[[blank]] → <p></p>", () => {
@@ -26,6 +27,38 @@ describe("html exporter — [[blank]] paragraph handling", () => {
     const html = mdiToHtml("文章\n\n```\n[[blank]]\n```\n\n続き", { bodyOnly: true });
     expect(html).not.toContain("");
     expect(html).not.toContain("[[blank]]");
+  });
+});
+
+// Regression for the PDF/EPUB leak (花様年華): the HTML pipeline (mdiToHtml) is
+// fed the *live Milkdown serializer output*, where MDI macros are escaped to
+// `\[\[blank]]`. Before the fix, mdiToHtml never normalized this, so MDI_BLANK_RE
+// (which matches the unescaped marker) missed it and `[[blank]]` leaked verbatim
+// into PDF / EPUB / print output. TXT/DOCX already normalized via MdiDocument;
+// these tests lock the HTML path to the same behavior.
+describe("html exporter — serializer-escaped [[blank]] (PDF/EPUB leak regression)", () => {
+  it("default (.mdi): \\[\\[blank]] (escaped) → <p></p>, no [[blank]] leak", () => {
+    const html = mdiToHtml("A\n\n\\[\\[blank]]\n\nB", { bodyOnly: true });
+    expect(html).toContain("<p></p>");
+    expect(html).not.toContain("[[blank]]");
+    expect(html).not.toContain("\\[");
+    // U+E000 sentinel must not leak
+    expect(html).not.toContain(String.fromCharCode(0xe000));
+  });
+
+  it(".mdi (explicit): \\[\\[blank]] (escaped) → <p></p>, no leak", () => {
+    const html = mdiToHtml("A\n\n\\[\\[blank]]\n\nB", { bodyOnly: true, fileType: ".mdi" });
+    expect(html).toContain("<p></p>");
+    expect(html).not.toContain("[[blank]]");
+    expect(html).not.toContain("\\[");
+  });
+
+  it(".md: \\[\\[blank]] (escaped) → preserved as literal text, NOT an empty <p> (DATA-LOSS guard)", () => {
+    const html = mdiToHtml("A\n\n\\[\\[blank]]\n\nB", { bodyOnly: true, fileType: ".md" });
+    // For non-.mdi the authored literal must survive — markdown-it un-escapes the
+    // backslash so the visible text is "[[blank]]" inside a real paragraph.
+    expect(html).toContain("[[blank]]");
+    expect(html).not.toContain("<p></p>");
   });
 });
 
@@ -62,6 +95,42 @@ describe("docx exporter — [[blank]] paragraph handling", () => {
     expect(pCount).toBeGreaterThanOrEqual(3);
     expect(documentXml).toContain("A");
     expect(documentXml).toContain("B");
+  });
+});
+
+// End-to-end EPUB regression: buildEpubFiles → splitIntoChapters → mdiToHtml.
+// The chapter xhtml is where [[blank]] previously leaked in the exported book
+// (3rd screenshot of #花様年華). Confirms fileType threads all the way through.
+describe("epub exporter — serializer-escaped [[blank]] in chapter xhtml", () => {
+  it("default (.mdi): \\[\\[blank]] → empty <p>, no [[blank]] leak in chapter-1.xhtml", () => {
+    const files = buildEpubFiles("# 第一章\n\nA\n\n\\[\\[blank]]\n\nB", {
+      metadata: { title: "テスト", language: "ja" },
+    });
+    const chapter = files.get("OEBPS/chapter-1.xhtml") as string;
+    expect(chapter).toBeTruthy();
+    expect(chapter).toContain("<p></p>");
+    expect(chapter).not.toContain("[[blank]]");
+    expect(chapter).not.toContain("\\[");
+  });
+
+  it(".mdi (explicit): unescaped [[blank]] → empty <p>, no leak", () => {
+    const files = buildEpubFiles("# 第一章\n\nA\n\n[[blank]]\n\nB", {
+      metadata: { title: "テスト", language: "ja" },
+      fileType: ".mdi",
+    });
+    const chapter = files.get("OEBPS/chapter-1.xhtml") as string;
+    expect(chapter).toContain("<p></p>");
+    expect(chapter).not.toContain("[[blank]]");
+  });
+
+  it(".md: \\[\\[blank]] → preserved as literal text, no empty <p> (DATA-LOSS guard)", () => {
+    const files = buildEpubFiles("# 第一章\n\nA\n\n\\[\\[blank]]\n\nB", {
+      metadata: { title: "note.md", language: "ja" },
+      fileType: ".md",
+    });
+    const chapter = files.get("OEBPS/chapter-1.xhtml") as string;
+    expect(chapter).toContain("[[blank]]");
+    expect(chapter).not.toContain("<p></p>");
   });
 });
 

--- a/lib/export/__tests__/mdi-to-html.test.ts
+++ b/lib/export/__tests__/mdi-to-html.test.ts
@@ -42,12 +42,33 @@ describe("mdiToHtml", () => {
     expect(html).toContain('外では<br class="mdi-break">変換する');
   });
 
-  it("preserves escaped MDI syntax as literal text", () => {
-    const html = mdiToHtml("\\{東京|とうきょう} \\^12^ \\[[br]]", { bodyOnly: true });
+  it(".md/.txt: preserves escaped MDI syntax as literal text (DATA-LOSS guard)", () => {
+    // Non-.mdi documents are raw authored text — the HTML pipeline must NOT
+    // recover serializer escapes, so author-written literals survive verbatim.
+    for (const fileType of [".md", ".txt"]) {
+      const html = mdiToHtml("\\{東京|とうきょう} \\^12^ \\[[br]]", { bodyOnly: true, fileType });
+      expect(html).toContain("{東京|とうきょう} ^12^ [[br]]");
+      expect(html).not.toContain("<ruby>");
+      expect(html).not.toContain('class="mdi-break"');
+      expect(html).not.toContain('class="mdi-tcy"');
+    }
+  });
 
-    expect(html).toContain("{東京|とうきょう} ^12^ [[br]]");
+  it(".mdi: recovers serializer-escaped bracket macros so they render (PDF/EPUB parity)", () => {
+    // The Milkdown serializer escapes the leading `[` of MDI bracket macros to
+    // `\[`. For ".mdi" the HTML pipeline un-escapes them (Step 0) — matching the
+    // save path and TXT/DOCX — so e.g. `\[[br]]` becomes a real <br> instead of
+    // leaking `[[br]]` as literal text. (Ruby `{…}` / tcy `^…^` are outside
+    // Step 0's recovery scope and intentionally stay literal.)
+    const html = mdiToHtml("\\{東京|とうきょう} \\^12^ \\[[br]]", {
+      bodyOnly: true,
+      fileType: ".mdi",
+    });
+    expect(html).toContain('<br class="mdi-break">');
+    expect(html).not.toContain("[[br]]");
+    // Ruby / tcy escapes are not in Step 0's scope → remain literal text.
+    expect(html).toContain("{東京|とうきょう} ^12^");
     expect(html).not.toContain("<ruby>");
-    expect(html).not.toContain('class="mdi-break"');
     expect(html).not.toContain('class="mdi-tcy"');
   });
 });

--- a/lib/export/epub-shared.ts
+++ b/lib/export/epub-shared.ts
@@ -21,6 +21,12 @@ export interface EpubExportOptions {
   chapterSplitLevel?: ChapterSplitLevel;
   coverImage?: Uint8Array;
   coverMediaType?: string;
+  /**
+   * Active document file type. Forwarded to mdiToHtml so editor-escaped MDI
+   * macros (e.g. `\[\[blank]]`) are un-escaped for ".mdi" and preserved as
+   * literals for ".md"/".txt". Absent → ".mdi".
+   */
+  fileType?: string;
 }
 
 /** Map chapter split level string to numeric value for splitIntoChapters() */
@@ -87,9 +93,9 @@ export function buildEpubFiles(
   const coverMediaType = validCoverType;
 
   const splitLevel = splitLevelToNumber(options.chapterSplitLevel);
-  const chapters = splitIntoChapters(content, splitLevel);
+  const chapters = splitIntoChapters(content, splitLevel, options.fileType);
   if (chapters.length === 0) {
-    const html = mdiToHtml(content, { bodyOnly: true });
+    const html = mdiToHtml(content, { bodyOnly: true, fileType: options.fileType });
     chapters.push({ title, htmlContent: html, level: 1 });
   }
   // When no splitting or single untitled chapter, use the book title

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -16,6 +16,7 @@ import {
   MDI_BREAK_RE,
   MDI_KERN_AMOUNT_RE,
   MDI_BLANK_RE,
+  MdiDocument,
 } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import { PAGE_DIMENSIONS } from "./pdf-export-settings";
 
@@ -245,13 +246,30 @@ export function mdiToHtml(
     typesetting?: Omit<MdiStylesheetOptions, "verticalWriting">;
     /** Google Font family name to inject as <link> tag (e.g. "Noto Serif JP") */
     googleFontFamily?: string;
+    /**
+     * Active document file type. Editor-serialized input escapes the leading `[`
+     * of MDI bracket macros (e.g. `\[\[blank]]`); ".mdi" un-escapes them back to
+     * markers so [[blank]] etc. convert correctly, while ".md"/".txt" preserve the
+     * authored literal (DATA-LOSS guard, see #1608). Absent → ".mdi".
+     */
+    fileType?: string;
   },
 ): string {
   const md = createMarkdownIt();
+  // Normalize editor-serialized output into canonical MDI text before rendering.
+  // The Milkdown serializer escapes the leading `[` of MDI macros to `\[`; without
+  // this, MDI_BLANK_RE (and the inline macro rules) never match and `[[blank]]`
+  // leaks as literal text into PDF/EPUB/print output. TXT/DOCX already normalize
+  // this way via MdiDocument — this brings the HTML pipeline to parity.
+  const fileType = options?.fileType ?? ".mdi";
+  const normalized =
+    fileType === ".mdi"
+      ? MdiDocument.fromEditorOutput(markdown, { fileType: ".mdi" }).toRawText()
+      : MdiDocument.fromRawText(markdown).toRawText();
   // Pre-process: replace [[blank]] paragraph markers with a U+E000 PUA sentinel.
   // markdown-it will wrap the sentinel in <p>…</p>; we swap it for an empty <p></p> after rendering.
   const BLANK_SENTINEL = "";
-  const preprocessed = markdown.replace(new RegExp(MDI_BLANK_RE.source, "gm"), BLANK_SENTINEL);
+  const preprocessed = normalized.replace(new RegExp(MDI_BLANK_RE.source, "gm"), BLANK_SENTINEL);
   const rawHtml = md.render(preprocessed);
   // Replace the sentinel paragraph with a true empty paragraph. Then final-sweep any
   // remaining sentinel that escaped the <p>…</p> wrap (e.g. inside fenced code blocks
@@ -326,10 +344,14 @@ export function mdiToHtml(
  * @param splitLevel - Max heading level to split on (1=H1, 2=H1+H2, 3=H1+H2+H3, 0=no split)
  * @returns Array of Chapter objects
  */
-export function splitIntoChapters(markdown: string, splitLevel: number = 1): Chapter[] {
+export function splitIntoChapters(
+  markdown: string,
+  splitLevel: number = 1,
+  fileType?: string,
+): Chapter[] {
   // No splitting — entire document is one chapter
   if (splitLevel <= 0) {
-    const html = mdiToHtml(markdown, { bodyOnly: true });
+    const html = mdiToHtml(markdown, { bodyOnly: true, fileType });
     return [{ title: "", htmlContent: html, level: 1 }];
   }
 
@@ -350,7 +372,7 @@ export function splitIntoChapters(markdown: string, splitLevel: number = 1): Cha
         const content = currentLines.join("\n").trim();
         chapters.push({
           title: currentTitle,
-          htmlContent: content ? mdiToHtml(content, { bodyOnly: true }) : "",
+          htmlContent: content ? mdiToHtml(content, { bodyOnly: true, fileType }) : "",
           level: currentLevel,
         });
       }
@@ -372,7 +394,7 @@ export function splitIntoChapters(markdown: string, splitLevel: number = 1): Cha
     const content = currentLines.join("\n").trim();
     chapters.push({
       title: currentTitle,
-      htmlContent: content ? mdiToHtml(content, { bodyOnly: true }) : "",
+      htmlContent: content ? mdiToHtml(content, { bodyOnly: true, fileType }) : "",
       level: currentLevel,
     });
   }

--- a/lib/export/pdf-exporter.ts
+++ b/lib/export/pdf-exporter.ts
@@ -31,6 +31,12 @@ export interface PdfExportOptions {
   textIndent?: number;
   /** Google Font family name — triggers <link> injection and CSP relaxation */
   googleFontFamily?: string;
+  /**
+   * Active document file type. Forwarded to mdiToHtml so editor-escaped MDI
+   * macros (e.g. `\[\[blank]]`) are un-escaped for ".mdi" and preserved as
+   * literals for ".md"/".txt". Absent → ".mdi".
+   */
+  fileType?: string;
 }
 
 /**
@@ -83,6 +89,7 @@ export async function generatePdf(content: string, options: PdfExportOptions): P
       margins: options.margins,
     },
     googleFontFamily: options.googleFontFamily,
+    fileType: options.fileType,
   });
 
   // Use a unique in-memory partition (no "persist:" prefix) per export so

--- a/lib/export/types.ts
+++ b/lib/export/types.ts
@@ -37,6 +37,11 @@ export interface PdfGenerationOptions {
   textIndent?: number;
   /** Google Font family name for PDF export (triggers <link> injection and CSP relaxation) */
   googleFontFamily?: string;
+  /**
+   * Active document file type. The HTML pipeline un-escapes MDI macros only for
+   * ".mdi"; ".md"/".txt" preserve authored `\[\[blank]]` literals. Absent → ".mdi".
+   */
+  fileType?: string;
 }
 
 export type ExportFormat = "pdf" | "epub" | "docx" | "txt" | "txt-ruby";

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -136,14 +136,17 @@ export function useExport({
 
         switch (format) {
           case "pdf":
+            // Thread fileType so the HTML pipeline un-escapes MDI macros for
+            // ".mdi" and preserves \[\[blank]] literals in ".md"/".txt".
             result = await window.electronAPI.exportPDF?.(content, {
               metadata,
               verticalWriting: false,
               pageSize: "A5",
+              fileType,
             });
             break;
           case "epub":
-            result = await window.electronAPI.exportEPUB?.(content, { metadata });
+            result = await window.electronAPI.exportEPUB?.(content, { metadata, fileType });
             break;
           case "docx":
             // Thread the active tab's file type so the main-process generateDocx
@@ -245,7 +248,7 @@ async function exportAsWeb(
     // Defensive fallback: normally PDF goes through dialog (line 103),
     // but if no dialog callback is wired, use default export settings.
     const defaults = toPdfExportSettings(await loadExportSettings());
-    const opened = await openWebPrintPreview(content, metadata, defaults);
+    const opened = await openWebPrintPreview(content, metadata, defaults, fileType);
     if (!opened) {
       notificationManager.warning(
         "ポップアップがブロックされました。ブラウザの設定を確認してください。",
@@ -273,7 +276,7 @@ async function exportAsWeb(
       }
       case "epub": {
         const { generateEpubBlob } = await import("./epub-web");
-        blob = await generateEpubBlob(content, { metadata });
+        blob = await generateEpubBlob(content, { metadata, fileType });
         suggestedName = `${baseName}.epub`;
         break;
       }

--- a/lib/export/web-print-preview.ts
+++ b/lib/export/web-print-preview.ts
@@ -21,6 +21,7 @@ export async function openWebPrintPreview(
   content: string,
   metadata: ExportMetadata,
   settings: PdfExportSettings,
+  fileType?: string,
 ): Promise<boolean> {
   // MUST be the first statement — synchronous, within user gesture
   const printWindow = window.open("", "_blank");
@@ -51,6 +52,7 @@ export async function openWebPrintPreview(
         pageSize: settings.pageSize,
         landscape: settings.landscape,
       },
+      fileType,
     });
 
     printWindow.document.open();

--- a/lib/services/notification-manager.ts
+++ b/lib/services/notification-manager.ts
@@ -3,6 +3,7 @@ import type {
   NotificationOptions,
   ProgressNotificationOptions,
   NotificationType,
+  NotificationAction,
 } from "@/types/notification";
 
 type NotificationListener = (notifications: NotificationItem[]) => void;
@@ -147,6 +148,21 @@ class NotificationManager {
         this.timers.set(id, timerId);
       }
     }
+  }
+
+  /**
+   * 既存メッセージの本文（と任意でアクション）を差し替える。
+   * カウントダウン表示など、同じトーストを生かしたまま内容だけ更新する用途。
+   * 対象が存在しなければ何もしない。
+   */
+  updateMessage(id: string, message: string, actions?: NotificationAction[]): void {
+    const notification = this.notifications.find((n) => n.id === id);
+    if (!notification) return;
+    notification.message = message;
+    if (actions !== undefined) {
+      notification.actions = actions;
+    }
+    this.notify();
   }
 
   /**

--- a/lib/services/startup-checks/__tests__/dict-auto-download.test.ts
+++ b/lib/services/startup-checks/__tests__/dict-auto-download.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { loadAppState } = vi.hoisted(() => ({ loadAppState: vi.fn() }));
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({ loadAppState }),
+}));
+vi.mock("@/lib/dict/dict-access", () => ({
+  getDictAccess: () => ({ invalidate: vi.fn() }),
+}));
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: {
+    showProgress: vi.fn(() => "id"),
+    updateProgress: vi.fn(),
+    updateMessage: vi.fn(),
+    showMessage: vi.fn(() => "id"),
+    dismiss: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { isAutoDownloadAllowed } from "@/lib/services/startup-checks/dict-auto-download";
+
+type ConnectionLike = { type?: string; saveData?: boolean };
+
+function setOnline(online: boolean) {
+  Object.defineProperty(navigator, "onLine", { value: online, configurable: true });
+}
+function setConnection(conn: ConnectionLike | undefined) {
+  Object.defineProperty(navigator, "connection", { value: conn, configurable: true });
+}
+
+describe("isAutoDownloadAllowed", () => {
+  beforeEach(() => {
+    loadAppState.mockReset();
+    loadAppState.mockResolvedValue(null);
+    setOnline(true);
+    setConnection(undefined);
+  });
+  afterEach(() => {
+    setConnection(undefined);
+    setOnline(true);
+  });
+
+  it("allows when online, no connection info, and power-save off", async () => {
+    expect(await isAutoDownloadAllowed()).toBe(true);
+  });
+
+  it("blocks when offline", async () => {
+    setOnline(false);
+    expect(await isAutoDownloadAllowed()).toBe(false);
+  });
+
+  it("blocks on a cellular connection (metered radio)", async () => {
+    setConnection({ type: "cellular" });
+    expect(await isAutoDownloadAllowed()).toBe(false);
+  });
+
+  it("blocks when the OS data-saver is on", async () => {
+    setConnection({ type: "wifi", saveData: true });
+    expect(await isAutoDownloadAllowed()).toBe(false);
+  });
+
+  it("allows on wifi without data-saver", async () => {
+    setConnection({ type: "wifi", saveData: false });
+    expect(await isAutoDownloadAllowed()).toBe(true);
+  });
+
+  it("blocks when the app power-save (throttle) mode is on", async () => {
+    loadAppState.mockResolvedValue({ powerSaveMode: true });
+    expect(await isAutoDownloadAllowed()).toBe(false);
+  });
+
+  it("allows when loadAppState throws (no signal → fall back to other gates)", async () => {
+    loadAppState.mockRejectedValue(new Error("storage error"));
+    expect(await isAutoDownloadAllowed()).toBe(true);
+  });
+});

--- a/lib/services/startup-checks/__tests__/dict-update-check.test.ts
+++ b/lib/services/startup-checks/__tests__/dict-update-check.test.ts
@@ -7,34 +7,31 @@ const { getDownloadState, checkForUpdate } = vi.hoisted(() => ({
 const { loadAppState } = vi.hoisted(() => ({
   loadAppState: vi.fn(),
 }));
-const { notifInfo, notifError } = vi.hoisted(() => ({
-  notifInfo: vi.fn(),
-  notifError: vi.fn(),
-}));
+const { isAutoDownloadAllowed, runDictDownloadWithProgress, startCountdownDownload } = vi.hoisted(
+  () => ({
+    isAutoDownloadAllowed: vi.fn(),
+    runDictDownloadWithProgress: vi.fn(),
+    startCountdownDownload: vi.fn(),
+  }),
+);
 vi.mock("@/lib/dict/dict-service", () => ({
   getDictService: () => ({ getDownloadState, checkForUpdate }),
 }));
 vi.mock("@/lib/storage/storage-service", () => ({
   getStorageService: () => ({ loadAppState }),
 }));
-vi.mock("@/lib/services/notification-manager", () => ({
-  notificationManager: { info: notifInfo, error: notifError, showMessage: vi.fn() },
+vi.mock("@/lib/services/startup-checks/dict-auto-download", () => ({
+  isAutoDownloadAllowed,
+  runDictDownloadWithProgress,
+  startCountdownDownload,
 }));
 
 import { dictUpdateCheck } from "@/lib/services/startup-checks/dict-update-check";
 
-const lastDownloadMock = { current: vi.fn(async (): Promise<unknown> => ({ success: true })) };
-
-function setElectronDict(present: boolean, download?: () => Promise<unknown>) {
+function setElectronDict(present: boolean) {
   if (present) {
-    const downloadFn = vi.fn(download ?? (async () => ({ success: true })));
-    lastDownloadMock.current = downloadFn;
     (window as unknown as { electronAPI?: unknown }).electronAPI = {
-      dict: {
-        download: downloadFn,
-        getStatus: vi.fn(async () => ({})),
-        checkUpdate: vi.fn(async () => ({})),
-      },
+      dict: { download: vi.fn(), getStatus: vi.fn(async () => ({})) },
     };
   } else {
     delete (window as unknown as { electronAPI?: unknown }).electronAPI;
@@ -46,10 +43,11 @@ describe("dictUpdateCheck", () => {
     getDownloadState.mockReset();
     checkForUpdate.mockReset();
     loadAppState.mockReset();
-    // Default: preference unset → update checking enabled.
-    loadAppState.mockResolvedValue(null);
-    notifInfo.mockReset();
-    notifError.mockReset();
+    loadAppState.mockResolvedValue(null); // preference unset → update checking enabled
+    isAutoDownloadAllowed.mockReset();
+    isAutoDownloadAllowed.mockResolvedValue(false); // default: manual-notice path
+    runDictDownloadWithProgress.mockReset();
+    startCountdownDownload.mockReset();
   });
   afterEach(() => setElectronDict(false));
 
@@ -60,18 +58,28 @@ describe("dictUpdateCheck", () => {
     expect(getDownloadState).not.toHaveBeenCalled();
   });
 
-  it("warns when the dictionary is not installed (Electron)", async () => {
+  it("warns when the dictionary is not installed (auto-download not allowed)", async () => {
     setElectronDict(true);
     getDownloadState.mockResolvedValue({ providerId: "genji", status: "not-installed" });
     const notice = await dictUpdateCheck.evaluate();
     expect(getDownloadState).toHaveBeenCalledWith("genji");
     expect(notice).toMatchObject({ id: "dict-not-installed", type: "warning" });
     expect(notice?.actions?.[0]?.label).toBe("今すぐダウンロード");
-    // Should not call checkForUpdate when not-installed
     expect(checkForUpdate).not.toHaveBeenCalled();
+    expect(startCountdownDownload).not.toHaveBeenCalled();
   });
 
-  it("informs when an update is available (via checkForUpdate)", async () => {
+  it("starts a 10s countdown (no notice) when not installed and auto-download is allowed", async () => {
+    setElectronDict(true);
+    getDownloadState.mockResolvedValue({ providerId: "genji", status: "not-installed" });
+    isAutoDownloadAllowed.mockResolvedValue(true);
+    const notice = await dictUpdateCheck.evaluate();
+    expect(notice).toBeNull();
+    expect(startCountdownDownload).toHaveBeenCalledTimes(1);
+    expect(startCountdownDownload.mock.calls[0][0]).toMatchObject({ seconds: 10 });
+  });
+
+  it("informs when an update is available (auto-download not allowed)", async () => {
     setElectronDict(true);
     getDownloadState.mockResolvedValue({ providerId: "genji", status: "installed" });
     checkForUpdate.mockResolvedValue({
@@ -84,6 +92,22 @@ describe("dictUpdateCheck", () => {
     expect(notice).toMatchObject({ id: "dict-update-available", type: "info" });
     expect(notice?.message).toContain("1.0.0");
     expect(notice?.message).toContain("1.1.0");
+    expect(startCountdownDownload).not.toHaveBeenCalled();
+  });
+
+  it("starts a 30s countdown (no notice) when an update is available and allowed", async () => {
+    setElectronDict(true);
+    getDownloadState.mockResolvedValue({ providerId: "genji", status: "installed" });
+    checkForUpdate.mockResolvedValue({
+      latestVersion: "1.1.0",
+      installedVersion: "1.0.0",
+      updateAvailable: true,
+    });
+    isAutoDownloadAllowed.mockResolvedValue(true);
+    const notice = await dictUpdateCheck.evaluate();
+    expect(notice).toBeNull();
+    expect(startCountdownDownload).toHaveBeenCalledTimes(1);
+    expect(startCountdownDownload.mock.calls[0][0]).toMatchObject({ seconds: 30 });
   });
 
   it("returns null when installed and up to date", async () => {
@@ -121,7 +145,6 @@ describe("dictUpdateCheck", () => {
       progress: 42,
     });
     expect(await dictUpdateCheck.evaluate()).toBeNull();
-    // Should not hit the network while a download is in progress
     expect(checkForUpdate).not.toHaveBeenCalled();
   });
 
@@ -131,7 +154,6 @@ describe("dictUpdateCheck", () => {
     loadAppState.mockResolvedValue({ dictAutoCheckUpdates: false });
     const notice = await dictUpdateCheck.evaluate();
     expect(notice).toBeNull();
-    // The network update check must NOT fire when the preference is OFF.
     expect(checkForUpdate).not.toHaveBeenCalled();
   });
 
@@ -141,8 +163,6 @@ describe("dictUpdateCheck", () => {
     loadAppState.mockResolvedValue({ dictAutoCheckUpdates: false });
     const notice = await dictUpdateCheck.evaluate();
     expect(notice).toMatchObject({ id: "dict-not-installed", type: "warning" });
-    // The "not installed" warning is independent of the auto-check preference,
-    // and must not trigger a network update check.
     expect(checkForUpdate).not.toHaveBeenCalled();
   });
 
@@ -155,41 +175,13 @@ describe("dictUpdateCheck", () => {
     expect(checkForUpdate).toHaveBeenCalledWith("genji");
   });
 
-  it("surfaces an error (not a success toast) when download resolves { success: false }", async () => {
-    setElectronDict(true, async () => ({
-      success: false,
-      error: "ダウンロードはすでに進行中です",
-    }));
+  it("manual download action delegates to runDictDownloadWithProgress", async () => {
+    setElectronDict(true);
     getDownloadState.mockResolvedValue({ providerId: "genji", status: "not-installed" });
     const notice = await dictUpdateCheck.evaluate();
-    expect(notice).toMatchObject({ id: "dict-not-installed" });
-
-    // Trigger the download action and let the resolved-failure path run.
     const onClick = notice?.actions?.[0]?.onClick;
     expect(onClick).toBeTypeOf("function");
     onClick?.();
-    // The optimistic "started" info toast fires synchronously.
-    expect(notifInfo).toHaveBeenCalledWith("辞書のダウンロードを開始しました。");
-    // Let the resolved promise's .then handler run.
-    await lastDownloadMock.current.mock.results[0]?.value;
-    await Promise.resolve();
-    expect(notifError).toHaveBeenCalledWith(
-      expect.stringContaining("ダウンロードはすでに進行中です"),
-    );
-  });
-
-  it("surfaces an error when download rejects", async () => {
-    setElectronDict(true, async () => {
-      throw new Error("checksum mismatch");
-    });
-    getDownloadState.mockResolvedValue({ providerId: "genji", status: "not-installed" });
-    const notice = await dictUpdateCheck.evaluate();
-    const onClick = notice?.actions?.[0]?.onClick;
-    onClick?.();
-    expect(notifInfo).toHaveBeenCalledWith("辞書のダウンロードを開始しました。");
-    // Let the rejected promise's .catch handler run.
-    await lastDownloadMock.current.mock.results[0]?.value.catch(() => {});
-    await Promise.resolve();
-    expect(notifError).toHaveBeenCalledWith(expect.stringContaining("checksum mismatch"));
+    expect(runDictDownloadWithProgress).toHaveBeenCalledTimes(1);
   });
 });

--- a/lib/services/startup-checks/dict-auto-download.ts
+++ b/lib/services/startup-checks/dict-auto-download.ts
@@ -1,0 +1,170 @@
+/**
+ * 辞書（幻辞）の自動ダウンロード共通ロジック。
+ *
+ * dict-corrupt-check / dict-update-check の両方から使う:
+ * - {@link isAutoDownloadAllowed} — 無人での ~526MB ダウンロードを許してよい回線か
+ *   （WiFi 等の非従量回線・データセーバー OFF・省電力モード OFF）を判定する。
+ * - {@link runDictDownloadWithProgress} — 実際のダウンロードを進捗トーストつきで実行。
+ * - {@link startCountdownDownload} — 「あと N 秒で自動ダウンロード」のキャンセル可能な
+ *   カウントダウントーストを表示し、0 で自動的にダウンロードを開始する。
+ *
+ * すべて Electron 専用（web には electronAPI.dict が無い）。
+ */
+import { getDictAccess } from "@/lib/dict/dict-access";
+import { getStorageService } from "@/lib/storage/storage-service";
+import { notificationManager } from "../notification-manager";
+import type { NotificationAction } from "@/types/notification";
+
+interface DictDownloadResult {
+  success: boolean;
+  version?: string;
+  error?: string;
+}
+
+interface ElectronDictApi {
+  download?: () => Promise<DictDownloadResult | undefined>;
+  onDownloadProgress?: (cb: (data: { progress: number }) => void) => () => void;
+}
+
+/** Network Information API（Chromium）の最小型。lib.dom に型が無いため自前定義。 */
+interface NetworkInformationLike {
+  type?: string;
+  saveData?: boolean;
+  effectiveType?: string;
+}
+
+function getElectronDict(): ElectronDictApi | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict;
+}
+
+/**
+ * 無人での自動ダウンロードを許可してよいか。
+ *
+ * 重い辞書（~526MB）を従量回線や省電力中に勝手に落とさないためのゲート。
+ * 判定材料（取得できないものは "安全側=許可" に倒す。確実に危険なときだけ拒否）:
+ * - オフライン（navigator.onLine === false）→ 拒否
+ * - セルラー回線（connection.type === "cellular"）→ 拒否（従量の可能性大）
+ * - OS データセーバー（connection.saveData === true）→ 拒否
+ * - アプリの省電力（節流）モード ON → 拒否
+ */
+export async function isAutoDownloadAllowed(): Promise<boolean> {
+  if (typeof navigator !== "undefined") {
+    if (navigator.onLine === false) return false;
+
+    const connection = (navigator as Navigator & { connection?: NetworkInformationLike })
+      .connection;
+    if (connection) {
+      // type が取れる環境（"wifi"/"ethernet"/"cellular"/"none"/"unknown" …）では
+      // セルラーのみ拒否。desktop では "unknown"/undefined が多いので許可側に倒す。
+      if (connection.type === "cellular" || connection.type === "none") return false;
+      if (connection.saveData === true) return false;
+    }
+  }
+
+  // アプリの省電力（節流）モード中は重いダウンロードを自動起動しない。
+  try {
+    const appState = await getStorageService().loadAppState();
+    if (appState?.powerSaveMode === true) return false;
+  } catch {
+    // 設定が読めない場合は判断材料が無いので、他の条件のみで許可する。
+  }
+
+  return true;
+}
+
+/**
+ * 辞書ダウンロードを進捗トーストつきで実行する（手動ボタン・カウントダウン共通）。
+ * 既定 UA の Chromium と同様、進捗 95% 以降は「展開中」に切り替える。
+ */
+export function runDictDownloadWithProgress(startMessage = "辞書をダウンロード中..."): void {
+  const dict = getElectronDict();
+  if (!dict?.download) return;
+
+  const progressId = notificationManager.showProgress(startMessage, { type: "info" });
+  const cleanup = dict.onDownloadProgress?.(({ progress }) => {
+    notificationManager.updateProgress(
+      progressId,
+      progress,
+      progress < 95 ? startMessage : "辞書を展開中...",
+    );
+  });
+
+  dict
+    .download()
+    .then((result) => {
+      if (result?.success === false) {
+        notificationManager.dismiss(progressId);
+        notificationManager.error(
+          `辞書のダウンロードに失敗しました：${result.error ?? "不明なエラー"}`,
+        );
+      } else {
+        // updateProgress(100) は 3 秒後に自動クローズする。最終イベントが
+        // 100 未満で coalesce された場合に備えて明示的に 100 にする。
+        notificationManager.updateProgress(progressId, 100, "辞書のダウンロードが完了しました");
+        // 新鮮な DB になったので "corrupt" ヘルス・負ルックアップのキャッシュを破棄。
+        getDictAccess().invalidate();
+      }
+    })
+    .catch((e: unknown) => {
+      console.warn("[dict] auto download failed:", e);
+      notificationManager.dismiss(progressId);
+      notificationManager.error(
+        `辞書のダウンロードに失敗しました：${e instanceof Error ? e.message : String(e)}`,
+      );
+    })
+    .finally(() => {
+      cleanup?.();
+    });
+}
+
+interface CountdownOptions {
+  /** カウントダウン秒数（未導入/破損は 10、更新は 30 を想定）。 */
+  seconds: number;
+  /** 残り秒数からトースト本文を生成する。 */
+  buildMessage: (remaining: number) => string;
+  /** ダウンロード進捗トーストの開始メッセージ。 */
+  downloadMessage: string;
+}
+
+/**
+ * キャンセル可能なカウントダウントーストを表示し、0 で自動ダウンロードを開始する。
+ * 「今すぐ」で即時開始、「キャンセル」で中止できる。
+ */
+export function startCountdownDownload(options: CountdownOptions): void {
+  let remaining = options.seconds;
+  // 開閉アクションが id/timer を先に参照する（カウントダウン開始前にクロージャを
+  // 生成する）ため、可変ホルダーに保持する。
+  const ctl: { id: string; timer: ReturnType<typeof setInterval> | null } = {
+    id: "",
+    timer: null,
+  };
+
+  const stop = (): void => {
+    if (ctl.timer !== null) clearInterval(ctl.timer);
+    notificationManager.dismiss(ctl.id);
+  };
+  const startNow = (): void => {
+    stop();
+    runDictDownloadWithProgress(options.downloadMessage);
+  };
+  const actions = (): NotificationAction[] => [
+    { label: "今すぐ", onClick: startNow },
+    { label: "キャンセル", onClick: stop },
+  ];
+
+  ctl.id = notificationManager.showMessage(options.buildMessage(remaining), {
+    type: "info",
+    duration: 0, // カウントダウン中は自動クローズしない
+    actions: actions(),
+  });
+
+  ctl.timer = setInterval(() => {
+    remaining -= 1;
+    if (remaining <= 0) {
+      startNow();
+      return;
+    }
+    notificationManager.updateMessage(ctl.id, options.buildMessage(remaining), actions());
+  }, 1000);
+}

--- a/lib/services/startup-checks/dict-corrupt-check.ts
+++ b/lib/services/startup-checks/dict-corrupt-check.ts
@@ -1,0 +1,70 @@
+/**
+ * Startup check: installed Japanese dictionary (Genji) is corrupt.
+ *
+ * Electron-only (no local DB on web). When {@link getDictAccess}'s health
+ * resolves to "corrupt" — the DB file exists but failed a fast integrity check
+ * (truncated download, bad header, missing table) — surface a warning that
+ * offers to re-download. This runs alongside {@link dictUpdateCheck}; the
+ * corrupt state takes precedence conceptually (a corrupt DB answers no queries).
+ */
+import { getDictAccess } from "@/lib/dict/dict-access";
+import { notificationManager } from "../notification-manager";
+import type { StartupCheck, StartupNotice } from "../startup-check-queue";
+
+interface DictDownloadResult {
+  success: boolean;
+  version?: string;
+  error?: string;
+}
+
+interface ElectronDictApi {
+  download?: () => Promise<DictDownloadResult | undefined>;
+}
+
+function getElectronDict(): ElectronDictApi | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict;
+}
+
+function startRedownload(): void {
+  const dict = getElectronDict();
+  if (!dict?.download) return;
+  notificationManager.info("辞書の再ダウンロードを開始しました。");
+  dict
+    .download()
+    .then((result) => {
+      if (result?.success === false) {
+        notificationManager.error(
+          `辞書の再ダウンロードに失敗しました：${result.error ?? "不明なエラー"}`,
+        );
+      } else {
+        // Clear cached "corrupt" health + negative lookups now that the DB is fresh.
+        getDictAccess().invalidate();
+      }
+    })
+    .catch((e: unknown) => {
+      console.warn("[dict] re-download failed:", e);
+      notificationManager.error(
+        `辞書の再ダウンロードに失敗しました：${e instanceof Error ? e.message : String(e)}`,
+      );
+    });
+}
+
+export const dictCorruptCheck: StartupCheck = {
+  id: "dict-corrupt",
+  async evaluate(): Promise<StartupNotice | null> {
+    // Electron-only feature; the browser has no local dictionary file.
+    if (!getElectronDict()) return null;
+
+    const health = await getDictAccess().getHealth();
+    if (health.state !== "corrupt") return null;
+
+    return {
+      id: "dict-corrupt",
+      type: "warning",
+      message: health.message ?? "辞書データが破損しています。再ダウンロードしてください。",
+      duration: 0, // keep until dismissed
+      actions: [{ label: "再ダウンロード", onClick: startRedownload }],
+    };
+  },
+};

--- a/lib/services/startup-checks/dict-corrupt-check.ts
+++ b/lib/services/startup-checks/dict-corrupt-check.ts
@@ -6,19 +6,20 @@
  * (truncated download, bad header, missing table) — surface a warning that
  * offers to re-download. This runs alongside {@link dictUpdateCheck}; the
  * corrupt state takes precedence conceptually (a corrupt DB answers no queries).
+ *
+ * WiFi 等の非従量回線かつ省電力 OFF のときは、10 秒カウントダウンで自動的に
+ * 再ダウンロードを開始する（#1639 follow-up）。それ以外は手動ボタンのみ。
  */
 import { getDictAccess } from "@/lib/dict/dict-access";
-import { notificationManager } from "../notification-manager";
+import {
+  isAutoDownloadAllowed,
+  runDictDownloadWithProgress,
+  startCountdownDownload,
+} from "./dict-auto-download";
 import type { StartupCheck, StartupNotice } from "../startup-check-queue";
 
-interface DictDownloadResult {
-  success: boolean;
-  version?: string;
-  error?: string;
-}
-
 interface ElectronDictApi {
-  download?: () => Promise<DictDownloadResult | undefined>;
+  download?: () => Promise<unknown>;
 }
 
 function getElectronDict(): ElectronDictApi | undefined {
@@ -26,29 +27,7 @@ function getElectronDict(): ElectronDictApi | undefined {
   return (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict;
 }
 
-function startRedownload(): void {
-  const dict = getElectronDict();
-  if (!dict?.download) return;
-  notificationManager.info("辞書の再ダウンロードを開始しました。");
-  dict
-    .download()
-    .then((result) => {
-      if (result?.success === false) {
-        notificationManager.error(
-          `辞書の再ダウンロードに失敗しました：${result.error ?? "不明なエラー"}`,
-        );
-      } else {
-        // Clear cached "corrupt" health + negative lookups now that the DB is fresh.
-        getDictAccess().invalidate();
-      }
-    })
-    .catch((e: unknown) => {
-      console.warn("[dict] re-download failed:", e);
-      notificationManager.error(
-        `辞書の再ダウンロードに失敗しました：${e instanceof Error ? e.message : String(e)}`,
-      );
-    });
-}
+const REDOWNLOAD_MESSAGE = "辞書を再ダウンロード中...";
 
 export const dictCorruptCheck: StartupCheck = {
   id: "dict-corrupt",
@@ -59,12 +38,27 @@ export const dictCorruptCheck: StartupCheck = {
     const health = await getDictAccess().getHealth();
     if (health.state !== "corrupt") return null;
 
+    // 回線・省電力が許せば 10 秒カウントダウンで自動再ダウンロード。
+    // その場合トーストはカウントダウン側が出すので、ここでは notice を返さない。
+    if (await isAutoDownloadAllowed()) {
+      startCountdownDownload({
+        seconds: 10,
+        buildMessage: (remaining) =>
+          `辞書データが破損しています。${remaining} 秒後に自動で再ダウンロードします。`,
+        downloadMessage: REDOWNLOAD_MESSAGE,
+      });
+      return null;
+    }
+
+    // 自動ダウンロード不可（オフライン/従量回線/省電力中）。手動ボタンのみ提示。
     return {
       id: "dict-corrupt",
       type: "warning",
       message: health.message ?? "辞書データが破損しています。再ダウンロードしてください。",
       duration: 0, // keep until dismissed
-      actions: [{ label: "再ダウンロード", onClick: startRedownload }],
+      actions: [
+        { label: "再ダウンロード", onClick: () => runDictDownloadWithProgress(REDOWNLOAD_MESSAGE) },
+      ],
     };
   },
 };

--- a/lib/services/startup-checks/dict-update-check.ts
+++ b/lib/services/startup-checks/dict-update-check.ts
@@ -13,58 +13,33 @@
  * API and returns `{ latestVersion, installedVersion, updateAvailable }`.
  * Network failures are swallowed so startup is never blocked by connectivity
  * problems and no error toast is surfaced.
+ *
+ * 自動化（#1639 follow-up）: WiFi 等の非従量回線かつ省電力 OFF のときは、
+ * - 未導入   → 10 秒カウントダウンで自動ダウンロード
+ * - 更新あり → 30 秒カウントダウンで自動更新
+ * を行う。条件を満たさない場合は従来どおり手動ボタンのトーストを出す。
  */
 import { getDictService } from "@/lib/dict/dict-service";
 import { getStorageService } from "@/lib/storage/storage-service";
-import { notificationManager } from "../notification-manager";
+import {
+  isAutoDownloadAllowed,
+  runDictDownloadWithProgress,
+  startCountdownDownload,
+} from "./dict-auto-download";
 import type { StartupCheck, StartupNotice } from "../startup-check-queue";
 
 const GENJI_PROVIDER_ID = "genji";
-
-/**
- * Result shape resolved by `electronAPI.dict.download()` (IPC `dict:download`).
- * The handler RESOLVES `{ success: false, error }` on recoverable failures
- * (another download running, checksum/URL validation, etc.) rather than
- * rejecting, so the caller must inspect `success` — not just rely on `.catch`.
- */
-interface DictDownloadResult {
-  success: boolean;
-  version?: string;
-  error?: string;
-}
+const DOWNLOAD_MESSAGE = "辞書をダウンロード中...";
+const UPDATE_MESSAGE = "辞書を更新中...";
 
 interface ElectronDictApi {
-  download?: () => Promise<DictDownloadResult | undefined>;
+  download?: () => Promise<unknown>;
   getStatus?: () => Promise<unknown>;
 }
 
 function getElectronDict(): ElectronDictApi | undefined {
   if (typeof window === "undefined") return undefined;
   return (window as Window & { electronAPI?: { dict?: ElectronDictApi } }).electronAPI?.dict;
-}
-
-function startDictDownload(): void {
-  const dict = getElectronDict();
-  if (!dict?.download) return;
-  notificationManager.info("辞書のダウンロードを開始しました。");
-  // The IPC handler resolves `{ success: false, error }` on recoverable
-  // failures instead of rejecting, so inspect the resolved result and surface
-  // the error rather than leaving the optimistic "started" toast standing.
-  dict
-    .download()
-    .then((result) => {
-      if (result?.success === false) {
-        notificationManager.error(
-          `辞書のダウンロードに失敗しました：${result.error ?? "不明なエラー"}`,
-        );
-      }
-    })
-    .catch((e: unknown) => {
-      console.warn("[dict] download failed:", e);
-      notificationManager.error(
-        `辞書のダウンロードに失敗しました：${e instanceof Error ? e.message : String(e)}`,
-      );
-    });
 }
 
 export const dictUpdateCheck: StartupCheck = {
@@ -76,13 +51,28 @@ export const dictUpdateCheck: StartupCheck = {
     const state = await getDictService().getDownloadState(GENJI_PROVIDER_ID);
 
     if (state.status === "not-installed") {
+      // 回線・省電力が許せば 10 秒カウントダウンで自動ダウンロード。
+      if (await isAutoDownloadAllowed()) {
+        startCountdownDownload({
+          seconds: 10,
+          buildMessage: (remaining) =>
+            `日本語辞書が未ダウンロードです。${remaining} 秒後に自動でダウンロードします。`,
+          downloadMessage: DOWNLOAD_MESSAGE,
+        });
+        return null;
+      }
       return {
         id: "dict-not-installed",
         type: "warning",
         message:
           "日本語辞書が未ダウンロードです。ダウンロードすると校正と辞書引きがより正確になります。",
         duration: 0, // keep until dismissed
-        actions: [{ label: "今すぐダウンロード", onClick: startDictDownload }],
+        actions: [
+          {
+            label: "今すぐダウンロード",
+            onClick: () => runDictDownloadWithProgress(DOWNLOAD_MESSAGE),
+          },
+        ],
       };
     }
 
@@ -121,12 +111,24 @@ export const dictUpdateCheck: StartupCheck = {
 
     const from = updateResult.installedVersion ?? "?";
     const to = updateResult.latestVersion ?? "?";
+
+    // 回線・省電力が許せば 30 秒カウントダウンで自動更新。
+    if (await isAutoDownloadAllowed()) {
+      startCountdownDownload({
+        seconds: 30,
+        buildMessage: (remaining) =>
+          `日本語辞書の更新があります（${from} → ${to}）。${remaining} 秒後に自動で更新します。`,
+        downloadMessage: UPDATE_MESSAGE,
+      });
+      return null;
+    }
+
     return {
       id: "dict-update-available",
       type: "info",
       message: `日本語辞書の更新があります（${from} → ${to}）。`,
       duration: 0,
-      actions: [{ label: "更新", onClick: startDictDownload }],
+      actions: [{ label: "更新", onClick: () => runDictDownloadWithProgress(UPDATE_MESSAGE) }],
     };
   },
 };

--- a/lib/storage/local-preferences.ts
+++ b/lib/storage/local-preferences.ts
@@ -15,6 +15,7 @@ const KEYS = {
   sidebarTopOrder: `${PREFIX}sidebar-top-order`,
   sidebarBottomOrder: `${PREFIX}sidebar-bottom-order`,
   searchHistory: `${PREFIX}search-history`,
+  genjiAnalysisExpanded: `${PREFIX}genji-analysis-expanded`,
 } as const;
 
 // One-time migration from old keys to new keys
@@ -143,5 +144,14 @@ export const localPreferences = {
   },
   setSearchHistory(entries: readonly string[]): void {
     set(KEYS.searchHistory, JSON.stringify(entries));
+  },
+
+  // --- 語彙統計「辞書データからの分析」セクションの開閉（既定: 展開）---
+  getGenjiAnalysisExpanded(): boolean {
+    // 未保存 (null) のときは既定で展開。明示的に "0" のときだけ折り畳み。
+    return get(KEYS.genjiAnalysisExpanded) !== "0";
+  },
+  setGenjiAnalysisExpanded(expanded: boolean): void {
+    set(KEYS.genjiAnalysisExpanded, expanded ? "1" : "0");
   },
 } as const;

--- a/lib/storage/local-preferences.ts
+++ b/lib/storage/local-preferences.ts
@@ -14,6 +14,7 @@ const KEYS = {
   rightTab: `${PREFIX}right-tab`,
   sidebarTopOrder: `${PREFIX}sidebar-top-order`,
   sidebarBottomOrder: `${PREFIX}sidebar-bottom-order`,
+  searchHistory: `${PREFIX}search-history`,
 } as const;
 
 // One-time migration from old keys to new keys
@@ -125,5 +126,22 @@ export const localPreferences = {
   },
   setSidebarBottomOrder(ids: string[]): void {
     set(KEYS.sidebarBottomOrder, JSON.stringify(ids));
+  },
+
+  // --- Search history ---
+  getSearchHistory(): string[] {
+    const raw = get(KEYS.searchHistory);
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return Array.isArray(parsed)
+        ? parsed.filter((value): value is string => typeof value === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  },
+  setSearchHistory(entries: readonly string[]): void {
+    set(KEYS.searchHistory, JSON.stringify(entries));
   },
 } as const;

--- a/lib/utils/__tests__/genji-word-info.test.ts
+++ b/lib/utils/__tests__/genji-word-info.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for buildGenjiWordInfoViewModel.
+ *
+ * We test only the pure function — no React, no DictService.
+ * The hook's async branching is validated by the state machine contracts
+ * documented in genji-word-info.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { buildGenjiWordInfoViewModel } from "../genji-word-info";
+import type { DictQueryResult, DictEntry } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEntry(overrides: Partial<DictEntry> = {}): DictEntry {
+  return {
+    id: "test-1",
+    entry: "雪",
+    reading: { primary: "ゆき", alternatives: [] },
+    partOfSpeech: "名詞",
+    inflections: [],
+    definitions: [
+      { gloss: "大気中の水蒸気が結晶して降る白いもの", register: "文章語" },
+      { gloss: "白色のたとえ" },
+      { gloss: "冬の風物詩" },
+      { gloss: "余分な四番目の語義" },
+    ],
+    relationships: {
+      homophones: [],
+      synonyms: ["白雪", "積雪", "降雪", "初雪", "粉雪", "余分な類義語"],
+      antonyms: [],
+      related: [],
+    },
+    source: "genji",
+    ...overrides,
+  };
+}
+
+function makeResult(entries: DictEntry[] = [makeEntry()]): DictQueryResult {
+  return { entries, noResults: false, providerUnavailable: false };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("buildGenjiWordInfoViewModel", () => {
+  it("extracts reading, partOfSpeech, register, glosses, synonyms from the first entry", () => {
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult());
+
+    expect(vm).not.toBeNull();
+    expect(vm!.word).toBe("雪");
+    expect(vm!.reading).toBe("ゆき");
+    expect(vm!.partOfSpeech).toBe("名詞");
+    expect(vm!.register).toBe("文章語");
+  });
+
+  it("limits glosses to 3 items maximum", () => {
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult());
+
+    expect(vm!.glosses).toHaveLength(3);
+    expect(vm!.glosses[0]).toBe("大気中の水蒸気が結晶して降る白いもの");
+    expect(vm!.glosses[2]).toBe("冬の風物詩");
+  });
+
+  it("limits synonyms to 5 items maximum", () => {
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult());
+
+    expect(vm!.synonyms).toHaveLength(5);
+    expect(vm!.synonyms[0]).toBe("白雪");
+    expect(vm!.synonyms[4]).toBe("粉雪");
+    // sixth should be excluded
+  });
+
+  it("returns null when result is null", () => {
+    expect(buildGenjiWordInfoViewModel("雪", null)).toBeNull();
+  });
+
+  it("returns null when result is undefined", () => {
+    expect(buildGenjiWordInfoViewModel("雪", undefined)).toBeNull();
+  });
+
+  it("returns null when providerUnavailable is true", () => {
+    const result: DictQueryResult = { entries: [], noResults: false, providerUnavailable: true };
+    expect(buildGenjiWordInfoViewModel("雪", result)).toBeNull();
+  });
+
+  it("returns null when entries array is empty", () => {
+    const result: DictQueryResult = { entries: [], noResults: true, providerUnavailable: false };
+    expect(buildGenjiWordInfoViewModel("雪", result)).toBeNull();
+  });
+
+  it("returns null when noResults is true with empty entries", () => {
+    const result: DictQueryResult = { entries: [], noResults: true, providerUnavailable: false };
+    expect(buildGenjiWordInfoViewModel("雪", result)).toBeNull();
+  });
+
+  it("handles entry with no definitions gracefully", () => {
+    const entry = makeEntry({ definitions: [] });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm).not.toBeNull();
+    expect(vm!.glosses).toHaveLength(0);
+    expect(vm!.register).toBeNull();
+  });
+
+  it("handles entry with no synonyms gracefully", () => {
+    const entry = makeEntry({
+      relationships: { homophones: [], synonyms: [], antonyms: [], related: [] },
+    });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm).not.toBeNull();
+    expect(vm!.synonyms).toHaveLength(0);
+  });
+
+  it("returns null partOfSpeech when entry has no partOfSpeech", () => {
+    const entry = makeEntry({ partOfSpeech: undefined });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm!.partOfSpeech).toBeNull();
+  });
+
+  it("returns null register when no definition carries a register", () => {
+    const entry = makeEntry({
+      definitions: [{ gloss: "読み込み無しの語義" }],
+    });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm!.register).toBeNull();
+  });
+
+  it("picks the first non-empty register across definitions", () => {
+    const entry = makeEntry({
+      definitions: [
+        { gloss: "最初の語義" },
+        { gloss: "二番目の語義", register: "口語" },
+        { gloss: "三番目の語義", register: "文章語" },
+      ],
+    });
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult([entry]));
+
+    expect(vm!.register).toBe("口語");
+  });
+
+  it("uses the word argument as the ViewModel word, not entry.entry", () => {
+    // Useful when the query surface and the headword differ slightly
+    const vm = buildGenjiWordInfoViewModel("QUERY", makeResult());
+    expect(vm!.word).toBe("QUERY");
+  });
+});

--- a/lib/utils/__tests__/readability-genji.test.ts
+++ b/lib/utils/__tests__/readability-genji.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { analyzeReadability, enrichReadabilityWithDict } from "../readability";
+import type { DictLookup } from "@/lib/dict/dict-types";
+import type { Token } from "@/lib/nlp-client/types";
+
+/**
+ * Tests for Tier 3 (幻辞 freq_rank) readability enrichment, #1627.
+ * Pure-function level — the health gating / DictAccess wiring lives in
+ * use-text-statistics.ts and is exercised there.
+ */
+
+const BASE_TEXT = "吾輩は猫である。名前はまだ無いが、彼は静かに庭を眺めていた。";
+
+function noun(basicForm: string): Token {
+  return {
+    surface: basicForm,
+    pos: "名詞",
+    basic_form: basicForm,
+    reading: "",
+    start: 0,
+    end: basicForm.length,
+  } as Token;
+}
+
+function lookup(map: Record<string, number | null>): Map<string, DictLookup> {
+  const out = new Map<string, DictLookup>();
+  for (const [word, freqRank] of Object.entries(map)) {
+    out.set(word, freqRank === null ? { found: false } : { found: true, freqRank });
+  }
+  return out;
+}
+
+describe("enrichReadabilityWithDict (Tier 3, #1627)", () => {
+  it("sets hasDictAnalysis=true and leaves scores untouched for an empty lookup map", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const result = enrichReadabilityWithDict(base, [], new Map());
+    expect(result.hasDictAnalysis).toBe(true);
+    expect(result.subScores.vocabulary).toBe(base.subScores.vocabulary);
+  });
+
+  it("sets hasDictAnalysis=true but does not change vocabulary when no content word is found", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const tokens = [noun("造語A"), noun("造語B")];
+    const result = enrichReadabilityWithDict(base, tokens, lookup({ 造語A: null, 造語B: null }));
+    expect(result.hasDictAnalysis).toBe(true);
+    expect(result.subScores.vocabulary).toBe(base.subScores.vocabulary);
+    expect(result.detail.vocabulary.avgFreqRank).toBeUndefined();
+  });
+
+  it("lowers the vocabulary subscore when rare words dominate", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const tokens = [noun("顰蹙"), noun("邂逅"), noun("瀟洒")];
+    // All rare (freq_rank > 50,000): rareWordRate = 1.0, avgFreqRank > 30,000.
+    const result = enrichReadabilityWithDict(
+      base,
+      tokens,
+      lookup({ 顰蹙: 62000, 邂逅: 58000, 瀟洒: 71000 }),
+    );
+    expect(result.hasDictAnalysis).toBe(true);
+    expect(result.subScores.vocabulary).toBeLessThan(base.subScores.vocabulary);
+    expect(result.detail.vocabulary.rareWordRate).toBe(1);
+    expect(result.detail.vocabulary.avgFreqRank).toBeGreaterThan(30_000);
+  });
+
+  it("gives a small bonus when common words dominate", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const tokens = [noun("猫"), noun("名前"), noun("庭")];
+    // All common (avg freq_rank < 3,000), no rare words.
+    const result = enrichReadabilityWithDict(
+      base,
+      tokens,
+      lookup({ 猫: 800, 名前: 400, 庭: 1500 }),
+    );
+    expect(result.hasDictAnalysis).toBe(true);
+    expect(result.subScores.vocabulary).toBeGreaterThanOrEqual(base.subScores.vocabulary);
+    expect(result.detail.vocabulary.rareWordRate).toBe(0);
+  });
+
+  it("recomputes the composite score and level from the adjusted subscores", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    const tokens = [noun("顰蹙"), noun("邂逅")];
+    const result = enrichReadabilityWithDict(base, tokens, lookup({ 顰蹙: 62000, 邂逅: 70000 }));
+    // Lower vocabulary → composite score should not exceed the base score.
+    expect(result.score).toBeLessThanOrEqual(base.score);
+    expect(["easy", "normal", "difficult"]).toContain(result.level);
+  });
+});

--- a/lib/utils/__tests__/readability-genji.test.ts
+++ b/lib/utils/__tests__/readability-genji.test.ts
@@ -76,6 +76,20 @@ describe("enrichReadabilityWithDict (Tier 3, #1627)", () => {
     expect(result.detail.vocabulary.rareWordRate).toBe(0);
   });
 
+  it("treats mid-rank words (10,000–50,000) as rare so the score actually moves (#1639)", () => {
+    const base = analyzeReadability(BASE_TEXT);
+    // 12,000 / 18,000 / 25,000 はかつての RARE_THRESHOLD (50,000) では稀少扱いされず
+    // スコアが動かなかった。新境界 (10,000) では稀少語率 = 1.0 で語彙スコアが下がる。
+    const tokens = [noun("逡巡"), noun("邂逅"), noun("泡沫")];
+    const result = enrichReadabilityWithDict(
+      base,
+      tokens,
+      lookup({ 逡巡: 12000, 邂逅: 18000, 泡沫: 25000 }),
+    );
+    expect(result.detail.vocabulary.rareWordRate).toBe(1);
+    expect(result.subScores.vocabulary).toBeLessThan(base.subScores.vocabulary);
+  });
+
   it("recomputes the composite score and level from the adjusted subscores", () => {
     const base = analyzeReadability(BASE_TEXT);
     const tokens = [noun("顰蹙"), noun("邂逅")];

--- a/lib/utils/__tests__/ruby-readings.test.ts
+++ b/lib/utils/__tests__/ruby-readings.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for lib/utils/ruby-readings.ts
+ *
+ * Covers:
+ *   - katakana→hiragana normalisation
+ *   - deduplication (order-preserving, case-insensitive normalised)
+ *   - buildReadingCandidates: Genji primary+alternatives + kuromoji merge
+ *   - buildReadingCandidates: Genji hit absent → kuromoji only
+ *   - buildReadingCandidates: empty inputs
+ *   - buildBatchReadingCandidates: multiple segments
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  katakanaToHiragana,
+  deduplicateReadings,
+  buildReadingCandidates,
+  buildBatchReadingCandidates,
+} from "../ruby-readings";
+import type { DictLookup, DictEntry } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDictEntry(primary: string, alternatives: string[] = []): DictEntry {
+  return {
+    id: `test-${primary}`,
+    entry: "雪女",
+    reading: { primary, alternatives },
+    definitions: [],
+    relationships: { homophones: [], synonyms: [], antonyms: [], related: [] },
+    source: "test",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// katakanaToHiragana
+// ---------------------------------------------------------------------------
+
+describe("katakanaToHiragana", () => {
+  it("converts full-width katakana to hiragana", () => {
+    expect(katakanaToHiragana("ユキオンナ")).toBe("ゆきおんな");
+  });
+
+  it("leaves hiragana unchanged", () => {
+    expect(katakanaToHiragana("ゆき")).toBe("ゆき");
+  });
+
+  it("leaves kanji and ASCII unchanged", () => {
+    expect(katakanaToHiragana("ABC漢字")).toBe("ABC漢字");
+  });
+
+  it("handles empty string", () => {
+    expect(katakanaToHiragana("")).toBe("");
+  });
+
+  it("converts mixed katakana/hiragana string", () => {
+    expect(katakanaToHiragana("ユキゆきオンナおんな")).toBe("ゆきゆきおんなおんな");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deduplicateReadings
+// ---------------------------------------------------------------------------
+
+describe("deduplicateReadings", () => {
+  it("removes exact duplicates", () => {
+    expect(deduplicateReadings(["ゆき", "ゆき", "おんな"])).toEqual(["ゆき", "おんな"]);
+  });
+
+  it("normalises katakana before deduplication", () => {
+    // katakana ユキ and hiragana ゆき should collapse to one entry
+    expect(deduplicateReadings(["ユキ", "ゆき"])).toEqual(["ゆき"]);
+  });
+
+  it("preserves first occurrence order", () => {
+    expect(deduplicateReadings(["おんな", "ゆき", "おんな"])).toEqual(["おんな", "ゆき"]);
+  });
+
+  it("removes empty strings and whitespace-only entries", () => {
+    expect(deduplicateReadings(["", "  ", "ゆき"])).toEqual(["ゆき"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(deduplicateReadings([])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildReadingCandidates
+// ---------------------------------------------------------------------------
+
+describe("buildReadingCandidates", () => {
+  it("returns only kuromoji reading when Genji has no match", () => {
+    const lookup: DictLookup = { found: false };
+    const result = buildReadingCandidates("ゆきおんな", lookup, []);
+    expect(result).toEqual(["ゆきおんな"]);
+  });
+
+  it("returns Genji primary first, then kuromoji (if different)", () => {
+    const lookup: DictLookup = { found: true, reading: "せつじょ" };
+    // kuromoji gives a different reading
+    const result = buildReadingCandidates("ゆきおんな", lookup, []);
+    expect(result[0]).toBe("せつじょ");
+    expect(result).toContain("ゆきおんな");
+  });
+
+  it("deduplicates Genji primary when kuromoji gives the same reading", () => {
+    const lookup: DictLookup = { found: true, reading: "ゆきおんな" };
+    const result = buildReadingCandidates("ゆきおんな", lookup, []);
+    // Should not repeat
+    expect(result).toEqual(["ゆきおんな"]);
+  });
+
+  it("includes DictEntry alternatives", () => {
+    const lookup: DictLookup = { found: true, reading: "ゆきおんな" };
+    const entry = makeDictEntry("ゆきおんな", ["せつじょ", "ゆきにょうぼう"]);
+    const result = buildReadingCandidates("ゆきおんな", lookup, [entry]);
+    // primary from DictLookup first, then entry alternatives
+    expect(result).toContain("せつじょ");
+    expect(result).toContain("ゆきにょうぼう");
+    // No duplicates: ゆきおんな appears once even though it's in DictLookup + entry primary
+    expect(result.filter((r) => r === "ゆきおんな").length).toBe(1);
+  });
+
+  it("handles undefined dictLookup gracefully", () => {
+    const result = buildReadingCandidates("ゆき", undefined, []);
+    expect(result).toEqual(["ゆき"]);
+  });
+
+  it("handles empty kuromojiReading and no Genji data", () => {
+    const result = buildReadingCandidates("", undefined, []);
+    expect(result).toEqual([]);
+  });
+
+  it("handles katakana kuromoji reading by normalising to hiragana", () => {
+    const lookup: DictLookup = { found: false };
+    const result = buildReadingCandidates("ユキ", lookup, []);
+    expect(result).toEqual(["ゆき"]);
+  });
+
+  it("merges multiple DictEntries with overlapping alternatives", () => {
+    const entry1 = makeDictEntry("とうきょう", ["とうけい"]);
+    const entry2 = makeDictEntry("とうきょう", ["とうけい", "もとのなまえ"]);
+    const result = buildReadingCandidates("とうきょう", undefined, [entry1, entry2]);
+    // Deduplicated: とうきょう, とうけい, もとのなまえ
+    expect(result).toEqual(["とうきょう", "とうけい", "もとのなまえ"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildBatchReadingCandidates
+// ---------------------------------------------------------------------------
+
+describe("buildBatchReadingCandidates", () => {
+  it("processes multiple segments independently", () => {
+    const inputs = [
+      { surface: "雪", kuromojiReading: "ゆき" },
+      {
+        surface: "女",
+        kuromojiReading: "おんな",
+        dictLookup: { found: true, reading: "じょ" } satisfies DictLookup,
+      },
+    ];
+    const results = buildBatchReadingCandidates(inputs);
+    expect(results).toHaveLength(2);
+    expect(results[0].candidates).toEqual(["ゆき"]);
+    // Genji reading first for 女
+    expect(results[1].candidates[0]).toBe("じょ");
+    expect(results[1].candidates).toContain("おんな");
+  });
+
+  it("returns empty candidates for segment with no reading data", () => {
+    const results = buildBatchReadingCandidates([{ surface: "　", kuromojiReading: "" }]);
+    expect(results[0].candidates).toEqual([]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(buildBatchReadingCandidates([])).toEqual([]);
+  });
+});

--- a/lib/utils/__tests__/vocabulary-genji.test.ts
+++ b/lib/utils/__tests__/vocabulary-genji.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  summarizeGenjiVocabulary,
+  freqRankDistributionToRows,
+  registerDistributionToRows,
+  FREQ_RANK_EVERYDAY,
+  FREQ_RANK_GENERAL,
+} from "@/lib/utils/vocabulary-genji";
+import type { DictLookup } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMap(entries: Array<[string, DictLookup]>): Map<string, DictLookup> {
+  return new Map(entries);
+}
+
+// ---------------------------------------------------------------------------
+// summarizeGenjiVocabulary — basic counts
+// ---------------------------------------------------------------------------
+
+describe("summarizeGenjiVocabulary", () => {
+  it("returns all-zero summary for empty word list", () => {
+    const summary = summarizeGenjiVocabulary([], makeMap([]));
+    expect(summary.freqRankDistribution.everyday).toBe(0);
+    expect(summary.freqRankDistribution.general).toBe(0);
+    expect(summary.freqRankDistribution.rare).toBe(0);
+    expect(summary.freqRankDistribution.unknown).toBe(0);
+    expect(summary.unknownWordCount).toBe(0);
+    expect(summary.totalLookedUp).toBe(0);
+    expect(summary.registerDistribution).toEqual({});
+  });
+
+  it("counts not-found words as unknown (辞書外)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["新語", "造語"],
+      makeMap([
+        ["新語", { found: false }],
+        ["造語", { found: false }],
+      ]),
+    );
+    expect(summary.freqRankDistribution.unknown).toBe(2);
+    expect(summary.unknownWordCount).toBe(2);
+    expect(summary.freqRankDistribution.everyday).toBe(0);
+  });
+
+  it("treats word absent from lookupMap as not-found", () => {
+    // "幽霊語" is not in the map at all — should count as unknown
+    const summary = summarizeGenjiVocabulary(["幽霊語"], makeMap([]));
+    expect(summary.freqRankDistribution.unknown).toBe(1);
+    expect(summary.unknownWordCount).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Bucket boundary tests
+  // -------------------------------------------------------------------------
+
+  it("places rank === FREQ_RANK_EVERYDAY in everyday bucket (boundary)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["境界語"],
+      makeMap([["境界語", { found: true, freqRank: FREQ_RANK_EVERYDAY }]]),
+    );
+    expect(summary.freqRankDistribution.everyday).toBe(1);
+    expect(summary.freqRankDistribution.general).toBe(0);
+  });
+
+  it("places rank === FREQ_RANK_EVERYDAY + 1 in general bucket (boundary)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["境界語"],
+      makeMap([["境界語", { found: true, freqRank: FREQ_RANK_EVERYDAY + 1 }]]),
+    );
+    expect(summary.freqRankDistribution.everyday).toBe(0);
+    expect(summary.freqRankDistribution.general).toBe(1);
+  });
+
+  it("places rank === FREQ_RANK_GENERAL in general bucket (boundary)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["境界語"],
+      makeMap([["境界語", { found: true, freqRank: FREQ_RANK_GENERAL }]]),
+    );
+    expect(summary.freqRankDistribution.general).toBe(1);
+    expect(summary.freqRankDistribution.rare).toBe(0);
+  });
+
+  it("places rank === FREQ_RANK_GENERAL + 1 in rare bucket (boundary)", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["境界語"],
+      makeMap([["境界語", { found: true, freqRank: FREQ_RANK_GENERAL + 1 }]]),
+    );
+    expect(summary.freqRankDistribution.rare).toBe(1);
+    expect(summary.freqRankDistribution.general).toBe(0);
+  });
+
+  it("places found word with undefined freqRank in general bucket", () => {
+    const summary = summarizeGenjiVocabulary(["読み"], makeMap([["読み", { found: true }]]));
+    expect(summary.freqRankDistribution.general).toBe(1);
+    expect(summary.freqRankDistribution.everyday).toBe(0);
+    expect(summary.freqRankDistribution.rare).toBe(0);
+    expect(summary.freqRankDistribution.unknown).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Mixed bucket distribution
+  // -------------------------------------------------------------------------
+
+  it("correctly distributes a mixed word list across all four buckets", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["猫", "走る", "碧落", "新語"],
+      makeMap([
+        ["猫", { found: true, freqRank: 500 }], // everyday
+        ["走る", { found: true, freqRank: 4_000 }], // general
+        ["碧落", { found: true, freqRank: 15_000 }], // rare
+        ["新語", { found: false }], // unknown
+      ]),
+    );
+    expect(summary.freqRankDistribution.everyday).toBe(1);
+    expect(summary.freqRankDistribution.general).toBe(1);
+    expect(summary.freqRankDistribution.rare).toBe(1);
+    expect(summary.freqRankDistribution.unknown).toBe(1);
+    expect(summary.totalLookedUp).toBe(4);
+  });
+
+  // -------------------------------------------------------------------------
+  // Register distribution
+  // -------------------------------------------------------------------------
+
+  it("accumulates register counts correctly", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["言う", "申す", "おっしゃる"],
+      makeMap([
+        ["言う", { found: true, freqRank: 100, register: "口語" }],
+        ["申す", { found: true, freqRank: 2_000, register: "文章語" }],
+        ["おっしゃる", { found: true, freqRank: 800, register: "口語" }],
+      ]),
+    );
+    expect(summary.registerDistribution["口語"]).toBe(2);
+    expect(summary.registerDistribution["文章語"]).toBe(1);
+  });
+
+  it("uses 'なし' key for found words with no register label", () => {
+    const summary = summarizeGenjiVocabulary(
+      ["猫", "犬"],
+      makeMap([
+        ["猫", { found: true, freqRank: 500 }], // no register
+        ["犬", { found: true, freqRank: 600 }], // no register
+      ]),
+    );
+    expect(summary.registerDistribution["なし"]).toBe(2);
+  });
+
+  it("does not add register entry for not-found words", () => {
+    const summary = summarizeGenjiVocabulary(["造語"], makeMap([["造語", { found: false }]]));
+    // No register key should exist because the word wasn't found
+    expect(Object.keys(summary.registerDistribution)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// freqRankDistributionToRows
+// ---------------------------------------------------------------------------
+
+describe("freqRankDistributionToRows", () => {
+  it("returns four rows in fixed order: 常用 → 一般 → 稀少 → 辞書外", () => {
+    const rows = freqRankDistributionToRows({
+      everyday: 10,
+      general: 20,
+      rare: 5,
+      unknown: 3,
+    });
+    expect(rows.map((r) => r.label)).toEqual(["常用", "一般", "稀少", "辞書外"]);
+    expect(rows.map((r) => r.count)).toEqual([10, 20, 5, 3]);
+  });
+
+  it("returns all-zero rows for empty distribution", () => {
+    const rows = freqRankDistributionToRows({
+      everyday: 0,
+      general: 0,
+      rare: 0,
+      unknown: 0,
+    });
+    expect(rows.every((r) => r.count === 0)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerDistributionToRows
+// ---------------------------------------------------------------------------
+
+describe("registerDistributionToRows", () => {
+  it("sorts by count descending", () => {
+    const rows = registerDistributionToRows({
+      文章語: 1,
+      口語: 5,
+      雅語: 3,
+    });
+    expect(rows[0].label).toBe("口語");
+    expect(rows[1].label).toBe("雅語");
+    expect(rows[2].label).toBe("文章語");
+  });
+
+  it("places 'なし' last regardless of count", () => {
+    const rows = registerDistributionToRows({
+      なし: 100,
+      口語: 2,
+    });
+    expect(rows[rows.length - 1].label).toBe("なし");
+  });
+
+  it("returns empty array for empty distribution", () => {
+    expect(registerDistributionToRows({})).toEqual([]);
+  });
+});

--- a/lib/utils/genji-word-info.ts
+++ b/lib/utils/genji-word-info.ts
@@ -106,6 +106,14 @@ const UNAVAILABLE: GenjiWordInfoState = { status: "unavailable" };
  * - On any error (network, IPC, corrupt DB) falls back gracefully to
  *   `{ status: "unavailable" }`.
  */
+/**
+ * Debounce window before the dictionary lookup fires after the selection
+ * settles. Selecting text dispatches selection-change continuously while the
+ * pointer drags; without this every intermediate selection would kick off a
+ * Genji IPC query and freeze the UI (#1639).
+ */
+const LOOKUP_DEBOUNCE_MS = 250;
+
 export function useGenjiWordInfo(selectedWord: string | null | undefined): GenjiWordInfoState {
   const [state, setState] = useState<GenjiWordInfoState>(IDLE);
 
@@ -117,36 +125,43 @@ export function useGenjiWordInfo(selectedWord: string | null | undefined): Genji
     }
 
     let cancelled = false;
-    setState(LOADING);
 
-    void (async () => {
-      try {
-        // Dynamic import keeps getDictService out of SSR / web-worker bundles
-        const { getDictService } = await import("@/lib/dict/dict-service");
-        const result = await getDictService().query(word, 1);
+    // Defer the (potentially IPC-backed) lookup until the selection stops
+    // changing. The previous result stays visible during the debounce window
+    // so the panel doesn't flicker to a loading state on every drag tick.
+    const timer = setTimeout(() => {
+      setState(LOADING);
 
-        if (cancelled) return;
+      void (async () => {
+        try {
+          // Dynamic import keeps getDictService out of SSR / web-worker bundles
+          const { getDictService } = await import("@/lib/dict/dict-service");
+          const result = await getDictService().query(word, 1);
 
-        if (result.providerUnavailable) {
-          setState(UNAVAILABLE);
-          return;
+          if (cancelled) return;
+
+          if (result.providerUnavailable) {
+            setState(UNAVAILABLE);
+            return;
+          }
+
+          const viewModel = buildGenjiWordInfoViewModel(word, result);
+          if (viewModel) {
+            setState({ status: "found", viewModel });
+          } else {
+            setState(NOT_FOUND);
+          }
+        } catch {
+          if (!cancelled) {
+            setState(UNAVAILABLE);
+          }
         }
-
-        const viewModel = buildGenjiWordInfoViewModel(word, result);
-        if (viewModel) {
-          setState({ status: "found", viewModel });
-        } else {
-          setState(NOT_FOUND);
-        }
-      } catch {
-        if (!cancelled) {
-          setState(UNAVAILABLE);
-        }
-      }
-    })();
+      })();
+    }, LOOKUP_DEBOUNCE_MS);
 
     return () => {
       cancelled = true;
+      clearTimeout(timer);
     };
   }, [selectedWord]);
 

--- a/lib/utils/genji-word-info.ts
+++ b/lib/utils/genji-word-info.ts
@@ -1,0 +1,154 @@
+/**
+ * Genji word-info utilities: extract a display-ready ViewModel from a
+ * DictQueryResult / DictEntry[], and a React hook that drives the async lookup.
+ *
+ * Design rules:
+ * - Pure functions are unit-testable without any React / browser env.
+ * - The hook is the only place that calls getDictService().
+ * - All failures are swallowed; callers receive null instead of throwing.
+ */
+
+import { useEffect, useState } from "react";
+
+import type { DictEntry } from "@/lib/dict/dict-types";
+import type { DictQueryResult } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// ViewModel
+// ---------------------------------------------------------------------------
+
+/** Maximum number of glosses shown in the inspector panel */
+const MAX_GLOSSES = 3;
+/** Maximum number of synonyms shown in the inspector panel */
+const MAX_SYNONYMS = 5;
+
+export interface GenjiWordInfoViewModel {
+  /** Surface form that was queried */
+  word: string;
+  /** Primary reading (kana) */
+  reading: string | null;
+  /** Part of speech from the first entry */
+  partOfSpeech: string | null;
+  /** Register label (口語/文章語/雅語 …) from the first definition that carries one */
+  register: string | null;
+  /** Up to MAX_GLOSSES gloss strings */
+  glosses: string[];
+  /** Up to MAX_SYNONYMS synonym strings */
+  synonyms: string[];
+}
+
+/**
+ * Extract the first non-empty register string across all definitions of one entry.
+ */
+function extractRegister(entry: DictEntry): string | null {
+  for (const def of entry.definitions) {
+    if (def.register && def.register.trim().length > 0) {
+      return def.register.trim();
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a display ViewModel from the first matching entry in a DictQueryResult.
+ *
+ * Returns null when:
+ * - `result` is null / undefined
+ * - `result.providerUnavailable` is true
+ * - `result.entries` is empty
+ */
+export function buildGenjiWordInfoViewModel(
+  word: string,
+  result: DictQueryResult | null | undefined,
+): GenjiWordInfoViewModel | null {
+  if (!result || result.providerUnavailable || result.entries.length === 0) {
+    return null;
+  }
+
+  const entry = result.entries[0];
+
+  const reading = entry.reading.primary.trim() || null;
+  const partOfSpeech = entry.partOfSpeech?.trim() || null;
+  const register = extractRegister(entry);
+  const glosses = entry.definitions
+    .map((d) => d.gloss.trim())
+    .filter((g) => g.length > 0)
+    .slice(0, MAX_GLOSSES);
+  const synonyms = (entry.relationships.synonyms ?? [])
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .slice(0, MAX_SYNONYMS);
+
+  return { word, reading, partOfSpeech, register, glosses, synonyms };
+}
+
+// ---------------------------------------------------------------------------
+// React hook
+// ---------------------------------------------------------------------------
+
+export type GenjiWordInfoState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "found"; viewModel: GenjiWordInfoViewModel }
+  | { status: "not-found" }
+  | { status: "unavailable" };
+
+const IDLE: GenjiWordInfoState = { status: "idle" };
+const LOADING: GenjiWordInfoState = { status: "loading" };
+const NOT_FOUND: GenjiWordInfoState = { status: "not-found" };
+const UNAVAILABLE: GenjiWordInfoState = { status: "unavailable" };
+
+/**
+ * Async hook that looks up `selectedWord` in the Genji dictionary and returns
+ * a typed state object for the UI to render.
+ *
+ * - When `selectedWord` is empty/null, returns `{ status: "idle" }`.
+ * - On any error (network, IPC, corrupt DB) falls back gracefully to
+ *   `{ status: "unavailable" }`.
+ */
+export function useGenjiWordInfo(selectedWord: string | null | undefined): GenjiWordInfoState {
+  const [state, setState] = useState<GenjiWordInfoState>(IDLE);
+
+  useEffect(() => {
+    const word = selectedWord?.trim();
+    if (!word) {
+      setState(IDLE);
+      return;
+    }
+
+    let cancelled = false;
+    setState(LOADING);
+
+    void (async () => {
+      try {
+        // Dynamic import keeps getDictService out of SSR / web-worker bundles
+        const { getDictService } = await import("@/lib/dict/dict-service");
+        const result = await getDictService().query(word, 1);
+
+        if (cancelled) return;
+
+        if (result.providerUnavailable) {
+          setState(UNAVAILABLE);
+          return;
+        }
+
+        const viewModel = buildGenjiWordInfoViewModel(word, result);
+        if (viewModel) {
+          setState({ status: "found", viewModel });
+        } else {
+          setState(NOT_FOUND);
+        }
+      } catch {
+        if (!cancelled) {
+          setState(UNAVAILABLE);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedWord]);
+
+  return state;
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -5,7 +5,12 @@
 import { stripMdiInlineSyntax } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import { analyzeReadability, cleanMarkdown } from "./readability";
 export type { EnhancedReadabilityAnalysis, ReadabilitySubScores } from "./readability-types";
-export { analyzeReadability, enrichReadabilityWithMorphology, cleanMarkdown } from "./readability";
+export {
+  analyzeReadability,
+  enrichReadabilityWithMorphology,
+  enrichReadabilityWithDict,
+  cleanMarkdown,
+} from "./readability";
 
 /**
  * 文字数から原稿用紙枚数を算出する

--- a/lib/utils/readability-types.ts
+++ b/lib/utils/readability-types.ts
@@ -36,6 +36,10 @@ export interface VocabularyMetrics {
   properNounRate?: number;
   /** kuromoji使用時のみ有効: type-token ratio（内容語） */
   ttr?: number;
+  /** 幻辞使用時のみ有効: ヒット語の freq_rank 平均（小さいほど一般語） */
+  avgFreqRank?: number;
+  /** 幻辞使用時のみ有効: 稀少語（freq_rank > RARE_THRESHOLD）の割合 */
+  rareWordRate?: number;
 }
 
 /** 構文に関する指標 */
@@ -102,4 +106,6 @@ export interface EnhancedReadabilityAnalysis {
   avgPunctuationSpacing: number;
   /** kuromoji形態素分析が反映されているか */
   hasMorphologicalAnalysis: boolean;
+  /** 幻辞（Genji）辞書による語彙補強が反映されているか */
+  hasDictAnalysis: boolean;
 }

--- a/lib/utils/readability.ts
+++ b/lib/utils/readability.ts
@@ -475,15 +475,19 @@ export function enrichReadabilityWithMorphology(
  *   「稀少語率」は小説における語彙の難度に直接影響する指標（JIS X 4051 準拠評価や
  *   文化庁「公用文作成の考え方」（2022）が「平易な語の選択」を求める背景から妥当）。
  *
- *   スコア補正: 平均 freq_rank が高いほど（稀少語が多いほど）語彙スコアを下げる。
- *   - 稀少語率 > 0.3 → -15 pt（明らかに難語が多い）
- *   - 稀少語率 0.2〜0.3 → -8 pt
- *   - 稀少語率 0.1〜0.2 → -4 pt
- *   - 平均 freq_rank > 30,000 → 追加 -10 pt
- *   - 平均 freq_rank 10,000〜30,000 → 追加 -5 pt
- *   - 平均 freq_rank < 3,000（平易語が多い）→ +5 pt ボーナス
+ *   スコア補正: 稀少語率（と補助的に平均 freq_rank）が高いほど語彙スコアを下げる。
+ *   - 稀少語率 > 0.4 → -25 pt（難語が支配的）
+ *   - 稀少語率 0.3〜0.4 → -18 pt
+ *   - 稀少語率 0.2〜0.3 → -12 pt
+ *   - 稀少語率 0.1〜0.2 → -6 pt
+ *   - 稀少語率 0.05〜0.1 → -3 pt
+ *   - 平均 freq_rank > 15,000 → 追加 -8 pt
+ *   - 平均 freq_rank 8,000〜15,000 → 追加 -4 pt
+ *   - 平均 freq_rank < 2,000（平易語が多い）→ +5 pt ボーナス
  */
-const RARE_THRESHOLD = 50_000;
+// 「稀少」の判定境界。語彙統計パネルの 稀少 バケット（FREQ_RANK_GENERAL = 10,000）と
+// 揃える。以前は 50,000 と過度に厳しく、稀少語が多い文章でもスコアがほぼ動かなかった（#1639）。
+const RARE_THRESHOLD = 10_000;
 
 /**
  * 幻辞（Genji）の freq_rank バッチ照合結果で語彙難易度サブスコアを補強する（Tier 3）。
@@ -535,16 +539,20 @@ export function enrichReadabilityWithDict(
   const avgFreqRank = Math.round(freqRanks.reduce((a, b) => a + b, 0) / freqRanks.length);
   const rareWordRate = rareCount / freqRanks.length;
 
-  // 語彙スコア補正: 稀少語率・平均 freq_rank に基づいてペナルティ/ボーナスを加算
+  // 語彙スコア補正: 稀少語率を主シグナル、平均 freq_rank を補助シグナルとして
+  // ペナルティ/ボーナスを加算。平均は高頻度の機能語・常用語に引っ張られて鈍いため、
+  // 稀少語率に重みを置く（#1639）。
   let vocabDelta = 0;
 
-  if (rareWordRate > 0.3) vocabDelta -= 15;
-  else if (rareWordRate > 0.2) vocabDelta -= 8;
-  else if (rareWordRate > 0.1) vocabDelta -= 4;
+  if (rareWordRate > 0.4) vocabDelta -= 25;
+  else if (rareWordRate > 0.3) vocabDelta -= 18;
+  else if (rareWordRate > 0.2) vocabDelta -= 12;
+  else if (rareWordRate > 0.1) vocabDelta -= 6;
+  else if (rareWordRate > 0.05) vocabDelta -= 3;
 
-  if (avgFreqRank > 30_000) vocabDelta -= 10;
-  else if (avgFreqRank > 10_000) vocabDelta -= 5;
-  else if (avgFreqRank < 3_000) vocabDelta += 5;
+  if (avgFreqRank > 15_000) vocabDelta -= 8;
+  else if (avgFreqRank > 8_000) vocabDelta -= 4;
+  else if (avgFreqRank < 2_000) vocabDelta += 5;
 
   const newVocabScore = Math.max(0, Math.min(100, base.subScores.vocabulary + vocabDelta));
 

--- a/lib/utils/readability.ts
+++ b/lib/utils/readability.ts
@@ -14,6 +14,7 @@
 
 import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import type { Token } from "@/lib/nlp-client/types";
+import type { DictLookup } from "@/lib/dict/dict-types";
 import type {
   EnhancedReadabilityAnalysis,
   ParagraphMetrics,
@@ -375,6 +376,7 @@ export function analyzeReadability(rawText: string): EnhancedReadabilityAnalysis
     avgSentenceLength,
     avgPunctuationSpacing: syntaxMetrics.avgPunctuationSpacing,
     hasMorphologicalAnalysis: false,
+    hasDictAnalysis: false,
   };
 }
 
@@ -458,5 +460,116 @@ export function enrichReadabilityWithMorphology(
       syntax: enrichedSyntax,
     },
     hasMorphologicalAnalysis: true,
+    hasDictAnalysis: base.hasDictAnalysis,
+  };
+}
+
+// ── Tier 3: Dictionary-based enrichment ───────────────────────────────────
+
+/**
+ * 幻辞 freq_rank を利用した語彙難易度算出の閾値・重み定数。
+ *
+ * 根拠:
+ *   Genji corpus は約 50 万語収録（推定）。freq_rank 1〜10,000 が一般語（常用〜準常用）、
+ *   10,001〜50,000 が準稀少語、50,001 以上が稀少語と大雑把に分類できる。
+ *   「稀少語率」は小説における語彙の難度に直接影響する指標（JIS X 4051 準拠評価や
+ *   文化庁「公用文作成の考え方」（2022）が「平易な語の選択」を求める背景から妥当）。
+ *
+ *   スコア補正: 平均 freq_rank が高いほど（稀少語が多いほど）語彙スコアを下げる。
+ *   - 稀少語率 > 0.3 → -15 pt（明らかに難語が多い）
+ *   - 稀少語率 0.2〜0.3 → -8 pt
+ *   - 稀少語率 0.1〜0.2 → -4 pt
+ *   - 平均 freq_rank > 30,000 → 追加 -10 pt
+ *   - 平均 freq_rank 10,000〜30,000 → 追加 -5 pt
+ *   - 平均 freq_rank < 3,000（平易語が多い）→ +5 pt ボーナス
+ */
+const RARE_THRESHOLD = 50_000;
+
+/**
+ * 幻辞（Genji）の freq_rank バッチ照合結果で語彙難易度サブスコアを補強する（Tier 3）。
+ *
+ * 純関数: 副作用なし。`getDictAccess()` の呼び出し・グレースフル劣化判断は呼び出し元が行う。
+ * `hasMorphologicalAnalysis` 付きの結果にも重ねがけ可能。
+ *
+ * @param base      - Tier 1 または Tier 2 の分析結果
+ * @param tokens    - kuromoji トークン配列（内容語の basic_form 抽出に使用）。
+ *                    Tier 1 のみの場合は空配列を渡すと基本形フォールバック動作。
+ * @param lookupMap - `DictAccess.lookupBatch()` が返す Map<headword, DictLookup>
+ * @returns 語彙サブスコアと detail.vocabulary を幻辞情報で補正した新しい分析結果
+ */
+export function enrichReadabilityWithDict(
+  base: EnhancedReadabilityAnalysis,
+  tokens: Token[],
+  lookupMap: Map<string, DictLookup>,
+): EnhancedReadabilityAnalysis {
+  if (lookupMap.size === 0) {
+    // 照合結果が空: hasDictAnalysis=true にして返す（呼び出し元が "ready" を確認済み）
+    return { ...base, hasDictAnalysis: true };
+  }
+
+  // 内容語の basic_form を収集（kuromoji トークン有り優先、なければ lookupMap のキーを使用）
+  const contentForms: string[] =
+    tokens.length > 0
+      ? tokens
+          .filter((t) => ["名詞", "動詞", "形容詞", "副詞"].includes(t.pos))
+          .map((t) => t.basic_form ?? t.surface)
+      : [...lookupMap.keys()];
+
+  // ヒットした内容語の freq_rank を収集
+  const freqRanks: number[] = [];
+  let rareCount = 0;
+
+  for (const form of contentForms) {
+    const lookup = lookupMap.get(form);
+    if (lookup?.found && lookup.freqRank !== undefined) {
+      freqRanks.push(lookup.freqRank);
+      if (lookup.freqRank > RARE_THRESHOLD) rareCount++;
+    }
+  }
+
+  if (freqRanks.length === 0) {
+    // 内容語が1件もヒットしない（辞書外文章等）: フラグだけ立てて返す
+    return { ...base, hasDictAnalysis: true };
+  }
+
+  const avgFreqRank = Math.round(freqRanks.reduce((a, b) => a + b, 0) / freqRanks.length);
+  const rareWordRate = rareCount / freqRanks.length;
+
+  // 語彙スコア補正: 稀少語率・平均 freq_rank に基づいてペナルティ/ボーナスを加算
+  let vocabDelta = 0;
+
+  if (rareWordRate > 0.3) vocabDelta -= 15;
+  else if (rareWordRate > 0.2) vocabDelta -= 8;
+  else if (rareWordRate > 0.1) vocabDelta -= 4;
+
+  if (avgFreqRank > 30_000) vocabDelta -= 10;
+  else if (avgFreqRank > 10_000) vocabDelta -= 5;
+  else if (avgFreqRank < 3_000) vocabDelta += 5;
+
+  const newVocabScore = Math.max(0, Math.min(100, base.subScores.vocabulary + vocabDelta));
+
+  const enrichedVocab: VocabularyMetrics = {
+    ...base.detail.vocabulary,
+    avgFreqRank,
+    rareWordRate,
+  };
+
+  const newSubScores: ReadabilitySubScores = {
+    ...base.subScores,
+    vocabulary: newVocabScore,
+  };
+
+  const score = Math.max(0, Math.min(100, compositeScore(newSubScores)));
+
+  return {
+    ...base,
+    score,
+    level: scoreToLevel(score),
+    subScores: newSubScores,
+    detail: {
+      ...base.detail,
+      vocabulary: enrichedVocab,
+    },
+    hasDictAnalysis: true,
   };
 }

--- a/lib/utils/ruby-readings.ts
+++ b/lib/utils/ruby-readings.ts
@@ -1,0 +1,125 @@
+/**
+ * ruby-readings — pure helpers to build per-segment reading candidate lists
+ * for the RubyDialog, merging kuromoji readings with Genji dictionary readings.
+ *
+ * Design goals:
+ *   - Pure functions: no side effects, fully testable without mocking
+ *   - Graceful degradation: Genji results are optional; kuromoji-only always works
+ *   - Deduplication + normalisation: katakana→hiragana, unique order-preserving
+ */
+
+import type { DictLookup } from "@/lib/dict/dict-types";
+import type { DictEntry } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Normalisation
+// ---------------------------------------------------------------------------
+
+/** Convert katakana to hiragana (full-width only). */
+export function katakanaToHiragana(str: string): string {
+  return str.replace(/[ァ-ヶ]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0x60));
+}
+
+// ---------------------------------------------------------------------------
+// Core pure functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Deduplicate an array of readings, normalising each to hiragana first.
+ * The first occurrence of each normalised form is preserved; order kept stable.
+ */
+export function deduplicateReadings(readings: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of readings) {
+    const normalised = katakanaToHiragana(r.trim());
+    if (normalised.length === 0) continue;
+    if (!seen.has(normalised)) {
+      seen.add(normalised);
+      out.push(normalised);
+    }
+  }
+  return out;
+}
+
+/**
+ * Build a candidate reading list for a single segment from:
+ *   - `kuromojiReading`: reading from kuromoji tokenizer (may be empty string)
+ *   - `dictLookup`: lightweight {@link DictLookup} from `getDictAccess().lookupBatch()`
+ *   - `dictEntries`: richer {@link DictEntry}[] from `getDictService().query()` (optional)
+ *
+ * Returns a deduplicated, hiragana-normalised array.  The first element is the
+ * "best" reading — kuromoji if Genji has nothing; Genji primary otherwise.
+ * If both match, kuromoji is still listed so the user can confirm it.
+ *
+ * Genji readings take precedence in ordering because the dictionary is more
+ * reliable for proper nouns and archaic words that kuromoji mislabels.
+ */
+export function buildReadingCandidates(
+  kuromojiReading: string,
+  dictLookup: DictLookup | undefined,
+  dictEntries: DictEntry[],
+): string[] {
+  const candidates: string[] = [];
+
+  // 1. Genji DictLookup primary (lightweight, always available when found)
+  if (dictLookup?.found && dictLookup.reading) {
+    candidates.push(dictLookup.reading);
+  }
+
+  // 2. Genji DictEntry readings (primary + alternatives from full query)
+  for (const entry of dictEntries) {
+    candidates.push(entry.reading.primary);
+    candidates.push(...entry.reading.alternatives);
+  }
+
+  // 3. kuromoji reading last (may duplicate Genji; dedup handles it)
+  if (kuromojiReading.length > 0) {
+    candidates.push(kuromojiReading);
+  }
+
+  return deduplicateReadings(candidates);
+}
+
+// ---------------------------------------------------------------------------
+// Batch builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Input descriptor for one kanji-containing segment.
+ */
+export interface SegmentReadingInput {
+  surface: string;
+  kuromojiReading: string;
+  /** From `getDictAccess().lookupBatch()`. Omit / undefined when Genji unavailable. */
+  dictLookup?: DictLookup;
+  /** From `getDictService().query(surface)`. Omit / empty when Genji unavailable. */
+  dictEntries?: DictEntry[];
+}
+
+/**
+ * Per-segment candidate list.
+ */
+export interface SegmentReadingCandidates {
+  surface: string;
+  /** Ordered candidates; first element is the recommended default. */
+  candidates: string[];
+}
+
+/**
+ * Build reading candidates for multiple segments in one call.
+ * Non-kanji segments (hasKanji === false) can be excluded before calling;
+ * they are passed through with `candidates: []` if included.
+ */
+export function buildBatchReadingCandidates(
+  inputs: SegmentReadingInput[],
+): SegmentReadingCandidates[] {
+  return inputs.map((input) => ({
+    surface: input.surface,
+    candidates: buildReadingCandidates(
+      input.kuromojiReading,
+      input.dictLookup,
+      input.dictEntries ?? [],
+    ),
+  }));
+}

--- a/lib/utils/vocabulary-genji.ts
+++ b/lib/utils/vocabulary-genji.ts
@@ -1,0 +1,161 @@
+/**
+ * Genji vocabulary enrichment utilities for the word-frequency panel.
+ *
+ * All functions in this module are pure (no side-effects, no async) so they
+ * can be unit-tested without mocking IPC / window / React.
+ *
+ * Bucket thresholds for frequency rank (freqRank):
+ *   常用 (everyday)  : rank ≤ 3 000  — roughly the top-3000 headwords in contemporary
+ *                       Japanese corpora; covers the bulk of newspaper/novel text.
+ *   一般 (general)   : 3 001–10 000  — standard vocabulary found in mid-range prose.
+ *   稀少 (rare)      : rank > 10 000  — low-frequency, archaic, or highly specialised terms.
+ *   辞書外 (unknown) : found === false — not in the dictionary at all (proper nouns,
+ *                       neologisms, typos, MDI meta-words, …).
+ *
+ * The boundaries are based on:
+ *   • 国語研究所「現代雑誌90誌の語彙調査」(1994) — top ~3500 types cover 90% of tokens.
+ *   • 日本語能力試験(JLPT)語彙リスト — N1 vocabulary ends around 10 000 items.
+ */
+
+import type { DictLookup } from "@/lib/dict/dict-types";
+
+// ---------------------------------------------------------------------------
+// Constants — bucket boundaries
+// ---------------------------------------------------------------------------
+
+/** Upper inclusive boundary for 常用 (everyday) frequency bucket. */
+export const FREQ_RANK_EVERYDAY = 3_000;
+
+/** Upper inclusive boundary for 一般 (general) frequency bucket. */
+export const FREQ_RANK_GENERAL = 10_000;
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/** Frequency rank distribution across the four buckets. */
+export interface FreqRankDistribution {
+  /** Words with freqRank ≤ FREQ_RANK_EVERYDAY */
+  everyday: number;
+  /** Words with freqRank in (FREQ_RANK_EVERYDAY, FREQ_RANK_GENERAL] */
+  general: number;
+  /** Words with freqRank > FREQ_RANK_GENERAL */
+  rare: number;
+  /** Words with found === false (no dictionary entry) */
+  unknown: number;
+}
+
+/** Register (文体) distribution keyed by register label. */
+export type RegisterDistribution = Record<string, number>;
+
+/** Aggregated Genji metrics for the vocabulary panel. */
+export interface GenjiVocabularySummary {
+  /** Frequency rank distribution. */
+  freqRankDistribution: FreqRankDistribution;
+  /**
+   * Register distribution.
+   * Keys are the register strings from DictLookup.register (e.g. "口語", "文章語", "雅語").
+   * The special key "なし" counts words that were found but carry no register label.
+   */
+  registerDistribution: RegisterDistribution;
+  /** Number of words not found in the dictionary (found === false). */
+  unknownWordCount: number;
+  /** Total number of unique words that were looked up. */
+  totalLookedUp: number;
+}
+
+// ---------------------------------------------------------------------------
+// Core aggregation function
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate Genji dictionary lookup results into panel-ready metrics.
+ *
+ * @param words      - Unique word strings to summarise (typically WordEntry.word list).
+ * @param lookupMap  - Map returned by DictAccess.lookupBatch(); words absent from the
+ *                     map are treated as not-found.
+ * @returns          - Aggregated summary (pure, no I/O).
+ */
+export function summarizeGenjiVocabulary(
+  words: readonly string[],
+  lookupMap: ReadonlyMap<string, DictLookup>,
+): GenjiVocabularySummary {
+  const freqRankDistribution: FreqRankDistribution = {
+    everyday: 0,
+    general: 0,
+    rare: 0,
+    unknown: 0,
+  };
+  const registerDistribution: RegisterDistribution = {};
+  let unknownWordCount = 0;
+
+  for (const word of words) {
+    const lookup = lookupMap.get(word) ?? { found: false };
+
+    if (!lookup.found) {
+      freqRankDistribution.unknown++;
+      unknownWordCount++;
+      continue;
+    }
+
+    // Frequency rank bucketing
+    const rank = lookup.freqRank;
+    if (rank === undefined) {
+      // Found in dictionary but rank not available — count as 一般 as a safe fallback.
+      freqRankDistribution.general++;
+    } else if (rank <= FREQ_RANK_EVERYDAY) {
+      freqRankDistribution.everyday++;
+    } else if (rank <= FREQ_RANK_GENERAL) {
+      freqRankDistribution.general++;
+    } else {
+      freqRankDistribution.rare++;
+    }
+
+    // Register distribution
+    const register = lookup.register ?? "なし";
+    registerDistribution[register] = (registerDistribution[register] ?? 0) + 1;
+  }
+
+  return {
+    freqRankDistribution,
+    registerDistribution,
+    unknownWordCount,
+    totalLookedUp: words.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a FreqRankDistribution to a sorted array of label/count pairs
+ * suitable for rendering. Order: 常用 → 一般 → 稀少 → 辞書外.
+ */
+export function freqRankDistributionToRows(
+  dist: FreqRankDistribution,
+): Array<{ label: string; count: number }> {
+  return [
+    { label: "常用", count: dist.everyday },
+    { label: "一般", count: dist.general },
+    { label: "稀少", count: dist.rare },
+    { label: "辞書外", count: dist.unknown },
+  ];
+}
+
+/**
+ * Convert a RegisterDistribution to a sorted array of label/count pairs,
+ * descending by count, with "なし" last.
+ */
+export function registerDistributionToRows(
+  dist: RegisterDistribution,
+): Array<{ label: string; count: number }> {
+  const rows = Object.entries(dist).map(([label, count]) => ({ label, count }));
+  rows.sort((a, b) => {
+    // Push "なし" to the end
+    if (a.label === "なし") return 1;
+    if (b.label === "なし") return -1;
+    return b.count - a.count;
+  });
+  return rows;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "electron-updater": "^6.8.9",
         "fflate": "^0.8.3",
         "kuromoji": "^0.1.2",
+        "kyujitai": "^1.3.0",
         "markdown-it": "^14.2.0",
         "next": "^16.2.9",
         "node-pty": "^1.0.0",
@@ -11763,6 +11764,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ivs": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ivs/-/ivs-2.0.2.tgz",
+      "integrity": "sha512-DxLpE5JtBJ2DEQl9nS8MRsxlXoxanbCCaW/2vdO5AILhxKMoo4OMz/QPRsk1Gf3PeFZYy6Dvm/Ta1WS3t6CXLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -12144,6 +12154,18 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/kyujitai": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/kyujitai/-/kyujitai-1.3.0.tgz",
+      "integrity": "sha512-BSd3fBpTWwkIVGQRDoEiKFdBLSW3vrAAHQlaK3v26+ecQ8AY/G7JLkpCP3kFZ3en8jRPyd1JykyIxvPL76OggA==",
+      "license": "MIT",
+      "dependencies": {
+        "ivs": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/language-subtag-registry": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "electron-updater": "^6.8.9",
     "fflate": "^0.8.3",
     "kuromoji": "^0.1.2",
+    "kyujitai": "^1.3.0",
     "markdown-it": "^14.2.0",
     "next": "^16.2.9",
     "node-pty": "^1.0.0",

--- a/packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts
@@ -26,6 +26,27 @@ describe("MdiDocument — typed derivations (#1449)", () => {
     expect(doc.toAnalysisText()).toBe("{漢字|かんじ}と^12^月\n\n");
   });
 
+  // Regression: in-app analysis/statistics panels (語彙統計 / 登場人物 / 読みやすさ)
+  // feed the LIVE editor buffer through `fromRawText().toAnalysisText()`. That
+  // buffer is the Milkdown serializer output, where the marker is escaped to
+  // `\[\[blank]]` (CommonMark escapes the leading `[`). The marker must still be
+  // stripped so kuromoji never tokenizes "blank" into the word-frequency list.
+  it("toAnalysisText strips the serializer-escaped marker \\[\\[blank]] (analysis leak fix)", () => {
+    const escaped = "A段落\n\n\\[\\[blank]]\n\nB段落";
+    const out = MdiDocument.fromRawText(escaped).toAnalysisText();
+    expect(out).not.toContain("blank");
+    expect(out).toBe("A段落\n\n\n\nB段落");
+  });
+
+  it("toAnalysisText strips the fully-escaped marker \\[\\[blank\\]\\]", () => {
+    expect(MdiDocument.fromRawText("\\[\\[blank\\]\\]").toAnalysisText()).not.toContain("blank");
+  });
+
+  it("toAnalysisText preserves an inline escaped occurrence (not a whole-line marker)", () => {
+    const inline = "foo \\[\\[blank]] bar";
+    expect(MdiDocument.fromRawText(inline).toAnalysisText()).toBe(inline);
+  });
+
   it("toExportText('txt') flattens syntax and turns markers into forced blank lines", () => {
     const txt = MdiDocument.fromRawText(RAW).toExportText("txt");
     expect(txt).not.toContain("[[blank]]");

--- a/packages/milkdown-plugin-japanese-novel/mdi-document.ts
+++ b/packages/milkdown-plugin-japanese-novel/mdi-document.ts
@@ -67,8 +67,31 @@ export const MDI_BLANK_MARKER = "[[blank]]";
  * before matching, so an indented "  [[blank]]" renders as a blank paragraph;
  * analysis text must strip the same lines (pre-#1449 the strip regex was
  * line-start-anchored, a marker-handling drift this module exists to end).
+ *
+ * Clean-form ONLY (`[[blank]]`). This must NOT match the serializer-escaped
+ * form `\[\[blank]]`, because the HTML export pipeline (`mdi-to-html.ts`)
+ * applies it AFTER a fileType-gated normalization: for ".md"/".txt" the escaped
+ * literal is intentionally preserved (DATA-LOSS guard, #1608), so matching the
+ * escaped form here would wrongly promote authored `\[\[blank]]` to a blank
+ * paragraph. Analysis-side stripping tolerates the escaped form via
+ * {@link MDI_BLANK_ANALYSIS_RE} instead.
  */
 export const MDI_BLANK_RE = /^[ \t]*\[\[blank\]\][ \t]*\r?$/gm;
+
+/**
+ * Analysis-only blank-marker matcher. Backslashes before each bracket are
+ * optional so it matches BOTH the clean form (`[[blank]]`) and the Milkdown
+ * serializer-escaped form (`\[\[blank]]`).
+ *
+ * In-app analysis/statistics panels (語彙統計 / 登場人物 / 読みやすさ) feed the
+ * LIVE editor buffer through `fromRawText().toAnalysisText()`. That buffer is
+ * serializer output, where the marker is escaped (CommonMark escapes the
+ * leading `[`); `fromRawText` skips the Step 0 un-escape that `fromEditorOutput`
+ * applies, so the escaped marker would otherwise survive into kuromoji and
+ * surface as a spurious "blank" token. Used ONLY by {@link stripMdiBlankMarkers}
+ * — NOT by the fileType-aware export pipeline.
+ */
+export const MDI_BLANK_ANALYSIS_RE = /^[ \t]*\\?\[\\?\[blank\\?\]\\?\][ \t]*\r?$/gm;
 
 /** Escaped MDI opening brace: \{ */
 export const MDI_ESC_BRACE_RE = /\\(\{)/g;
@@ -99,13 +122,16 @@ export function isMdiBlankParagraphLine(line: string): boolean {
  * (NLP, word count, readability, etc.).
  * Replaces the marker line with empty string; surrounding blank lines remain.
  * Inline occurrences (`foo [[blank]] bar`) are preserved as literal text.
+ * Both the clean (`[[blank]]`) and serializer-escaped (`\[\[blank]]`) forms are
+ * stripped (see {@link MDI_BLANK_ANALYSIS_RE}) — analysis consumers read the
+ * live editor buffer, which carries the escaped form.
  * CRLF note: on CRLF files a preceding \r is absorbed; normalize line endings
  * before passing if required.
  *
  * Prefer `MdiDocument.fromRawText(text).toAnalysisText()` in new code.
  */
 export function stripMdiBlankMarkers(content: string): string {
-  return content.replace(MDI_BLANK_RE, "");
+  return content.replace(MDI_BLANK_ANALYSIS_RE, "");
 }
 
 // ---------------------------------------------------------------------------

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -9,7 +9,7 @@ import type {
 import type { Token, WordEntry, TokenizeProgress } from "@/lib/nlp-client/types";
 import type { VFSWatchEvent } from "@/lib/vfs/types";
 import type { KeymapOverrides } from "@/lib/keymap/keymap-types";
-import type { DictEntry, DictDownloadStatus } from "@/lib/dict/dict-types";
+import type { DictEntry, DictDownloadStatus, DictLookup } from "@/lib/dict/dict-types";
 import type { PdfGenerationOptions } from "@/lib/export/types";
 
 export {};
@@ -289,6 +289,16 @@ declare global {
       query: (term: string, limit?: number) => Promise<DictEntry[]>;
       /** Query entries by kana reading (homophone lookup) */
       queryByReading: (reading: string, limit?: number) => Promise<DictEntry[]>;
+      /**
+       * Exact-match batch lookup (lightweight projection) for analysis features.
+       * Terms with no match are omitted from the result array.
+       */
+      lookupBatch: (terms: string[]) => Promise<Array<{ entry: string } & DictLookup>>;
+      /** Fast integrity check; `ok: false` means the DB should be re-downloaded. */
+      verify: () => Promise<{
+        ok: boolean;
+        reason?: "not-installed" | "schema" | "malformed";
+      }>;
       /** Get current installation status */
       getStatus: () => Promise<{
         status: DictDownloadStatus;


### PR DESCRIPTION
## Weekly Release — v1.2.16

最終バージョンは main-push の `Compute Version` job が自動採番（直近タグ v1.2.15 + 1 の見込み）。

### Changes included (origin/main..origin/dev)

- #1648 #1639 検証フィードバック（辞書UI/分析/自動DL）＋縦書きスクロール・トラックパッド修正
- #1647 検索パネルを全面強化（正規表現・表記ゆれ・ルビ・範囲指定ほか / #1645）
- #1646 検索窓を dockview パネル外へ移し入力反映バグ修正
- #1644 スナップショットカードのクリックで差分表示＋最初の差分へ自動スクロール
- #1643 2つの検索UIを単一stateで同期し非表示時にハイライト消去
- #1642 比較が無反応／省電力提案トーストの二重表示を修正
- #1641 省電力モードをトースト提案化＋品詞/比較の不具合修正
- #1640 語彙統計など分析パネルへの [[blank]] マーカー混入を修正
- #1638 型態分析に選択語の幻辞情報（語義/レジスター/類義語）を表示（#1625）
- #1637 ルビ入力に幻辞の読み候補を追加（#1629）
- #1636 読みやすさの語彙難易度を幻辞 freq_rank ベースに強化（#1627）
- #1635 語彙統計に幻辞の頻度ランク/レジスター/辞書外語数を追加（#1626）
- #1634 幻辞分析アクセス層 dict-access（#1624）
- #1632 PDF/DOCX/EPUB で [[blank]] が文字列リークする問題を根本修正
- #1630 バブルメニューに書式解除ボタンを追加

### Merge notes
- コンフリクトなし（自動マージ成功）。main 限定の shell-quote(#1590) は dev 側も同 1.8.4 のため silent drop なしを確認。
- package.json `version` は両ブランチ `1.2.0` のまま（バージョンは git タグで管理）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)