### PR TITLE
feat(export): 全角スペース字下げオプションを追加（TXT/PDF/DOCX）

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,8 @@ import "@/lib/dockview/dockview-theme.css";
 import { useElectronMenuHandlers } from "@/lib/menu/use-electron-menu-handlers";
 import { useExport } from "@/lib/export/use-export";
 import { openWebPrintPreview } from "@/lib/export/web-print-preview";
+import TxtExportDialog from "@/components/TxtExportDialog";
+import type { TxtIndentOptions } from "@/lib/export/txt-exporter";
 import type { ExportMetadata } from "@/lib/export/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { DocxExportSettings } from "@/lib/export/docx-export-settings";
@@ -663,6 +665,27 @@ export default function EditorPage() {
     setPrintDialogState({ content, metadata });
   }, []);
 
+  // TXT export 字下げ dialog. The export hook awaits the user's choice via a
+  // promise resolved when the dialog is confirmed (options) or cancelled (null).
+  const [txtDialogFormat, setTxtDialogFormat] = useState<"txt" | "txt-ruby" | null>(null);
+  const txtOptionsResolverRef = useRef<((options: TxtIndentOptions | null) => void) | null>(null);
+
+  const handleRequestTxtExportOptions = useCallback(
+    (format: "txt" | "txt-ruby"): Promise<TxtIndentOptions | null> =>
+      new Promise<TxtIndentOptions | null>((resolve) => {
+        txtOptionsResolverRef.current = resolve;
+        setTxtDialogFormat(format);
+      }),
+    [],
+  );
+
+  const resolveTxtExportOptions = useCallback((options: TxtIndentOptions | null) => {
+    setTxtDialogFormat(null);
+    const resolve = txtOptionsResolverRef.current;
+    txtOptionsResolverRef.current = null;
+    resolve?.(options);
+  }, []);
+
   const handleExportDialogRequest = useCallback(
     (format: "pdf" | "docx" | "epub", content: string, metadata: ExportMetadata) => {
       const state: ExportDialogState = {
@@ -703,6 +726,7 @@ export default function EditorPage() {
           pageNumberFormat: settings.pageNumberFormat,
           pageNumberPosition: settings.pageNumberPosition,
           textIndent: settings.textIndent,
+          fullwidthSpaceIndent: settings.fullwidthSpaceIndent,
           googleFontFamily: settings.googleFontFamily,
           // Thread the active tab's snapshotted file type so the HTML pipeline
           // un-escapes MDI macros only for ".mdi" and preserves \[\[blank]]
@@ -773,6 +797,7 @@ export default function EditorPage() {
             pageNumberFormat: settings.pageNumberFormat,
             pageNumberPosition: settings.pageNumberPosition,
             textIndent: settings.textIndent,
+            fullwidthSpaceIndent: settings.fullwidthSpaceIndent,
             googleFontFamily: settings.googleFontFamily,
           });
         } catch (error) {
@@ -955,6 +980,7 @@ export default function EditorPage() {
     getIsEditorTabActive: useCallback(() => isEditorTabActiveRef.current, []),
     onExportDialogRequest: handleExportDialogRequest,
     onPrintDialogRequest: handlePrintDialogRequest,
+    onRequestTxtExportOptions: handleRequestTxtExportOptions,
   });
 
   // System file open: tab manager handles loading; we just update editor key
@@ -1483,6 +1509,12 @@ export default function EditorPage() {
           showSaveToast,
           saveToastExiting,
         }}
+      />
+      <TxtExportDialog
+        isOpen={txtDialogFormat != null}
+        format={txtDialogFormat ?? "txt"}
+        onConfirm={(options) => resolveTxtExportOptions(options)}
+        onCancel={() => resolveTxtExportOptions(null)}
       />
     </>
   );

--- a/components/ExportDialog.tsx
+++ b/components/ExportDialog.tsx
@@ -322,6 +322,7 @@ function ExportDialogInner({
           pageNumberFormat: previewSettings.pageNumberFormat,
           pageNumberPosition: previewSettings.pageNumberPosition,
           textIndent: previewSettings.textIndent,
+          fullwidthSpaceIndent: previewSettings.fullwidthSpaceIndent,
           googleFontFamily: previewSettings.googleFontFamily,
           fileType,
         });
@@ -684,6 +685,40 @@ function ExportDialogInner({
                 onChange={(e) => updateField("textIndent", clampFloat(e.target.value, 0, 4))}
               />
             </div>
+
+            {/* Full-width-space indent toggle (PDF/DOCX only) */}
+            {!isEpub && (
+              <div>
+                <div className="flex items-center justify-between">
+                  <label className={labelClass + " mb-0"}>全角スペースで字下げ</label>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={settings.fullwidthSpaceIndent}
+                    onClick={() =>
+                      updateField("fullwidthSpaceIndent", !settings.fullwidthSpaceIndent)
+                    }
+                    className={clsx(
+                      "relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors",
+                      settings.fullwidthSpaceIndent ? "bg-accent" : "bg-border-secondary",
+                    )}
+                  >
+                    <span
+                      className={clsx(
+                        "inline-block h-5 w-5 transform rounded-full bg-background transition-transform",
+                        settings.fullwidthSpaceIndent ? "translate-x-6" : "translate-x-1",
+                      )}
+                    />
+                  </button>
+                </div>
+                {settings.fullwidthSpaceIndent && (
+                  <p className="text-xs text-foreground-tertiary mt-1">
+                    段落の先頭に全角スペース（U+3000）を{Math.max(0, Math.round(settings.textIndent))}
+                    個挿入します。書式上の字下げ（em）は無効になります。
+                  </p>
+                )}
+              </div>
+            )}
 
             {/* ── Page number section (PDF/DOCX only) ── */}
             {!isEpub && (

--- a/components/TxtExportDialog.tsx
+++ b/components/TxtExportDialog.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import clsx from "clsx";
+import GlassDialog from "@/shared/ui/GlassDialog";
+import {
+  loadExportSettings,
+  saveExportSettings,
+  DEFAULT_EXPORT_SETTINGS,
+} from "@/lib/export/export-settings";
+import type { UnifiedExportSettings } from "@/lib/export/export-settings";
+import type { TxtIndentOptions } from "@/lib/export/txt-exporter";
+
+interface TxtExportDialogProps {
+  isOpen: boolean;
+  /** Which TXT variant is being exported (affects only the heading). */
+  format: "txt" | "txt-ruby";
+  /** Called with the chosen 字下げ options when the user confirms. */
+  onConfirm: (options: TxtIndentOptions) => void;
+  /** Called when the user cancels or dismisses the dialog. */
+  onCancel: () => void;
+}
+
+const MIN_COUNT = 1;
+const MAX_COUNT = 4;
+
+function clampCount(value: number): number {
+  if (!Number.isFinite(value)) return MIN_COUNT;
+  return Math.min(MAX_COUNT, Math.max(MIN_COUNT, Math.round(value)));
+}
+
+/**
+ * Lightweight dialog shown before a TXT / TXT(ruby) export. Asks whether to
+ * apply literal full-width-space (U+3000) 字下げ and, if so, how many spaces.
+ * Choices are persisted in the unified export settings so they are remembered.
+ */
+export default function TxtExportDialog({
+  isOpen,
+  format,
+  onConfirm,
+  onCancel,
+}: TxtExportDialogProps): React.ReactNode {
+  const [fullwidth, setFullwidth] = useState<boolean>(
+    DEFAULT_EXPORT_SETTINGS.txtFullwidthSpaceIndent,
+  );
+  const [count, setCount] = useState<number>(DEFAULT_EXPORT_SETTINGS.txtIndentCount);
+  // Snapshot of the full settings object so confirm-time persistence does not
+  // clobber unrelated (PDF/DOCX/EPUB) fields.
+  const loadedRef = useRef<UnifiedExportSettings>(DEFAULT_EXPORT_SETTINGS);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    let cancelled = false;
+    void loadExportSettings().then((loaded) => {
+      if (cancelled) return;
+      loadedRef.current = loaded;
+      setFullwidth(loaded.txtFullwidthSpaceIndent);
+      setCount(clampCount(loaded.txtIndentCount));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleConfirm = (): void => {
+    const indentCount = clampCount(count);
+    void saveExportSettings({
+      ...loadedRef.current,
+      txtFullwidthSpaceIndent: fullwidth,
+      txtIndentCount: indentCount,
+    });
+    onConfirm({ fullwidthSpaceIndent: fullwidth, indentCount });
+  };
+
+  const labelClass = "block text-sm font-medium text-foreground-secondary mb-1";
+
+  return (
+    <GlassDialog
+      isOpen
+      onBackdropClick={onCancel}
+      ariaLabel="テキストエクスポート設定"
+      panelClassName="mx-4 w-full max-w-md p-6"
+    >
+      <h2 className="text-lg font-semibold text-foreground mb-1">
+        {format === "txt-ruby" ? "テキスト（ルビ付き）エクスポート" : "テキストエクスポート"}
+      </h2>
+      <p className="text-xs text-foreground-tertiary mb-4">字下げの方法を選択してください。</p>
+
+      <div className="space-y-4">
+        {/* Full-width-space toggle */}
+        <div className="flex items-center justify-between">
+          <label className={labelClass + " mb-0"}>全角スペースで字下げする</label>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={fullwidth}
+            onClick={() => setFullwidth((v) => !v)}
+            className={clsx(
+              "relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors",
+              fullwidth ? "bg-accent" : "bg-border-secondary",
+            )}
+          >
+            <span
+              className={clsx(
+                "inline-block h-5 w-5 transform rounded-full bg-background transition-transform",
+                fullwidth ? "translate-x-6" : "translate-x-1",
+              )}
+            />
+          </button>
+        </div>
+
+        {/* Space count (only when enabled) */}
+        {fullwidth && (
+          <div>
+            <label className={labelClass}>字数（全角スペースの数）</label>
+            <input
+              type="number"
+              className="w-full px-3 py-2 rounded-lg text-sm bg-background-secondary border border-border text-foreground"
+              min={MIN_COUNT}
+              max={MAX_COUNT}
+              step={1}
+              value={count}
+              onChange={(e) => setCount(clampCount(Number(e.target.value)))}
+            />
+            <p className="text-xs text-foreground-tertiary mt-1">
+              各段落の先頭に全角スペース（U+3000）を{clampCount(count)}個挿入します。
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-6 space-y-2">
+        <button
+          type="button"
+          className="w-full px-4 py-2 rounded-lg text-sm bg-accent text-accent-foreground hover:bg-accent-hover transition-colors"
+          onClick={handleConfirm}
+        >
+          エクスポート
+        </button>
+        <button
+          type="button"
+          className="w-full px-4 py-2 rounded-lg text-sm text-foreground-secondary hover:bg-hover transition-colors"
+          onClick={onCancel}
+        >
+          キャンセル
+        </button>
+      </div>
+    </GlassDialog>
+  );
+}

--- a/lib/export/__tests__/fullwidth-space-indent.test.ts
+++ b/lib/export/__tests__/fullwidth-space-indent.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import { unzipSync, strFromU8 } from "fflate";
+
+import { mdiToPlainText, mdiToRubyText } from "../txt-exporter";
+import { mdiToHtml } from "../mdi-to-html";
+import { generateDocxBlob } from "../docx-exporter";
+import { DEFAULT_DOCX_SETTINGS } from "../docx-export-settings";
+import {
+  DEFAULT_EXPORT_SETTINGS,
+  toPdfExportSettings,
+  toDocxExportSettings,
+} from "../export-settings";
+import {
+  fullwidthIndentCount,
+  fullwidthIndentPrefix,
+  FULLWIDTH_SPACE,
+} from "../fullwidth-indent";
+
+const U3000 = "　";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+describe("fullwidth-indent helpers", () => {
+  it("FULLWIDTH_SPACE is U+3000", () => {
+    expect(FULLWIDTH_SPACE).toBe(U3000);
+    expect(FULLWIDTH_SPACE.charCodeAt(0)).toBe(0x3000);
+  });
+
+  it("fullwidthIndentCount rounds em values and floors at 0", () => {
+    expect(fullwidthIndentCount(1)).toBe(1);
+    expect(fullwidthIndentCount(1.5)).toBe(2);
+    expect(fullwidthIndentCount(0.4)).toBe(0);
+    expect(fullwidthIndentCount(0)).toBe(0);
+    expect(fullwidthIndentCount(-3)).toBe(0);
+    expect(fullwidthIndentCount(Number.NaN)).toBe(0);
+  });
+
+  it("fullwidthIndentPrefix repeats the space and returns empty at 0", () => {
+    expect(fullwidthIndentPrefix(0)).toBe("");
+    expect(fullwidthIndentPrefix(1)).toBe(U3000);
+    expect(fullwidthIndentPrefix(3)).toBe(U3000 + U3000 + U3000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TXT export
+// ---------------------------------------------------------------------------
+
+describe("TXT export — fullwidth-space 字下げ", () => {
+  it("prepends one full-width space to each paragraph line", () => {
+    // toExportText collapses the blank line between paragraphs into a single
+    // newline for Japanese typesetting, so both lines are non-empty content.
+    const out = mdiToPlainText("一行目\n\n二行目", ".mdi", {
+      fullwidthSpaceIndent: true,
+      indentCount: 1,
+    });
+    expect(out).toBe(`${U3000}一行目\n${U3000}二行目`);
+  });
+
+  it("never prefixes a genuinely empty line", () => {
+    // Direct check on the line-level guard: leading content + empty line.
+    const out = mdiToPlainText(".md blank line\n\n\n\nafter", ".md", {
+      fullwidthSpaceIndent: true,
+      indentCount: 1,
+    });
+    // No line should be just the prefix (empty lines stay empty).
+    for (const line of out.split("\n")) {
+      expect(line).not.toBe(U3000);
+    }
+  });
+
+  it("honors the requested count", () => {
+    const out = mdiToPlainText("本文", ".mdi", {
+      fullwidthSpaceIndent: true,
+      indentCount: 3,
+    });
+    expect(out).toBe(`${U3000}${U3000}${U3000}本文`);
+  });
+
+  it("does nothing when disabled (legacy behavior)", () => {
+    const out = mdiToPlainText("本文", ".mdi", {
+      fullwidthSpaceIndent: false,
+      indentCount: 2,
+    });
+    expect(out).toBe("本文");
+  });
+
+  it("does nothing when no options are passed", () => {
+    expect(mdiToPlainText("本文")).toBe("本文");
+  });
+
+  it("applies to ruby export too", () => {
+    const out = mdiToRubyText("{漢字|かんじ}", ".mdi", {
+      fullwidthSpaceIndent: true,
+      indentCount: 1,
+    });
+    expect(out).toBe(`${U3000}漢字（かんじ）`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PDF / print (mdiToHtml) injection
+// ---------------------------------------------------------------------------
+
+describe("PDF export — fullwidth-space injection into <p>", () => {
+  it("prepends full-width spaces to each non-empty paragraph", () => {
+    const html = mdiToHtml("A\n\nB", { bodyOnly: true, fullwidthSpaceIndentCount: 1 });
+    expect(html).toContain(`<p>${U3000}A</p>`);
+    expect(html).toContain(`<p>${U3000}B</p>`);
+  });
+
+  it("leaves [[blank]] paragraphs untouched", () => {
+    const html = mdiToHtml("A\n\n[[blank]]\n\nB", {
+      bodyOnly: true,
+      fullwidthSpaceIndentCount: 1,
+    });
+    expect(html).toContain("<p></p>");
+    expect(html).not.toContain(`<p>${U3000}</p>`);
+    expect(html).toContain(`<p>${U3000}A</p>`);
+  });
+
+  it("injects the requested number of spaces", () => {
+    const html = mdiToHtml("A", { bodyOnly: true, fullwidthSpaceIndentCount: 2 });
+    expect(html).toContain(`<p>${U3000}${U3000}A</p>`);
+  });
+
+  it("does not inject when count is 0 / absent", () => {
+    expect(mdiToHtml("A", { bodyOnly: true, fullwidthSpaceIndentCount: 0 })).toContain("<p>A</p>");
+    expect(mdiToHtml("A", { bodyOnly: true })).toContain("<p>A</p>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DOCX export
+// ---------------------------------------------------------------------------
+
+async function docxDocumentXml(content: string, fullwidthSpaceIndent: boolean): Promise<string> {
+  const blob = await generateDocxBlob(content, {
+    metadata: { title: "t", language: "ja" },
+    settings: { ...DEFAULT_DOCX_SETTINGS, textIndent: 1, fullwidthSpaceIndent },
+    fileType: ".mdi",
+  });
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  const files = unzipSync(bytes);
+  return strFromU8(files["word/document.xml"]);
+}
+
+// ---------------------------------------------------------------------------
+// Unified settings
+// ---------------------------------------------------------------------------
+
+describe("export settings — fullwidth-space fields", () => {
+  it("defaults are all off / count 1", () => {
+    expect(DEFAULT_EXPORT_SETTINGS.fullwidthSpaceIndent).toBe(false);
+    expect(DEFAULT_EXPORT_SETTINGS.txtFullwidthSpaceIndent).toBe(false);
+    expect(DEFAULT_EXPORT_SETTINGS.txtIndentCount).toBe(1);
+  });
+
+  it("toPdfExportSettings carries fullwidthSpaceIndent", () => {
+    const pdf = toPdfExportSettings({ ...DEFAULT_EXPORT_SETTINGS, fullwidthSpaceIndent: true });
+    expect(pdf.fullwidthSpaceIndent).toBe(true);
+  });
+
+  it("toDocxExportSettings carries fullwidthSpaceIndent", () => {
+    const docx = toDocxExportSettings({ ...DEFAULT_EXPORT_SETTINGS, fullwidthSpaceIndent: true });
+    expect(docx.fullwidthSpaceIndent).toBe(true);
+  });
+});
+
+describe("DOCX export — fullwidth-space 字下げ", () => {
+  it("prepends full-width space to paragraph text and zeroes firstLine indent", async () => {
+    const xml = await docxDocumentXml("本文一", true);
+    expect(xml).toContain(`${U3000}本文一`);
+    expect(xml).toContain('w:firstLine="0"');
+  });
+
+  it("uses the Word firstLine indent (no literal space) when disabled", async () => {
+    const xml = await docxDocumentXml("本文一", false);
+    // 1em at 12pt = 240 twips
+    expect(xml).toContain('w:firstLine="240"');
+    expect(xml).not.toContain(`${U3000}本文一`);
+  });
+});

--- a/lib/export/docx-export-settings.ts
+++ b/lib/export/docx-export-settings.ts
@@ -19,6 +19,12 @@ export interface DocxExportSettings {
   lineSpacing: number;
   margins: { top: number; bottom: number; left: number; right: number };
   textIndent: number;
+  /**
+   * Render 字下げ as literal full-width spaces (U+3000) prepended to each
+   * paragraph instead of a Word `firstLine` indent. Count is derived from
+   * `textIndent` (rounded). Absent → false.
+   */
+  fullwidthSpaceIndent?: boolean;
   showPageNumbers: boolean;
   pageNumberFormat: "simple" | "dash" | "fraction";
   pageNumberPosition:
@@ -39,6 +45,7 @@ export const DEFAULT_DOCX_SETTINGS: DocxExportSettings = {
   lineSpacing: 1.5,
   margins: { top: 20, bottom: 20, left: 20, right: 20 },
   textIndent: 1,
+  fullwidthSpaceIndent: false,
   showPageNumbers: false,
   pageNumberFormat: "simple",
   pageNumberPosition: "bottom-center",
@@ -140,6 +147,10 @@ export function sanitizeSettings(raw: Partial<DocxExportSettings>): DocxExportSe
           : d.margins.right,
     },
     textIndent: typeof raw.textIndent === "number" ? clamp(raw.textIndent, 0, 4) : d.textIndent,
+    fullwidthSpaceIndent:
+      typeof raw.fullwidthSpaceIndent === "boolean"
+        ? raw.fullwidthSpaceIndent
+        : d.fullwidthSpaceIndent,
     showPageNumbers:
       typeof raw.showPageNumbers === "boolean" ? raw.showPageNumbers : d.showPageNumbers,
     pageNumberFormat: (["simple", "dash", "fraction"] as const).includes(

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -35,6 +35,8 @@ import {
   sanitizeSettings,
 } from "./docx-export-settings";
 
+import { fullwidthIndentCount, fullwidthIndentPrefix } from "./fullwidth-indent";
+
 import type { DocxExportSettings, DocxFontConfig } from "./docx-export-settings";
 
 export interface DocxExportOptions {
@@ -306,10 +308,18 @@ function createParagraph(
   settings: DocxExportSettings,
   fontConfig: DocxFontConfig,
 ): Paragraph {
+  // Full-width-space 字下げ: prepend literal U+3000 characters to the paragraph
+  // text and suppress the Word `firstLine` indent (count from textIndent, rounded)
+  // so the two indentation mechanisms never stack.
+  const fullwidthCount = settings.fullwidthSpaceIndent
+    ? fullwidthIndentCount(settings.textIndent)
+    : 0;
+  const effectiveText = fullwidthCount > 0 ? fullwidthIndentPrefix(fullwidthCount) + text : text;
+  const firstLineTwips = fullwidthCount > 0 ? 0 : emToTwips(settings.textIndent, settings.fontSize);
   return new Paragraph({
     spacing: { before: 0, after: 120 },
-    indent: { firstLine: emToTwips(settings.textIndent, settings.fontSize) },
-    children: parseInlineFormatting(text, fontConfig),
+    indent: { firstLine: firstLineTwips },
+    children: parseInlineFormatting(effectiveText, fontConfig),
   });
 }
 

--- a/lib/export/export-settings.ts
+++ b/lib/export/export-settings.ts
@@ -48,6 +48,16 @@ export interface UnifiedExportSettings {
   pageNumberFormat: PageNumberFormat;
   pageNumberPosition: PageNumberPosition;
   textIndent: number;
+  /**
+   * When true, PDF/DOCX 字下げ is rendered as literal full-width spaces (U+3000)
+   * prepended to each paragraph instead of a layout indent. The number of spaces
+   * is derived from `textIndent` (rounded). Default false. EPUB is unaffected.
+   */
+  fullwidthSpaceIndent: boolean;
+  /** TXT export: prepend literal full-width spaces (U+3000) as 字下げ. Default false. */
+  txtFullwidthSpaceIndent: boolean;
+  /** TXT export: number of full-width spaces to prepend when enabled (1–4). */
+  txtIndentCount: number;
   // EPUB-specific
   epubPublisher: string;
   epubIdentifier: string;
@@ -66,6 +76,9 @@ export const DEFAULT_EXPORT_SETTINGS: UnifiedExportSettings = {
   pageNumberFormat: "simple",
   pageNumberPosition: "bottom-center",
   textIndent: 1,
+  fullwidthSpaceIndent: false,
+  txtFullwidthSpaceIndent: false,
+  txtIndentCount: 1,
   epubPublisher: "",
   epubIdentifier: "",
   epubChapterSplitLevel: "h1",
@@ -180,6 +193,7 @@ export function toPdfExportSettings(s: UnifiedExportSettings): PdfExportSettings
     pageNumberFormat: s.pageNumberFormat,
     pageNumberPosition: s.pageNumberPosition,
     textIndent: s.textIndent,
+    fullwidthSpaceIndent: s.fullwidthSpaceIndent,
     googleFontFamily: isGoogleFont ? s.fontFamily : undefined,
   };
 }
@@ -204,6 +218,7 @@ export function toDocxExportSettings(s: UnifiedExportSettings): DocxExportSettin
     lineSpacing: Math.round(lineHeightRatio * 10) / 10,
     margins: { ...s.margins },
     textIndent: s.textIndent,
+    fullwidthSpaceIndent: s.fullwidthSpaceIndent,
     showPageNumbers: s.showPageNumbers,
     pageNumberFormat: s.pageNumberFormat,
     pageNumberPosition: s.pageNumberPosition,
@@ -307,6 +322,18 @@ function sanitize(raw: Partial<UnifiedExportSettings>): UnifiedExportSettings {
       ? (raw.pageNumberPosition as PageNumberPosition)
       : d.pageNumberPosition,
     textIndent: typeof raw.textIndent === "number" ? clamp(raw.textIndent, 0, 4) : d.textIndent,
+    fullwidthSpaceIndent:
+      typeof raw.fullwidthSpaceIndent === "boolean"
+        ? raw.fullwidthSpaceIndent
+        : d.fullwidthSpaceIndent,
+    txtFullwidthSpaceIndent:
+      typeof raw.txtFullwidthSpaceIndent === "boolean"
+        ? raw.txtFullwidthSpaceIndent
+        : d.txtFullwidthSpaceIndent,
+    txtIndentCount:
+      typeof raw.txtIndentCount === "number"
+        ? clamp(Math.round(raw.txtIndentCount), 1, 4)
+        : d.txtIndentCount,
     epubPublisher: typeof raw.epubPublisher === "string" ? raw.epubPublisher : d.epubPublisher,
     epubIdentifier: typeof raw.epubIdentifier === "string" ? raw.epubIdentifier : d.epubIdentifier,
     epubChapterSplitLevel: VALID_CHAPTER_SPLIT_LEVELS.includes(

--- a/lib/export/fullwidth-indent.ts
+++ b/lib/export/fullwidth-indent.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared helpers for full-width-space (U+3000) 字下げ.
+ *
+ * Some Japanese submission/typesetting workflows require paragraph indentation
+ * to be expressed as literal full-width spaces in the text itself (rather than
+ * as a layout property such as CSS `text-indent` or Word `firstLine`). This
+ * module centralizes the character and the count derivation so the TXT, PDF and
+ * DOCX exporters stay consistent.
+ *
+ * No DOM / Electron / Node dependencies — safe to import from any export path.
+ */
+
+/** Full-width space character (U+3000) used for literal 字下げ. */
+export const FULLWIDTH_SPACE = "　";
+
+/**
+ * Number of full-width spaces to prepend, derived from an em indent value.
+ * PDF/DOCX reuse the existing 字下げ（em）value rounded to the nearest integer.
+ */
+export function fullwidthIndentCount(textIndentEm: number): number {
+  if (!Number.isFinite(textIndentEm)) return 0;
+  return Math.max(0, Math.round(textIndentEm));
+}
+
+/** Prefix string of `count` full-width spaces (empty string when count <= 0). */
+export function fullwidthIndentPrefix(count: number): string {
+  return count > 0 ? FULLWIDTH_SPACE.repeat(count) : "";
+}

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -253,6 +253,13 @@ export function mdiToHtml(
      * authored literal (DATA-LOSS guard, see #1608). Absent → ".mdi".
      */
     fileType?: string;
+    /**
+     * When > 0, prepend this many literal full-width spaces (U+3000) to each
+     * non-empty paragraph as 字下げ. The caller is responsible for suppressing
+     * the CSS `text-indent` (see pdf-exporter / web-print-preview) to avoid
+     * double indentation. Blank ([[blank]]) paragraphs are left untouched.
+     */
+    fullwidthSpaceIndentCount?: number;
   },
 ): string {
   const md = createMarkdownIt();
@@ -274,9 +281,18 @@ export function mdiToHtml(
   // Replace the sentinel paragraph with a true empty paragraph. Then final-sweep any
   // remaining sentinel that escaped the <p>…</p> wrap (e.g. inside fenced code blocks
   // where markdown-it emits <pre><code>…</code></pre> instead of <p>).
-  const bodyHtml = rawHtml
+  let bodyHtml = rawHtml
     .replace(new RegExp(`<p>${BLANK_SENTINEL}\\s*</p>`, "g"), "<p></p>")
     .replace(new RegExp(BLANK_SENTINEL, "g"), "");
+
+  // Full-width-space 字下げ: inject literal U+3000 characters at the start of
+  // each non-empty paragraph. The negative lookahead skips empty `<p></p>`
+  // (blank-paragraph markers) so they stay empty.
+  const fullwidthCount = options?.fullwidthSpaceIndentCount ?? 0;
+  if (fullwidthCount > 0) {
+    const prefix = "　".repeat(fullwidthCount);
+    bodyHtml = bodyHtml.replace(/<p>(?!<\/p>)/g, `<p>${prefix}`);
+  }
 
   if (options?.bodyOnly) {
     return bodyHtml;

--- a/lib/export/pdf-export-settings.ts
+++ b/lib/export/pdf-export-settings.ts
@@ -24,6 +24,12 @@ export interface PdfExportSettings {
     | "top-center"
     | "top-right";
   textIndent: number;
+  /**
+   * Render 字下げ as literal full-width spaces (U+3000) prepended to each
+   * paragraph instead of a CSS `text-indent`. Count is derived from `textIndent`
+   * (rounded). Default/absent → false.
+   */
+  fullwidthSpaceIndent?: boolean;
   /** Google Font family name for PDF export (triggers <link> injection) */
   googleFontFamily?: string;
 }
@@ -40,6 +46,7 @@ export const DEFAULT_PDF_SETTINGS: PdfExportSettings = {
   pageNumberFormat: "simple",
   pageNumberPosition: "bottom-center",
   textIndent: 1,
+  fullwidthSpaceIndent: false,
 };
 
 // Import and re-export comprehensive page dimensions from page-sizes module

--- a/lib/export/pdf-exporter.ts
+++ b/lib/export/pdf-exporter.ts
@@ -29,6 +29,12 @@ export interface PdfExportOptions {
     | "top-right";
   /** First-line indent in em units */
   textIndent?: number;
+  /**
+   * Render 字下げ as literal full-width spaces (U+3000) prepended to each
+   * paragraph instead of a CSS `text-indent`. Count is derived from `textIndent`
+   * (rounded). Absent → false.
+   */
+  fullwidthSpaceIndent?: boolean;
   /** Google Font family name — triggers <link> injection and CSP relaxation */
   googleFontFamily?: string;
   /**
@@ -53,6 +59,15 @@ export async function generatePdf(content: string, options: PdfExportOptions): P
   // Dynamic import for Electron (only available in main process at runtime)
   const { BrowserWindow } = await import("electron");
   const { mdiToHtml } = await import("./mdi-to-html");
+  const { fullwidthIndentCount } = await import("./fullwidth-indent");
+
+  // Full-width-space 字下げ: when enabled, the indent is expressed as literal
+  // U+3000 characters injected into each paragraph (see mdiToHtml), so the CSS
+  // `text-indent` must be suppressed to avoid double indentation.
+  const fullwidthSpaceCount = options.fullwidthSpaceIndent
+    ? fullwidthIndentCount(options.textIndent ?? 0)
+    : 0;
+  const effectiveTextIndentEm = fullwidthSpaceCount > 0 ? 0 : options.textIndent;
 
   // Build typesetting options when chars/lines are specified
   const hasTypesetting = options.charsPerLine != null && options.linesPerPage != null;
@@ -72,7 +87,7 @@ export async function generatePdf(content: string, options: PdfExportOptions): P
           fontFamily: options.fontFamily,
           fontSizeMm,
           lineHeightRatio,
-          textIndentEm: options.textIndent,
+          textIndentEm: effectiveTextIndentEm,
           margins,
           pageSize: options.pageSize ?? "A5",
           landscape: options.landscape ?? false,
@@ -90,6 +105,7 @@ export async function generatePdf(content: string, options: PdfExportOptions): P
     },
     googleFontFamily: options.googleFontFamily,
     fileType: options.fileType,
+    fullwidthSpaceIndentCount: fullwidthSpaceCount,
   });
 
   // Use a unique in-memory partition (no "persist:" prefix) per export so

--- a/lib/export/txt-exporter.ts
+++ b/lib/export/txt-exporter.ts
@@ -11,6 +11,29 @@
  */
 
 import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
+import { fullwidthIndentPrefix } from "./fullwidth-indent";
+
+/** Options controlling literal full-width-space (U+3000) 字下げ for TXT export. */
+export interface TxtIndentOptions {
+  /** When true, prepend full-width spaces to each non-empty line. */
+  fullwidthSpaceIndent: boolean;
+  /** Number of full-width spaces to prepend (>= 1 when enabled). */
+  indentCount: number;
+}
+
+/**
+ * Prepend `count` full-width spaces (U+3000) to each non-empty line.
+ * Blank lines are preserved as-is so paragraph spacing is not disturbed.
+ */
+function applyFullwidthIndent(text: string, options?: TxtIndentOptions): string {
+  if (!options?.fullwidthSpaceIndent) return text;
+  const prefix = fullwidthIndentPrefix(options.indentCount);
+  if (!prefix) return text;
+  return text
+    .split("\n")
+    .map((line) => (line.length > 0 ? prefix + line : line))
+    .join("\n");
+}
 
 /**
  * Build the source MDI document for an export, branching on file type.
@@ -41,8 +64,12 @@ function buildExportDocument(content: string, fileType: string): MdiDocument {
  * @param fileType - Active document file extension (".mdi" | ".md" | ".txt").
  *   Defaults to ".mdi". See {@link buildExportDocument} for the branch rationale.
  */
-export function mdiToPlainText(content: string, fileType: string = ".mdi"): string {
-  return buildExportDocument(content, fileType).toExportText("txt");
+export function mdiToPlainText(
+  content: string,
+  fileType: string = ".mdi",
+  indent?: TxtIndentOptions,
+): string {
+  return applyFullwidthIndent(buildExportDocument(content, fileType).toExportText("txt"), indent);
 }
 
 /**
@@ -53,6 +80,13 @@ export function mdiToPlainText(content: string, fileType: string = ".mdi"): stri
  *   authored text (non-`.mdi`)
  * @param fileType - Active document file extension. See {@link mdiToPlainText}.
  */
-export function mdiToRubyText(content: string, fileType: string = ".mdi"): string {
-  return buildExportDocument(content, fileType).toExportText("txt-ruby");
+export function mdiToRubyText(
+  content: string,
+  fileType: string = ".mdi",
+  indent?: TxtIndentOptions,
+): string {
+  return applyFullwidthIndent(
+    buildExportDocument(content, fileType).toExportText("txt-ruby"),
+    indent,
+  );
 }

--- a/lib/export/types.ts
+++ b/lib/export/types.ts
@@ -35,6 +35,8 @@ export interface PdfGenerationOptions {
     | "top-center"
     | "top-right";
   textIndent?: number;
+  /** Render 字下げ as literal full-width spaces (U+3000) instead of CSS text-indent. */
+  fullwidthSpaceIndent?: boolean;
   /** Google Font family name for PDF export (triggers <link> injection and CSP relaxation) */
   googleFontFamily?: string;
   /**

--- a/lib/export/use-export.ts
+++ b/lib/export/use-export.ts
@@ -5,6 +5,7 @@ import { isElectronRenderer } from "@/lib/utils/runtime-env";
 import { notificationManager } from "@/lib/services/notification-manager";
 import { saveBlobFile } from "./save-blob-file";
 import { mdiToPlainText, mdiToRubyText } from "./txt-exporter";
+import type { TxtIndentOptions } from "./txt-exporter";
 import { openWebPrintPreview } from "./web-print-preview";
 import { loadExportSettings, toPdfExportSettings } from "./export-settings";
 import type { SupportedFileExtension } from "@/lib/project/project-types";
@@ -37,6 +38,13 @@ interface UseExportParams {
     metadata: ExportMetadata,
   ) => void;
   onPrintDialogRequest?: (content: string, metadata: ExportMetadata) => void;
+  /**
+   * When provided, TXT / TXT(ruby) export first asks the user for 字下げ
+   * (full-width-space) options via a dialog. Resolves with the chosen options,
+   * or `null` if the user cancelled (export is then aborted). When omitted,
+   * TXT export runs directly with no indentation (legacy behavior).
+   */
+  onRequestTxtExportOptions?: (format: "txt" | "txt-ruby") => Promise<TxtIndentOptions | null>;
 }
 
 /**
@@ -50,6 +58,7 @@ export function useExport({
   getIsEditorTabActive,
   onExportDialogRequest,
   onPrintDialogRequest,
+  onRequestTxtExportOptions,
 }: UseExportParams): {
   exportAs: (format: ExportFormat) => Promise<void>;
   printDocument: () => void;
@@ -87,13 +96,24 @@ export function useExport({
 
       // TXT exports are client-side (no Electron IPC needed)
       if (format === "txt" || format === "txt-ruby") {
+        // Ask the user whether to apply full-width-space 字下げ. A null result
+        // means the dialog was cancelled — abort the export silently.
+        let indentOptions: TxtIndentOptions | undefined;
+        if (onRequestTxtExportOptions) {
+          const chosen = await onRequestTxtExportOptions(format);
+          if (chosen === null) return;
+          indentOptions = chosen;
+        }
+
         const progressId = notificationManager.showProgress(`${label}をエクスポート中...`, {
           type: "info",
         });
 
         try {
           const converted =
-            format === "txt" ? mdiToPlainText(content, fileType) : mdiToRubyText(content, fileType);
+            format === "txt"
+              ? mdiToPlainText(content, fileType, indentOptions)
+              : mdiToRubyText(content, fileType, indentOptions);
 
           const baseName = title.replace(/\.(mdi|md|txt)$/i, "");
           const suffix = format === "txt-ruby" ? "_ruby" : "";
@@ -175,7 +195,15 @@ export function useExport({
         notificationManager.error(`${label}のエクスポートに失敗しました: ${message}`);
       }
     },
-    [getContent, getTitle, getFileType, getIsEditorTabActive, isElectron, onExportDialogRequest],
+    [
+      getContent,
+      getTitle,
+      getFileType,
+      getIsEditorTabActive,
+      isElectron,
+      onExportDialogRequest,
+      onRequestTxtExportOptions,
+    ],
   );
 
   const printDocument = useCallback(() => {

--- a/lib/export/web-print-preview.ts
+++ b/lib/export/web-print-preview.ts
@@ -1,5 +1,6 @@
 import { mdiToHtml } from "./mdi-to-html";
 import { calculateTypesetting } from "./pdf-export-settings";
+import { fullwidthIndentCount } from "./fullwidth-indent";
 
 import type { ExportMetadata } from "./types";
 import type { PdfExportSettings } from "./pdf-export-settings";
@@ -40,6 +41,11 @@ export async function openWebPrintPreview(
       settings.verticalWriting,
       settings.landscape,
     );
+    // Full-width-space 字下げ: literal U+3000 injected into paragraphs replaces
+    // the CSS text-indent (suppress it to avoid double indentation).
+    const fullwidthSpaceCount = settings.fullwidthSpaceIndent
+      ? fullwidthIndentCount(settings.textIndent)
+      : 0;
     const html = mdiToHtml(content, {
       metadata,
       verticalWriting: settings.verticalWriting,
@@ -47,12 +53,13 @@ export async function openWebPrintPreview(
         fontFamily: settings.fontFamily, // Already a CSS string — no reverse lookup
         fontSizeMm,
         lineHeightRatio,
-        textIndentEm: settings.textIndent,
+        textIndentEm: fullwidthSpaceCount > 0 ? 0 : settings.textIndent,
         margins: settings.margins,
         pageSize: settings.pageSize,
         landscape: settings.landscape,
       },
       fileType,
+      fullwidthSpaceIndentCount: fullwidthSpaceCount,
     });
 
     printWindow.document.open();

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -101,6 +101,7 @@ declare global {
           lineSpacing?: number;
           margins?: { top: number; bottom: number; left: number; right: number };
           textIndent?: number;
+          fullwidthSpaceIndent?: boolean;
           showPageNumbers?: boolean;
         };
         // Active tab's file type. The main-process generateDocx un-escapes MDI


### PR DESCRIPTION
## 概要

エクスポート時の字下げを「全角スペース（U+3000）の実文字」で行うオプションを追加しました。

### TXT
- エクスポート時にダイアログを表示し、**全角スペースで字下げするか**＋**字数（1〜4）**を選択できる（既定 OFF）
- ON 時は各段落行の先頭に全角スペースを挿入

### PDF / DOCX
- 字下げ設定に **「全角スペースで字下げ」チェックボックス** を追加（既定 OFF）
- ON 時は既存の「字下げ（em）」値を全角スペース数として段落頭に実文字を挿入し、書式上のインデント（CSS `text-indent` / Word `firstLine`）は無効化（二重字下げ防止）
- PDF プレビューにも反映

### EPUB
- 対象外（従来の em 字下げを維持）

## 実装

| 領域 | 変更 |
| --- | --- |
| 共有 | `lib/export/fullwidth-indent.ts`（U+3000・字数算出・prefix ヘルパー） |
| TXT | `components/TxtExportDialog.tsx` 新規 / `txt-exporter.ts` に字下げ適用 / `use-export.ts`・`app/page.tsx` で結線 |
| PDF | `mdi-to-html.ts` が `<p>` へ全角スペース注入（`[[blank]]` は除外）/ `pdf-exporter.ts`・`web-print-preview.ts` で結線 |
| DOCX | `docx-exporter.ts` `createParagraph` で実文字挿入＋`firstLine` 無効化 |
| 設定 | `UnifiedExportSettings` に `fullwidthSpaceIndent` / `txtFullwidthSpaceIndent` / `txtIndentCount` を追加（永続化・サニタイズ込み） |
| 型 | `PdfExportOptions` / `PdfGenerationOptions` / `DocxExportSettings` / `types/electron.d.ts` |

## テスト

- `lib/export/__tests__/fullwidth-space-indent.test.ts`（18 件）— ヘルパー / TXT / PDF(HTML) / DOCX(XML) / 設定変換
- `npm run type-check` ✓
- `vitest run lib/export` — 126 件全通過 ✓
- 変更ファイル ESLint ✓

## 関連 issue

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)