### PR TITLE
fix(linting): 無視した校正が一覧から消えるロード競合を修正

### DIFF
--- a/lib/editor-page/__tests__/use-ignored-corrections.test.tsx
+++ b/lib/editor-page/__tests__/use-ignored-corrections.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Regression tests for useIgnoredCorrections — the load/optimistic-update race.
+ *
+ * Bug: on a slow VFS (e.g. Google Drive), the initial async load of
+ * ignored-corrections.json can resolve AFTER the user has optimistically
+ * ignored a correction, clobbering the freshly-ignored entry back to the stale
+ * on-disk snapshot. The item then vanishes from the editor and from the
+ * "無視された指摘" list, even though it persisted to disk.
+ *
+ * Fix: a monotonic mutation-version guard discards any in-flight load result
+ * once a local mutation (ignore / unignore / clear) has occurred.
+ */
+
+// Tell React this is a controlled test environment so act() flushes effects.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import type { IgnoredCorrection, EditorMode, ProjectMode } from "@/lib/project/project-types";
+
+// ---------------------------------------------------------------------------
+// Controllable mock service: loadIgnoredCorrections returns a deferred promise
+// so the test can interleave an ignore() before the load resolves.
+// ---------------------------------------------------------------------------
+
+let resolveLoad: (data: IgnoredCorrection[]) => void;
+let loadPromise: Promise<IgnoredCorrection[]>;
+const addImpl = vi.fn<(r: string, t: string, c?: string) => Promise<IgnoredCorrection[]>>();
+
+function resetService(): void {
+  loadPromise = new Promise<IgnoredCorrection[]>((res) => {
+    resolveLoad = res;
+  });
+}
+resetService();
+
+vi.mock("@/lib/services/ignored-corrections-service", () => ({
+  getIgnoredCorrectionsService: () => ({
+    loadIgnoredCorrections: () => loadPromise,
+    loadIgnoredCorrectionsStandalone: () => loadPromise,
+    addIgnoredCorrection: (r: string, t: string, c?: string) => addImpl(r, t, c),
+    addIgnoredCorrectionStandalone: (_f: string, r: string, t: string, c?: string) =>
+      addImpl(r, t, c),
+    removeIgnoredCorrection: vi.fn(),
+    clearIgnoredCorrections: vi.fn(),
+    clearAllIgnoredCorrectionsStandalone: vi.fn(),
+  }),
+}));
+
+import { useIgnoredCorrections } from "../use-ignored-corrections";
+
+const PROJECT_MODE = {
+  type: "project",
+  projectId: "p1",
+  name: "テスト",
+} as unknown as ProjectMode;
+
+// Harness that surfaces the hook's state + actions to the test. A mutable
+// holder (not a reassigned binding) keeps the react-hooks lint rule happy.
+const hookRef: { current: ReturnType<typeof useIgnoredCorrections> | null } = { current: null };
+function Harness({ mode }: { mode: EditorMode }): null {
+  // Test harness: deliberately publish the hook's value to an outer holder so
+  // the test can drive it. Not a production render pattern.
+  // eslint-disable-next-line react-hooks/immutability
+  hookRef.current = useIgnoredCorrections(mode);
+  return null;
+}
+function latest(): ReturnType<typeof useIgnoredCorrections> {
+  if (!hookRef.current) throw new Error("hook not mounted");
+  return hookRef.current;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  resetService();
+  addImpl.mockReset();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("useIgnoredCorrections — load/optimistic race", () => {
+  it("keeps an optimistic ignore even when the initial load resolves late with stale data", async () => {
+    // addIgnoredCorrection resolves with the authoritative post-write list.
+    addImpl.mockResolvedValue([{ ruleId: "rule-a", text: "時", addedAt: 1, context: undefined }]);
+
+    act(() => {
+      root.render(<Harness mode={PROJECT_MODE} />);
+    });
+
+    // The initial load is still in flight. User ignores a correction.
+    act(() => {
+      latest().ignoreCorrection("rule-a", "時");
+    });
+    expect(latest().ignoredCorrections).toHaveLength(1);
+
+    // Now the slow initial load resolves with the STALE (empty) on-disk snapshot.
+    await act(async () => {
+      resolveLoad([]);
+      await loadPromise;
+    });
+
+    // The stale load must NOT clobber the freshly-ignored entry.
+    expect(latest().ignoredCorrections).toHaveLength(1);
+    expect(latest().ignoredCorrections[0]).toMatchObject({ ruleId: "rule-a", text: "時" });
+  });
+
+  it("applies the initial load when no mutation raced it", async () => {
+    act(() => {
+      root.render(<Harness mode={PROJECT_MODE} />);
+    });
+
+    await act(async () => {
+      resolveLoad([{ ruleId: "rule-b", text: "事", addedAt: 2, context: undefined }]);
+      await loadPromise;
+    });
+
+    expect(latest().ignoredCorrections).toHaveLength(1);
+    expect(latest().ignoredCorrections[0]).toMatchObject({ ruleId: "rule-b", text: "事" });
+  });
+});

--- a/lib/editor-page/use-ignored-corrections.ts
+++ b/lib/editor-page/use-ignored-corrections.ts
@@ -38,10 +38,19 @@ export interface UseIgnoredCorrectionsResult {
 export function useIgnoredCorrections(editorMode: EditorMode): UseIgnoredCorrectionsResult {
   const [ignoredCorrections, setIgnoredCorrections] = useState<IgnoredCorrection[]>([]);
   const loadedModeRef = useRef<string | null>(null);
+  // Bumped on every local mutation (ignore / unignore / clear). The initial
+  // load captures this value and discards its (potentially stale) result if a
+  // mutation happened while it was in flight — otherwise a slow VFS read (e.g.
+  // Google Drive) can resolve AFTER an optimistic ignore and clobber the
+  // freshly-ignored entry back to the on-disk snapshot, making the item vanish
+  // from both the editor and the "無視された指摘" list.
+  const mutationVersionRef = useRef(0);
 
   // Load on mount or mode change
   useEffect(() => {
     let cancelled = false;
+    const versionAtLoad = mutationVersionRef.current;
+    const isStale = (): boolean => cancelled || versionAtLoad !== mutationVersionRef.current;
 
     const modeKey = editorMode
       ? editorMode.type === "project"
@@ -64,21 +73,21 @@ export function useIgnoredCorrections(editorMode: EditorMode): UseIgnoredCorrect
       service
         .loadIgnoredCorrections()
         .then((data) => {
-          if (!cancelled) setIgnoredCorrections(data);
+          if (!isStale()) setIgnoredCorrections(data);
         })
         .catch((err) => {
           console.warn("[useIgnoredCorrections] Failed to load:", err);
-          if (!cancelled) setIgnoredCorrections([]);
+          if (!isStale()) setIgnoredCorrections([]);
         });
     } else if (isStandaloneMode(editorMode)) {
       service
         .loadIgnoredCorrectionsStandalone(editorMode.fileName)
         .then((data) => {
-          if (!cancelled) setIgnoredCorrections(data);
+          if (!isStale()) setIgnoredCorrections(data);
         })
         .catch((err) => {
           console.warn("[useIgnoredCorrections] Failed to load standalone:", err);
-          if (!cancelled) setIgnoredCorrections([]);
+          if (!isStale()) setIgnoredCorrections([]);
         });
     }
 
@@ -96,6 +105,8 @@ export function useIgnoredCorrections(editorMode: EditorMode): UseIgnoredCorrect
     (ruleId: string, text: string, paragraphText?: string) => {
       const context = paragraphText ? hashString(paragraphText) : undefined;
       const service = getIgnoredCorrectionsService();
+      // Invalidate any in-flight initial load so it can't clobber this mutation.
+      mutationVersionRef.current += 1;
 
       if (editorMode && isProjectMode(editorMode)) {
         // Optimistic update: update UI immediately, then persist to VFS in background
@@ -131,6 +142,8 @@ export function useIgnoredCorrections(editorMode: EditorMode): UseIgnoredCorrect
   const unignoreCorrection = useCallback(
     (ruleId: string, text: string, context?: string) => {
       const service = getIgnoredCorrectionsService();
+      // Invalidate any in-flight initial load so it can't clobber this mutation.
+      mutationVersionRef.current += 1;
 
       if (editorMode && isProjectMode(editorMode)) {
         service
@@ -151,6 +164,8 @@ export function useIgnoredCorrections(editorMode: EditorMode): UseIgnoredCorrect
 
   const clearIgnoredCorrections = useCallback(async (): Promise<void> => {
     const service = getIgnoredCorrectionsService();
+    // Invalidate any in-flight initial load so it can't clobber the cleared state.
+    mutationVersionRef.current += 1;
 
     if (editorMode && isProjectMode(editorMode)) {
       await service.clearIgnoredCorrections();


### PR DESCRIPTION
## Summary

- 遅い VFS（Google Drive 同期下の `.illusions/ignored-corrections.json` など）で、**無視した指摘がエディタと「無視された指摘」一覧の両方から消える**不具合を修正
- 原因は初回ロードと楽観更新のレース：ファイルを開いた直後に走る非同期ロードが、ユーザーの「無視」操作より**後**に解決し、追加したばかりの項目をディスク上の古い（空の）スナップショットで上書きしていた

## 再現シナリオ（花様年華 / Google Drive）

1. 校正の指摘を「無視」→ 楽観更新で一覧に表示・`addIgnoredCorrection` がディスクへ保存
2. t0 に開始していた**遅い初回ロード**が `[]` で解決し state を上書き → 項目が UI から消失
3. 「無視された指摘」ダイアログを開くと空（＝報告された症状）

## Changes

| ファイル | 変更 |
| --- | --- |
| `lib/editor-page/use-ignored-corrections.ts` | 単調増加 `mutationVersionRef` を導入。初回ロードは開始時バージョンを捕捉し、ロード中に mutation（ignore / unignore / clear）が起きていれば結果を破棄。`ignore` / `unignore` / `clear` の冒頭でバージョンを bump |
| `lib/editor-page/__tests__/use-ignored-corrections.test.tsx` | 実レンダリング（`createRoot` + `act`）でレースを再現する回帰テストを新規追加 |

## Test plan

- [x] `npx vitest run lib/editor-page lib/services/__tests__/ignored-corrections-service.test.ts` → 190 passed
- [x] ガードを外すと新テストが RED になり、入れると GREEN になることを確認（バグを実際に捕捉）
- [x] `tsc --noEmit` / `eslint`（新規エラーなし）/ `prettier --check` クリーン

関連 issue なし