### PR TITLE
fix(ci): beta 版番号の先頭ゼロを除去し valid semver に揃える

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,17 +112,23 @@ jobs:
 
           # main: use computed version as-is
           # beta: append timestamped prerelease suffix so every beta build gets a
-          #   unique, monotonically-increasing version (vX.Y.Z-beta.YYYYMMDD.HHMMSS).
+          #   unique, monotonically-increasing version (vX.Y.Z-beta.YYYYMMDD.<seconds>).
           #   BASE_VERSION already equals the next stable patch (beta tags are
           #   excluded by the ^[0-9]+$ filter above), so the X.Y.Z prefix matches
           #   the version this beta will be promoted to on main.
+          #   NOTE: semver forbids leading zeros in numeric prerelease identifiers, and
+          #   electron-builder normalizes "043021" → "43021". We pre-strip the leading
+          #   zeros from the HHMMSS component (10# = force base-10) so the git tag, the
+          #   GitHub release, and the in-app version stay identical and valid.
           # alpha|dev: append branch name as a plain prerelease suffix
           case "$BRANCH_NAME" in
             main)
               FULL_VERSION="${BASE_VERSION}"
               ;;
             beta)
-              FULL_VERSION="${BASE_VERSION}-beta.$(date -u +%Y%m%d.%H%M%S)"
+              BETA_DATE=$(date -u +%Y%m%d)
+              BETA_TIME=$(date -u +%H%M%S)
+              FULL_VERSION="${BASE_VERSION}-beta.${BETA_DATE}.$((10#$BETA_TIME))"
               ;;
             alpha|dev)
               FULL_VERSION="${BASE_VERSION}-${BRANCH_NAME}"
@@ -160,10 +166,11 @@ jobs:
               exit 1
             fi
           else
-            # beta uses a timestamped identifier (X.Y.Z-beta.YYYYMMDD.HHMMSS);
+            # beta uses a timestamped identifier (X.Y.Z-beta.YYYYMMDD.<seconds>) where the
+            # trailing seconds component is leading-zero-stripped (valid semver numeric id);
             # alpha/dev use a bare channel suffix (X.Y.Z-alpha / X.Y.Z-dev).
-            if ! echo "$FULL" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-(alpha|dev|beta\.[0-9]{8}\.[0-9]{6})$'; then
-              echo "::error::Prerelease full version '${FULL}' has invalid format (expected X.Y.Z-(alpha|dev) or X.Y.Z-beta.YYYYMMDD.HHMMSS)"
+            if ! echo "$FULL" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-(alpha|dev|beta\.[0-9]{8}\.[0-9]+)$'; then
+              echo "::error::Prerelease full version '${FULL}' has invalid format (expected X.Y.Z-(alpha|dev) or X.Y.Z-beta.YYYYMMDD.N)"
               exit 1
             fi
           fi


### PR DESCRIPTION
## 背景（細部の不備）
`v1.2.20-beta.20260619.043021` の時刻 `043021` は **先頭ゼロ付き数値**で semver 違反。
electron-builder は内部で `43021` に正規化するため、**配信メタデータ(latest.yml)は valid・
配信は正常**だったが、**git タグ/Release 名だけ `043021`（無効）**となり実版番号とずれていた。

## 修正
HHMMSS を `$((10#$BETA_TIME))` で10進数化して先頭ゼロを除去。
→ タグ・GitHub Release・実アプリ版番号がすべて `...beta.20260619.43021`（electron-builder の
正規化と一致・valid semver）に揃う。validate 正規表現も `beta\.[0-9]{8}\.[0-9]+` に更新。

検証: 時刻 043021/000000/003005/235959/120000 すべて valid semver・単調増加・`> 1.2.19`。

## 関連 issue
関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)