### PR TITLE
style(rulesets): RulesetCard の prettier フォーマット修正

### DIFF
--- a/components/settings/linting/RulesetCard.tsx
+++ b/components/settings/linting/RulesetCard.tsx
@@ -160,9 +160,7 @@ export default function RulesetCard({
                 更新あり
               </span>
             )}
-            {syncing && (
-              <Loader2 className="w-3.5 h-3.5 animate-spin text-accent flex-shrink-0" />
-            )}
+            {syncing && <Loader2 className="w-3.5 h-3.5 animate-spin text-accent flex-shrink-0" />}
           </div>
 
           {/* メタ行: 出典 + 各種バッジ。chevron 幅ぶん字下げして name と揃える。


### PR DESCRIPTION
## 概要
#1812 のマージ後に `dev` で Format Check が失敗していたため修正します。`RulesetCard` の syncing スピナー JSX を prettier 規定どおり1行に収めるだけで、**挙動変更なし**。

## 関連 issue
関連 issue なし（#1812 の follow-up）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)