### PR TITLE
fix(inspector): ファイル情報パネルの二重左ボーダーを解消

### DIFF
--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -184,7 +184,7 @@ export default function Inspector({
   return (
     <aside
       className={clsx(
-        "h-full bg-background border-l border-border flex flex-col transition-opacity duration-150",
+        "h-full bg-background flex flex-col transition-opacity duration-150",
         !isTabReady && "opacity-0 pointer-events-none",
         className,
       )}


### PR DESCRIPTION
## 概要

縦書き表示でエディタ領域の**左右の境界線の太さが非対称**になる UI バグを修正します。

## 原因

ファイル情報パネル（インスペクタ）は `ResizablePanel side="right"` でラップされており、`shared/ui/ResizablePanel.tsx:91` で既に `border-l border-border`（1px）が付与されています。

ところが #1798 で内側の `Inspector` の `<aside>` にも `border-l border-border` を**追加**したため、右側の左境界線だけ 1px ボーダーが**二重**になり、左側のファイルパネル（`border-r` 1px）に対して太く見えていました。

## 修正

Inspector 側の重複した `border-l border-border` を削除し、ResizablePanel が提供する単一ボーダーに一本化します。これで左右の境界線が同じ 1px に揃います。

- 変更: `components/Inspector.tsx`（1 行）

## 関連 issue

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)