### PR TITLE
feat(inspector): 検出結果に「無視された指摘」リンクとポップアップを追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1104,12 +1104,16 @@ export default function EditorPage() {
   );
 
   // --- Ignored corrections hook ---
-  const { ignoredCorrections, ignoreCorrection, clearIgnoredCorrections } =
+  const { ignoredCorrections, ignoreCorrection, unignoreCorrection, clearIgnoredCorrections } =
     useIgnoredCorrections(editorMode);
 
   const ignoredCorrectionsContextValue = useMemo(
-    () => ({ clear: clearIgnoredCorrections }),
-    [clearIgnoredCorrections],
+    () => ({
+      items: ignoredCorrections,
+      clear: clearIgnoredCorrections,
+      unignore: unignoreCorrection,
+    }),
+    [ignoredCorrections, clearIgnoredCorrections, unignoreCorrection],
   );
 
   // Sync ignoredCorrections to ProseMirror plugin

--- a/components/inspector/CorrectionsPanel.tsx
+++ b/components/inspector/CorrectionsPanel.tsx
@@ -21,11 +21,13 @@ import type { CorrectionModeId } from "@/lib/linting/correction-config";
 import { DEFAULT_POS_COLORS } from "@/packages/milkdown-plugin-japanese-novel/pos-highlight/pos-colors";
 import InfoTooltip from "./InfoTooltip";
 import IssueCard from "./IssueCard";
+import IgnoredCorrectionsDialog from "./IgnoredCorrectionsDialog";
 import {
   useLintingSettings,
   usePosHighlightSettings,
   usePowerSettings,
 } from "@/contexts/EditorSettingsContext";
+import { useIgnoredCorrectionsContext } from "@/contexts/IgnoredCorrectionsContext";
 
 import type { LintIssue, Severity } from "@/lib/linting";
 import type { SeverityFilter, EnrichedLintIssue } from "./types";
@@ -106,9 +108,11 @@ export default function CorrectionsPanel({
   const { lintingEnabled, lintingRuleConfigs, onLintingEnabledChange, onLintingRuleConfigChange } =
     useLintingSettings();
   const { powerSaveMode, onTemporarilyDisablePowerSave } = usePowerSettings();
+  const ignoredCorrections = useIgnoredCorrectionsContext();
   const [severityFilter, setSeverityFilter] = useState<SeverityFilter>("all");
   const [sortMode, setSortMode] = useState<SortMode>("category");
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [showIgnoredDialog, setShowIgnoredDialog] = useState(false);
   const issueListRef = useRef<HTMLDivElement>(null);
 
   const filteredIssues = useMemo(() => {
@@ -568,7 +572,28 @@ export default function CorrectionsPanel({
           ) : (
             renderFlatList()
           )}
+
+          {/* Ignored corrections entry point */}
+          {ignoredCorrections && (
+            <div className="pt-3 text-center">
+              <button
+                type="button"
+                onClick={() => setShowIgnoredDialog(true)}
+                className="text-xs text-accent transition-colors hover:text-accent-hover hover:underline"
+              >
+                無視された指摘
+                {ignoredCorrections.items.length > 0 && `（${ignoredCorrections.items.length}件）`}
+              </button>
+            </div>
+          )}
         </>
+      )}
+
+      {ignoredCorrections && (
+        <IgnoredCorrectionsDialog
+          isOpen={showIgnoredDialog}
+          onClose={() => setShowIgnoredDialog(false)}
+        />
       )}
     </div>
   );

--- a/components/inspector/IgnoredCorrectionsDialog.tsx
+++ b/components/inspector/IgnoredCorrectionsDialog.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type React from "react";
+import { useMemo } from "react";
+import { X, RotateCcw } from "lucide-react";
+
+import GlassDialog from "@/shared/ui/GlassDialog";
+import { useIgnoredCorrectionsContext } from "@/contexts/IgnoredCorrectionsContext";
+import { LINT_RULES_META } from "@/lib/linting/lint-presets";
+import ClearIgnoredCorrectionsButton from "@/components/settings/linting/ClearIgnoredCorrectionsButton";
+
+export interface IgnoredCorrectionsDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/** ruleId → 日本語ルール名（内蔵ルールのみ。外部/不明は ruleId をそのまま表示）。 */
+const RULE_NAME_MAP: ReadonlyMap<string, string> = new Map(
+  LINT_RULES_META.map((r) => [r.id, r.nameJa]),
+);
+
+/**
+ * Lists the corrections the user has chosen to ignore (and only those), letting
+ * them restore individual entries or wipe the whole memory. Opened from the
+ * "無視された指摘" link in the corrections inspector.
+ */
+export default function IgnoredCorrectionsDialog({
+  isOpen,
+  onClose,
+}: IgnoredCorrectionsDialogProps): React.ReactElement | null {
+  const ctx = useIgnoredCorrectionsContext();
+
+  // Newest first — most recently ignored entries are the likeliest to revisit.
+  const items = useMemo(
+    () => (ctx ? [...ctx.items].sort((a, b) => b.addedAt - a.addedAt) : []),
+    [ctx],
+  );
+
+  if (!ctx) return null;
+
+  return (
+    <GlassDialog
+      isOpen={isOpen}
+      onBackdropClick={onClose}
+      ariaLabel="無視された指摘"
+      panelClassName="mx-4 w-full max-w-md p-0 flex flex-col max-h-[70vh]"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+        <h2 className="text-sm font-medium text-foreground flex-1">
+          無視された指摘
+          {items.length > 0 && (
+            <span className="ml-1.5 text-xs text-foreground-tertiary">{items.length}件</span>
+          )}
+        </h2>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="閉じる"
+          className="p-1 text-foreground-tertiary hover:text-foreground hover:bg-hover rounded transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {/* Body — only the ignored entries, never the active ones */}
+      <div className="flex-1 overflow-y-auto px-2 py-2 min-h-0">
+        {items.length === 0 ? (
+          <p className="px-2 py-6 text-center text-sm text-foreground-tertiary">
+            無視された指摘はありません
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {items.map((item) => {
+              const ruleName = RULE_NAME_MAP.get(item.ruleId) ?? item.ruleId;
+              return (
+                <li
+                  key={`${item.ruleId}-${item.text}-${item.context ?? ""}`}
+                  className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-hover transition-colors"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-foreground truncate">「{item.text}」</div>
+                    <div className="text-[11px] text-foreground-tertiary truncate">
+                      {ruleName}
+                      {item.context && <span className="ml-1">・この箇所のみ</span>}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => ctx.unignore(item.ruleId, item.text, item.context)}
+                    className="flex items-center gap-1 text-xs px-2 py-1 text-foreground-secondary border border-border rounded hover:bg-hover hover:text-foreground transition-colors flex-shrink-0"
+                    title="この指摘の無視を解除する"
+                  >
+                    <RotateCcw className="w-3 h-3" />
+                    解除
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {/* Footer — bulk clear (same action as the settings page) */}
+      {items.length > 0 && (
+        <div className="px-4 py-3 border-t border-border">
+          <ClearIgnoredCorrectionsButton />
+        </div>
+      )}
+    </GlassDialog>
+  );
+}

--- a/contexts/IgnoredCorrectionsContext.tsx
+++ b/contexts/IgnoredCorrectionsContext.tsx
@@ -2,18 +2,24 @@
 
 import React, { createContext, useContext } from "react";
 
+import type { IgnoredCorrection } from "@/lib/project/project-types";
+
 /**
- * Exposes a way to clear the "ignored corrections" memory from anywhere in the
- * editor tree (e.g. the linting settings tab) without prop-drilling through
- * the settings modal. The underlying state lives in `useIgnoredCorrections`
- * in page.tsx; this context only surfaces the clear action.
+ * Exposes the "ignored corrections" memory to the editor tree (the linting
+ * settings tab and the corrections inspector) without prop-drilling. The
+ * underlying state lives in `useIgnoredCorrections` in page.tsx; this context
+ * surfaces the current list and the mutating actions.
  */
 export interface IgnoredCorrectionsContextValue {
+  /** Ignored corrections for the currently open file/project. */
+  items: IgnoredCorrection[];
   /**
    * Clear ALL ignored corrections for the current editor mode.
    * Project mode → the current project; standalone mode → every file.
    */
   clear: () => Promise<void>;
+  /** Remove a single ignored correction so the issue surfaces again. */
+  unignore: (ruleId: string, text: string, context?: string) => void;
 }
 
 const IgnoredCorrectionsContext = createContext<IgnoredCorrectionsContextValue | null>(null);


### PR DESCRIPTION
## 概要

検出結果パネルに「無視された指摘」リンクを追加し、クリックで**無視した指摘だけ**を一覧するポップアップを表示する。検出中の指摘は混ぜない。ポップアップから個別解除でき、フッターには設定ページと同じ「無視した校正をすべて消去」ボタンを配置した。

## 変更点

| 領域 | 内容 |
| --- | --- |
| `contexts/IgnoredCorrectionsContext.tsx` | context を `items`（無視リスト）・`unignore`（個別解除）まで拡張（`clear` は既存） |
| `app/page.tsx` | `useIgnoredCorrections` の `ignoredCorrections` / `unignoreCorrection` を context value に供給 |
| `components/inspector/IgnoredCorrectionsDialog.tsx`（新規） | `GlassDialog` ベースのポップアップ。無視リスト表示・各行の個別解除・フッターに全消去ボタン |
| `components/inspector/CorrectionsPanel.tsx` | パネル下部に「無視された指摘（N件）」リンク、クリックでダイアログ表示 |

- ルール名は内蔵ルールを `LINT_RULES_META` から解決（外部/不明は ruleId 表示）。
- 個別解除・全消去とも、既存の同期 effect（`ignoredCorrections` 変更 → プラグイン再同期）により指摘が即再表示される。
- context 不在（PopoutEditorWindow 等）ではリンク・ダイアログとも非表示。

## Test plan

- [ ] 指摘を複数「無視」→ 検出結果パネルの「無視された指摘（N件）」をクリック → 無視した指摘のみが一覧される（検出中の指摘は出ない）
- [ ] 行の「解除」で個別に無視解除 → 該当指摘が検出結果へ再表示される
- [ ] フッターの「無視した校正をすべて消去」→ 確認 → 全消去・トースト・一覧が空になる
- [ ] スタンドアロン / プロジェクト両モードで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)