### PR TITLE
feat(web): Web版サービス終了告知モーダルを追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import WelcomeScreen from "@/components/WelcomeScreen";
 import PopoutEditorWindow from "@/components/PopoutEditorWindow";
 import CreateProjectWizard from "@/components/CreateProjectWizard";
 import PermissionPrompt from "@/components/PermissionPrompt";
+import WebSunsetNotice from "@/components/WebSunsetNotice";
 import { useRubyTcy } from "@/lib/editor-page/use-ruby-tcy";
 import { useLintHandlers } from "@/lib/editor-page/use-lint-handlers";
 import { useTabManager } from "@/lib/tab-manager";
@@ -1169,6 +1170,9 @@ export default function EditorPage() {
 
     return (
       <div className="h-screen flex flex-col overflow-hidden relative">
+        {/* Web版サービス終了の告知（Web版でのみ毎回表示） */}
+        <WebSunsetNotice />
+
         {/* Web menu bar (only for non-Electron environment) */}
         {!isElectron && (
           <WebMenuBar
@@ -1326,156 +1330,160 @@ export default function EditorPage() {
   } as const;
 
   return (
-    <EditorLayout
-      providers={{
-        diffTabContextValue,
-        terminalTabContextValue,
-        settings,
-        settingsHandlers,
-      }}
-      chrome={{
-        currentFile,
-        isDirty,
-        isElectron,
-        handleMenuAction,
-        recentProjects,
-        compactMode,
-      }}
-      dialogs={{
-        unsavedWarning,
-        pendingCloseTabId,
-        pendingCloseFileName,
-        handleCloseTabSave,
-        handleCloseTabDiscard,
-        handleCloseTabCancel,
-        showDesktopOnlyDialog,
-        setShowDesktopOnlyDialog,
-        confirmRemoveRecent,
-        setConfirmRemoveRecent,
-        handleDeleteRecentProject,
-        showSettingsModal,
-        setShowSettingsModal,
-        settingsInitialCategory,
-        setSettingsInitialCategory,
-        showRubyDialog,
-        setShowRubyDialog,
-        rubySelectedText,
-        handleApplyRuby,
-        exportDialog: {
-          state: exportDialogState,
-          onClose: () => setExportDialogState(null),
-          onPdfExport: handlePdfExportConfirm,
-          onDocxExport: handleDocxExportConfirm,
-          onEpubExport: handleEpubExportConfirm,
-          content: exportDialogState?.content ?? "",
-          metadata: exportDialogState?.metadata ?? { title: "" },
-          fileType: exportDialogState?.fileType,
-        },
-        printDialog: {
-          state: printDialogState,
-          onClose: () => setPrintDialogState(null),
-          onPrint: handlePrintConfirm,
-          content: printDialogState?.content ?? "",
-          metadata: printDialogState?.metadata ?? { title: "" },
-        },
-      }}
-      recovery={{
-        wasAutoRecovered,
-        dismissedRecovery,
-        recoveryExiting,
-        setRecoveryExiting,
-        currentFileName: currentFile?.name,
-      }}
-      upgrade={{
-        showUpgradeBanner,
-        upgradeBannerDismissed,
-        editorMode,
-        featuresProjectMode: features.projectMode,
-        handleUpgrade,
-        handleUpgradeDismiss,
-      }}
-      activityBar={{
-        topView,
-        bottomView,
-        setTopView,
-        setBottomView,
-        handleNewTerminalTab,
-      }}
-      mainArea={{
-        tabs,
-        editorMode,
-        newTab,
-        openFile,
-        setNewFileTrigger,
-        handleTabBarContextMenu,
-        tabBarMenu,
-        handleTabBarMenuAction,
-        closeTabBarMenu,
-        handleDockviewReady,
-        sidebarPanelProps,
-        tabsRef,
-        editorDiff,
-        setEditorDiff,
-        editorDomRef,
-        handleChange,
-        handleInsertText,
-        onSelectionChange: (count: number, cells: number, pages: number) => {
-          setSelectedCharCount(count);
-          setSelectedManuscriptCells(cells);
-          setSelectedManuscriptPages(pages);
-          // 選択語を幻辞ルックアップ用に保持する。
-          // 大きな選択（段落・全選択）では textBetween が O(n) で重く、語の辞書引きにも
-          // 不向きなので閾値を超えたら早期に null。実際の辞書引きの debounce は
-          // useGenjiWordInfo 側で行う（選択ドラッグ中の連続 IPC を抑制）。
-          if (count > 0 && count <= SELECTED_WORD_MAX_CHARS && editorViewRef.current) {
-            const { selection, doc } = editorViewRef.current.state;
-            const text = doc.textBetween(selection.from, selection.to, "").trim();
-            // 単語単位（空白区切り）の先頭語、または選択全体（日本語は空白なし）
-            const word = text.split(/\s+/)[0] ?? null;
-            setSelectedWord(word || null);
-          } else {
-            setSelectedWord(null);
-          }
-        },
-        onSelectionRangeChange: (range: SearchRange | null) => {
-          setSearchSelectionRange(range);
-          if (!range) setSelectionOnly(false);
-        },
-        searchOpenTrigger,
-        searchInitialTerm,
-        // 共有検索 state（SearchDialog は <main> でレンダリング）
-        searchTerm,
-        caseSensitive,
-        searchMatches,
-        currentMatchIndex,
-        isSearchDialogOpen,
-        onSearchTermChange: setSearchTerm,
-        onCaseSensitiveChange: setCaseSensitive,
-        onCurrentMatchIndexChange: setCurrentMatchIndex,
-        onOpenSearchDialog: openSearchDialog,
-        onCloseSearchDialog: closeSearchDialog,
-        onToggleSearchDialog: toggleSearchDialog,
-        setEditorViewInstance,
-        handleShowAllSearchResults,
-        ruleRunner,
-        handleLintIssuesUpdated,
-        handleNlpError,
-        handleOpenRubyDialog,
-        handleToggleTcy,
-        handleOpenDictionary,
-        handleShowLintHint,
-        handleIgnoreCorrection,
-        switchTab,
-        updateTab,
-      }}
-      inspector={{
-        isRightPanelCollapsed,
-        handleToggleRightPanel,
-        activeEditorTab,
-        props: inspectorProps,
-        showSaveToast,
-        saveToastExiting,
-      }}
-    />
+    <>
+      {/* Web版サービス終了の告知（Web版でのみ毎回表示） */}
+      <WebSunsetNotice />
+      <EditorLayout
+        providers={{
+          diffTabContextValue,
+          terminalTabContextValue,
+          settings,
+          settingsHandlers,
+        }}
+        chrome={{
+          currentFile,
+          isDirty,
+          isElectron,
+          handleMenuAction,
+          recentProjects,
+          compactMode,
+        }}
+        dialogs={{
+          unsavedWarning,
+          pendingCloseTabId,
+          pendingCloseFileName,
+          handleCloseTabSave,
+          handleCloseTabDiscard,
+          handleCloseTabCancel,
+          showDesktopOnlyDialog,
+          setShowDesktopOnlyDialog,
+          confirmRemoveRecent,
+          setConfirmRemoveRecent,
+          handleDeleteRecentProject,
+          showSettingsModal,
+          setShowSettingsModal,
+          settingsInitialCategory,
+          setSettingsInitialCategory,
+          showRubyDialog,
+          setShowRubyDialog,
+          rubySelectedText,
+          handleApplyRuby,
+          exportDialog: {
+            state: exportDialogState,
+            onClose: () => setExportDialogState(null),
+            onPdfExport: handlePdfExportConfirm,
+            onDocxExport: handleDocxExportConfirm,
+            onEpubExport: handleEpubExportConfirm,
+            content: exportDialogState?.content ?? "",
+            metadata: exportDialogState?.metadata ?? { title: "" },
+            fileType: exportDialogState?.fileType,
+          },
+          printDialog: {
+            state: printDialogState,
+            onClose: () => setPrintDialogState(null),
+            onPrint: handlePrintConfirm,
+            content: printDialogState?.content ?? "",
+            metadata: printDialogState?.metadata ?? { title: "" },
+          },
+        }}
+        recovery={{
+          wasAutoRecovered,
+          dismissedRecovery,
+          recoveryExiting,
+          setRecoveryExiting,
+          currentFileName: currentFile?.name,
+        }}
+        upgrade={{
+          showUpgradeBanner,
+          upgradeBannerDismissed,
+          editorMode,
+          featuresProjectMode: features.projectMode,
+          handleUpgrade,
+          handleUpgradeDismiss,
+        }}
+        activityBar={{
+          topView,
+          bottomView,
+          setTopView,
+          setBottomView,
+          handleNewTerminalTab,
+        }}
+        mainArea={{
+          tabs,
+          editorMode,
+          newTab,
+          openFile,
+          setNewFileTrigger,
+          handleTabBarContextMenu,
+          tabBarMenu,
+          handleTabBarMenuAction,
+          closeTabBarMenu,
+          handleDockviewReady,
+          sidebarPanelProps,
+          tabsRef,
+          editorDiff,
+          setEditorDiff,
+          editorDomRef,
+          handleChange,
+          handleInsertText,
+          onSelectionChange: (count: number, cells: number, pages: number) => {
+            setSelectedCharCount(count);
+            setSelectedManuscriptCells(cells);
+            setSelectedManuscriptPages(pages);
+            // 選択語を幻辞ルックアップ用に保持する。
+            // 大きな選択（段落・全選択）では textBetween が O(n) で重く、語の辞書引きにも
+            // 不向きなので閾値を超えたら早期に null。実際の辞書引きの debounce は
+            // useGenjiWordInfo 側で行う（選択ドラッグ中の連続 IPC を抑制）。
+            if (count > 0 && count <= SELECTED_WORD_MAX_CHARS && editorViewRef.current) {
+              const { selection, doc } = editorViewRef.current.state;
+              const text = doc.textBetween(selection.from, selection.to, "").trim();
+              // 単語単位（空白区切り）の先頭語、または選択全体（日本語は空白なし）
+              const word = text.split(/\s+/)[0] ?? null;
+              setSelectedWord(word || null);
+            } else {
+              setSelectedWord(null);
+            }
+          },
+          onSelectionRangeChange: (range: SearchRange | null) => {
+            setSearchSelectionRange(range);
+            if (!range) setSelectionOnly(false);
+          },
+          searchOpenTrigger,
+          searchInitialTerm,
+          // 共有検索 state（SearchDialog は <main> でレンダリング）
+          searchTerm,
+          caseSensitive,
+          searchMatches,
+          currentMatchIndex,
+          isSearchDialogOpen,
+          onSearchTermChange: setSearchTerm,
+          onCaseSensitiveChange: setCaseSensitive,
+          onCurrentMatchIndexChange: setCurrentMatchIndex,
+          onOpenSearchDialog: openSearchDialog,
+          onCloseSearchDialog: closeSearchDialog,
+          onToggleSearchDialog: toggleSearchDialog,
+          setEditorViewInstance,
+          handleShowAllSearchResults,
+          ruleRunner,
+          handleLintIssuesUpdated,
+          handleNlpError,
+          handleOpenRubyDialog,
+          handleToggleTcy,
+          handleOpenDictionary,
+          handleShowLintHint,
+          handleIgnoreCorrection,
+          switchTab,
+          updateTab,
+        }}
+        inspector={{
+          isRightPanelCollapsed,
+          handleToggleRightPanel,
+          activeEditorTab,
+          props: inspectorProps,
+          showSaveToast,
+          saveToastExiting,
+        }}
+      />
+    </>
   );
 }

--- a/components/WebSunsetNotice.tsx
+++ b/components/WebSunsetNotice.tsx
@@ -80,6 +80,17 @@ export default function WebSunsetNotice(): React.JSX.Element | null {
         <p>
           今後とも皆様にご満足いただけるサービスの提供に努めてまいりますので、引き続き「illusions」をよろしくお願い申し上げます。
         </p>
+        <p>
+          詳しくは公式X（旧Twitter）のお知らせをご覧ください：
+          <a
+            href="https://x.com/illusionsapp/status/2067584687867146588"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent underline underline-offset-2 hover:text-accent-hover break-all"
+          >
+            https://x.com/illusionsapp/status/2067584687867146588
+          </a>
+        </p>
       </div>
 
       <div className="mt-6 flex items-center justify-end gap-3">

--- a/components/WebSunsetNotice.tsx
+++ b/components/WebSunsetNotice.tsx
@@ -64,17 +64,15 @@ export default function WebSunsetNotice(): React.JSX.Element | null {
           引き続き「illusions」をご利用いただくにあたり、大変お手数ではございますが、以下のボタンよりデスクトップ版アプリのダウンロードをお願い申し上げます。
         </p>
 
-        <div className="rounded-lg border border-border bg-background p-3">
-          <h3 className="text-sm font-semibold text-foreground">■ ご案内と注意事項</h3>
-          <ul className="mt-2 list-disc space-y-1 pl-5">
-            <li>
-              現在ご利用中のアカウントやデータは、デスクトップ版にてログインしていただくことで、そのまま引き継いでご利用いただけます。
-            </li>
-            <li>
-              Web版のサービス終了日（2027年1月1日）以降は、ブラウザからのアクセスができなくなりますので、お早めの移行をお願いいたします。
-            </li>
-          </ul>
-        </div>
+        <h3 className="font-semibold text-foreground">■ ご案内と注意事項</h3>
+        <ul className="list-disc space-y-1 pl-5">
+          <li>
+            現在ご利用中のアカウントやデータは、デスクトップ版にてログインしていただくことで、そのまま引き継いでご利用いただけます。
+          </li>
+          <li>
+            Web版のサービス終了日（2027年1月1日）以降は、ブラウザからのアクセスができなくなりますので、お早めの移行をお願いいたします。
+          </li>
+        </ul>
 
         <p>
           ユーザーの皆様には多大なるご迷惑とご不便をおかけいたしますことを、深くお詫び申し上げます。

--- a/components/WebSunsetNotice.tsx
+++ b/components/WebSunsetNotice.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import GlassDialog from "@/components/GlassDialog";
+import DesktopAppDownloadButton from "@/components/DesktopAppDownloadButton";
+import { isElectronRenderer } from "@/lib/utils/runtime-env";
+
+/**
+ * Web版サービス終了の告知モーダル。
+ *
+ * - Web版でのみ表示する（Electron版では何も描画しない）。
+ * - アプリ起動（ページロード）ごとに毎回自動で開く。
+ * - ユーザーは手動で閉じられる（「今後表示しない」のような永続化はしない）。
+ *
+ * ルート遷移（WelcomeScreen → Editor）でコンポーネントが再マウントされても
+ * 同一ロード内で二重に開かないよう、モジュールレベルのフラグでガードする。
+ */
+
+/** 1回のページロード内で既に表示したかどうか（ルート遷移での再表示を防ぐ） */
+let shownThisLoad = false;
+
+export default function WebSunsetNotice(): React.JSX.Element | null {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    // Electron版では告知不要
+    if (isElectronRenderer()) return;
+    if (shownThisLoad) return;
+    shownThisLoad = true;
+    // 実行環境判定は window 依存のためマウント後にしか行えない。
+    // SSR/Electron との hydration ずれを避けるため、初期 state ではなく
+    // マウント後に開く（mount-time setState は意図的）。
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setIsOpen(true);
+  }, []);
+
+  if (!isOpen) return null;
+
+  const close = (): void => setIsOpen(false);
+
+  return (
+    <GlassDialog
+      isOpen={isOpen}
+      onBackdropClick={close}
+      ariaLabel="「illusions Web版」サービス終了のお知らせ"
+      panelClassName="mx-4 w-full max-w-lg p-6"
+    >
+      <h2 className="text-lg font-semibold text-foreground">
+        【重要】「illusions Web版」サービス終了およびデスクトップ版移行のお願い
+      </h2>
+
+      <div className="mt-3 max-h-[60vh] space-y-3 overflow-y-auto pr-1 text-sm leading-relaxed text-foreground-secondary">
+        <p>平素より「illusions」をご利用いただき、誠にありがとうございます。</p>
+        <p>
+          この度、誠に勝手ながら「illusions Web版」は、
+          <strong className="text-foreground">2027年1月1日</strong>
+          をもちまして、サービスの提供を終了させていただくこととなりました。これまでWeb版をご愛顧いただきました皆様に、心より厚く御礼申し上げます。
+        </p>
+        <p>
+          今後は、より安定した快適な環境を提供するため、デスクトップ版へサービスを統合させていただきます。
+        </p>
+        <p>
+          引き続き「illusions」をご利用いただくにあたり、大変お手数ではございますが、以下のボタンよりデスクトップ版アプリのダウンロードをお願い申し上げます。
+        </p>
+
+        <div className="rounded-lg border border-border bg-background p-3">
+          <h3 className="text-sm font-semibold text-foreground">■ ご案内と注意事項</h3>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            <li>
+              現在ご利用中のアカウントやデータは、デスクトップ版にてログインしていただくことで、そのまま引き継いでご利用いただけます。
+            </li>
+            <li>
+              Web版のサービス終了日（2027年1月1日）以降は、ブラウザからのアクセスができなくなりますので、お早めの移行をお願いいたします。
+            </li>
+          </ul>
+        </div>
+
+        <p>
+          ユーザーの皆様には多大なるご迷惑とご不便をおかけいたしますことを、深くお詫び申し上げます。
+        </p>
+        <p>
+          今後とも皆様にご満足いただけるサービスの提供に努めてまいりますので、引き続き「illusions」をよろしくお願い申し上げます。
+        </p>
+      </div>
+
+      <div className="mt-6 flex items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={close}
+          className="rounded-lg px-4 py-2 text-sm font-medium text-foreground-secondary hover:bg-hover transition-colors"
+        >
+          閉じる
+        </button>
+        <DesktopAppDownloadButton label="デスクトップ版をダウンロード" />
+      </div>
+    </GlassDialog>
+  );
+}


### PR DESCRIPTION
## 概要

Web版のサービス終了（**2027年1月1日**）とデスクトップ版への移行を案内するモーダルを追加する。

## 挙動

- **Web版でのみ表示**（`isElectronRenderer()` で判定。Electron版では何も描画しない）
- アプリ起動（ページロード）ごとに**毎回**自動で開く
- ユーザーは**手動で閉じられる**（「今後表示しない」のような永続化はしない）
- デスクトップ版ダウンロードページへ誘導（既存 `DesktopAppDownloadButton`）

## 実装

- 新規 `components/WebSunsetNotice.tsx` — 既存 `GlassDialog` をベースに構築
- `app/page.tsx` — WelcomeScreen / Editor の両レンダリングパスに配置
- 同一ロード内のルート遷移での二重表示はモジュールレベルフラグで防止
- `app/page.tsx` の大きな差分は fragment 化に伴う Prettier 再インデントのみ（`git diff -w` で論理変更は挿入分のみ）

## 検証

- `tsc --noEmit`: 変更ファイルにエラーなし
- `eslint`: クリーン
- Prettier 整形済み

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)