### PR TITLE
fix(linting): 校正モード切替が実行時にルールを切り替えない退行を修正

### DIFF
--- a/components/settings/LintingSettings.tsx
+++ b/components/settings/LintingSettings.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import type React from "react";
+import { useMemo } from "react";
 import clsx from "clsx";
 
 import type { Severity } from "@/lib/linting/types";
 import type { CorrectionConfig } from "@/lib/linting/correction-config";
+import type { ModeRuleMetaInput } from "@/lib/linting/mode-rule-configs";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
 import { useIgnoredCorrectionsContext } from "@/contexts/IgnoredCorrectionsContext";
 
@@ -57,6 +59,20 @@ function LintingSettingsInner({
 
   const showCorrectionConfig = Boolean(correctionConfig && onCorrectionConfigChange);
 
+  // Flatten every loaded rule's metadata so the mode selector can derive
+  // enabled/disabled from each rule's applicableModes (#1809/#1810 regression).
+  const loadedRules = useMemo<ModeRuleMetaInput[]>(
+    () =>
+      rulesetStatus.rulesets.flatMap((ruleset) =>
+        ruleset.rules.map((rule) => ({
+          ruleId: rule.ruleId,
+          applicableModes: rule.applicableModes,
+          defaultConfig: rule.defaultConfig,
+        })),
+      ),
+    [rulesetStatus.rulesets],
+  );
+
   return (
     <div className="space-y-6">
       {/* ① Master toggle */}
@@ -93,6 +109,7 @@ function LintingSettingsInner({
           <ModeSelector
             correctionConfig={correctionConfig}
             disabled={!lintingEnabled}
+            loadedRules={loadedRules}
             onCorrectionConfigChange={onCorrectionConfigChange}
             onLintingRuleConfigsBatchChange={onLintingRuleConfigsBatchChange}
           />

--- a/components/settings/linting/ModeSelector.tsx
+++ b/components/settings/linting/ModeSelector.tsx
@@ -6,17 +6,24 @@ import clsx from "clsx";
 
 import type { CorrectionConfig } from "@/lib/linting/correction-config";
 import type { CorrectionModeId } from "@/lib/linting/correction-config";
+import { CORRECTION_MODE_IDS, CORRECTION_MODES } from "@/lib/linting/correction-modes";
 import {
-  CORRECTION_MODE_IDS,
-  CORRECTION_MODES,
-  MODE_TO_PRESET,
-} from "@/lib/linting/correction-modes";
-import { LINT_PRESETS } from "@/lib/linting/lint-presets";
+  buildModeRuleConfigsFromRules,
+  type ModeRuleMetaInput,
+} from "@/lib/linting/mode-rule-configs";
 import type { Severity } from "@/lib/linting/types";
 
 interface ModeSelectorProps {
   correctionConfig: CorrectionConfig;
   disabled?: boolean;
+  /**
+   * Metadata of every currently-loaded rule (flattened across all rulesets).
+   * Mode switching derives the enabled/disabled config from each rule's
+   * `applicableModes`, so this MUST reflect the live ruleset state — passing an
+   * empty/stale list silently makes the mode pills no-ops (the #1809/#1810
+   * regression this prop exists to fix).
+   */
+  loadedRules: readonly ModeRuleMetaInput[];
   onCorrectionConfigChange: (config: Partial<CorrectionConfig>) => void;
   onLintingRuleConfigsBatchChange: (
     configs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>,
@@ -26,6 +33,7 @@ interface ModeSelectorProps {
 export default function ModeSelector({
   correctionConfig,
   disabled,
+  loadedRules,
   onCorrectionConfigChange,
   onLintingRuleConfigsBatchChange,
 }: ModeSelectorProps): React.ReactElement {
@@ -37,13 +45,13 @@ export default function ModeSelector({
         mode: mode.id,
         guidelines: [...mode.defaultGuidelines],
       });
-      const presetId = MODE_TO_PRESET[modeId as CorrectionModeId];
-      const preset = presetId ? LINT_PRESETS[presetId] : undefined;
-      if (preset) {
-        onLintingRuleConfigsBatchChange({ ...preset.configs });
-      }
+      // Build a complete config map (every loaded rule) from the rules'
+      // applicableModes so the batch handler's replace semantics is correct:
+      // rules opting into this mode are enabled, all others disabled.
+      const configs = buildModeRuleConfigsFromRules(mode.id, loadedRules);
+      onLintingRuleConfigsBatchChange(configs);
     },
-    [onCorrectionConfigChange, onLintingRuleConfigsBatchChange],
+    [loadedRules, onCorrectionConfigChange, onLintingRuleConfigsBatchChange],
   );
 
   return (

--- a/components/settings/linting/__tests__/ModeSelector-mode-switch.test.tsx
+++ b/components/settings/linting/__tests__/ModeSelector-mode-switch.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Integration regression test for the #1809/#1810 mode-switch wiring.
+ *
+ * After built-in rules were zeroed out, `ModeSelector` fed
+ * `LINT_PRESETS[presetId].configs` (now always `{}`) to the batch handler, so
+ * clicking a mode pill emitted an empty map — no rule was ever enabled or
+ * disabled, and the manual config got clobbered with `{}`.
+ *
+ * The fix derives the config from each loaded rule's `applicableModes`. This
+ * test renders the real component with representative runtime rule metadata and
+ * asserts the emitted batch map actually toggles rules per the selected mode.
+ * With the old code this assertion fails (the map would be empty).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import ModeSelector from "../ModeSelector";
+import type { ModeRuleMetaInput } from "@/lib/linting/mode-rule-configs";
+import type { CorrectionConfig } from "@/lib/linting/correction-config";
+import type { Severity } from "@/lib/linting/types";
+
+const LOADED_RULES: ModeRuleMetaInput[] = [
+  {
+    ruleId: "me2-17-repetition-symbols",
+    applicableModes: ["novel"],
+    defaultConfig: { enabled: true, severity: "info" },
+  },
+  {
+    ruleId: "jtf-1-2-1",
+    applicableModes: ["official", "academic"],
+    defaultConfig: { enabled: true, severity: "error" },
+  },
+];
+
+const BASE_CONFIG: CorrectionConfig = {
+  enabled: true,
+  mode: "novel",
+  guidelines: [],
+  ruleOverrides: {},
+  ignoredCorrections: [],
+};
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function clickModeButton(label: string): void {
+  const button = [...container.querySelectorAll("button")].find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!button) throw new Error(`mode button "${label}" not found`);
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("ModeSelector — mode switch actually toggles rules (regression #1809/#1810)", () => {
+  it("emits a non-empty config map that enables the selected mode's rules", () => {
+    const onBatch =
+      vi.fn<(configs: Record<string, { enabled: boolean; severity: Severity }>) => void>();
+
+    act(() => {
+      root.render(
+        <ModeSelector
+          correctionConfig={BASE_CONFIG}
+          loadedRules={LOADED_RULES}
+          onCorrectionConfigChange={() => {}}
+          onLintingRuleConfigsBatchChange={onBatch}
+        />,
+      );
+    });
+
+    // Switch to 公用文 (official): jtf-1-2-1 should turn on, novel-only rule off.
+    clickModeButton("公用文");
+
+    expect(onBatch).toHaveBeenCalledTimes(1);
+    const configs = onBatch.mock.calls[0][0];
+
+    // The whole point of the regression: the map must NOT be empty.
+    expect(Object.keys(configs).length).toBeGreaterThan(0);
+    expect(configs["jtf-1-2-1"]).toEqual({ enabled: true, severity: "error" });
+    expect(configs["me2-17-repetition-symbols"].enabled).toBe(false);
+  });
+
+  it("selecting 小説 (novel) enables the novel-only rule and disables the others", () => {
+    const onBatch =
+      vi.fn<(configs: Record<string, { enabled: boolean; severity: Severity }>) => void>();
+
+    act(() => {
+      root.render(
+        <ModeSelector
+          correctionConfig={{ ...BASE_CONFIG, mode: "official" }}
+          loadedRules={LOADED_RULES}
+          onCorrectionConfigChange={() => {}}
+          onLintingRuleConfigsBatchChange={onBatch}
+        />,
+      );
+    });
+
+    clickModeButton("小説");
+
+    const configs = onBatch.mock.calls[0][0];
+    expect(configs["me2-17-repetition-symbols"].enabled).toBe(true);
+    expect(configs["jtf-1-2-1"].enabled).toBe(false);
+  });
+});

--- a/lib/editor-page/use-ai-settings.ts
+++ b/lib/editor-page/use-ai-settings.ts
@@ -235,6 +235,10 @@ export function useAiSettings(): UseAiSettingsResult {
 
   const handleLintingRuleConfigsBatchChange = useCallback(
     (configs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>) => {
+      // Replace (not merge): callers pass a COMPLETE map covering every loaded
+      // rule (see buildModeRuleConfigsFromRules), so replacement correctly
+      // enables the new mode's rules and disables the rest. A partial map here
+      // would silently drop rules; keep the contract "complete map = replace".
       setLintingRuleConfigs(configs);
       void persistAppState({ lintingRuleConfigs: configs }).catch((e) =>
         console.error("Failed to persist lintingRuleConfigs:", e),

--- a/lib/linting/__tests__/mode-rule-configs-runtime.test.ts
+++ b/lib/linting/__tests__/mode-rule-configs-runtime.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+
+import { buildModeRuleConfigsFromRules, type ModeRuleMetaInput } from "../mode-rule-configs";
+import { CORRECTION_MODE_IDS } from "../correction-modes";
+import type { CorrectionModeId } from "../correction-config";
+
+/**
+ * Regression guard for the #1809/#1810 mode-switch wiring.
+ *
+ * The legacy `buildModeRuleConfigs(modeId)` iterates `LINT_RULES_META`, which is
+ * now empty (all rules moved to external rulesets), so its tests pass vacuously
+ * and cannot detect that mode switching toggles nothing at runtime. This suite
+ * exercises `buildModeRuleConfigsFromRules` with representative *runtime* rule
+ * metadata — the only source that actually exists in production today.
+ */
+
+// Representative metadata mirroring what useRulesetStatus() supplies per rule.
+const RULES: ModeRuleMetaInput[] = [
+  {
+    // novel-only rule
+    ruleId: "me2-17-repetition-symbols",
+    applicableModes: ["novel"],
+    defaultConfig: { enabled: true, severity: "info" },
+  },
+  {
+    // shared across official + academic (the two "strict" modes)
+    ruleId: "jtf-1-2-1",
+    applicableModes: ["official", "academic"],
+    defaultConfig: { enabled: true, severity: "error" },
+  },
+  {
+    // universal-ish rule present in several modes
+    ruleId: "nh-6-ji-zu-di-du-exceptions",
+    applicableModes: ["novel", "official", "blog", "academic", "sns"],
+    defaultConfig: { enabled: true, severity: "error" },
+  },
+  {
+    // opted into NO mode — manual toggle only, must always be disabled by a mode
+    ruleId: "me2-11-vertical-numbers",
+    applicableModes: [],
+    defaultConfig: { enabled: false, severity: "warning" },
+  },
+];
+
+describe("buildModeRuleConfigsFromRules — runtime applicableModes wiring", () => {
+  it("enables exactly the rules whose applicableModes include the selected mode", () => {
+    for (const mode of CORRECTION_MODE_IDS) {
+      const configs = buildModeRuleConfigsFromRules(mode, RULES);
+      for (const rule of RULES) {
+        const expected = (rule.applicableModes ?? []).includes(mode);
+        expect(configs[rule.ruleId].enabled).toBe(expected);
+      }
+    }
+  });
+
+  it("switching novel -> official flips the membership of the affected rules", () => {
+    const novel = buildModeRuleConfigsFromRules("novel", RULES);
+    const official = buildModeRuleConfigsFromRules("official", RULES);
+
+    // novel-only rule: on in novel, off in official
+    expect(novel["me2-17-repetition-symbols"].enabled).toBe(true);
+    expect(official["me2-17-repetition-symbols"].enabled).toBe(false);
+
+    // official/academic rule: off in novel, on in official
+    expect(novel["jtf-1-2-1"].enabled).toBe(false);
+    expect(official["jtf-1-2-1"].enabled).toBe(true);
+  });
+
+  it("a rule with empty applicableModes is disabled under every mode", () => {
+    for (const mode of CORRECTION_MODE_IDS) {
+      const configs = buildModeRuleConfigsFromRules(mode, RULES);
+      expect(configs["me2-11-vertical-numbers"].enabled).toBe(false);
+    }
+  });
+
+  it("returns a COMPLETE map covering every supplied rule (replace-safe)", () => {
+    for (const mode of CORRECTION_MODE_IDS) {
+      const configs = buildModeRuleConfigsFromRules(mode, RULES);
+      expect(Object.keys(configs).sort()).toEqual(RULES.map((r) => r.ruleId).sort());
+    }
+  });
+
+  it("carries the rule's default severity (falling back to warning)", () => {
+    const configs = buildModeRuleConfigsFromRules("official", RULES);
+    expect(configs["jtf-1-2-1"].severity).toBe("error");
+    expect(configs["me2-17-repetition-symbols"].severity).toBe("info");
+
+    // Missing/invalid severity falls back to "warning".
+    const fallback = buildModeRuleConfigsFromRules("novel", [
+      { ruleId: "x-no-default", applicableModes: ["novel"] },
+      {
+        ruleId: "x-bad-sev",
+        applicableModes: ["novel"],
+        defaultConfig: { enabled: true, severity: "critical" },
+      },
+    ]);
+    expect(fallback["x-no-default"].severity).toBe("warning");
+    expect(fallback["x-bad-sev"].severity).toBe("warning");
+  });
+
+  it("preserves skipDialogue from defaultConfig when present", () => {
+    const configs = buildModeRuleConfigsFromRules("novel", [
+      {
+        ruleId: "x-skip",
+        applicableModes: ["novel"],
+        defaultConfig: { enabled: true, severity: "warning", skipDialogue: true },
+      },
+    ]);
+    expect(configs["x-skip"].skipDialogue).toBe(true);
+  });
+
+  it("an empty rule list yields an empty map (Web has no rulesets)", () => {
+    for (const mode of CORRECTION_MODE_IDS) {
+      expect(buildModeRuleConfigsFromRules(mode, [])).toEqual({});
+    }
+  });
+
+  it("ignores invalid / unknown mode ids in applicableModes (strict membership)", () => {
+    const configs = buildModeRuleConfigsFromRules("novel", [
+      {
+        ruleId: "x-bogus-mode",
+        applicableModes: ["definitely-not-a-mode" as CorrectionModeId, "official"],
+        defaultConfig: { enabled: true, severity: "warning" },
+      },
+    ]);
+    // novel is not listed -> disabled
+    expect(configs["x-bogus-mode"].enabled).toBe(false);
+  });
+
+  it("keeps the first entry on duplicate ruleIds", () => {
+    const configs = buildModeRuleConfigsFromRules("novel", [
+      { ruleId: "dup", applicableModes: ["novel"], defaultConfig: { severity: "error" } },
+      { ruleId: "dup", applicableModes: [], defaultConfig: { severity: "info" } },
+    ]);
+    expect(configs["dup"].enabled).toBe(true);
+    expect(configs["dup"].severity).toBe("error");
+  });
+});

--- a/lib/linting/mode-rule-configs.ts
+++ b/lib/linting/mode-rule-configs.ts
@@ -1,0 +1,83 @@
+/**
+ * Mode → rule-config derivation from runtime ruleset metadata.
+ *
+ * Background (#1809/#1810 regression): the built-in rule tables were zeroed out
+ * when every rule moved to external rulesets, so the legacy `LINT_PRESETS` /
+ * `buildModeRuleConfigs(modeId)` path (which iterates the now-empty
+ * `LINT_RULES_META`) can no longer enable/disable anything on a mode switch.
+ *
+ * The only runtime source of truth for "which rules are loaded and which modes
+ * they opt into" is each loaded ruleset's per-rule metadata (`applicableModes`,
+ * `defaultConfig`). This module derives a complete, mode-specific config map
+ * from that metadata so switching modes actually toggles rules at runtime.
+ *
+ * Strict membership: a rule's `enabled` is decided solely by whether the
+ * selected mode is in its `applicableModes`. The severity comes from the rule's
+ * `defaultConfig` (falling back to "warning"). The returned map covers EVERY
+ * known rule, so the batch handler can safely replace the whole config object
+ * without dropping rules that belong to the new mode.
+ */
+import type { Severity } from "./types";
+import type { CorrectionModeId } from "./correction-config";
+
+/** Per-rule config shape applied on mode switch. */
+export interface ModeRuleConfig {
+  enabled: boolean;
+  severity: Severity;
+  skipDialogue?: boolean;
+}
+
+/**
+ * Minimal rule metadata needed to derive a mode config. A structural subset of
+ * both the SDK `RulesetRuleMeta` and the renderer's `useRulesetStatus`
+ * `RulesetRuleMeta`, so either can be passed without adaptation.
+ */
+export interface ModeRuleMetaInput {
+  ruleId: string;
+  /** Modes this rule opts into. Missing/empty = never auto-enabled by a mode. */
+  applicableModes?: readonly string[];
+  defaultConfig?: { enabled?: boolean; severity?: string; skipDialogue?: boolean };
+}
+
+const VALID_SEVERITIES = new Set<Severity>(["error", "warning", "info"]);
+
+function normalizeSeverity(value: string | undefined): Severity {
+  return value !== undefined && VALID_SEVERITIES.has(value as Severity)
+    ? (value as Severity)
+    : "warning";
+}
+
+/**
+ * Build the effective per-rule config map for a correction mode from the
+ * currently-loaded rule metadata.
+ *
+ * - `enabled = applicableModes.includes(modeId)` (strict membership)
+ * - `severity = defaultConfig.severity ?? "warning"`
+ * - `skipDialogue` is carried over from `defaultConfig` when present
+ *
+ * The result intentionally covers every rule in `rules` so callers may replace
+ * the whole `lintingRuleConfigs` object. Duplicate ruleIds keep the first entry.
+ *
+ * @param modeId Selected correction mode.
+ * @param rules Flattened metadata of every loaded rule (across all rulesets).
+ * @returns ruleId → config map covering every supplied rule.
+ */
+export function buildModeRuleConfigsFromRules(
+  modeId: CorrectionModeId,
+  rules: readonly ModeRuleMetaInput[],
+): Record<string, ModeRuleConfig> {
+  const out: Record<string, ModeRuleConfig> = {};
+  for (const rule of rules) {
+    if (!rule.ruleId || Object.prototype.hasOwnProperty.call(out, rule.ruleId)) continue;
+    const modes = rule.applicableModes ?? [];
+    const config: ModeRuleConfig = {
+      enabled: modes.includes(modeId),
+      severity: normalizeSeverity(rule.defaultConfig?.severity),
+    };
+    if (rule.defaultConfig?.skipDialogue !== undefined) {
+      config.skipDialogue = rule.defaultConfig.skipDialogue;
+    }
+    out[rule.ruleId] = config;
+  }
+  return out;
+}


### PR DESCRIPTION
## 退行の内容

内蔵ルールゼロ化 (#1809 / #1810) 以降、**校正モード（ModeSelector のピル）を切り替えても実行時にルールが一切 enabled/disabled されない**退行が発生していました。さらにモード切替のたびに、手動でトグルした個別設定まで空 `{}` で上書きされていました。

## 原因

1. `ModeSelector.handleModeChange` が `LINT_PRESETS[presetId].configs` を batch ハンドラへ渡していたが、内蔵ルールゼロ化で `LINT_PRESETS[*].configs` は**全モード空 `{}`**（`LINT_RULES_META = []`）になっていた。
2. `use-ai-settings` の batch ハンドラは**置換**で `lintingRuleConfigs` を設定するため、空 `{}` を渡されると全設定が消える。
3. ルール on/off の唯一の経路は `lintingRuleConfigs`（guideline 経路は retired 済み）。
4. 外部 ruleset の `applicableModes` をランタイム反映する経路が production から呼ばれていなかった。

結果、直近の「6 ルールセット × `applicableModes` 監査（69件中20件修正）」が**実行時にゼロ反映**になっていました。

## 修正

- **新規 `lib/linting/mode-rule-configs.ts`**: 純粋関数 `buildModeRuleConfigsFromRules(modeId, rules)` を追加。各ルールの `applicableModes` から `enabled`、`defaultConfig.severity` から `severity` を決定し、**全既知ルールを網羅した完全マップ**を生成（strict membership）。
- **`ModeSelector`**: ランタイムのルールメタ（`useRulesetStatus` 由来）を `loadedRules` prop で受け取り、上記関数でマップを構築。死蔵の `LINT_PRESETS` / `MODE_TO_PRESET` 依存を排除。
- **`LintingSettings`**: 既存の `useRulesetStatus().rulesets[*].rules` を flatten して `ModeSelector` へ供給（**新規 IPC なし、renderer 内で完結**）。
- **`use-ai-settings`**: batch ハンドラの replace セマンティクスを「**完全マップ＝置換**」契約としてコメントで明示。完全マップを渡す方針なので置換のままで整合。

これにより `applicableModes` 監査が**実行時に効くようになります**。モードを選ぶと、そのモードの `applicableModes` に含まれるルールが enabled、含まれないものが disabled になります。

## 追加テスト

- `lib/linting/__tests__/mode-rule-configs-runtime.test.ts` — 代表的な runtime ルールメタを absorb し、モードごとの enabled/disabled・severity フォールバック・完全網羅・空モード・不正/不明モード・重複 ruleId の扱いを検証。既存 `mode-rule-configs.test.ts` は `LINT_RULES_META = []` で空ループ自明 pass のため退行を検出できない点を補完。
- `components/settings/linting/__tests__/ModeSelector-mode-switch.test.tsx` — 実コンポーネントをレンダリングし、モードピル click で**非空かつ正しい** config マップが emit されることを検証。

**修正前に落ちることの確認**: `ModeSelector` を旧挙動（`onLintingRuleConfigsBatchChange({})`）へ一時パッチして上記コンポーネントテストを実行 → `Cannot read properties of undefined (reading 'enabled')` で 2 件失敗。修正コードへ戻すと全 pass することを確認済み。

## ゲート

- `type-check` ✅ / `lint` ✅（0 errors）/ `check:boundaries` ✅ / `test` ✅（158 files / 1873 tests pass）

## 関連 issue

関連 issue なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)