### PR TITLE
feat(rulesets): 公式校正ルールセットの初回起動・自動ダウンロード（同意不要）

### DIFF
--- a/electron/__tests__/rulesets-manager.test.ts
+++ b/electron/__tests__/rulesets-manager.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for the rulesets-manager pure helpers and the official list.
+ * Network/fs paths are not exercised here (they require live GitHub/disk); the
+ * extracted pure helpers carry the version/compatibility/selection logic.
+ */
+import { describe, it, expect } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+
+const {
+  selectReleaseAssets,
+  isCompatibleEngineApi,
+  needsUpdate,
+  normalizeDigest,
+  SUPPORTED_ENGINE_API,
+} = require("../rulesets-manager") as {
+  selectReleaseAssets: (assets: unknown) => { index: unknown; manifest: unknown };
+  isCompatibleEngineApi: (m: unknown) => boolean;
+  needsUpdate: (installed: string | null, latest: string | null) => boolean;
+  normalizeDigest: (d: unknown) => string | null;
+  SUPPORTED_ENGINE_API: number;
+};
+
+const { OFFICIAL_RULESETS } = require("../official-rulesets") as {
+  OFFICIAL_RULESETS: ReadonlyArray<{ id: string; owner: string; repo: string }>;
+};
+
+describe("OFFICIAL_RULESETS", () => {
+  it("every entry has id/owner/repo strings", () => {
+    expect(OFFICIAL_RULESETS.length).toBeGreaterThan(0);
+    for (const r of OFFICIAL_RULESETS) {
+      expect(typeof r.id).toBe("string");
+      expect(typeof r.owner).toBe("string");
+      expect(typeof r.repo).toBe("string");
+    }
+  });
+
+  it("includes the 現代仮名遣い ruleset", () => {
+    expect(OFFICIAL_RULESETS.some((r) => r.id === "com.illusions-lab.gendai-kanazukai")).toBe(true);
+  });
+
+  it("ids are unique", () => {
+    const ids = OFFICIAL_RULESETS.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("selectReleaseAssets", () => {
+  it("picks index.js and manifest.json, ignoring other assets", () => {
+    const { index, manifest } = selectReleaseAssets([
+      { name: "manifest.json", browser_download_url: "u1" },
+      { name: "index.js", browser_download_url: "u2" },
+      { name: "com.example-v1.0.0.zip", browser_download_url: "u3" },
+    ]) as { index: { name: string }; manifest: { name: string } };
+    expect(index.name).toBe("index.js");
+    expect(manifest.name).toBe("manifest.json");
+  });
+
+  it("returns null for a missing asset and tolerates non-arrays", () => {
+    expect(selectReleaseAssets([{ name: "index.js" }]).manifest).toBeNull();
+    expect(selectReleaseAssets(undefined)).toEqual({ index: null, manifest: null });
+    expect(selectReleaseAssets(null)).toEqual({ index: null, manifest: null });
+  });
+});
+
+describe("isCompatibleEngineApi", () => {
+  it("accepts the supported engine api only", () => {
+    expect(isCompatibleEngineApi({ engineApi: SUPPORTED_ENGINE_API })).toBe(true);
+    expect(isCompatibleEngineApi({ engineApi: SUPPORTED_ENGINE_API + 1 })).toBe(false);
+    expect(isCompatibleEngineApi({})).toBe(false);
+    expect(isCompatibleEngineApi(null)).toBe(false);
+  });
+});
+
+describe("needsUpdate", () => {
+  it("downloads when not installed, skips when tags match", () => {
+    expect(needsUpdate(null, "v1.0.0")).toBe(true);
+    expect(needsUpdate("v1.0.0", "v1.0.0")).toBe(false);
+    expect(needsUpdate("v1.0.0", "v1.1.0")).toBe(true);
+  });
+
+  it("does nothing when there is no latest tag", () => {
+    expect(needsUpdate(null, null)).toBe(false);
+    expect(needsUpdate("v1.0.0", null)).toBe(false);
+  });
+});
+
+describe("normalizeDigest", () => {
+  it("strips the sha256: prefix and lowercases", () => {
+    expect(normalizeDigest("sha256:ABCDEF")).toBe("abcdef");
+    expect(normalizeDigest("AbC123")).toBe("abc123");
+  });
+
+  it("returns null for non-strings or empty", () => {
+    expect(normalizeDigest(undefined)).toBeNull();
+    expect(normalizeDigest(123)).toBeNull();
+    expect(normalizeDigest("sha256:")).toBeNull();
+  });
+});

--- a/electron/ipc/rulesets-ipc.js
+++ b/electron/ipc/rulesets-ipc.js
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+/**
+ * Rulesets IPC handlers — main process.
+ * Follows the same pattern as dict-ipc.js. All handlers are fail-safe: they
+ * return an empty/neutral value rather than throwing across the IPC boundary.
+ */
+
+const { ipcMain } = require("electron");
+const { getRulesetsManager } = require("../rulesets-manager");
+const { RULESETS_CHANNELS } = require("../lib/ipc-channels");
+
+function registerRulesetsHandlers() {
+  const mgr = getRulesetsManager();
+
+  // List installed (downloaded) official/external rulesets on disk.
+  ipcMain.handle(RULESETS_CHANNELS.invoke.listInstalled, async () => {
+    try {
+      return mgr.listInstalled();
+    } catch (err) {
+      console.error("[Rulesets IPC] rulesets:list-installed failed:", err);
+      return [];
+    }
+  });
+
+  // Download/update every official ruleset that is missing or out of date.
+  ipcMain.handle(RULESETS_CHANNELS.invoke.sync, async () => {
+    try {
+      return await mgr.syncAllOfficial();
+    } catch (err) {
+      console.error("[Rulesets IPC] rulesets:sync failed:", err);
+      return [];
+    }
+  });
+
+  // Check latest release tags vs installed, without downloading.
+  ipcMain.handle(RULESETS_CHANNELS.invoke.checkUpdate, async () => {
+    try {
+      return await mgr.checkUpdate();
+    } catch (err) {
+      console.error("[Rulesets IPC] rulesets:check-update failed:", err);
+      return [];
+    }
+  });
+}
+
+module.exports = { registerRulesetsHandlers };

--- a/electron/lib/__tests__/ipc-bridge.test.ts
+++ b/electron/lib/__tests__/ipc-bridge.test.ts
@@ -44,6 +44,7 @@ const {
   EDITOR_CHANNELS,
   NLP_CHANNELS,
   PTY_CHANNELS,
+  RULESETS_CHANNELS,
 } = channels;
 
 const { createIpcBridge } = require("../../../electron/lib/ipc-bridge") as {
@@ -280,6 +281,15 @@ describe("ipc-channels: pinned channel names (public IPC contract)", () => {
       exit: "pty:exit",
     });
   });
+
+  it("rulesets invoke channels keep their historical string values", () => {
+    expect(RULESETS_CHANNELS.invoke).toEqual({
+      listInstalled: "rulesets:list-installed",
+      sync: "rulesets:sync",
+      checkUpdate: "rulesets:check-update",
+    });
+    expect(RULESETS_CHANNELS.event).toEqual({});
+  });
 });
 
 describe("ipc bridge: preload ↔ main handler registration cannot drift", () => {
@@ -315,6 +325,7 @@ describe("ipc bridge: preload ↔ main handler registration cannot drift", () =>
     { constName: "EDITOR_CHANNELS", group: EDITOR_CHANNELS, mainFile: "ipc/editor-ipc.js" },
     { constName: "NLP_CHANNELS", group: NLP_CHANNELS, mainFile: "ipc/nlp-ipc.js" },
     { constName: "PTY_CHANNELS", group: PTY_CHANNELS, mainFile: "ipc/pty-ipc.js" },
+    { constName: "RULESETS_CHANNELS", group: RULESETS_CHANNELS, mainFile: "ipc/rulesets-ipc.js" },
   ];
 
   it.each(invokeRegistrations)(

--- a/electron/lib/ipc-channels.js
+++ b/electron/lib/ipc-channels.js
@@ -239,6 +239,16 @@ const UPDATE_CHANNELS = Object.freeze({
   event: Object.freeze({}),
 });
 
+// Official校正ルールセットの自動DL/更新 (electron/ipc/rulesets-ipc.js)
+const RULESETS_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    listInstalled: "rulesets:list-installed",
+    sync: "rulesets:sync",
+    checkUpdate: "rulesets:check-update",
+  }),
+  event: Object.freeze({}),
+});
+
 // Integrated terminal PTY sessions (electron/ipc/pty-ipc.js)
 const PTY_CHANNELS = Object.freeze({
   invoke: Object.freeze({
@@ -271,4 +281,5 @@ module.exports = {
   NLP_CHANNELS,
   PTY_CHANNELS,
   UPDATE_CHANNELS,
+  RULESETS_CHANNELS,
 };

--- a/electron/main.js
+++ b/electron/main.js
@@ -43,6 +43,8 @@ const { registerAuthHandlers, handleAuthCallback } = require("./ipc/auth-ipc");
 const { registerEditorHandlers } = require("./ipc/editor-ipc");
 const { registerDictHandlers } = require("./ipc/dict-ipc");
 const { getDictManager } = require("./dict-manager");
+const { registerRulesetsHandlers } = require("./ipc/rulesets-ipc");
+const { getRulesetsManager } = require("./rulesets-manager");
 const { DICT_CHANNELS } = require("./lib/ipc-channels");
 
 process.on("uncaughtException", (err) => {
@@ -202,6 +204,7 @@ app.whenReady().then(async () => {
   registerAuthHandlers();
   registerEditorHandlers();
   registerDictHandlers();
+  registerRulesetsHandlers();
 
   // Power state monitoring
   powerMonitor.on("on-ac", () => broadcastPowerState("ac"));
@@ -240,6 +243,23 @@ app.whenReady().then(async () => {
       console.error("[Dict] Auto update check failed:", err);
     }
   }, 5000);
+
+  // 公式校正ルールセットの自動ダウンロード/更新（同意不要・サイレント・best-effort）。
+  // 起動を妨げないよう遅延実行し、失敗は握りつぶす（オフライン等でも問題なし）。
+  // AppState の rulesetsAutoSync が明示的に false のときのみ無効化。
+  setTimeout(async () => {
+    try {
+      const appState = await getStorageManager().loadAppState();
+      if (appState?.rulesetsAutoSync === false) return;
+      const summary = await getRulesetsManager().syncAllOfficial();
+      const installed = summary.filter((s) => s.status === "installed");
+      if (installed.length > 0) {
+        console.log("[Rulesets] auto-sync installed:", installed.map((s) => s.id).join(", "));
+      }
+    } catch (err) {
+      console.warn("[Rulesets] auto-sync failed:", err);
+    }
+  }, 6000);
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) void createMainWindow();

--- a/electron/official-rulesets.js
+++ b/electron/official-rulesets.js
@@ -1,0 +1,26 @@
+/**
+ * Built-in (official) ruleset registry.
+ *
+ * illusions ships a curated list of first-party校正ルールセット that are
+ * auto-downloaded from their GitHub Releases into `~/.illusions/rulesets/<id>/`
+ * on launch (see electron/rulesets-manager.js). These are NOT bundled into the
+ * app — they live in their own repos (1 repo = 1 ruleset) and are fetched so
+ * they can be updated independently of the app release cycle.
+ *
+ * To add an official ruleset: publish a `v*` release in its repo (with
+ * `index.js` + `manifest.json` assets, as the ruleset template's release.yml
+ * does) and add an entry here.
+ */
+
+/** @typedef {{ id: string, owner: string, repo: string }} OfficialRuleset */
+
+/** @type {ReadonlyArray<OfficialRuleset>} */
+const OFFICIAL_RULESETS = Object.freeze([
+  Object.freeze({
+    id: "com.illusions-lab.gendai-kanazukai",
+    owner: "illusions-lab",
+    repo: "illusions-ruleset-gendai-kanazukai",
+  }),
+]);
+
+module.exports = { OFFICIAL_RULESETS };

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -25,6 +25,7 @@ const {
   NLP_CHANNELS,
   PTY_CHANNELS,
   UPDATE_CHANNELS,
+  RULESETS_CHANNELS,
 } = require("./lib/ipc-channels");
 
 contextBridge.exposeInMainWorld("electronAPI", {
@@ -197,6 +198,14 @@ contextBridge.exposeInMainWorld("electronAPI", {
     download: invokeChannel(DICT_CHANNELS.invoke.download, { arity: 0 }),
     onDownloadProgress: eventChannel(DICT_CHANNELS.event.downloadProgress),
     onUpdateAvailable: eventChannel(DICT_CHANNELS.event.updateAvailable),
+  },
+  rulesets: {
+    /** List installed (downloaded) official/external rulesets on disk. */
+    listInstalled: invokeChannel(RULESETS_CHANNELS.invoke.listInstalled, { arity: 0 }),
+    /** Download/update every official ruleset that is missing or out of date. */
+    sync: invokeChannel(RULESETS_CHANNELS.invoke.sync, { arity: 0 }),
+    /** Check latest release tags vs installed, without downloading. */
+    checkUpdate: invokeChannel(RULESETS_CHANNELS.invoke.checkUpdate, { arity: 0 }),
   },
   pty: {
     /** Spawn a new PTY session. Returns { sessionId } or { error }. */

--- a/electron/rulesets-manager.js
+++ b/electron/rulesets-manager.js
@@ -110,6 +110,38 @@ class RulesetsManager {
     }
   }
 
+  /** True when the installed dir has BOTH required asset files (not just a tag). */
+  _isInstalledComplete(id) {
+    const dir = this._rulesetDir(id);
+    return (
+      fs.existsSync(path.join(dir, ASSET_MANIFEST)) && fs.existsSync(path.join(dir, ASSET_INDEX))
+    );
+  }
+
+  /**
+   * Recover from a crash that happened during a swap: if a COMPLETE staged
+   * release is present but the install is missing/incomplete, promote it with no
+   * network access (heals even offline). Otherwise discard stale/partial staging.
+   */
+  _recoverStaging(id, dir, staging) {
+    try {
+      const stagedComplete =
+        fs.existsSync(path.join(staging, ASSET_MANIFEST)) &&
+        fs.existsSync(path.join(staging, ASSET_INDEX)) &&
+        fs.existsSync(path.join(staging, VERSION_FILE));
+      if (stagedComplete && !this._isInstalledComplete(id)) {
+        fs.rmSync(dir, { recursive: true, force: true });
+        fs.mkdirSync(path.dirname(dir), { recursive: true });
+        fs.renameSync(staging, dir);
+        console.log(`[Rulesets] recovered staged install for ${id}`);
+      } else {
+        fs.rmSync(staging, { recursive: true, force: true });
+      }
+    } catch {
+      /* best-effort recovery — never throws */
+    }
+  }
+
   /**
    * List installed rulesets (those with both manifest.json and index.js).
    * @returns {Array<{ id: string, version: string|null, tag: string|null }>}
@@ -201,7 +233,23 @@ class RulesetsManager {
     return summary;
   }
 
+  /**
+   * Sync a single official ruleset. MUST be called under the syncAllOfficial
+   * `_syncing` guard (the only call paths serialize through it), so its use of a
+   * stable per-id staging dir cannot race a concurrent sync of the same id.
+   */
   async _syncOne(spec) {
+    const dir = this._rulesetDir(spec.id);
+    // Stage the FULL release in a sibling dir, then swap it in with a single
+    // rename. The final dir is therefore only ever the old complete version,
+    // briefly absent, or the new complete version — never a half-written pair
+    // (e.g. new manifest + old code). Staging dirs use a "." prefix so
+    // listInstalled() skips them.
+    const staging = path.join(this._rootDir(), `.staging-${spec.id}`);
+
+    // Heal a crash that interrupted a previous swap before doing any network I/O.
+    this._recoverStaging(spec.id, dir, staging);
+
     const release = await this._fetchLatestRelease(spec);
     const latestTag = release?.tag_name ?? null;
     const { index: indexAsset, manifest: manifestAsset } = selectReleaseAssets(release?.assets);
@@ -211,7 +259,9 @@ class RulesetsManager {
     }
 
     const installedTag = this._readInstalledTag(spec.id);
-    if (!needsUpdate(installedTag, latestTag)) {
+    // Re-install when the tag differs OR the on-disk bundle is incomplete — a
+    // surviving .release-tag must not mask a missing/corrupt asset file.
+    if (!needsUpdate(installedTag, latestTag) && this._isInstalledComplete(spec.id)) {
       return { id: spec.id, status: "up-to-date", detail: latestTag };
     }
 
@@ -220,14 +270,6 @@ class RulesetsManager {
     if (!this._isAllowedAssetUrl(indexUrl) || !this._isAllowedAssetUrl(manifestUrl)) {
       return { id: spec.id, status: "skipped", detail: "asset host not allowed" };
     }
-
-    const dir = this._rulesetDir(spec.id);
-    // Stage the FULL release in a sibling dir, then swap it in with a single
-    // rename. The final dir is therefore only ever the old complete version,
-    // briefly absent, or the new complete version — never a half-written pair
-    // (e.g. new manifest + old code). Staging dirs use a "." prefix so
-    // listInstalled() skips them.
-    const staging = path.join(this._rootDir(), `.staging-${spec.id}`);
 
     try {
       fs.rmSync(staging, { recursive: true, force: true });
@@ -301,6 +343,11 @@ class RulesetsManager {
           requestUrl,
           { headers: { "User-Agent": "illusions-app", Accept: "application/vnd.github.v3+json" } },
           (res) => {
+            // Attach the error handler before draining/branching so a reset
+            // while a redirect/404/non-200 body drains can't raise an unhandled
+            // 'error' on the IncomingMessage (which would crash the main process).
+            res.on("error", reject);
+
             if ([301, 302, 303, 307, 308].includes(res.statusCode ?? 0)) {
               const location = res.headers.location;
               if (location) {
@@ -336,7 +383,6 @@ class RulesetsManager {
                 reject(err);
               }
             });
-            res.on("error", reject);
           },
         );
         req.on("error", reject);
@@ -354,34 +400,57 @@ class RulesetsManager {
    */
   _downloadFile(url, destPath, expectedDigest) {
     return new Promise((resolve, reject) => {
+      // Operation-wide guards (span all redirect hops):
+      // - `settled` makes resolve/reject fire exactly once.
+      // - `piping` flips true once a 200 body is being piped; from then on the
+      //   ONLY settlement path is the pipeline callback (which fires after both
+      //   streams close), so cleanup never races an open fd — including when a
+      //   stale earlier hop's request/timeout errors after we've moved on.
+      let settled = false;
+      let piping = false;
+      const fail = (err) => {
+        if (!settled) {
+          settled = true;
+          reject(err);
+        }
+      };
+      const succeed = (value) => {
+        if (!settled) {
+          settled = true;
+          resolve(value);
+        }
+      };
+
       const doRequest = (requestUrl, redirectCount = 0) => {
         if (redirectCount > 5) {
-          reject(new Error("ダウンロードのリダイレクトが最大回数を超えました"));
+          fail(new Error("ダウンロードのリダイレクトが最大回数を超えました"));
           return;
         }
         let parsed;
         try {
           parsed = new URL(requestUrl);
         } catch {
-          reject(new Error("ダウンロードURLの形式が不正です"));
+          fail(new Error("ダウンロードURLの形式が不正です"));
           return;
         }
         if (parsed.protocol !== "https:") {
-          reject(new Error("https 以外のダウンロード先は許可されていません"));
+          fail(new Error("https 以外のダウンロード先は許可されていません"));
           return;
         }
         // Re-validate the host on EVERY hop (including redirects), so a redirect
         // can never steer the download to a host outside the allowlist.
         if (!ALLOWED_DOWNLOAD_HOSTS.has(parsed.hostname)) {
-          reject(new Error("ダウンロード先のホストが許可されていません"));
+          fail(new Error("ダウンロード先のホストが許可されていません"));
           return;
         }
-        // Once the body is being piped, the ONLY settlement path is the
-        // pipeline callback (which fires after both streams close). req errors /
-        // timeout after that point destroy the source, which the pipeline turns
-        // into its callback — so we never reject before the fd is closed.
-        let piping = false;
         const req = https.get(requestUrl, { headers: { "User-Agent": "illusions-app" } }, (res) => {
+          // Always attach an error handler before draining/branching, so a reset
+          // while a redirect/non-200 body drains can't crash the main process
+          // with an unhandled 'error'. Once piping, pipeline owns the error.
+          res.on("error", (err) => {
+            if (!piping) fail(err);
+          });
+
           if ([301, 302, 303, 307, 308].includes(res.statusCode ?? 0)) {
             const location = res.headers.location;
             if (location) {
@@ -390,7 +459,7 @@ class RulesetsManager {
               try {
                 nextUrl = new URL(location, requestUrl).toString();
               } catch {
-                reject(new Error("リダイレクト先URLが不正です"));
+                fail(new Error("リダイレクト先URLが不正です"));
                 return;
               }
               doRequest(nextUrl, redirectCount + 1);
@@ -399,7 +468,7 @@ class RulesetsManager {
           }
           if (res.statusCode !== 200) {
             res.resume();
-            reject(new Error(`HTTP ${res.statusCode}`));
+            fail(new Error(`HTTP ${res.statusCode}`));
             return;
           }
           let received = 0;
@@ -419,21 +488,21 @@ class RulesetsManager {
           piping = true;
           pipeline(res, fs.createWriteStream(destPath), (err) => {
             if (err) {
-              reject(err);
+              fail(err);
               return;
             }
             const actual = hash.digest("hex");
             if (expectedDigest && actual !== expectedDigest) {
-              reject(new Error("ダウンロードのチェックサム検証に失敗しました"));
+              fail(new Error("ダウンロードのチェックサム検証に失敗しました"));
               return;
             }
-            resolve(actual);
+            succeed(actual);
           });
         });
         // Pre-response failures (DNS/connect) settle here; once piping, the
         // pipeline callback owns settlement so cleanup never races an open fd.
         req.on("error", (err) => {
-          if (!piping) reject(err);
+          if (!piping) fail(err);
         });
         req.setTimeout(REQUEST_TIMEOUT_MS, () => {
           req.destroy(new Error("ダウンロードがタイムアウトしました"));

--- a/electron/rulesets-manager.js
+++ b/electron/rulesets-manager.js
@@ -350,51 +350,59 @@ class RulesetsManager {
           reject(new Error("https 以外のダウンロード先は許可されていません"));
           return;
         }
-        https
-          .get(requestUrl, { headers: { "User-Agent": "illusions-app" } }, (res) => {
-            if ([301, 302, 303, 307, 308].includes(res.statusCode ?? 0)) {
-              const location = res.headers.location;
-              if (location) {
-                res.resume();
-                doRequest(new URL(location, requestUrl).toString(), redirectCount + 1);
-                return;
-              }
-            }
-            if (res.statusCode !== 200) {
+        // Re-validate the host on EVERY hop (including redirects), so a redirect
+        // can never steer the download to a host outside the allowlist.
+        if (!ALLOWED_DOWNLOAD_HOSTS.has(parsed.hostname)) {
+          reject(new Error("ダウンロード先のホストが許可されていません"));
+          return;
+        }
+        const req = https.get(requestUrl, { headers: { "User-Agent": "illusions-app" } }, (res) => {
+          if ([301, 302, 303, 307, 308].includes(res.statusCode ?? 0)) {
+            const location = res.headers.location;
+            if (location) {
               res.resume();
-              reject(new Error(`HTTP ${res.statusCode}`));
+              doRequest(new URL(location, requestUrl).toString(), redirectCount + 1);
               return;
             }
-            let received = 0;
-            let aborted = false;
-            const hash = crypto.createHash("sha256");
-            const fileStream = fs.createWriteStream(destPath);
-            res.on("data", (chunk) => {
-              if (aborted) return;
-              received += chunk.length;
-              if (received > MAX_ASSET_BYTES) {
-                aborted = true;
-                res.destroy();
-                fileStream.destroy();
-                reject(new Error("ダウンロードサイズが上限を超えました"));
-                return;
-              }
-              hash.update(chunk);
-            });
-            res.pipe(fileStream);
-            fileStream.on("close", () => {
-              if (aborted) return;
-              const actual = hash.digest("hex");
-              if (expectedDigest && actual !== expectedDigest) {
-                reject(new Error("ダウンロードのチェックサム検証に失敗しました"));
-                return;
-              }
-              resolve(actual);
-            });
-            fileStream.on("error", reject);
-            res.on("error", reject);
-          })
-          .on("error", reject);
+          }
+          if (res.statusCode !== 200) {
+            res.resume();
+            reject(new Error(`HTTP ${res.statusCode}`));
+            return;
+          }
+          let received = 0;
+          let aborted = false;
+          const hash = crypto.createHash("sha256");
+          const fileStream = fs.createWriteStream(destPath);
+          res.on("data", (chunk) => {
+            if (aborted) return;
+            received += chunk.length;
+            if (received > MAX_ASSET_BYTES) {
+              aborted = true;
+              res.destroy();
+              fileStream.destroy();
+              reject(new Error("ダウンロードサイズが上限を超えました"));
+              return;
+            }
+            hash.update(chunk);
+          });
+          res.pipe(fileStream);
+          fileStream.on("close", () => {
+            if (aborted) return;
+            const actual = hash.digest("hex");
+            if (expectedDigest && actual !== expectedDigest) {
+              reject(new Error("ダウンロードのチェックサム検証に失敗しました"));
+              return;
+            }
+            resolve(actual);
+          });
+          fileStream.on("error", reject);
+          res.on("error", reject);
+        });
+        req.on("error", reject);
+        req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+          req.destroy(new Error("ダウンロードがタイムアウトしました"));
+        });
       };
       doRequest(url);
     });

--- a/electron/rulesets-manager.js
+++ b/electron/rulesets-manager.js
@@ -22,6 +22,7 @@ const path = require("path");
 const os = require("os");
 const https = require("https");
 const crypto = require("crypto");
+const { pipeline } = require("stream");
 
 const { OFFICIAL_RULESETS } = require("./official-rulesets");
 
@@ -293,7 +294,14 @@ class RulesetsManager {
               const location = res.headers.location;
               if (location) {
                 res.resume();
-                doRequest(new URL(location, requestUrl).toString(), redirectCount + 1);
+                let nextUrl;
+                try {
+                  nextUrl = new URL(location, requestUrl).toString();
+                } catch {
+                  reject(new Error("リダイレクト先URLが不正です"));
+                  return;
+                }
+                doRequest(nextUrl, redirectCount + 1);
                 return;
               }
             }
@@ -317,6 +325,7 @@ class RulesetsManager {
                 reject(err);
               }
             });
+            res.on("error", reject);
           },
         );
         req.on("error", reject);
@@ -361,7 +370,14 @@ class RulesetsManager {
             const location = res.headers.location;
             if (location) {
               res.resume();
-              doRequest(new URL(location, requestUrl).toString(), redirectCount + 1);
+              let nextUrl;
+              try {
+                nextUrl = new URL(location, requestUrl).toString();
+              } catch {
+                reject(new Error("リダイレクト先URLが不正です"));
+                return;
+              }
+              doRequest(nextUrl, redirectCount + 1);
               return;
             }
           }
@@ -371,24 +387,24 @@ class RulesetsManager {
             return;
           }
           let received = 0;
-          let aborted = false;
           const hash = crypto.createHash("sha256");
-          const fileStream = fs.createWriteStream(destPath);
           res.on("data", (chunk) => {
-            if (aborted) return;
             received += chunk.length;
+            hash.update(chunk);
             if (received > MAX_ASSET_BYTES) {
-              aborted = true;
-              res.destroy();
-              fileStream.destroy();
-              reject(new Error("ダウンロードサイズが上限を超えました"));
+              // Destroy the source with an error; pipeline tears down the write
+              // stream and fires its callback with this error.
+              res.destroy(new Error("ダウンロードサイズが上限を超えました"));
+            }
+          });
+          // pipeline() destroys the destination on ANY source error (network
+          // error, timeout-triggered req.destroy, size-cap abort), closing the
+          // fd before we settle — avoids leaked/locked temp files.
+          pipeline(res, fs.createWriteStream(destPath), (err) => {
+            if (err) {
+              reject(err);
               return;
             }
-            hash.update(chunk);
-          });
-          res.pipe(fileStream);
-          fileStream.on("close", () => {
-            if (aborted) return;
             const actual = hash.digest("hex");
             if (expectedDigest && actual !== expectedDigest) {
               reject(new Error("ダウンロードのチェックサム検証に失敗しました"));
@@ -396,8 +412,6 @@ class RulesetsManager {
             }
             resolve(actual);
           });
-          fileStream.on("error", reject);
-          res.on("error", reject);
         });
         req.on("error", reject);
         req.setTimeout(REQUEST_TIMEOUT_MS, () => {

--- a/electron/rulesets-manager.js
+++ b/electron/rulesets-manager.js
@@ -1,0 +1,419 @@
+/* eslint-disable no-console */
+/**
+ * Rulesets manager — main process.
+ *
+ * Auto-downloads official校正ルールセット (electron/official-rulesets.js) from
+ * their GitHub Releases into `~/.illusions/rulesets/<id>/` so they are present
+ * for the (future) external ruleset loader. Mirrors the dictionary downloader
+ * (electron/dict-manager.js): GitHub Releases API, https-only with redirect
+ * handling, host allowlist, sha256 verification, atomic install, fail-safe.
+ *
+ * Fail-safe: a failure for one ruleset (offline, no release, bad checksum,
+ * incompatible engineApi) never throws to callers and never blocks the others
+ * or app startup — it is logged and skipped.
+ *
+ * NOTE: downloading only places files on disk. They become active校正ルール only
+ * once the external ruleset loader (worker Blob import) is wired up. This module
+ * is intentionally independent of that loader.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const https = require("https");
+const crypto = require("crypto");
+
+const { OFFICIAL_RULESETS } = require("./official-rulesets");
+
+// Mirrors ENGINE_API_VERSION in lib/linting/sdk/ruleset-types.ts. A downloaded
+// ruleset whose manifest targets a different engine is skipped (incompatible).
+const SUPPORTED_ENGINE_API = 1;
+
+const ASSET_INDEX = "index.js";
+const ASSET_MANIFEST = "manifest.json";
+const VERSION_FILE = ".release-tag";
+
+// Hosts GitHub serves release assets / API from. Asset URLs not on this list
+// are rejected (defense against a tampered/redirected download target).
+const ALLOWED_DOWNLOAD_HOSTS = new Set([
+  "github.com",
+  "objects.githubusercontent.com",
+  "release-assets.githubusercontent.com",
+]);
+
+const MAX_ASSET_BYTES = 5 * 1024 * 1024; // 5 MB cap per asset (rulesets are tiny)
+const REQUEST_TIMEOUT_MS = 15000;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (exported for unit tests — no I/O).
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick the index.js / manifest.json assets from a GitHub release's asset list.
+ * @returns {{ index: object|null, manifest: object|null }}
+ */
+function selectReleaseAssets(assets) {
+  const list = Array.isArray(assets) ? assets : [];
+  return {
+    index: list.find((a) => a && a.name === ASSET_INDEX) ?? null,
+    manifest: list.find((a) => a && a.name === ASSET_MANIFEST) ?? null,
+  };
+}
+
+/** True when a parsed manifest targets the supported engine API. */
+function isCompatibleEngineApi(manifest) {
+  return !!manifest && manifest.engineApi === SUPPORTED_ENGINE_API;
+}
+
+/** True when the latest release tag differs from what is installed. */
+function needsUpdate(installedTag, latestTag) {
+  if (!latestTag) return false;
+  return !installedTag || installedTag !== latestTag;
+}
+
+/** Normalize a GitHub `digest` ("sha256:abc…") to a bare lowercase hex string. */
+function normalizeDigest(digest) {
+  if (typeof digest !== "string") return null;
+  return digest.replace(/^sha256:/i, "").toLowerCase() || null;
+}
+
+class RulesetsManager {
+  constructor() {
+    this._syncing = false;
+  }
+
+  /** Root directory for external/official rulesets: ~/.illusions/rulesets/ */
+  _rootDir() {
+    return path.join(os.homedir(), ".illusions", "rulesets");
+  }
+
+  _rulesetDir(id) {
+    return path.join(this._rootDir(), id);
+  }
+
+  _isAllowedAssetUrl(url) {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === "https:" && ALLOWED_DOWNLOAD_HOSTS.has(parsed.hostname);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Read the installed release tag for an id, or null. */
+  _readInstalledTag(id) {
+    try {
+      return fs.readFileSync(path.join(this._rulesetDir(id), VERSION_FILE), "utf8").trim() || null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * List installed rulesets (those with both manifest.json and index.js).
+   * @returns {Array<{ id: string, version: string|null, tag: string|null }>}
+   */
+  listInstalled() {
+    const root = this._rootDir();
+    let entries;
+    try {
+      entries = fs.readdirSync(root, { withFileTypes: true });
+    } catch {
+      return []; // root not created yet
+    }
+    const out = [];
+    for (const ent of entries) {
+      if (!ent.isDirectory()) continue;
+      const dir = path.join(root, ent.name);
+      const manifestPath = path.join(dir, ASSET_MANIFEST);
+      const indexPath = path.join(dir, ASSET_INDEX);
+      if (!fs.existsSync(manifestPath) || !fs.existsSync(indexPath)) continue;
+      let version = null;
+      let id = ent.name;
+      try {
+        const m = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+        if (m && typeof m.version === "string") version = m.version;
+        if (m && typeof m.id === "string") id = m.id;
+      } catch {
+        // keep dir name as id, version null
+      }
+      out.push({ id, version, tag: this._readInstalledTag(ent.name) });
+    }
+    return out;
+  }
+
+  /** Fetch the latest release JSON for an official ruleset spec. */
+  async _fetchLatestRelease(spec) {
+    const url = `https://api.github.com/repos/${spec.owner}/${spec.repo}/releases/latest`;
+    return this._fetchJson(url);
+  }
+
+  /**
+   * Check the latest release tag vs installed, without downloading.
+   * @returns {Array<{ id, installedTag, latestTag, updateAvailable, hasRelease }>}
+   */
+  async checkUpdate() {
+    const results = [];
+    for (const spec of OFFICIAL_RULESETS) {
+      try {
+        const release = await this._fetchLatestRelease(spec);
+        const latestTag = release?.tag_name ?? null;
+        const { index, manifest } = selectReleaseAssets(release?.assets);
+        const hasRelease = !!latestTag && !!index && !!manifest;
+        const installedTag = this._readInstalledTag(spec.id);
+        results.push({
+          id: spec.id,
+          installedTag,
+          latestTag,
+          hasRelease,
+          updateAvailable: hasRelease && needsUpdate(installedTag, latestTag),
+        });
+      } catch (err) {
+        results.push({ id: spec.id, error: String(err?.message ?? err) });
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Download + install every official ruleset that is missing or out of date.
+   * Best-effort and fail-safe: never throws; returns a per-ruleset summary.
+   * @returns {Array<{ id, status: "installed"|"up-to-date"|"skipped"|"error", detail?: string }>}
+   */
+  async syncAllOfficial() {
+    if (this._syncing) return [{ id: "*", status: "skipped", detail: "sync already running" }];
+    this._syncing = true;
+    const summary = [];
+    try {
+      for (const spec of OFFICIAL_RULESETS) {
+        try {
+          summary.push(await this._syncOne(spec));
+        } catch (err) {
+          console.warn(`[Rulesets] sync failed for ${spec.id}:`, err);
+          summary.push({ id: spec.id, status: "error", detail: String(err?.message ?? err) });
+        }
+      }
+    } finally {
+      this._syncing = false;
+    }
+    return summary;
+  }
+
+  async _syncOne(spec) {
+    const release = await this._fetchLatestRelease(spec);
+    const latestTag = release?.tag_name ?? null;
+    const { index: indexAsset, manifest: manifestAsset } = selectReleaseAssets(release?.assets);
+
+    if (!latestTag || !indexAsset || !manifestAsset) {
+      return { id: spec.id, status: "skipped", detail: "no installable release" };
+    }
+
+    const installedTag = this._readInstalledTag(spec.id);
+    if (!needsUpdate(installedTag, latestTag)) {
+      return { id: spec.id, status: "up-to-date", detail: latestTag };
+    }
+
+    const indexUrl = indexAsset.browser_download_url;
+    const manifestUrl = manifestAsset.browser_download_url;
+    if (!this._isAllowedAssetUrl(indexUrl) || !this._isAllowedAssetUrl(manifestUrl)) {
+      return { id: spec.id, status: "skipped", detail: "asset host not allowed" };
+    }
+
+    const dir = this._rulesetDir(spec.id);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpManifest = path.join(dir, `${ASSET_MANIFEST}.download`);
+    const tmpIndex = path.join(dir, `${ASSET_INDEX}.download`);
+
+    try {
+      // 1. manifest first — validate engineApi before fetching code.
+      await this._downloadFile(manifestUrl, tmpManifest, normalizeDigest(manifestAsset.digest));
+      let manifest;
+      try {
+        manifest = JSON.parse(fs.readFileSync(tmpManifest, "utf8"));
+      } catch {
+        throw new Error("manifest.json が不正なJSONです");
+      }
+      if (!isCompatibleEngineApi(manifest)) {
+        return {
+          id: spec.id,
+          status: "skipped",
+          detail: `engineApi ${manifest?.engineApi} 非対応（要 ${SUPPORTED_ENGINE_API}）`,
+        };
+      }
+
+      // 2. code asset.
+      await this._downloadFile(indexUrl, tmpIndex, normalizeDigest(indexAsset.digest));
+
+      // 3. atomic install: move temps into place, then record the tag.
+      fs.renameSync(tmpManifest, path.join(dir, ASSET_MANIFEST));
+      fs.renameSync(tmpIndex, path.join(dir, ASSET_INDEX));
+      fs.writeFileSync(path.join(dir, VERSION_FILE), latestTag, "utf8");
+
+      console.log(`[Rulesets] installed ${spec.id} ${latestTag}`);
+      return {
+        id: spec.id,
+        status: "installed",
+        detail: latestTag,
+      };
+    } finally {
+      for (const p of [tmpManifest, tmpIndex]) {
+        try {
+          if (fs.existsSync(p)) fs.unlinkSync(p);
+        } catch {
+          /* ignore cleanup errors */
+        }
+      }
+    }
+  }
+
+  /** GET JSON with redirect handling + timeout. */
+  _fetchJson(url) {
+    return new Promise((resolve, reject) => {
+      const doRequest = (requestUrl, redirectCount = 0) => {
+        if (redirectCount > 5) {
+          reject(new Error("GitHub API のリダイレクトが最大回数を超えました"));
+          return;
+        }
+        let parsed;
+        try {
+          parsed = new URL(requestUrl);
+        } catch {
+          reject(new Error("URL の形式が不正です"));
+          return;
+        }
+        if (parsed.protocol !== "https:") {
+          reject(new Error("https 以外の接続は許可されていません"));
+          return;
+        }
+        const req = https.get(
+          requestUrl,
+          { headers: { "User-Agent": "illusions-app", Accept: "application/vnd.github.v3+json" } },
+          (res) => {
+            if ([301, 302, 303, 307, 308].includes(res.statusCode ?? 0)) {
+              const location = res.headers.location;
+              if (location) {
+                res.resume();
+                doRequest(new URL(location, requestUrl).toString(), redirectCount + 1);
+                return;
+              }
+            }
+            if (res.statusCode === 404) {
+              res.resume();
+              reject(new Error("リリースが見つかりません (404)"));
+              return;
+            }
+            if (res.statusCode !== 200) {
+              res.resume();
+              reject(new Error(`GitHub API が HTTP ${res.statusCode} を返しました`));
+              return;
+            }
+            let data = "";
+            res.setEncoding("utf8");
+            res.on("data", (chunk) => (data += chunk));
+            res.on("end", () => {
+              try {
+                resolve(JSON.parse(data));
+              } catch (err) {
+                reject(err);
+              }
+            });
+          },
+        );
+        req.on("error", reject);
+        req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+          req.destroy(new Error("GitHub API リクエストがタイムアウトしました"));
+        });
+      };
+      doRequest(url);
+    });
+  }
+
+  /**
+   * Download a URL to destPath (https only, redirects, size cap). When
+   * expectedDigest (sha256 hex) is provided, verify it and reject on mismatch.
+   */
+  _downloadFile(url, destPath, expectedDigest) {
+    return new Promise((resolve, reject) => {
+      const doRequest = (requestUrl, redirectCount = 0) => {
+        if (redirectCount > 5) {
+          reject(new Error("ダウンロードのリダイレクトが最大回数を超えました"));
+          return;
+        }
+        let parsed;
+        try {
+          parsed = new URL(requestUrl);
+        } catch {
+          reject(new Error("ダウンロードURLの形式が不正です"));
+          return;
+        }
+        if (parsed.protocol !== "https:") {
+          reject(new Error("https 以外のダウンロード先は許可されていません"));
+          return;
+        }
+        https
+          .get(requestUrl, { headers: { "User-Agent": "illusions-app" } }, (res) => {
+            if ([301, 302, 303, 307, 308].includes(res.statusCode ?? 0)) {
+              const location = res.headers.location;
+              if (location) {
+                res.resume();
+                doRequest(new URL(location, requestUrl).toString(), redirectCount + 1);
+                return;
+              }
+            }
+            if (res.statusCode !== 200) {
+              res.resume();
+              reject(new Error(`HTTP ${res.statusCode}`));
+              return;
+            }
+            let received = 0;
+            let aborted = false;
+            const hash = crypto.createHash("sha256");
+            const fileStream = fs.createWriteStream(destPath);
+            res.on("data", (chunk) => {
+              if (aborted) return;
+              received += chunk.length;
+              if (received > MAX_ASSET_BYTES) {
+                aborted = true;
+                res.destroy();
+                fileStream.destroy();
+                reject(new Error("ダウンロードサイズが上限を超えました"));
+                return;
+              }
+              hash.update(chunk);
+            });
+            res.pipe(fileStream);
+            fileStream.on("close", () => {
+              if (aborted) return;
+              const actual = hash.digest("hex");
+              if (expectedDigest && actual !== expectedDigest) {
+                reject(new Error("ダウンロードのチェックサム検証に失敗しました"));
+                return;
+              }
+              resolve(actual);
+            });
+            fileStream.on("error", reject);
+            res.on("error", reject);
+          })
+          .on("error", reject);
+      };
+      doRequest(url);
+    });
+  }
+}
+
+let _instance = null;
+function getRulesetsManager() {
+  if (!_instance) _instance = new RulesetsManager();
+  return _instance;
+}
+
+module.exports = {
+  getRulesetsManager,
+  RulesetsManager,
+  // pure helpers (testing)
+  selectReleaseAssets,
+  isCompatibleEngineApi,
+  needsUpdate,
+  normalizeDigest,
+  SUPPORTED_ENGINE_API,
+};

--- a/electron/rulesets-manager.js
+++ b/electron/rulesets-manager.js
@@ -118,25 +118,39 @@ class RulesetsManager {
     );
   }
 
+  /** True when a directory holds a full release (manifest + code + tag). */
+  _dirHasFullRelease(d) {
+    return (
+      fs.existsSync(path.join(d, ASSET_MANIFEST)) &&
+      fs.existsSync(path.join(d, ASSET_INDEX)) &&
+      fs.existsSync(path.join(d, VERSION_FILE))
+    );
+  }
+
   /**
-   * Recover from a crash that happened during a swap: if a COMPLETE staged
-   * release is present but the install is missing/incomplete, promote it with no
-   * network access (heals even offline). Otherwise discard stale/partial staging.
+   * Recover from a crash mid-swap, with NO network access (heals even offline):
+   * if the install is missing/incomplete but a COMPLETE copy survives in staging
+   * or in the backup dir, promote it. Then discard any transient leftovers.
    */
   _recoverStaging(id, dir, staging) {
+    const backup = `${dir}.backup`;
     try {
-      const stagedComplete =
-        fs.existsSync(path.join(staging, ASSET_MANIFEST)) &&
-        fs.existsSync(path.join(staging, ASSET_INDEX)) &&
-        fs.existsSync(path.join(staging, VERSION_FILE));
-      if (stagedComplete && !this._isInstalledComplete(id)) {
-        fs.rmSync(dir, { recursive: true, force: true });
-        fs.mkdirSync(path.dirname(dir), { recursive: true });
-        fs.renameSync(staging, dir);
-        console.log(`[Rulesets] recovered staged install for ${id}`);
-      } else {
-        fs.rmSync(staging, { recursive: true, force: true });
+      if (!this._isInstalledComplete(id)) {
+        for (const src of [staging, backup]) {
+          if (this._dirHasFullRelease(src)) {
+            fs.rmSync(dir, { recursive: true, force: true });
+            fs.mkdirSync(path.dirname(dir), { recursive: true });
+            fs.renameSync(src, dir);
+            console.log(
+              `[Rulesets] recovered ${src === staging ? "staged" : "backup"} install for ${id}`,
+            );
+            break;
+          }
+        }
       }
+      // Drop any leftover transient dirs (already-consumed ones rm to no-ops).
+      fs.rmSync(staging, { recursive: true, force: true });
+      fs.rmSync(backup, { recursive: true, force: true });
     } catch {
       /* best-effort recovery — never throws */
     }
@@ -302,11 +316,30 @@ class RulesetsManager {
         normalizeDigest(indexAsset.digest),
       );
 
-      // 3. record the tag inside staging, then swap the staged dir into place.
+      // 3. record the tag inside staging, then swap it in WITHOUT destroying the
+      //    old install first: rename old→backup, staging→dir, then drop backup.
+      //    A failed rename restores the backup, so we can never lose both copies;
+      //    a crash mid-swap is healed by _recoverStaging() on the next run.
       fs.writeFileSync(path.join(staging, VERSION_FILE), latestTag, "utf8");
-      fs.rmSync(dir, { recursive: true, force: true });
       fs.mkdirSync(path.dirname(dir), { recursive: true });
-      fs.renameSync(staging, dir);
+      const backup = `${dir}.backup`;
+      fs.rmSync(backup, { recursive: true, force: true });
+      const hadOld = fs.existsSync(dir);
+      if (hadOld) fs.renameSync(dir, backup);
+      try {
+        fs.renameSync(staging, dir);
+      } catch (err) {
+        if (hadOld) {
+          try {
+            fs.rmSync(dir, { recursive: true, force: true });
+          } catch {
+            /* ignore */
+          }
+          fs.renameSync(backup, dir); // restore the old install
+        }
+        throw err;
+      }
+      fs.rmSync(backup, { recursive: true, force: true });
 
       console.log(`[Rulesets] installed ${spec.id} ${latestTag}`);
       return { id: spec.id, status: "installed", detail: latestTag };
@@ -351,7 +384,6 @@ class RulesetsManager {
             if ([301, 302, 303, 307, 308].includes(res.statusCode ?? 0)) {
               const location = res.headers.location;
               if (location) {
-                res.resume();
                 let nextUrl;
                 try {
                   nextUrl = new URL(location, requestUrl).toString();
@@ -359,7 +391,9 @@ class RulesetsManager {
                   reject(new Error("リダイレクト先URLが不正です"));
                   return;
                 }
-                doRequest(nextUrl, redirectCount + 1);
+                // Recurse only after this response drains (see _downloadFile).
+                res.on("end", () => doRequest(nextUrl, redirectCount + 1));
+                res.resume();
                 return;
               }
             }
@@ -454,7 +488,6 @@ class RulesetsManager {
           if ([301, 302, 303, 307, 308].includes(res.statusCode ?? 0)) {
             const location = res.headers.location;
             if (location) {
-              res.resume();
               let nextUrl;
               try {
                 nextUrl = new URL(location, requestUrl).toString();
@@ -462,7 +495,11 @@ class RulesetsManager {
                 fail(new Error("リダイレクト先URLが不正です"));
                 return;
               }
-              doRequest(nextUrl, redirectCount + 1);
+              // Start the next hop only AFTER this response fully drains, so a
+              // late error on this (now-finished) hop can't reject while the
+              // next hop is mid-flight.
+              res.on("end", () => doRequest(nextUrl, redirectCount + 1));
+              res.resume();
               return;
             }
           }

--- a/electron/rulesets-manager.js
+++ b/electron/rulesets-manager.js
@@ -125,6 +125,7 @@ class RulesetsManager {
     const out = [];
     for (const ent of entries) {
       if (!ent.isDirectory()) continue;
+      if (ent.name.startsWith(".")) continue; // skip .staging-* and other hidden dirs
       const dir = path.join(root, ent.name);
       const manifestPath = path.join(dir, ASSET_MANIFEST);
       const indexPath = path.join(dir, ASSET_INDEX);
@@ -221,16 +222,26 @@ class RulesetsManager {
     }
 
     const dir = this._rulesetDir(spec.id);
-    fs.mkdirSync(dir, { recursive: true });
-    const tmpManifest = path.join(dir, `${ASSET_MANIFEST}.download`);
-    const tmpIndex = path.join(dir, `${ASSET_INDEX}.download`);
+    // Stage the FULL release in a sibling dir, then swap it in with a single
+    // rename. The final dir is therefore only ever the old complete version,
+    // briefly absent, or the new complete version — never a half-written pair
+    // (e.g. new manifest + old code). Staging dirs use a "." prefix so
+    // listInstalled() skips them.
+    const staging = path.join(this._rootDir(), `.staging-${spec.id}`);
 
     try {
+      fs.rmSync(staging, { recursive: true, force: true });
+      fs.mkdirSync(staging, { recursive: true });
+
       // 1. manifest first — validate engineApi before fetching code.
-      await this._downloadFile(manifestUrl, tmpManifest, normalizeDigest(manifestAsset.digest));
+      await this._downloadFile(
+        manifestUrl,
+        path.join(staging, ASSET_MANIFEST),
+        normalizeDigest(manifestAsset.digest),
+      );
       let manifest;
       try {
-        manifest = JSON.parse(fs.readFileSync(tmpManifest, "utf8"));
+        manifest = JSON.parse(fs.readFileSync(path.join(staging, ASSET_MANIFEST), "utf8"));
       } catch {
         throw new Error("manifest.json が不正なJSONです");
       }
@@ -243,26 +254,26 @@ class RulesetsManager {
       }
 
       // 2. code asset.
-      await this._downloadFile(indexUrl, tmpIndex, normalizeDigest(indexAsset.digest));
+      await this._downloadFile(
+        indexUrl,
+        path.join(staging, ASSET_INDEX),
+        normalizeDigest(indexAsset.digest),
+      );
 
-      // 3. atomic install: move temps into place, then record the tag.
-      fs.renameSync(tmpManifest, path.join(dir, ASSET_MANIFEST));
-      fs.renameSync(tmpIndex, path.join(dir, ASSET_INDEX));
-      fs.writeFileSync(path.join(dir, VERSION_FILE), latestTag, "utf8");
+      // 3. record the tag inside staging, then swap the staged dir into place.
+      fs.writeFileSync(path.join(staging, VERSION_FILE), latestTag, "utf8");
+      fs.rmSync(dir, { recursive: true, force: true });
+      fs.mkdirSync(path.dirname(dir), { recursive: true });
+      fs.renameSync(staging, dir);
 
       console.log(`[Rulesets] installed ${spec.id} ${latestTag}`);
-      return {
-        id: spec.id,
-        status: "installed",
-        detail: latestTag,
-      };
+      return { id: spec.id, status: "installed", detail: latestTag };
     } finally {
-      for (const p of [tmpManifest, tmpIndex]) {
-        try {
-          if (fs.existsSync(p)) fs.unlinkSync(p);
-        } catch {
-          /* ignore cleanup errors */
-        }
+      // Remove staging if the swap did not consume it (error / skip path).
+      try {
+        fs.rmSync(staging, { recursive: true, force: true });
+      } catch {
+        /* ignore cleanup errors */
       }
     }
   }
@@ -365,6 +376,11 @@ class RulesetsManager {
           reject(new Error("ダウンロード先のホストが許可されていません"));
           return;
         }
+        // Once the body is being piped, the ONLY settlement path is the
+        // pipeline callback (which fires after both streams close). req errors /
+        // timeout after that point destroy the source, which the pipeline turns
+        // into its callback — so we never reject before the fd is closed.
+        let piping = false;
         const req = https.get(requestUrl, { headers: { "User-Agent": "illusions-app" } }, (res) => {
           if ([301, 302, 303, 307, 308].includes(res.statusCode ?? 0)) {
             const location = res.headers.location;
@@ -400,6 +416,7 @@ class RulesetsManager {
           // pipeline() destroys the destination on ANY source error (network
           // error, timeout-triggered req.destroy, size-cap abort), closing the
           // fd before we settle — avoids leaked/locked temp files.
+          piping = true;
           pipeline(res, fs.createWriteStream(destPath), (err) => {
             if (err) {
               reject(err);
@@ -413,7 +430,11 @@ class RulesetsManager {
             resolve(actual);
           });
         });
-        req.on("error", reject);
+        // Pre-response failures (DNS/connect) settle here; once piping, the
+        // pipeline callback owns settlement so cleanup never races an open fd.
+        req.on("error", (err) => {
+          if (!piping) reject(err);
+        });
         req.setTimeout(REQUEST_TIMEOUT_MS, () => {
           req.destroy(new Error("ダウンロードがタイムアウトしました"));
         });

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -322,6 +322,32 @@ declare global {
         callback: (data: { latestVersion: string; updateAvailable: boolean }) => void,
       ) => () => void;
     };
+    /** Official校正ルールセットの自動ダウンロード/更新（Electronのみ） */
+    rulesets?: {
+      /** List installed (downloaded) official/external rulesets on disk. */
+      listInstalled: () => Promise<
+        Array<{ id: string; version: string | null; tag: string | null }>
+      >;
+      /** Download/update every official ruleset that is missing or out of date. */
+      sync: () => Promise<
+        Array<{
+          id: string;
+          status: "installed" | "up-to-date" | "skipped" | "error";
+          detail?: string;
+        }>
+      >;
+      /** Check latest release tags vs installed, without downloading. */
+      checkUpdate: () => Promise<
+        Array<{
+          id: string;
+          installedTag?: string | null;
+          latestTag?: string | null;
+          hasRelease?: boolean;
+          updateAvailable?: boolean;
+          error?: string;
+        }>
+      >;
+    };
     /** PTY session management */
     pty?: {
       /**


### PR DESCRIPTION
## 概要

公式校正ルールセットを **初回起動時にサイレントで自動ダウンロード**する仕組みを追加（Electron 版のみ・ユーザー同意不要）。辞典(幻辞)の DL 基盤を流用。

- `electron/official-rulesets.js`: 内蔵(公式)ルールセット一覧。第一号 `com.illusions-lab.gendai-kanazukai`。
- `electron/rulesets-manager.js`: GitHub Releases から `~/.illusions/rulesets/<id>/` へ `index.js` + `manifest.json` を取得。https限定・ホスト許可リスト（リダイレクト各hop再検証）・sha256検証・size上限・タイムアウト・engineApi互換チェック・**非破壊スワップ＋クラッシュ自己修復（オフライン可）**・全 fail-safe。
- `electron/ipc/rulesets-ipc.js` + `RULESETS_CHANNELS` + preload bridge + `types/electron.d.ts`: `list-installed` / `sync` / `check-update`。
- `electron/main.js`: 起動6秒後にサイレント自動同期（best-effort、`AppState.rulesetsAutoSync=false` で無効化可）。
- テスト: manager の pure helper 単体 + ipc-bridge drift に RULESETS 追加。electron 全 **222 テスト green** / tsc 0 / bundle:electron OK。

> このPRは**基盤非依存**（`lib/linting/{sdk,toolkit,registry}`・`docs/ruleset` に触れない）。#1783 の forward-revert と無衝突で、3-way マージで基盤を復活させません。
>
> 注: DL はファイル**事前配置のみ**。実際の校正反映は外部ローダ（worker Blob import）配線後（後続フェーズ）。

## レビュー

Codex 独立レビューを 5 パス実施し、検出された重大バグ（リダイレクト解析の例外漏れ／pipe リーク／settle 競合／設置の原子性／非破壊スワップ／リダイレクトhop競合／res未処理エラーによる main クラッシュ／tag残存時の再修復）を全て修正。最終パスで「重大バグ 0」に収束。

## テスト方法（手動・Electron 版）

> 前提: e2e で実際に DL させるには `illusions-lab/illusions-ruleset-gendai-kanazukai` に `v*` リリース（`index.js` + `manifest.json` アセット）が必要。未リリースの間は "no installable release" でスキップされる（仕様どおり）。

1. 初回状態を再現: `rm -rf ~/.illusions/rulesets`
2. Electron 版 illusions を起動。
3. 起動から約6秒後、メインプロセスがサイレントに取得（**同意ダイアログ／トーストは出ない**）。ターミナルログに `[Rulesets] installed com.illusions-lab.gendai-kanazukai <tag>` が出る。
4. `~/.illusions/rulesets/com.illusions-lab.gendai-kanazukai/` に `index.js` + `manifest.json` + `.release-tag` が配置されることを確認。
5. **再起動** → 既に最新なら再DLしない（ログに installed が出ない／`up-to-date`）。
6. **不完全状態の修復**: `index.js` を削除して再起動 → 不完全とみなし再DL される。
7. **オフライン**で起動 → DL 失敗を握りつぶし、アプリは正常に起動（fail-safe・起動を妨げない）。
8. **無効化**: AppState の `rulesetsAutoSync` を `false` にして再起動 → 自動DL されない。
9. **手動 API**（renderer DevTools console）:
   - `await window.electronAPI.rulesets.listInstalled()`
   - `await window.electronAPI.rulesets.checkUpdate()`
   - `await window.electronAPI.rulesets.sync()`

## 関連 issue

関連 issue なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)