### PR TITLE
fix(quicklook): 一時keychainを検索リストに追加してcodesign鍵解決を修正

### DIFF
--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -65,6 +65,13 @@ function signAppex(appexPath) {
   const keychainPassword = "mdiql-temp";
   const entitlements = path.join(__dirname, "..", "build", "entitlements.mac.plist");
 
+  // The user keychain search list. `codesign` resolves the signing identity's
+  // private key via the search list, so our throwaway keychain must be added to
+  // it (just passing `--keychain` is not enough; without this codesign fails
+  // with "The specified item could not be found in the keychain"). We restore
+  // the original list afterwards so electron-builder's own signing is unaffected.
+  let prevSearchList = null;
+
   try {
     const certFile = resolveCertFile(cscLink, tmpDir);
 
@@ -90,6 +97,12 @@ function signAppex(appexPath) {
       keychainPassword,
       keychain,
     ]);
+
+    prevSearchList = run("/usr/bin/security", ["list-keychains", "-d", "user"])
+      .split("\n")
+      .map((line) => line.trim().replace(/^"|"$/g, ""))
+      .filter(Boolean);
+    run("/usr/bin/security", ["list-keychains", "-d", "user", "-s", keychain, ...prevSearchList]);
 
     const identities = run("/usr/bin/security", [
       "find-identity",
@@ -123,6 +136,13 @@ function signAppex(appexPath) {
     run("/usr/bin/codesign", ["--verify", "--strict", "--verbose=2", appexPath]);
     console.log(`[QuickLook] ✅ ${APPEX_NAME} signed with Developer ID + hardened runtime`);
   } finally {
+    if (prevSearchList) {
+      try {
+        run("/usr/bin/security", ["list-keychains", "-d", "user", "-s", ...prevSearchList]);
+      } catch {
+        /* best-effort restore */
+      }
+    }
     try {
       run("/usr/bin/security", ["delete-keychain", keychain]);
     } catch {


### PR DESCRIPTION
## 背景

#1778（afterPack 自前署名）で identity 解決まで到達したが、`codesign` が失敗：

```
[QuickLook] Signing MDIQuickLook.appex with Developer ID Application: Junpei Ikuta (***)
codesign --sign C34B... --keychain .../mdiql.keychain-db ... MDIQuickLook.appex
error: The specified item could not be found in the keychain.
```

`codesign` は identity の**秘密鍵をキーチェーン検索リスト**から解決する。`--keychain` を指定しても、その keychain が検索リストに無いと鍵が見つからない（干渉回避のため検索リスト追加を省いていたのが原因）。

## 修正

- 署名前に `security list-keychains -d user -s <tmp keychain> <既存...>` で一時 keychain を検索リストへ追加
- `finally` で元の検索リストへ復元し、electron-builder 本体の署名に干渉しないようにする

これは electron-builder 自身の keychain セットアップ（macCodeSign.js）と同じ手順。

## 検証
- ✅ 構文/prettier、埋め込み・CSC無しスキップをローカル確認
- ⚠️ 実署名は CI のみ。dev の macOS ビルドで最終確認

## 関連 issue
なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)