### PR TITLE
fix(quicklook): mac.binaries で .appex を署名対象に追加し notarization 失敗を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,9 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
+      "binaries": [
+        "Contents/PlugIns/MDIQuickLook.appex"
+      ],
       "extendInfo": {
         "UTExportedTypeDeclarations": [
           {

--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -6,9 +6,15 @@
 // `extraFiles`): files added via `extraFiles` are copied but NOT code-signed,
 // so the nested Mach-O fails notarization ("not signed with a valid Developer
 // ID certificate / no secure timestamp / hardened runtime not enabled").
-// By copying it into Contents/PlugIns here, electron-builder's osx-sign step
-// signs it with the Developer ID identity, hardened runtime, secure timestamp,
-// and inherited entitlements as part of the normal signing walk.
+//
+// Two pieces are required and must stay in sync:
+//   1. This hook copies the .appex into Contents/PlugIns before signing.
+//   2. `build.mac.binaries` in package.json lists the .appex so osx-sign seals
+//      it. osx-sign's walk only signs nested `.app`/`.framework` *bundles*
+//      automatically (see @electron/osx-sign util.js walkAsync) — a `.appex`
+//      bundle is otherwise left unsealed, which makes the parent app signing
+//      fail with "In subcomponent ...MDIQuickLook.appex: code object is not
+//      signed at all". `mac.binaries` adds it to the sign list explicitly.
 
 const path = require("path");
 const fs = require("fs");


### PR DESCRIPTION
## 背景

#1772（afterPack 埋め込み）後も dev の macOS ビルドが署名で失敗：

```
codesign ... Contents/MacOS/illusions
  In subcomponent: .../Contents/PlugIns/MDIQuickLook.appex:
  code object is not signed at all
```

## 根本原因

`@electron/osx-sign` の `walkAsync`（util.js）は、ディレクトリのうち **`.app` と `.framework` だけ**をバンドルとして署名リストに追加する。`.appex` はその対象外のため、

- appex 内の Mach-O（`Contents/MacOS/MDIQuickLook`）はゆるく署名されるが
- **appex バンドル自体が封緘されない**（`_CodeSignature` なし）

結果、親アプリ署名時に「未署名サブコンポーネント」として弾かれていた。

## 修正

`build.mac.binaries` に `Contents/PlugIns/MDIQuickLook.appex` を追加。

- electron-builder（`MacTargetHelper.buildSignOptions`）が相対パスを app の Contents から解決し、osx-sign の `opts.binaries` に転送
- osx-sign は binaries を署名リストに加える（sign.js L144）
- deepest-first 順で **inner binary → appex バンドル封緘 → main app** となり整合
- appex は Developer ID + hardened runtime + secure timestamp + 継承 entitlements で封緘される

afterPack フック（#1772）でのコピーと `mac.binaries` の2つが揃って機能する旨をコメントに明記。

## 検証
- ✅ JSON/prettier/構文チェック green
- ⏳ **最終確認は dev の macOS ビルド（実署名・notarization）**

## 関連 issue
なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)