### PR TITLE
style: storage.ts の行末空白を除去（format:check 修正）

### DIFF
--- a/platform/browser/storage.ts
+++ b/platform/browser/storage.ts
@@ -403,7 +403,7 @@ export class WebStorageProvider implements IStorageService {
   /**
    * No-op for Web. Project handles are managed by ProjectManager via IndexedDB.
    */
-   
+
   async addRecentProject(_project: RecentProject): Promise<void> {
     // Web uses ProjectManager for directory handle persistence, not this API.
   }
@@ -419,7 +419,7 @@ export class WebStorageProvider implements IStorageService {
   /**
    * No-op for Web. Project handles are managed by ProjectManager via IndexedDB.
    */
-   
+
   async removeRecentProject(_projectId: string): Promise<void> {
     // Web uses ProjectManager for directory handle persistence, not this API.
   }


### PR DESCRIPTION
## 概要
`platform/browser/storage.ts` の no-op メソッド docstring 直後に残っていた行末空白を除去し、CI の `format:check`（`prettier --check`）を green にする。

PR #1802 のマージ後に dev 側で `format:check` が落ちる状態になっていたため、その解消。機能変更なし。

## Test plan
- [x] `npx prettier --check "platform/browser/storage.ts"` → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)