### PR TITLE
test(updater): beta opt-in 更新挙動のテスト＋純粋ポリシー分離

### DIFF
--- a/electron/__tests__/auto-updater.test.ts
+++ b/electron/__tests__/auto-updater.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Wiring & regression guards for the beta-aware auto-update flow (#1782 / #1785).
+ *
+ * `electron/auto-updater.js` は electron-updater を最上位で require するため vitest 環境では
+ * そのままロードできない（実体が electron に触れてクラッシュする）。決定ロジックは純粋関数
+ * `electron/lib/update-policy.js` に分離して update-policy.test.ts で検証済み。ここでは、
+ * その純粋ロジックが正しく「メニューの手動チェック導線」へ結線されていることを、ソース不変条件
+ * （drift guard、ipc-bridge.test.ts と同方針）として固定する。
+ *
+ * 守りたい要件:
+ *   「ベータ版アップデートを受け取る」ON ＋ メニュー「アップデートを確認」→ beta 版へ更新。
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const autoUpdaterSrc = fs.readFileSync(path.resolve(__dirname, "../auto-updater.js"), "utf8");
+const menuSrc = fs.readFileSync(path.resolve(__dirname, "../menu.js"), "utf8");
+
+describe("auto-updater.js — opt-in wiring", () => {
+  it("純粋ポリシー resolveUpdaterFlags を使って更新フラグを決める", () => {
+    expect(autoUpdaterSrc).toContain('require("./lib/update-policy")');
+    expect(autoUpdaterSrc).toMatch(/resolveUpdaterFlags\(\s*appState\?\.allowBetaUpdates\s*\)/);
+  });
+
+  it("手動チェックは autoUpdater.checkForUpdates() の直前に opt-in を再評価する（順序保証）", () => {
+    const applyIdx = autoUpdaterSrc.indexOf("await applyBetaOptIn()");
+    const checkIdx = autoUpdaterSrc.indexOf("autoUpdater.checkForUpdates()");
+    expect(applyIdx).toBeGreaterThan(-1);
+    expect(checkIdx).toBeGreaterThan(-1);
+    // applyBetaOptIn の await がチェック呼び出しより前に位置すること
+    expect(applyIdx).toBeLessThan(checkIdx);
+  });
+
+  it("checkForUpdates は async（opt-in の await を待ってから実チェックする）", () => {
+    expect(autoUpdaterSrc).toMatch(/async function checkForUpdates\s*\(/);
+  });
+
+  it("#1785 回帰防止: autoUpdater.channel を代入しない（latest*.yml フォールバックに依存）", () => {
+    expect(autoUpdaterSrc).not.toMatch(/autoUpdater\.channel\s*=/);
+  });
+
+  it("opt-in 変更の即時反映 reevaluateUpdateChannel を公開する", () => {
+    expect(autoUpdaterSrc).toMatch(/module\.exports\s*=\s*{[^}]*reevaluateUpdateChannel/);
+  });
+});
+
+describe("menu.js — 「アップデートを確認」導線", () => {
+  it("メニュー項目が手動チェック checkForUpdates(true) を呼ぶ", () => {
+    expect(menuSrc).toContain("アップデートを確認");
+    expect(menuSrc).toMatch(/checkForUpdates\(true\)/);
+  });
+});

--- a/electron/auto-updater.js
+++ b/electron/auto-updater.js
@@ -5,6 +5,7 @@ const { app, dialog } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const log = require("electron-log");
 const { isDev, isMicrosoftStoreApp } = require("./app-constants");
+const { resolveUpdaterFlags } = require("./lib/update-policy");
 
 // auto-updater のログ設定
 autoUpdater.logger = log;
@@ -32,10 +33,12 @@ async function applyBetaOptIn() {
   try {
     const { getStorageManager } = require("./ipc/storage-ipc");
     const appState = await getStorageManager().loadAppState();
-    const allowBeta = appState?.allowBetaUpdates === true;
-    autoUpdater.allowPrerelease = allowBeta;
-    autoUpdater.allowDowngrade = !allowBeta;
-    log.info(`アップデート設定: allowPrerelease=${allowBeta}, allowDowngrade=${!allowBeta}`);
+    const { allowPrerelease, allowDowngrade } = resolveUpdaterFlags(appState?.allowBetaUpdates);
+    autoUpdater.allowPrerelease = allowPrerelease;
+    autoUpdater.allowDowngrade = allowDowngrade;
+    log.info(
+      `アップデート設定: allowPrerelease=${allowPrerelease}, allowDowngrade=${allowDowngrade}`,
+    );
   } catch (e) {
     log.error("beta opt-in 設定の読み込みに失敗しました:", e);
   }

--- a/electron/lib/__tests__/update-policy.test.ts
+++ b/electron/lib/__tests__/update-policy.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Unit tests for the pure auto-update policy (#1782 / #1785).
+ *
+ * 要件の核: 「ベータ版アップデートを受け取る」ON のとき beta（プレリリース）を受信でき、
+ * OFF のとき最新安定版へ戻る、という判定ロジックを電子依存なしで検証する。
+ */
+import { describe, expect, it } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { resolveUpdaterFlags } = require("../update-policy") as {
+  resolveUpdaterFlags: (v: unknown) => { allowPrerelease: boolean; allowDowngrade: boolean };
+};
+
+describe("resolveUpdaterFlags", () => {
+  it("beta ON → プレリリース受信、ダウングレード不可", () => {
+    expect(resolveUpdaterFlags(true)).toEqual({
+      allowPrerelease: true,
+      allowDowngrade: false,
+    });
+  });
+
+  it("beta OFF → 安定版のみ、最新安定版へ戻すため downgrade 許可", () => {
+    expect(resolveUpdaterFlags(false)).toEqual({
+      allowPrerelease: false,
+      allowDowngrade: true,
+    });
+  });
+
+  it.each([undefined, null, 0, "", "true", 1, {}])(
+    "真偽値 true 以外 (%s) は安全側 = beta OFF 扱い",
+    (value) => {
+      expect(resolveUpdaterFlags(value)).toEqual({
+        allowPrerelease: false,
+        allowDowngrade: true,
+      });
+    },
+  );
+
+  it("allowPrerelease と allowDowngrade は常に相反する（同時に true/ false にならない）", () => {
+    for (const v of [true, false, undefined, "x"]) {
+      const { allowPrerelease, allowDowngrade } = resolveUpdaterFlags(v);
+      expect(allowPrerelease).toBe(!allowDowngrade);
+    }
+  });
+});

--- a/electron/lib/update-policy.js
+++ b/electron/lib/update-policy.js
@@ -1,0 +1,29 @@
+/**
+ * Pure auto-update channel policy (#1782 / #1785).
+ *
+ * electron / electron-updater に一切依存しない純粋関数として切り出し、単体テスト可能に
+ * する（lib/editor-page/power-policy.ts と同じ方針）。autoUpdater への副作用（プロパティ
+ * 代入や checkForUpdates 呼び出し）は呼び出し側 electron/auto-updater.js が担う。
+ *
+ * 重要: ここでは `channel` を一切決めない。GitHub provider は beta プレリリースの
+ * `latest*.yml` にフォールバックして更新を解決するため、`autoUpdater.channel` は
+ * 未設定のままにする（channel="beta" を立てると beta-*.yml 404 で失敗する）。
+ */
+
+/**
+ * beta opt-in フラグから autoUpdater に設定すべき更新挙動を決める。
+ *
+ * @param {unknown} allowBetaUpdates - AppState.allowBetaUpdates（真偽値以外は false 扱い）
+ * @returns {{ allowPrerelease: boolean, allowDowngrade: boolean }}
+ *   - allowPrerelease: ON のとき true（最新 beta プレリリースを受信）
+ *   - allowDowngrade : OFF のとき true（プレリリース実行中でも最新安定版へ戻す）
+ */
+function resolveUpdaterFlags(allowBetaUpdates) {
+  const allowBeta = allowBetaUpdates === true;
+  return {
+    allowPrerelease: allowBeta,
+    allowDowngrade: !allowBeta,
+  };
+}
+
+module.exports = { resolveUpdaterFlags };


### PR DESCRIPTION
## 目的
「ベータ版アップデートを受け取る」ON ＋ メニュー「アップデートを確認」→ **beta 版へ更新**、
という導線を回帰なく保証するテストを追加する。

## 変更
- `electron/lib/update-policy.js`（新規）: `resolveUpdaterFlags()` を純粋関数として分離
  （electron 非依存。`lib/editor-page/power-policy.ts` と同方針）。`applyBetaOptIn` がこれを使用。
- `electron/lib/__tests__/update-policy.test.ts`: ON→`allowPrerelease=true`/OFF→`allowDowngrade=true`/
  非 boolean は安全側（beta OFF 扱い）/ 両フラグが常に相反することを検証。
- `electron/__tests__/auto-updater.test.ts`: 結線の drift guard
  - opt-in を `autoUpdater.checkForUpdates()` の直前で `await` する順序
  - `autoUpdater.channel` を代入しない（#1785 回帰防止）
  - メニュー「アップデートを確認」が `checkForUpdates(true)`（手動）を呼ぶ

> 注: `auto-updater.js` は electron-updater を最上位 require するため vitest 実環境で
> ロードできない。決定ロジックを純粋関数へ分離して直接検証し、結線はソース不変条件で固定した。

## 検証
- `npm run type-check` ✅ / electron テスト 226 件 ✅（新規 16 件含む）/ prettier ✅

## 関連 issue
関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)