### PR TITLE
fix(quicklook): afterPack で .appex を自前 Developer ID 署名し notarization 失敗を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,9 +170,6 @@
       "gatekeeperAssess": false,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
-      "binaries": [
-        "Contents/PlugIns/MDIQuickLook.appex"
-      ],
       "extendInfo": {
         "UTExportedTypeDeclarations": [
           {

--- a/quicklook/README.md
+++ b/quicklook/README.md
@@ -31,10 +31,19 @@ principal class を持つ Quick Look Preview Extension を `<App>.app/Contents/P
      拡張の `QLSupportedContentTypes` に**永遠にマッチしません**。これが旧構成で
      プレビューが出なかったもう一つの根本原因です。
 
-3. **PlugIns への埋め込み + 署名**（`package.json` の `mac.extraFiles`）
-   - `Contents/PlugIns/MDIQuickLook.appex` に配置。electron-builder が nested code として
-     Developer ID で署名・notarize します。`~/Library/QuickLook` への手動コピーや
-     `qlmanage -r` は不要（pluginkit が自動検出）。
+3. **PlugIns への埋め込み + 署名**（`scripts/embed-quicklook.js`、afterPack フック）
+   - 署名前に `.appex` を `Contents/PlugIns/MDIQuickLook.appex` へコピーし、afterPack
+     フック内で **Developer ID + hardened runtime + secure timestamp** で署名する。
+   - **なぜ afterPack で自前署名するか**: electron-builder の署名ステップ
+     (@electron/osx-sign / MacTargetHelper) は `Contents/PlugIns` 配下を
+     **既定で署名対象から除外**する（`ignore` コールバック内の
+     `file.startsWith("/Contents/PlugIns", appPath.length)`）。そのため
+     `extraFiles` でも `mac.binaries` でも appex は署名されず、親アプリ署名・
+     notarization が「code object is not signed at all」で失敗する。afterPack は
+     アプリ署名より前に走るので、ここで CSC_LINK/CSC_KEY_PASSWORD から一時
+     keychain を作って appex を署名しておけば、electron-builder は PlugIns を
+     触らないため署名が保持され、親の封緘が成功する。
+   - `~/Library/QuickLook` への手動コピーや `qlmanage -r` は不要（pluginkit が自動検出）。
 
 ## ビルド
 

--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -1,25 +1,136 @@
 /* eslint-disable no-console */
-// electron-builder afterPack hook.
+// electron-builder afterPack hook: embed AND code-sign the MDI Quick Look
+// Preview Extension (.appex) for the packaged macOS app.
 //
-// Embeds the MDI Quick Look Preview Extension (.appex) into the packaged macOS
-// app *before* code signing. This is intentionally an afterPack hook (not
-// `extraFiles`): files added via `extraFiles` are copied but NOT code-signed,
-// so the nested Mach-O fails notarization ("not signed with a valid Developer
-// ID certificate / no secure timestamp / hardened runtime not enabled").
+// Why this hook does the signing itself (instead of letting electron-builder
+// sign it):
+//   - `extraFiles` copies the .appex but never code-signs it.
+//   - electron-builder's signer (@electron/osx-sign via MacTargetHelper)
+//     *explicitly ignores everything under Contents/PlugIns*
+//     (`file.startsWith("/Contents/PlugIns", appPath.length)` in its `ignore`
+//     callback). So neither the .appex bundle nor its inner Mach-O is ever
+//     signed by electron-builder — and a `mac.binaries` entry is ignored for
+//     the same reason. The unsigned nested bundle then fails the parent app
+//     signing / notarization ("code object is not signed at all").
 //
-// Two pieces are required and must stay in sync:
-//   1. This hook copies the .appex into Contents/PlugIns before signing.
-//   2. `build.mac.binaries` in package.json lists the .appex so osx-sign seals
-//      it. osx-sign's walk only signs nested `.app`/`.framework` *bundles*
-//      automatically (see @electron/osx-sign util.js walkAsync) — a `.appex`
-//      bundle is otherwise left unsealed, which makes the parent app signing
-//      fail with "In subcomponent ...MDIQuickLook.appex: code object is not
-//      signed at all". `mac.binaries` adds it to the sign list explicitly.
+// Therefore we sign the .appex here, in afterPack (which runs *before* the app
+// is signed), using a throwaway keychain built from the same CSC_LINK /
+// CSC_KEY_PASSWORD credentials electron-builder uses. When electron-builder
+// later signs the app it leaves Contents/PlugIns untouched, so our signature
+// survives and the parent seal succeeds.
+//
+// On builds without signing credentials (local `--dir` builds, forks) the
+// .appex is left as-is; those artifacts are not notarized.
 
 const path = require("path");
 const fs = require("fs");
+const os = require("os");
+const { execFileSync } = require("child_process");
 
 const APPEX_NAME = "MDIQuickLook.appex";
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { stdio: ["ignore", "pipe", "pipe"], ...opts })
+    .toString()
+    .trim();
+}
+
+/** Resolve CSC_LINK (base64 p12, file path, or file:// URL) to a local .p12 path. */
+function resolveCertFile(cscLink, tmpDir) {
+  if (cscLink.startsWith("file://")) {
+    return cscLink.slice("file://".length);
+  }
+  if (fs.existsSync(cscLink)) {
+    return cscLink;
+  }
+  const p12 = path.join(tmpDir, "mdiql-cert.p12");
+  fs.writeFileSync(p12, Buffer.from(cscLink, "base64"));
+  return p12;
+}
+
+/** Code-sign the .appex with Developer ID using a throwaway keychain. */
+function signAppex(appexPath) {
+  const cscLink = process.env.CSC_LINK;
+  const cscPassword = process.env.CSC_KEY_PASSWORD || "";
+
+  if (process.env.CSC_IDENTITY_AUTO_DISCOVERY === "false" || !cscLink) {
+    console.log(
+      `[QuickLook] No signing credentials (CSC_LINK); leaving ${APPEX_NAME} unsigned (non-notarized build).`,
+    );
+    return;
+  }
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "mdiql-sign-"));
+  const keychain = path.join(tmpDir, "mdiql.keychain-db");
+  const keychainPassword = "mdiql-temp";
+  const entitlements = path.join(__dirname, "..", "build", "entitlements.mac.plist");
+
+  try {
+    const certFile = resolveCertFile(cscLink, tmpDir);
+
+    run("/usr/bin/security", ["create-keychain", "-p", keychainPassword, keychain]);
+    run("/usr/bin/security", ["unlock-keychain", "-p", keychainPassword, keychain]);
+    run("/usr/bin/security", ["set-keychain-settings", keychain]);
+    run("/usr/bin/security", [
+      "import",
+      certFile,
+      "-k",
+      keychain,
+      "-T",
+      "/usr/bin/codesign",
+      "-P",
+      cscPassword,
+    ]);
+    run("/usr/bin/security", [
+      "set-key-partition-list",
+      "-S",
+      "apple-tool:,apple:,codesign:",
+      "-s",
+      "-k",
+      keychainPassword,
+      keychain,
+    ]);
+
+    const identities = run("/usr/bin/security", [
+      "find-identity",
+      "-v",
+      "-p",
+      "codesigning",
+      keychain,
+    ]);
+    const match = identities.match(/\b([0-9A-F]{40})\b\s+"(Developer ID Application[^"]*)"/);
+    if (!match) {
+      throw new Error(
+        `No "Developer ID Application" identity found in imported certificate.\n${identities}`,
+      );
+    }
+    const identityHash = match[1];
+    console.log(`[QuickLook] Signing ${APPEX_NAME} with ${match[2]}`);
+
+    run("/usr/bin/codesign", [
+      "--sign",
+      identityHash,
+      "--force",
+      "--keychain",
+      keychain,
+      "--timestamp",
+      "--options",
+      "runtime",
+      "--entitlements",
+      entitlements,
+      appexPath,
+    ]);
+    run("/usr/bin/codesign", ["--verify", "--strict", "--verbose=2", appexPath]);
+    console.log(`[QuickLook] ✅ ${APPEX_NAME} signed with Developer ID + hardened runtime`);
+  } finally {
+    try {
+      run("/usr/bin/security", ["delete-keychain", keychain]);
+    } catch {
+      /* keychain may not exist if setup failed early */
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
 
 exports.default = async function embedQuickLook(context) {
   const { electronPlatformName, appOutDir, packager } = context;
@@ -47,8 +158,8 @@ exports.default = async function embedQuickLook(context) {
   fs.mkdirSync(pluginsDir, { recursive: true });
   fs.rmSync(dest, { recursive: true, force: true });
   fs.cpSync(appexSource, dest, { recursive: true });
+  console.log(`[QuickLook] Embedded ${APPEX_NAME} into ${pluginsDir}`);
 
-  console.log(
-    `[QuickLook] Embedded ${APPEX_NAME} into ${pluginsDir} (will be signed by electron-builder)`,
-  );
+  // electron-builder ignores Contents/PlugIns during signing, so sign here.
+  signAppex(dest);
 };


### PR DESCRIPTION
## RED 3回の真因（実ログで確定）

`@electron/osx-sign` を駆動する electron-builder の `MacTargetHelper.buildSignOptions` は、署名対象を決める `ignore` コールバックで **`Contents/PlugIns` 配下を既定で除外**している：

```js
return (file.endsWith(".kext") ||
    file.startsWith("/Contents/PlugIns", appPath.length) ||  // ← PlugIns を丸ごと無視
    ...);
```

そのため `extraFiles`（#1769）でも afterPack 埋め込み（#1772）でも `mac.binaries`（#1776）でも、**appex は electron-builder に一切署名されない**。未署名の nested バンドルが親アプリ署名時に弾かれていた：

```
In subcomponent: .../Contents/PlugIns/MDIQuickLook.appex:
code object is not signed at all
```

## 修正

electron-builder が PlugIns を触らない以上、**afterPack（アプリ署名より前）で appex を自前署名**するのが唯一の正解：

- `embed-quicklook.js`：CSC_LINK / CSC_KEY_PASSWORD から一時 keychain を作成 → `Developer ID Application` で `--options runtime --timestamp --entitlements` 署名 → `codesign --verify --strict` → keychain 破棄。electron-builder は PlugIns を無視するので署名が保持され、親アプリの封緘が成功する
- electron-builder の keychain セットアップ手順（create-keychain / unlock / import -T codesign / set-key-partition-list / find-identity）をミラー
- CSC 無し（ローカル `--dir` / fork）は署名スキップ
- 不要になった `mac.binaries` を削除
- README に PlugIns 除外と afterPack 自前署名の経緯を明記

## 検証
- ✅ JSON/prettier/構文、afterPack フックの埋め込み・CSC無しスキップをローカル確認
- ⚠️ **実 Developer ID 署名・notarization は CI でしか実行できない**ため、最終確認は dev の macOS ビルドで行う（keychain 操作・identity 解決を含む署名経路は CI が初検証）

## 関連 issue
なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)