### PR TITLE
fix(quicklook): .appex を afterPack で署名前に埋め込み notarization 失敗を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
         ]
       }
     ],
+    "afterPack": "scripts/embed-quicklook.js",
     "afterSign": "scripts/notarize.js",
     "mac": {
       "category": "public.app-category.productivity",
@@ -169,12 +170,6 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
-      "extraFiles": [
-        {
-          "from": "build/quicklook/MDIQuickLook.appex",
-          "to": "PlugIns/MDIQuickLook.appex"
-        }
-      ],
       "extendInfo": {
         "UTExportedTypeDeclarations": [
           {

--- a/scripts/build-quicklook.sh
+++ b/scripts/build-quicklook.sh
@@ -50,9 +50,11 @@ build_arch "x86_64-apple-macos10.15" "${X64_BIN}"
 # Combine into a universal binary so the extension loads on both architectures.
 lipo -create "${ARM64_BIN}" "${X64_BIN}" -output "${OUT_DIR}/MacOS/MDIQuickLook"
 
-# Ad-hoc sign so the bundle is loadable in local/dev builds. Release builds are
-# re-signed with the Developer ID identity by electron-builder.
-codesign --force --sign - --timestamp=none "${APPEX_DIR}" 2>/dev/null || true
+# NOTE: do NOT code-sign here. The .appex is embedded into the app by the
+# electron-builder afterPack hook (scripts/embed-quicklook.js) and signed by
+# electron-builder's osx-sign step with the Developer ID identity, hardened
+# runtime, and a secure timestamp. A pre-applied ad-hoc signature would only
+# risk interfering with that flow.
 
 echo "Built ${APPEX_DIR}"
 lipo -info "${OUT_DIR}/MacOS/MDIQuickLook"

--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+// electron-builder afterPack hook.
+//
+// Embeds the MDI Quick Look Preview Extension (.appex) into the packaged macOS
+// app *before* code signing. This is intentionally an afterPack hook (not
+// `extraFiles`): files added via `extraFiles` are copied but NOT code-signed,
+// so the nested Mach-O fails notarization ("not signed with a valid Developer
+// ID certificate / no secure timestamp / hardened runtime not enabled").
+// By copying it into Contents/PlugIns here, electron-builder's osx-sign step
+// signs it with the Developer ID identity, hardened runtime, secure timestamp,
+// and inherited entitlements as part of the normal signing walk.
+
+const path = require("path");
+const fs = require("fs");
+
+const APPEX_NAME = "MDIQuickLook.appex";
+
+exports.default = async function embedQuickLook(context) {
+  const { electronPlatformName, appOutDir, packager } = context;
+
+  if (electronPlatformName !== "darwin") {
+    return;
+  }
+
+  const appexSource = path.join(__dirname, "..", "build", "quicklook", APPEX_NAME);
+
+  if (!fs.existsSync(appexSource)) {
+    // The .appex is produced by `npm run build:quicklook` (macOS only), which
+    // runs before electron:build in CI. Missing here means it was not built.
+    console.warn(
+      `[QuickLook] ${APPEX_NAME} not found at ${appexSource}; skipping embed. ` +
+        "Run `npm run build:quicklook` before packaging on macOS.",
+    );
+    return;
+  }
+
+  const appName = packager.appInfo.productFilename;
+  const pluginsDir = path.join(appOutDir, `${appName}.app`, "Contents", "PlugIns");
+  const dest = path.join(pluginsDir, APPEX_NAME);
+
+  fs.mkdirSync(pluginsDir, { recursive: true });
+  fs.rmSync(dest, { recursive: true, force: true });
+  fs.cpSync(appexSource, dest, { recursive: true });
+
+  console.log(`[QuickLook] Embedded ${APPEX_NAME} into ${pluginsDir} (will be signed by electron-builder)`);
+};

--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -42,5 +42,7 @@ exports.default = async function embedQuickLook(context) {
   fs.rmSync(dest, { recursive: true, force: true });
   fs.cpSync(appexSource, dest, { recursive: true });
 
-  console.log(`[QuickLook] Embedded ${APPEX_NAME} into ${pluginsDir} (will be signed by electron-builder)`);
+  console.log(
+    `[QuickLook] Embedded ${APPEX_NAME} into ${pluginsDir} (will be signed by electron-builder)`,
+  );
 };


### PR DESCRIPTION
## 背景

#1769 マージ後の dev ビルドで **macOS x64 ビルドが notarization で失敗**（RED）。原因は埋め込んだ `MDIQuickLook.appex` の nested バイナリが署名されていなかったこと：

```
Contents/PlugIns/MDIQuickLook.appex/Contents/MacOS/MDIQuickLook
  - The binary is not signed with a valid Developer ID certificate.
  - The signature does not include a secure timestamp.
  - The executable does not have the hardened runtime enabled.
```

`mac.extraFiles` で配置したコードは **コピーされるだけで osx-sign の署名ウォークに入らない**ため、ad-hoc 署名のまま notarization に回り失敗していた。

## 修正

- **`scripts/embed-quicklook.js`（afterPack フック）を追加**：署名前に `.appex` を `<app>.app/Contents/PlugIns/` へコピー。これにより electron-builder の osx-sign が **Developer ID + hardened runtime + secure timestamp + 継承 entitlements** で署名する（Quick Look 拡張・Spotlight importer 埋め込みの定石）
- `package.json`：`mac.extraFiles` の appex 配置を削除し `afterPack` を追加（`extendInfo` の UTI export は維持）
- `build-quicklook.sh`：ad-hoc codesign を削除（osx-sign が `--force` で再署名）

## 検証

- ✅ afterPack フックをモック context で実行し、`Contents/PlugIns/MDIQuickLook.appex` に binary/Info.plist が正しく配置されることを確認。非 darwin は no-op
- ✅ appex は universal（x86_64 + arm64）でビルド継続
- ⏳ **最終確認は dev の macOS ビルド（実 Developer ID 署名 + notarization）**。これが green になればリリース可能

> Developer ID 署名は CI でしか実行できないため、署名・notarization の最終確認は dev ビルドで行います。

## 関連 issue
なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)