### PR TITLE
feat(rulesets): 校正ルールセットの一括更新・自動更新・更新通知＋更新時のworker破棄エラー修正

### DIFF
--- a/components/settings/LintingSettings.tsx
+++ b/components/settings/LintingSettings.tsx
@@ -11,6 +11,7 @@ import { useIgnoredCorrectionsContext } from "@/contexts/IgnoredCorrectionsConte
 import ModeSelector from "./linting/ModeSelector";
 import RulesetList from "./linting/RulesetList";
 import MarketplaceEntryCard from "./linting/MarketplaceEntryCard";
+import RulesetAutoUpdateToggle from "./linting/RulesetAutoUpdateToggle";
 import ClearIgnoredCorrectionsButton from "./linting/ClearIgnoredCorrectionsButton";
 import { useRulesetStatus } from "./linting/useRulesetStatus";
 
@@ -112,6 +113,13 @@ function LintingSettingsInner({
           disabled={!lintingEnabled}
           rulesetStatus={isElectron ? rulesetStatus : undefined}
         />
+
+        {/* ルールセット自動更新トグル（Electron のみ） */}
+        {isElectron && (
+          <div className="mt-4 pt-4 border-t border-border">
+            <RulesetAutoUpdateToggle disabled={!lintingEnabled} />
+          </div>
+        )}
 
         {/* Web fallback note */}
         {!isElectron && (

--- a/components/settings/linting/RulesetAutoUpdateToggle.tsx
+++ b/components/settings/linting/RulesetAutoUpdateToggle.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import type React from "react";
+import { useEffect, useState } from "react";
+
+import { getStorageService } from "@/lib/storage/storage-service";
+import { persistAppState } from "@/lib/storage/app-state-manager";
+import SettingsField from "../primitives/SettingsField";
+import SettingsToggle from "../primitives/SettingsToggle";
+
+/**
+ * 「校正ルールセットを自動更新する」トグル（Electron 専用）。
+ *
+ * AppState `rulesetAutoUpdate`（既定 true）を直接読み書きする自己完結コンポーネント。
+ * 起動時チェック {@link ruleset-update-check} が同じキーを参照し、ON のとき更新を
+ * 自動適用、OFF のとき手動トーストを出す。
+ */
+export default function RulesetAutoUpdateToggle({
+  disabled,
+}: {
+  disabled?: boolean;
+}): React.ReactElement {
+  // 既定 ON。永続値が読めるまでは ON 表示（明示的 false のときだけ OFF）。
+  const [autoUpdate, setAutoUpdate] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getStorageService()
+      .loadAppState()
+      .then((appState) => {
+        if (cancelled) return;
+        if (appState?.rulesetAutoUpdate === false) setAutoUpdate(false);
+      })
+      .catch(() => {
+        // 読めない場合は既定（ON）のまま。
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleChange = (value: boolean): void => {
+    setAutoUpdate(value);
+    void persistAppState({ rulesetAutoUpdate: value }).catch((e: unknown) =>
+      console.error("校正ルールセット設定の保存に失敗しました", e),
+    );
+  };
+
+  return (
+    <SettingsField
+      label="校正ルールセットを自動更新する"
+      description="起動時に新しいバージョンが見つかった場合、自動でダウンロードして適用します"
+      htmlFor="ruleset-auto-update"
+      inline
+    >
+      <SettingsToggle
+        id="ruleset-auto-update"
+        checked={autoUpdate}
+        onChange={handleChange}
+        disabled={disabled}
+      />
+    </SettingsField>
+  );
+}

--- a/components/settings/linting/RulesetCard.tsx
+++ b/components/settings/linting/RulesetCard.tsx
@@ -135,31 +135,48 @@ export default function RulesetCard({
         controlsDisabled && !error && "opacity-70",
       )}
     >
-      {/* Card header */}
+      {/* Card header — 2 段構成。タイトル行は折り返さず name を truncate、
+          メタチップ（出典・ライセンス・購入）は別行で flex-wrap させて
+          横並びの混雑による折り返し崩れ（「更新あり」の文字割れ等）を防ぐ。 */}
       <div className="flex items-center gap-2 px-3 py-2.5 bg-background-tertiary/50">
-        <button
-          onClick={() => setExpanded((v) => !v)}
-          className="flex items-center gap-1.5 flex-1 min-w-0 text-left"
-          aria-expanded={expanded}
-        >
-          {expanded ? (
-            <ChevronDown className="w-3.5 h-3.5 text-foreground-tertiary flex-shrink-0" />
-          ) : (
-            <ChevronRight className="w-3.5 h-3.5 text-foreground-tertiary flex-shrink-0" />
+        {/* 左カラム: タイトル行 + メタ行 */}
+        <div className="flex flex-col gap-1 flex-1 min-w-0">
+          {/* タイトル行: 展開ボタン（chevron + name）+ 更新あり + 同期スピナー */}
+          <div className="flex items-center gap-1.5 min-w-0">
+            <button
+              onClick={() => setExpanded((v) => !v)}
+              className="flex items-center gap-1.5 min-w-0 text-left"
+              aria-expanded={expanded}
+            >
+              {expanded ? (
+                <ChevronDown className="w-3.5 h-3.5 text-foreground-tertiary flex-shrink-0" />
+              ) : (
+                <ChevronRight className="w-3.5 h-3.5 text-foreground-tertiary flex-shrink-0" />
+              )}
+              <span className="text-sm font-medium text-foreground truncate">{nameJa}</span>
+            </button>
+            {updateAvailable && (
+              <span className="text-[10px] font-medium text-warning bg-warning/10 border border-warning/30 px-1.5 py-0.5 rounded leading-none flex-shrink-0 whitespace-nowrap">
+                更新あり
+              </span>
+            )}
+            {syncing && (
+              <Loader2 className="w-3.5 h-3.5 animate-spin text-accent flex-shrink-0" />
+            )}
+          </div>
+
+          {/* メタ行: 出典 + 各種バッジ。chevron 幅ぶん字下げして name と揃える。
+              購入リンク（<a>）はボタン外に出し、不正な入れ子とクリック競合を回避。 */}
+          {(publisherJa || source || license) && (
+            <div className="flex items-center gap-x-2 gap-y-1 flex-wrap pl-5">
+              {publisherJa && (
+                <span className="text-xs text-foreground/50 whitespace-nowrap">{publisherJa}</span>
+              )}
+              <SourceBadge source={source} />
+              <LicenseBadge license={license} licenseUrl={licenseUrl} purchaseUrl={purchaseUrl} />
+            </div>
           )}
-          <span className="text-sm font-medium text-foreground truncate">{nameJa}</span>
-          {publisherJa && (
-            <span className="text-xs text-foreground/50 flex-shrink-0">{publisherJa}</span>
-          )}
-          <SourceBadge source={source} />
-          <LicenseBadge license={license} licenseUrl={licenseUrl} purchaseUrl={purchaseUrl} />
-          {updateAvailable && (
-            <span className="text-[10px] font-medium text-warning bg-warning/10 border border-warning/30 px-1.5 py-0.5 rounded leading-none">
-              更新あり
-            </span>
-          )}
-          {syncing && <Loader2 className="w-3.5 h-3.5 animate-spin text-accent ml-1" />}
-        </button>
+        </div>
 
         {/* Version */}
         {(version || tag) && (

--- a/components/settings/linting/RulesetList.tsx
+++ b/components/settings/linting/RulesetList.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import type React from "react";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
+import { RefreshCw, Loader2 } from "lucide-react";
+import clsx from "clsx";
 
 import type { Severity } from "@/lib/linting/types";
 import {
@@ -80,6 +82,21 @@ export default function RulesetList({
     onLintingRuleConfigsBatchChange({ ...LINT_DEFAULT_CONFIGS });
   }, [onLintingRuleConfigsBatchChange]);
 
+  // 一括更新（Electron のみ）。更新ありの公式ルールセットを sync() でまとめて
+  // ダウンロードする。syncAllOfficial は差分のみ落とすため最新は触らない。
+  const [bulkUpdating, setBulkUpdating] = useState(false);
+  const updatableCount = rulesetStatus?.rulesets.filter((r) => r.updateAvailable).length ?? 0;
+  const anySyncing = bulkUpdating || (rulesetStatus?.rulesets.some((r) => r.syncing) ?? false);
+  const handleUpdateAll = useCallback(async () => {
+    if (!rulesetStatus) return;
+    setBulkUpdating(true);
+    try {
+      await rulesetStatus.sync();
+    } finally {
+      setBulkUpdating(false);
+    }
+  }, [rulesetStatus]);
+
   // Build legacy pack rules (内蔵)
   const ruleMetaMap = new Map(LINT_RULES_META.map((r) => [r.id, r]));
 
@@ -107,6 +124,25 @@ export default function RulesetList({
       {/* Section heading + bulk actions */}
       <div className="flex items-center gap-2 flex-wrap">
         <h3 className="text-sm font-medium text-foreground flex-1">校正ルールセット</h3>
+        {/* 一括更新ボタン（Electron かつ更新ありが 1 件以上のときのみ表示） */}
+        {rulesetStatus && updatableCount > 0 && (
+          <button
+            onClick={() => void handleUpdateAll()}
+            disabled={anySyncing}
+            className={clsx(
+              "flex items-center gap-1 text-xs px-2 py-1 rounded font-medium transition-colors",
+              "bg-accent/10 text-accent border border-accent/30 hover:bg-accent/20",
+              "disabled:opacity-50 disabled:cursor-not-allowed",
+            )}
+          >
+            {anySyncing ? (
+              <Loader2 className="w-3 h-3 animate-spin" />
+            ) : (
+              <RefreshCw className="w-3 h-3" />
+            )}
+            すべて更新（{updatableCount}）
+          </button>
+        )}
         <button
           onClick={handleEnableAll}
           className="text-xs px-2 py-1 text-foreground-secondary hover:text-foreground hover:bg-hover rounded transition-colors"

--- a/lib/editor-page/use-startup-checks.ts
+++ b/lib/editor-page/use-startup-checks.ts
@@ -6,11 +6,14 @@ import { useEffect, useRef } from "react";
 import { startupCheckQueue } from "@/lib/services/startup-check-queue";
 import { dictUpdateCheck } from "@/lib/services/startup-checks/dict-update-check";
 import { dictCorruptCheck } from "@/lib/services/startup-checks/dict-corrupt-check";
+import { rulesetUpdateCheck } from "@/lib/services/startup-checks/ruleset-update-check";
 
 // Register built-in checks once at module load. register() is idempotent per id.
 // Corrupt is checked before update: a corrupt DB needs re-download regardless of version.
 startupCheckQueue.register(dictCorruptCheck);
 startupCheckQueue.register(dictUpdateCheck);
+// 校正ルールセットの更新確認（Electron 専用。自動更新が ON なら即適用）。
+startupCheckQueue.register(rulesetUpdateCheck);
 
 export function useStartupChecks(): void {
   const ranRef = useRef(false);

--- a/lib/linting/__tests__/external-ruleset-loader.subscribe.test.ts
+++ b/lib/linting/__tests__/external-ruleset-loader.subscribe.test.ts
@@ -1,0 +1,103 @@
+/**
+ * subscribeRulesetChanges の teardown 耐性テスト。
+ *
+ * ルールセット更新（changed イベント）の適用中に proxy が dispose されると
+ * loadRuleset / unloadRuleset が WorkerDisposedError / WorkerStaleError を投げる。
+ * これは teardown / HMR / remount の正常系なので、エラー報告（console.error /
+ * notificationManager.warning）せず静かに無視しなければならない（#WorkerDisposedError）。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { warning } = vi.hoisted(() => ({ warning: vi.fn() }));
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { warning },
+}));
+
+import { subscribeRulesetChanges } from "@/lib/linting/external-ruleset-loader";
+import type { RuleRunnerProxy } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
+
+type ChangedCb = (data: { reason: "installed" | "updated" | "uninstalled"; ids: string[] }) => void;
+
+let changedCb: ChangedCb | null = null;
+
+function installApi(readModuleImpl: (id: string) => Promise<unknown>): void {
+  (window as unknown as { electronAPI?: unknown }).electronAPI = {
+    rulesets: {
+      onChanged: (cb: ChangedCb) => {
+        changedCb = cb;
+        return () => {
+          changedCb = null;
+        };
+      },
+      readModule: readModuleImpl,
+    },
+  };
+}
+
+function namedError(name: string): Error {
+  const e = new Error(name);
+  e.name = name;
+  return e;
+}
+
+/** microtask キューを数回流して then/catch を確定させる。 */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe("subscribeRulesetChanges — worker teardown tolerance", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warning.mockClear();
+    changedCb = null;
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errorSpy.mockRestore();
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  });
+
+  it("swallows WorkerDisposedError thrown by loadRuleset during a change (no error report)", async () => {
+    installApi(async (id) => ({ ok: true, id, tag: "v1", manifest: {}, code: "/* code */" }));
+    const proxy = {
+      loadRuleset: vi.fn(() => Promise.reject(namedError("WorkerDisposedError"))),
+      unloadRuleset: vi.fn(() => Promise.resolve({ ok: true })),
+    } as unknown as RuleRunnerProxy;
+
+    subscribeRulesetChanges(proxy);
+    changedCb?.({ reason: "installed", ids: ["com.test.x"] });
+    await flush();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it("swallows WorkerStaleError on the uninstall path", async () => {
+    installApi(async (id) => ({ ok: true, id, tag: "v1", manifest: {}, code: "" }));
+    const proxy = {
+      loadRuleset: vi.fn(() => Promise.resolve({ ok: true })),
+      unloadRuleset: vi.fn(() => Promise.reject(namedError("WorkerStaleError"))),
+    } as unknown as RuleRunnerProxy;
+
+    subscribeRulesetChanges(proxy);
+    changedCb?.({ reason: "uninstalled", ids: ["com.test.x"] });
+    await flush();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("still reports a genuine (non-teardown) load failure", async () => {
+    installApi(async (id) => ({ ok: true, id, tag: "v1", manifest: {}, code: "" }));
+    const proxy = {
+      loadRuleset: vi.fn(() => Promise.reject(new Error("boom"))),
+      unloadRuleset: vi.fn(() => Promise.resolve({ ok: true })),
+    } as unknown as RuleRunnerProxy;
+
+    subscribeRulesetChanges(proxy);
+    changedCb?.({ reason: "installed", ids: ["com.test.x"] });
+    await flush();
+
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/lib/linting/external-ruleset-loader.ts
+++ b/lib/linting/external-ruleset-loader.ts
@@ -46,6 +46,17 @@ function getRulesetsApi(): ElectronRulesetsApi | null {
   );
 }
 
+/**
+ * proxy が dispose / stale 状態のとき loadRuleset/unloadRuleset が投げる
+ * WorkerDisposedError・WorkerStaleError は teardown / HMR / remount の正常系。
+ * 失敗ではないので呼び出し側で静かに飲み込む（name 判定でクラス結合を避ける）。
+ */
+function isBenignWorkerTeardown(err: unknown): boolean {
+  return (
+    err instanceof Error && (err.name === "WorkerDisposedError" || err.name === "WorkerStaleError")
+  );
+}
+
 // -------------------------------------------------------------------------
 // Public API
 // -------------------------------------------------------------------------
@@ -88,8 +99,8 @@ export async function syncLoadedRulesets(proxy: RuleRunnerProxy): Promise<void> 
         failedIds.push(info.id);
       }
     } catch (err) {
-      // 破棄済み worker への load は teardown / HMR の正常系。失敗扱いせず静かに中断。
-      if (err instanceof Error && err.name === "WorkerDisposedError") {
+      // 破棄済み / stale worker への load は teardown / HMR の正常系。失敗扱いせず静かに中断。
+      if (isBenignWorkerTeardown(err)) {
         return;
       }
       console.error(`[external-ruleset-loader] failed to load ruleset "${info.id}":`, err);
@@ -122,6 +133,8 @@ export function subscribeRulesetChanges(proxy: RuleRunnerProxy): () => void {
     for (const id of ids) {
       if (reason === "uninstalled") {
         proxy.unloadRuleset(id).catch((err) => {
+          // worker 破棄後の unload は teardown の正常系。静かに無視。
+          if (isBenignWorkerTeardown(err)) return;
           console.error(`[external-ruleset-loader] unloadRuleset(${id}) failed:`, err);
         });
       } else {
@@ -150,6 +163,9 @@ export function subscribeRulesetChanges(proxy: RuleRunnerProxy): () => void {
             });
           })
           .catch((err) => {
+            // 更新適用中に worker が破棄された（タブ閉鎖 / HMR / remount）場合は
+            // teardown の正常系。エラー報告せず静かに中断する（#WorkerDisposedError 対策）。
+            if (isBenignWorkerTeardown(err)) return;
             console.error(`[external-ruleset-loader] change handler for "${id}" threw:`, err);
           });
       }

--- a/lib/services/startup-checks/__tests__/ruleset-update-check.test.ts
+++ b/lib/services/startup-checks/__tests__/ruleset-update-check.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { loadAppState } = vi.hoisted(() => ({ loadAppState: vi.fn() }));
+const { showMessage, dismiss, success, warning, error, info } = vi.hoisted(() => ({
+  showMessage: vi.fn(() => "toast-id"),
+  dismiss: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({ loadAppState }),
+}));
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { showMessage, dismiss, success, warning, error, info },
+}));
+
+import {
+  rulesetUpdateCheck,
+  runRulesetSync,
+} from "@/lib/services/startup-checks/ruleset-update-check";
+
+const checkUpdate = vi.fn();
+const sync = vi.fn();
+
+function setElectronRulesets(present: boolean): void {
+  if (present) {
+    (window as unknown as { electronAPI?: unknown }).electronAPI = {
+      rulesets: { checkUpdate, sync },
+    };
+  } else {
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  }
+}
+
+describe("rulesetUpdateCheck", () => {
+  beforeEach(() => {
+    checkUpdate.mockReset();
+    sync.mockReset();
+    sync.mockResolvedValue([]);
+    loadAppState.mockReset();
+    loadAppState.mockResolvedValue(null); // 既定 ON（未設定）
+    showMessage.mockClear();
+    dismiss.mockClear();
+    success.mockClear();
+    warning.mockClear();
+    error.mockClear();
+  });
+  afterEach(() => setElectronRulesets(false));
+
+  it("returns null on Web (no electronAPI.rulesets) without checking", async () => {
+    setElectronRulesets(false);
+    expect(await rulesetUpdateCheck.evaluate()).toBeNull();
+    expect(checkUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no ruleset has an update", async () => {
+    setElectronRulesets(true);
+    checkUpdate.mockResolvedValue([
+      { id: "a", updateAvailable: false },
+      { id: "b", updateAvailable: false },
+    ]);
+    expect(await rulesetUpdateCheck.evaluate()).toBeNull();
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it("silently suppresses when checkUpdate throws (network failure)", async () => {
+    setElectronRulesets(true);
+    checkUpdate.mockRejectedValue(new Error("network timeout"));
+    expect(await rulesetUpdateCheck.evaluate()).toBeNull();
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it("auto-updates (no notice) when updates exist and auto-update is ON by default", async () => {
+    setElectronRulesets(true);
+    checkUpdate.mockResolvedValue([
+      { id: "a", updateAvailable: true },
+      { id: "b", updateAvailable: false },
+    ]);
+    const notice = await rulesetUpdateCheck.evaluate();
+    expect(notice).toBeNull();
+    // runRulesetSync が即 sync() を呼ぶ
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a manual notice (no sync) when auto-update is explicitly OFF", async () => {
+    setElectronRulesets(true);
+    loadAppState.mockResolvedValue({ rulesetAutoUpdate: false });
+    checkUpdate.mockResolvedValue([
+      { id: "a", updateAvailable: true },
+      { id: "b", updateAvailable: true },
+    ]);
+    const notice = await rulesetUpdateCheck.evaluate();
+    expect(notice).toMatchObject({ id: "ruleset-update-available", type: "info" });
+    expect(notice?.message).toContain("2");
+    expect(notice?.actions?.[0]?.label).toBe("更新");
+    expect(sync).not.toHaveBeenCalled();
+  });
+
+  it("manual notice action triggers a sync", async () => {
+    setElectronRulesets(true);
+    loadAppState.mockResolvedValue({ rulesetAutoUpdate: false });
+    checkUpdate.mockResolvedValue([{ id: "a", updateAvailable: true }]);
+    const notice = await rulesetUpdateCheck.evaluate();
+    notice?.actions?.[0]?.onClick?.();
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-updates when rulesetAutoUpdate is explicitly true", async () => {
+    setElectronRulesets(true);
+    loadAppState.mockResolvedValue({ rulesetAutoUpdate: true });
+    checkUpdate.mockResolvedValue([{ id: "a", updateAvailable: true }]);
+    expect(await rulesetUpdateCheck.evaluate()).toBeNull();
+    expect(sync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runRulesetSync", () => {
+  beforeEach(() => {
+    sync.mockReset();
+    showMessage.mockClear();
+    dismiss.mockClear();
+    success.mockClear();
+    warning.mockClear();
+    error.mockClear();
+  });
+  afterEach(() => setElectronRulesets(false));
+
+  it("is a no-op on Web", () => {
+    setElectronRulesets(false);
+    runRulesetSync();
+    expect(showMessage).not.toHaveBeenCalled();
+  });
+
+  it("reports installed count on success", async () => {
+    setElectronRulesets(true);
+    sync.mockResolvedValue([
+      { id: "a", status: "installed" },
+      { id: "b", status: "up-to-date" },
+    ]);
+    runRulesetSync();
+    // microtask を流す
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(dismiss).toHaveBeenCalledWith("toast-id");
+    expect(success).toHaveBeenCalledWith("校正ルールセットを更新しました（1 件）。");
+  });
+
+  it("surfaces an error toast when sync rejects", async () => {
+    setElectronRulesets(true);
+    sync.mockRejectedValue(new Error("boom"));
+    runRulesetSync();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(error).toHaveBeenCalled();
+  });
+});

--- a/lib/services/startup-checks/ruleset-update-check.ts
+++ b/lib/services/startup-checks/ruleset-update-check.ts
@@ -1,0 +1,136 @@
+/**
+ * Startup check: 校正ルールセット（公式）の更新確認。
+ *
+ * 公式ルールセットの配信は Electron 専用（web には `electronAPI.rulesets` が無い）。
+ * ブラウザでは何もしない。
+ *
+ * 動作（辞書の dict-update-check を踏襲、ただしルールセットの資産は数 KB と軽量なので
+ * 回線種別・省電力ゲートは設けず、更新があれば即適用する）:
+ * - `checkUpdate()`（IPC `rulesets:check-update`）で各公式ルールセットの最新タグ vs
+ *   インストール済みタグを比較し、更新ありの件数を得る。
+ * - 自動更新が ON（AppState `rulesetAutoUpdate` が `false` 以外。既定 ON）なら、進捗トースト
+ *   付きで `sync()` を実行して自動適用する。トーストは下の `runRulesetSync` が出すので
+ *   notice は返さない。
+ * - 自動更新が OFF のときは「更新があります」トーストに「更新」ボタンを付けて手動適用させる。
+ *
+ * ネットワーク失敗は握り潰し、起動を妨げない（エラートーストも出さない）。
+ */
+import { getStorageService } from "@/lib/storage/storage-service";
+import { notificationManager } from "../notification-manager";
+import type { StartupCheck, StartupNotice } from "../startup-check-queue";
+
+interface RulesetUpdateInfo {
+  id: string;
+  updateAvailable?: boolean;
+  error?: string;
+}
+
+interface RulesetSyncResult {
+  id: string;
+  status: "installed" | "up-to-date" | "skipped" | "error";
+  detail?: string;
+}
+
+interface ElectronRulesetsApi {
+  checkUpdate?: () => Promise<RulesetUpdateInfo[]>;
+  sync?: () => Promise<RulesetSyncResult[]>;
+}
+
+function getElectronRulesets(): ElectronRulesetsApi | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as Window & { electronAPI?: { rulesets?: ElectronRulesetsApi } }).electronAPI
+    ?.rulesets;
+}
+
+const SYNC_MESSAGE = "校正ルールセットを更新中...";
+
+/**
+ * `sync()`（全公式ルールセットの差分ダウンロード）を進捗トースト付きで実行する。
+ * 自動更新・手動「更新」ボタンの両方から使う。完了時にインストール件数を要約表示し、
+ * 1 件も更新が無ければ静かに閉じる。worker への再読み込みは main 側の `changed`
+ * イベント → subscribeRulesetChanges が担うため、ここでは行わない。
+ */
+export function runRulesetSync(): void {
+  const api = getElectronRulesets();
+  if (!api?.sync) return;
+
+  const progressId = notificationManager.showMessage(SYNC_MESSAGE, {
+    type: "info",
+    duration: 0,
+  });
+
+  api
+    .sync()
+    .then((summary) => {
+      notificationManager.dismiss(progressId);
+      const installed = Array.isArray(summary)
+        ? summary.filter((s) => s.status === "installed").length
+        : 0;
+      const failed = Array.isArray(summary)
+        ? summary.filter((s) => s.status === "error").length
+        : 0;
+      if (failed > 0) {
+        notificationManager.warning(
+          `校正ルールセットを更新しました（${installed} 件）。${failed} 件は失敗しました。`,
+        );
+      } else if (installed > 0) {
+        notificationManager.success(`校正ルールセットを更新しました（${installed} 件）。`);
+      }
+    })
+    .catch((err: unknown) => {
+      notificationManager.dismiss(progressId);
+      console.warn("[ruleset-update-check] sync failed:", err);
+      notificationManager.error(
+        `校正ルールセットの更新に失敗しました：${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+}
+
+export const rulesetUpdateCheck: StartupCheck = {
+  id: "ruleset-update",
+  async evaluate(): Promise<StartupNotice | null> {
+    const api = getElectronRulesets();
+    // Electron 専用機能。web には公式ルールセットの配信が無い。
+    if (!api?.checkUpdate) return null;
+
+    // 最新タグ vs インストール済みタグ（ダウンロードはしない）。
+    // ネットワーク/IPC エラーは握り潰して起動を妨げない。
+    let results: RulesetUpdateInfo[];
+    try {
+      results = await api.checkUpdate();
+    } catch (err) {
+      console.warn("[ruleset-update-check] update check failed (network?):", err);
+      return null;
+    }
+
+    const updatable = Array.isArray(results)
+      ? results.filter((r) => r.updateAvailable === true)
+      : [];
+    if (updatable.length === 0) return null;
+
+    // 自動更新の設定（AppState `rulesetAutoUpdate`）。既定 ON のため、明示的に
+    // `false` のときだけ無効扱い。読めない場合は安全側で ON 扱い。
+    let autoUpdate = true;
+    try {
+      const appState = await getStorageService().loadAppState();
+      if (appState?.rulesetAutoUpdate === false) autoUpdate = false;
+    } catch {
+      // 設定が読めない場合は既定（ON）のまま。
+    }
+
+    if (autoUpdate) {
+      // 軽量資産なのでカウントダウンを挟まず即適用。トーストは runRulesetSync が出す。
+      runRulesetSync();
+      return null;
+    }
+
+    // 自動更新 OFF。手動適用のためのトーストを出す。
+    return {
+      id: "ruleset-update-available",
+      type: "info",
+      message: `校正ルールセットに更新があります（${updatable.length} 件）。`,
+      duration: 0, // 手動で閉じるまで保持
+      actions: [{ label: "更新", onClick: () => runRulesetSync() }],
+    };
+  },
+};

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -188,6 +188,8 @@ export interface AppState {
   // アップデート設定
   /** ベータ版（プレリリース）アップデートを受け取る（デフォルト: false） */
   allowBetaUpdates?: boolean;
+  /** 起動時に校正ルールセットの更新を自動で適用する（デフォルト: true） */
+  rulesetAutoUpdate?: boolean;
 }
 
 /**


### PR DESCRIPTION
## 概要
校正ルールセット設定の UX を強化し、更新適用時に発生していた `WorkerDisposedError` を修正します。

## 🐛 Bug 修正：更新時の `WorkerDisposedError`
更新適用中（`changed` → `readModule` → `loadRuleset`）に proxy が dispose される（タブ閉鎖／HMR／remount）と `loadRuleset` が同期 throw し、外側 `.catch` で `console.error` として漏れていた。`syncLoadedRulesets` には name 判定の握り潰しがあったが**変更ハンドラ側に欠けていた**。
- `isBenignWorkerTeardown()`（`WorkerDisposedError` + `WorkerStaleError`）を抽出し、install/update・uninstall の両経路で teardown 正常系として静かに無視。

## 機能
1. **UI 排版修正**（`RulesetCard`）: ヘッダを2段構成化（タイトル行 + 折り返し可能なメタ行）。「更新あり」バッジの文字割れ・混雑による崩れを解消。`購入へ`(`<a>`) をボタン外に出し不正な入れ子とクリック競合も回避。
2. **一括更新ボタン**（`RulesetList`）: 「すべて更新（N）」を追加（Electron かつ更新ありが1件以上）。`sync()` で差分まとめてダウンロード、同期中は spinner + disable。
3. **更新通知**（`ruleset-update-check`）: 起動時チェックを新設し `startupCheckQueue` に登録。自動更新 OFF 時は「更新」ボタン付き info トースト。
4. **自動更新（既定 ON）**: AppState `rulesetAutoUpdate`（既定 true）+ 自己完結 `RulesetAutoUpdateToggle` 設定。ON のとき起動時に更新を即適用（資産は KB 級のため回線/省電力ゲートは設けない）。

## テスト
- `ruleset-update-check`（自動/手動分岐・no-op・エラー握り潰し）10 件
- `subscribeRulesetChanges` の teardown 耐性 3 件
- typecheck 0 error / eslint clean / 既存 startup-checks・loader テスト緑

## 関連 issue
関連 issue なし（#1792「日本語表記ルールブック 第2版 原文受領待ち」は本 PR と無関係）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)