### PR TITLE
feat(inspector): ファイル情報パネルに左ボーダーを追加

### DIFF
--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -184,7 +184,7 @@ export default function Inspector({
   return (
     <aside
       className={clsx(
-        "h-full bg-background flex flex-col transition-opacity duration-150",
+        "h-full bg-background border-l border-border flex flex-col transition-opacity duration-150",
         !isTabReady && "opacity-0 pointer-events-none",
         className,
       )}


### PR DESCRIPTION
## Summary

- 右側のファイル情報パネル（Inspector）とエディタ領域の境界が視覚的に曖昧だったため、パネル左辺にボーダーを追加して区切りを明確化
- 既存テーマトークン `border-border` を使用するため、ダーク／ライト両モードで自動的に整合する

## Changes

| ファイル | 変更内容 |
| --- | --- |
| `components/Inspector.tsx` | 最外側の `<aside>` に `border-l border-border` を追加 |

## Test plan

- [ ] アプリ起動後、右側パネルとエディタの間に左ボーダーが表示される
- [ ] ダーク／ライト両モードでボーダー色がパネル内部の他ボーダーと整合する

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)