### PR TITLE
feat(linting): rulesetPrefix + ルールセット開発docs(docs/ruleset) + edgeテスト拡充

### DIFF
--- a/docs/ruleset/README.md
+++ b/docs/ruleset/README.md
@@ -1,0 +1,105 @@
+---
+title: 校正ルールセット開発ドキュメント
+status: draft
+updated: 2026-06-19
+---
+
+# 校正ルールセット開発
+
+illusions の校正(lint)ルールは **ルールセット**という単位で配布される。ルールセットは
+`RulesetModule` を default export する**コードモジュール**で、`createRules(ctx)` が具体的な
+`LintRule[]` を返す。**1リポジトリ = 1ルールセット**。
+
+- 組み込みルールセット: illusions 本体に同梱（静的 import）。
+- 外部ルールセット: `~/.illusions/rulesets/<id>/` に配置（Electron のみ。Web は組み込みのみで縮退）。
+
+> このディレクトリが校正ルールセット開発の正本。旧 `docs/linting/` は廃止済み（本ディレクトリへ統合）。
+
+## ドキュメント一覧
+
+| ドキュメント                             | 内容                                                                      |
+| ---------------------------------------- | ------------------------------------------------------------------------- |
+| [authoring.md](./authoring.md)           | SDK 契約・`ctx.toolkit` リファレンス・辞典依存・`rulesetPrefix`           |
+| [structure.md](./structure.md)           | 「1リポジトリ=1ルールセット」の標準ディレクトリ構成・配置先・コンテナ形式 |
+| [sample-ruleset.md](./sample-ruleset.md) | 写経用テンプレート（manifest / index / docs / test）                      |
+| [closed-source.md](./closed-source.md)   | 難読化・WASM・`.illruleset`・サーバー評価による保護段階                   |
+
+テンプレートリポジトリ: **`illusions-lab/illusions-ruleset-template`**（`Use this template` から開始）。
+
+## クイックスタート
+
+### 1. テンプレートから作る
+
+```bash
+# GitHub の illusions-ruleset-template で "Use this template" → クローン
+git clone https://github.com/<you>/<your-ruleset>.git
+cd <your-ruleset>
+npm install
+```
+
+### 2. メタを編集（manifest.json）
+
+`id`（逆ドメイン推奨）, `nameJa`, `version`, `engineApi`(=1), `rulesetPrefix`、そして各ルールの
+`rules[]`（`ruleId` / `level` / `defaultConfig` / `docs` 正負例）を記述する。manifest は
+**コードを実行せずに**読まれる純データ。
+
+### 3. ルールを書く（src/rules/<ruleId>.ts）
+
+```ts
+import type { LintRule, LintRuleConfig, RulesetContext, RulesetManifest } from "illusions-lint-sdk";
+
+export function createMyRule(ctx: RulesetContext, manifest: RulesetManifest): LintRule {
+  const meta = manifest.rules.find((r) => r.ruleId === "my-fw-exclaim")!;
+  const { AbstractL1Rule } = ctx.bases; // ← import せず ctx から受け取る
+  class MyRule extends AbstractL1Rule {
+    lint(text: string, config: LintRuleConfig) {
+      if (!config.enabled) return [];
+      return ctx.toolkit.regexReplace({
+        text,
+        pattern: /！/,
+        ruleId: this.id,
+        severity: config.severity,
+        message: "use !",
+        messageJa: "全角『！』は半角『!』に。",
+        replacement: () => "!",
+      });
+    }
+  }
+  return new MyRule(ctx.toolkit.toJsonRuleMeta(meta, manifest), {
+    id: meta.ruleId,
+    name: meta.nameJa,
+    nameJa: meta.nameJa,
+    description: meta.descriptionJa,
+    descriptionJa: meta.descriptionJa,
+    defaultConfig: meta.defaultConfig,
+  });
+}
+```
+
+**SDK は `import type` のみ**。基底クラス・道具は `ctx.bases` / `ctx.toolkit` から受け取る（未バンドルの
+外部モジュールは値 import を実行時に解決できない）。
+
+### 4. ドキュメントとテスト
+
+- `docs/rules/<ruleId>.md` に「何をするルールか」を1ルール1ファイルで記述。
+- `test/<ruleId>.test.ts` で positive 例→0 / negative 例→≥1 のゴールデン。
+
+### 5. 検証してビルド
+
+```bash
+npm run check      # typecheck + test + build
+```
+
+`dist/index.js` + `manifest.json` が成果物。
+
+### 6. 配布・公開
+
+- `~/.illusions/rulesets/<id>/` に `dist/index.js` + `manifest.json` を置く（手動導入）。
+- GitHub repo に topic **`illusions-ruleset`** を付けると、illusions マーケットプレイスが自動収集・公開する。
+- `v*` タグを push するとリリースに成果物が添付される。
+
+## 重要な制約
+
+- `manifest.engineApi` は本体の `ENGINE_API_VERSION`（現在 **1**）と一致させる（不一致は隔離）。
+- 辞典依存ルールは `requires: [{ kind: "dict", dictId: "genji" }]` を宣言（未DL時は自動無効化＋警告）。
+- `ruleId` は安定値。`rulesetPrefix` で名前空間を付け、衝突を予防する。

--- a/docs/ruleset/authoring.md
+++ b/docs/ruleset/authoring.md
@@ -30,6 +30,7 @@ const ruleset: RulesetModule = {
     version: "1.0.0",
     engineApi: 1, // ENGINE_API_VERSION と一致必須
     license: "MIT",
+    rulesetPrefix: "my-", // 全 ruleId 共通の接頭辞（任意・衝突回避用）
     guidelines: [
       {
         id: "my-guideline",
@@ -73,6 +74,10 @@ export default ruleset;
 ### ruleId / guidelineId は安定値
 
 ユーザー設定・プリセット・保存済み状態と結びつくため、一度公開した `ruleId` / `guidelineId` は変えない。
+
+### rulesetPrefix（任意）
+
+`rulesetPrefix` は、このルールセットの**全 `ruleId` が共有する接頭辞**を宣言する（例 `"rule_ME2_"`, `"nihongo_hyouki_"`, `"my-"`）。マーケットプレイスでの**ルールID衝突を避ける**ための名前空間。設定すると、接頭辞で始まらない `ruleId` があるとき registry が警告（非致命）を出す。複数ルールセットで同じ `ruleId` が衝突した場合は「先勝ち＋警告」で安全に処理されるが、接頭辞を付けておけば衝突自体を予防できる。
 
 ## 2. createRules(ctx) と RulesetContext
 
@@ -169,6 +174,6 @@ expect(rule.lint("すごい！", cfg).length).toBeGreaterThan(0); // negative
 
 ## 関連
 
-- リポジトリ構造: [ruleset-structure.md](./ruleset-structure.md)
+- リポジトリ構造: [structure.md](./structure.md)
 - sample テンプレート: [sample-ruleset.md](./sample-ruleset.md)
 - クローズドソース配布: [closed-source.md](./closed-source.md)

--- a/docs/ruleset/closed-source.md
+++ b/docs/ruleset/closed-source.md
@@ -38,5 +38,5 @@ updated: 2026-06-19
 
 ## 関連
 
-- リポジトリ構造: [ruleset-structure.md](./ruleset-structure.md)
-- 作成ガイド: [ruleset-authoring.md](./ruleset-authoring.md)
+- リポジトリ構造: [structure.md](./structure.md)
+- 作成ガイド: [authoring.md](./authoring.md)

--- a/docs/ruleset/sample-ruleset.md
+++ b/docs/ruleset/sample-ruleset.md
@@ -7,7 +7,7 @@ updated: 2026-06-19
 # サンプル・ルールセット（写経用テンプレート）
 
 新しいルールセット開発の出発点。最小2ルール（L1 regex 1つ ＋ 辞典依存 1つ）を含む。
-**製品としては同梱しない**（別リポジトリの起点）。コードは [ruleset-authoring.md](./ruleset-authoring.md)
+**製品としては同梱しない**（別リポジトリの起点）。コードは [authoring.md](./authoring.md)
 の契約に従う。
 
 ## `manifest.json`
@@ -147,5 +147,5 @@ describe("sample-fw-exclaim", () => {
 
 ## 関連
 
-- 作成ガイド: [ruleset-authoring.md](./ruleset-authoring.md)
-- リポジトリ構造: [ruleset-structure.md](./ruleset-structure.md)
+- 作成ガイド: [authoring.md](./authoring.md)
+- リポジトリ構造: [structure.md](./structure.md)

--- a/docs/ruleset/structure.md
+++ b/docs/ruleset/structure.md
@@ -51,6 +51,6 @@ my-ruleset/
 
 ## 関連
 
-- 作成ガイド: [ruleset-authoring.md](./ruleset-authoring.md)
+- 作成ガイド: [authoring.md](./authoring.md)
 - sample テンプレート: [sample-ruleset.md](./sample-ruleset.md)
 - クローズドソース配布: [closed-source.md](./closed-source.md)

--- a/lib/linting/registry/__tests__/ruleset-context-factory.test.ts
+++ b/lib/linting/registry/__tests__/ruleset-context-factory.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import type { GenjiHealth } from "@/lib/dict/dict-access";
+
+import { createRulesetContext, resolveRulesetContext } from "../ruleset-context-factory";
+
+const fakeDict = {
+  async lookupBatch() {
+    return new Map();
+  },
+  async has() {
+    return false;
+  },
+};
+
+describe("createRulesetContext", () => {
+  it("wires bases, toolkit, and engineApi", () => {
+    const ctx = createRulesetContext({ dictHealth: { state: "ready" }, dict: fakeDict });
+    expect(ctx.engineApi).toBe(1);
+    expect(typeof ctx.bases.AbstractL1Rule).toBe("function");
+    expect(typeof ctx.toolkit.regexReplace).toBe("function");
+    expect(ctx.toolkit.nfkc("ﾄﾞ")).toBe("ド");
+  });
+
+  it("derives dict requirement satisfaction from health (ready)", () => {
+    const ctx = createRulesetContext({ dictHealth: { state: "ready" }, dict: fakeDict });
+    expect(ctx.deps.dictState).toBe("ready");
+    expect(ctx.deps.requirements.get("dict:genji")).toBe(true);
+    expect(ctx.toolkit.dict.ready).toBe(true);
+  });
+
+  it.each(["not-installed", "web-fallback", "corrupt", "unknown"] as const)(
+    "marks dict requirement unmet when health is %s",
+    (state) => {
+      const ctx = createRulesetContext({ dictHealth: { state } as GenjiHealth, dict: fakeDict });
+      expect(ctx.deps.dictState).toBe(state);
+      expect(ctx.deps.requirements.get("dict:genji")).toBe(false);
+      expect(ctx.toolkit.dict.ready).toBe(false);
+    },
+  );
+
+  it("honors an explicit requirements override", () => {
+    const ctx = createRulesetContext({
+      dictHealth: { state: "not-installed" },
+      dict: fakeDict,
+      requirements: new Map([["dict:genji", true]]),
+    });
+    expect(ctx.deps.requirements.get("dict:genji")).toBe(true);
+  });
+});
+
+describe("resolveRulesetContext", () => {
+  it("builds a context from the live dictionary singleton (web-fallback in node)", async () => {
+    const ctx = await resolveRulesetContext();
+    expect(ctx.engineApi).toBe(1);
+    expect(typeof ctx.deps.dictState).toBe("string");
+    // No window in the test env → dictionary is not "ready".
+    expect(ctx.deps.requirements.get("dict:genji")).toBe(false);
+  });
+});

--- a/lib/linting/registry/__tests__/ruleset-fixtures.ts
+++ b/lib/linting/registry/__tests__/ruleset-fixtures.ts
@@ -41,6 +41,8 @@ interface MakeModuleOptions {
   dictRuleIds?: string[];
   /** make createRules throw */
   createThrows?: boolean;
+  /** declared shared rule-id prefix */
+  rulesetPrefix?: string;
 }
 
 function ruleMeta(
@@ -77,6 +79,7 @@ export function makeModule(opts: MakeModuleOptions): RulesetModule {
     version: "1.0.0",
     engineApi: opts.engineApi ?? ENGINE_API_VERSION,
     license: "MIT",
+    ...(opts.rulesetPrefix ? { rulesetPrefix: opts.rulesetPrefix } : {}),
     guidelines: opts.guidelineId
       ? [
           {

--- a/lib/linting/registry/__tests__/ruleset-registry.test.ts
+++ b/lib/linting/registry/__tests__/ruleset-registry.test.ts
@@ -107,6 +107,37 @@ describe("RulesetRegistry — registration & isolation", () => {
   });
 });
 
+describe("RulesetRegistry — rulesetPrefix", () => {
+  it("accepts rules that all carry the declared prefix", () => {
+    const reg = new RulesetRegistry();
+    reg.registerExternal(
+      makeModule({ id: "ext.p", ruleIds: ["myteam-a", "myteam-b"], rulesetPrefix: "myteam-" }),
+    );
+    expect(reg.getWarnings()).toHaveLength(0);
+    expect(reg.getManifests()[0].rulesetPrefix).toBe("myteam-");
+  });
+
+  it("warns (non-fatal) about a ruleId missing the prefix", () => {
+    const reg = new RulesetRegistry();
+    reg.registerExternal(
+      makeModule({ id: "ext.p2", ruleIds: ["myteam-a", "stray"], rulesetPrefix: "myteam-" }),
+    );
+    const w = reg.getWarnings().find((x) => x.code === "prefix-mismatch");
+    expect(w?.detail).toBe("stray");
+    // still loads both rules — prefix is advisory, not fatal
+    expect(reg.buildRules(makeContext()).map((r) => r.id)).toEqual(["myteam-a", "stray"]);
+  });
+
+  it("rejects a non-string rulesetPrefix as an invalid manifest", () => {
+    const reg = new RulesetRegistry();
+    const broken = makeModule({ id: "ext.p3" });
+    // @ts-expect-error corrupt the prefix type for the test
+    broken.manifest.rulesetPrefix = 123;
+    reg.registerExternal(broken);
+    expect(reg.getWarnings()[0].code).toBe("invalid-manifest");
+  });
+});
+
 describe("RulesetRegistry — derived metadata", () => {
   it("merges guidelines and builds the rule→guideline map", () => {
     const reg = new RulesetRegistry();
@@ -117,6 +148,28 @@ describe("RulesetRegistry — derived metadata", () => {
     expect([...reg.buildGuidelines().keys()]).toEqual(["gl-1"]);
     expect(reg.buildRuleGuidelineMap().get("r1")).toBe("gl-1");
     expect(reg.buildRulesMeta().map((m) => m.ruleId)).toEqual(["r1", "r2"]);
+  });
+
+  it("merges guidelines across multiple rulesets (dedup by id)", () => {
+    const reg = new RulesetRegistry();
+    reg.registerBuiltin(makeModule({ id: "builtin.a", ruleIds: ["a1"], guidelineId: "gl-a" }));
+    reg.registerBuiltin(makeModule({ id: "builtin.b", ruleIds: ["b1"], guidelineId: "gl-b" }));
+    reg.registerBuiltin(makeModule({ id: "builtin.c", ruleIds: ["c1"], guidelineId: "gl-a" }));
+    expect([...reg.buildGuidelines().keys()].sort()).toEqual(["gl-a", "gl-b"]);
+  });
+
+  it("returns an empty rule list when nothing is registered", () => {
+    const reg = new RulesetRegistry();
+    expect(reg.buildRules(makeContext())).toEqual([]);
+    expect(reg.getManifests()).toHaveLength(0);
+    expect(reg.getWarnings()).toHaveLength(0);
+  });
+
+  it("exposes quarantined entries via getEntries", () => {
+    const reg = new RulesetRegistry();
+    reg.registerExternal(makeModule({ id: "builtin.x" })); // reserved-namespace → quarantined
+    const entries = reg.getEntries();
+    expect(entries.some((e) => e.status === "quarantined")).toBe(true);
   });
 });
 
@@ -147,5 +200,16 @@ describe("RulesetRegistry — requirement gating (dict)", () => {
     const gate = reg.buildRequirementGate(makeContext("ready"));
     expect(gate.disabledRuleIds.size).toBe(0);
     expect(gate.warnings).toHaveLength(0);
+  });
+
+  it("applies a manifest-level requirement to every rule in the ruleset", () => {
+    const reg = new RulesetRegistry();
+    const mod = makeModule({ id: "builtin.dict3", ruleIds: ["a", "b"] });
+    mod.manifest.requires = [{ kind: "dict", dictId: "genji" }];
+    reg.registerBuiltin(mod);
+
+    const gate = reg.buildRequirementGate(makeContext("not-installed"));
+    expect([...gate.disabledRuleIds].sort()).toEqual(["a", "b"]);
+    expect(gate.warnings).toHaveLength(2);
   });
 });

--- a/lib/linting/registry/ruleset-registry.ts
+++ b/lib/linting/registry/ruleset-registry.ts
@@ -34,7 +34,8 @@ export type RulesetWarningCode =
   | "invalid-manifest"
   | "create-failed"
   | "duplicate-rule-id"
-  | "requirement-unmet";
+  | "requirement-unmet"
+  | "prefix-mismatch";
 
 export interface RulesetWarning {
   rulesetId: string;
@@ -66,6 +67,9 @@ export function validateManifest(manifest: unknown): string | null {
   if (typeof m.nameJa !== "string") return "missing nameJa";
   if (typeof m.version !== "string") return "missing version";
   if (typeof m.engineApi !== "number") return "missing engineApi";
+  if (m.rulesetPrefix !== undefined && typeof m.rulesetPrefix !== "string") {
+    return "rulesetPrefix must be a string";
+  }
   if (!Array.isArray(m.guidelines)) return "guidelines must be an array";
   if (!Array.isArray(m.rules)) return "rules must be an array";
   for (const r of m.rules) {
@@ -148,6 +152,20 @@ export class RulesetRegistry {
     }
 
     this.entries.set(manifest.id, { manifest, source, status: "ok", module: mod });
+
+    // Soft check: every ruleId should carry the declared rulesetPrefix.
+    if (manifest.rulesetPrefix) {
+      for (const rule of manifest.rules) {
+        if (!rule.ruleId.startsWith(manifest.rulesetPrefix)) {
+          this.warnings.push({
+            rulesetId: manifest.id,
+            code: "prefix-mismatch",
+            messageJa: `ルールID「${rule.ruleId}」は宣言された接頭辞「${manifest.rulesetPrefix}」で始まっていません。`,
+            detail: rule.ruleId,
+          });
+        }
+      }
+    }
   }
 
   private quarantine(

--- a/lib/linting/sdk/index.ts
+++ b/lib/linting/sdk/index.ts
@@ -7,7 +7,7 @@
  * `createRules`, because an un-bundled external module cannot resolve value
  * imports against illusions internals at runtime.
  *
- * @see docs/linting/ruleset-authoring.md
+ * @see docs/ruleset/authoring.md
  */
 
 // Engine version + module contract

--- a/lib/linting/sdk/ruleset-types.ts
+++ b/lib/linting/sdk/ruleset-types.ts
@@ -85,6 +85,13 @@ export interface RulesetManifest {
   /** Engine API version this ruleset targets. Must equal {@link ENGINE_API_VERSION}. */
   engineApi: number;
   license: string;
+  /**
+   * Common naming prefix shared by every `ruleId` in this ruleset
+   * (e.g. "rule_ME2_", "nihongo_hyouki_", "myteam-"). Used to namespace rules
+   * and avoid cross-ruleset collisions in the marketplace. When set, the
+   * registry warns about any rule whose id does not start with it.
+   */
+  rulesetPrefix?: string;
   guidelines: RulesetGuidelineMeta[];
   rules: RulesetRuleMeta[];
   /** Ruleset-wide requirements. */

--- a/lib/linting/toolkit/__tests__/regex-replace.test.ts
+++ b/lib/linting/toolkit/__tests__/regex-replace.test.ts
@@ -44,6 +44,29 @@ describe("regexReplace", () => {
     expect(issues).toHaveLength(0);
   });
 
+  it("passes through reference and custom fix labels", () => {
+    const issues = regexReplace({
+      ...BASE,
+      text: "あ！",
+      pattern: /！/,
+      replacement: () => "!",
+      reference: { standard: "JTF", section: "3.2.1" },
+      fixLabel: "Half-width",
+      fixLabelJa: "半角に",
+    });
+    expect(issues[0].reference).toEqual({ standard: "JTF", section: "3.2.1" });
+    expect(issues[0].fix).toMatchObject({
+      label: "Half-width",
+      labelJa: "半角に",
+      replacement: "!",
+    });
+  });
+
+  it("omits reference when not provided", () => {
+    const issues = regexReplace({ ...BASE, text: "あ！", pattern: /！/, replacement: () => "!" });
+    expect(issues[0].reference).toBeUndefined();
+  });
+
   it("supports a custom span", () => {
     const issues = regexReplace({
       ...BASE,

--- a/lib/linting/toolkit/__tests__/unit-detector.test.ts
+++ b/lib/linting/toolkit/__tests__/unit-detector.test.ts
@@ -73,4 +73,27 @@ describe("detectUnits — edges", () => {
     });
     expect(issues).toHaveLength(2);
   });
+
+  it("keeps the first spec when two specs claim the same span with different corrects", () => {
+    const issues = detectUnits({
+      ...BASE,
+      text: "2 KW",
+      units: [
+        { pattern: /(?<=\d\s*)KW\b/g, correct: "kW" },
+        { pattern: /(?<=\d\s*)KW\b/g, correct: "MW" },
+      ],
+    });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].fix?.replacement).toBe("kW");
+  });
+
+  it("uses a custom Japanese message when provided", () => {
+    const issues = detectUnits({
+      ...BASE,
+      text: "2 KW",
+      units: [{ pattern: /(?<=\d\s*)KW\b/g, correct: "kW" }],
+      messageJa: (m, c) => `「${m}」→「${c}」`,
+    });
+    expect(issues[0].messageJa).toBe("「KW」→「kW」");
+  });
 });


### PR DESCRIPTION
## 概要

#1770 で入れた校正ルールセット基盤への**追補**。`rulesetPrefix` フィールド、開発ドキュメントの集約（`docs/ruleset/`、quickstart 付き）、edge ケーステストの拡充。**既存 lint には未接続＝挙動不変**。

## 変更内容
- **SDK**: `RulesetManifest.rulesetPrefix?`（全 `ruleId` 共通の接頭辞。marketplace でのルールID衝突を予防する名前空間）。
- **registry**: `rulesetPrefix` 非一致を**非致命の warning(`prefix-mismatch`)**で報告。`rulesetPrefix` の型検証を追加。
- **docs**: `docs/ruleset/` を新設（`README`=quickstart、`authoring`/`structure`/`sample-ruleset`/`closed-source`）。**旧 `docs/linting/` は廃止し統合**。`@/lib/linting/sdk` の `@see` と AGENTS 参照も更新。
- **テスト(edge 拡充)**: context-factory（dict health→requirements / 各 health 状態 / override / live singleton）、prefix（一致/非一致 warning/型不正）、単位 dedup（同一スパン競合は先勝ち / カスタム msg）、regexReplace（reference/fixLabel/省略）、registry（空→[] / 隔離 entry 露出 / manifest-level requires / guideline 多重マージ）。

## テスト
- lint 全体 **127 tests green**、`tsc` 0 errors、ESLint/Prettier クリーン（lint-staged 通過）。

## 関連
- 続き: #1770（ルールセット基盤）
- Related to #912（拡張システム基盤）/ #1628 / #1623（辞典依存ルール）

🤖 Generated with [Claude Code](https://claude.com/claude-code)