### PR TITLE
chore(ci): stale worktree テスト除外＋Code Quality を beta/alpha でも実行

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,9 +2,9 @@ name: Code Quality
 
 on:
   pull_request:
-    branches: [dev, main]
+    branches: [dev, beta, alpha, main]
   push:
-    branches: [dev, main]
+    branches: [dev, beta, alpha, main]
   workflow_dispatch:
 
 jobs:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import path from "path";
 
 export default defineConfig({
@@ -6,6 +6,9 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     include: ["**/__tests__/**/*.test.ts", "**/__tests__/**/*.test.tsx"],
+    // stale worktree コピー（.claude/worktrees/agent-*）配下の __tests__ が
+    // テスト探索に混入して false-RED を起こすのを防ぐ
+    exclude: [...configDefaults.exclude, ".claude/worktrees/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "html"],


### PR DESCRIPTION
## 目的
最近の作業分析で判明した「機械的チェックがすり抜ける」摩擦を、無リスクの範囲で塞ぐ。

## 変更
1. **vitest: stale worktree 除外** — `.claude/worktrees/**` をテスト探索から除外。残骸 worktree 内の `__tests__` が収集され false-RED を出す事故（release Phase 0.5 実績）を防止。
2. **quality.yml: beta/alpha トリガ追加** — Code Quality (Lint / Format Check / Test & Coverage) を beta/alpha でも実行。

## なぜ beta/alpha が必要か
required status check を司る repository ruleset は dev/beta/alpha/main を**共用**している。Code Quality を required 化する際、これらの check が beta/alpha で走らないと、dev→beta マージや週次 beta→main 昇格 PR が必須 check の永久 pending で**ブロック**される。本 PR はその gate 化の安全な前提整備。

## gate 化（required status check）は本 PR には含めない
本 PR マージ後、dev が緑かつ beta でも Code Quality が走る状態になってから、別途 ruleset 更新で gate 化する（マージ強制を変える操作のため別ステップ）。

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)