### PR TITLE
chore(ci): pre-push で check:boundaries を実行

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+# pre-commit の lint-staged は import boundary を見ないため、
+# push 前にここで boundary 違反を捕捉する（#1807 の CI すり抜け対策）
+npm run check:boundaries

--- a/components/settings/linting/RulesetCard.tsx
+++ b/components/settings/linting/RulesetCard.tsx
@@ -160,9 +160,7 @@ export default function RulesetCard({
                 更新あり
               </span>
             )}
-            {syncing && (
-              <Loader2 className="w-3.5 h-3.5 animate-spin text-accent flex-shrink-0" />
-            )}
+            {syncing && <Loader2 className="w-3.5 h-3.5 animate-spin text-accent flex-shrink-0" />}
           </div>
 
           {/* メタ行: 出典 + 各種バッジ。chevron 幅ぶん字下げして name と揃える。


### PR DESCRIPTION
## 目的
import boundary 違反が push → CI まですり抜ける穴を塞ぐ。

pre-commit の lint-staged は prettier/eslint のみで `check:boundaries` を実行しないため、boundary 違反は CI で初めて赤くなり「補釘コミット」を生んでいた（#1807 実績）。push 前に捕捉する。

## 変更
- `.husky/pre-push` 新設: `npm run check:boundaries`（~1秒、`--no-verify` でバイパス可）

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)