### PR TITLE
fix(linting): インスペクタのモード切替＋空config初期化を配線（#1817 残課題）

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,8 +42,9 @@ import { useEditorLifecycle } from "@/lib/editor-page/use-editor-lifecycle";
 import { useElectronEvents } from "@/lib/editor-page/use-electron-events";
 import { useProjectLifecycle } from "@/lib/editor-page/use-project-lifecycle";
 import { useLinting } from "@/lib/editor-page/use-linting";
-import { CORRECTION_MODES, MODE_TO_PRESET } from "@/lib/linting/correction-modes";
-import { LINT_PRESETS } from "@/lib/linting/lint-presets";
+import { CORRECTION_MODES } from "@/lib/linting/correction-modes";
+import { buildModeRuleConfigsFromRules } from "@/lib/linting/mode-rule-configs";
+import { useInstalledRuleMetas } from "@/lib/editor-page/use-installed-rule-metas";
 import type { CorrectionModeId } from "@/lib/linting/correction-config";
 import { usePowerSaving } from "@/lib/editor-page/use-power-saving";
 import { useIgnoredCorrections } from "@/lib/editor-page/use-ignored-corrections";
@@ -182,6 +183,24 @@ export default function EditorPage() {
   } = settingsHandlers;
 
   const isElectron = typeof window !== "undefined" && isElectronRenderer();
+
+  // Rule metas of every installed external ruleset (all lint rules now live in
+  // external rulesets). The inspector's correction-mode dropdown derives its
+  // per-rule config map from these, mirroring the settings ModeSelector (#1817).
+  const loadedRules = useInstalledRuleMetas();
+
+  // After the external rulesets load, seed the rule config map for the current
+  // mode when nothing has been configured yet (fresh install, or a prior
+  // empty-config state left by the #1809/#1810 regression). Without this every
+  // rule stays disabled and nothing is detected until the user re-picks a mode.
+  // Guarded on an empty map so it never clobbers real user settings.
+  useEffect(() => {
+    if (loadedRules.length === 0) return;
+    if (Object.keys(lintingRuleConfigs).length > 0) return;
+    handleLintingRuleConfigsBatchChange(
+      buildModeRuleConfigsFromRules(correctionConfig.mode, loadedRules),
+    );
+  }, [loadedRules, lintingRuleConfigs, correctionConfig.mode, handleLintingRuleConfigsBatchChange]);
 
   // Derive a stable per-window key from the project root path (Electron project mode).
   // This key scopes tabs and dockview layout so multiple windows with different projects
@@ -1360,8 +1379,7 @@ export default function EditorPage() {
     onCorrectionModeChange: (modeId: CorrectionModeId) => {
       const mode = CORRECTION_MODES[modeId];
       handleCorrectionConfigChange({ mode: modeId, guidelines: [...mode.defaultGuidelines] });
-      const preset = LINT_PRESETS[MODE_TO_PRESET[modeId]];
-      if (preset) handleLintingRuleConfigsBatchChange({ ...preset.configs });
+      handleLintingRuleConfigsBatchChange(buildModeRuleConfigsFromRules(modeId, loadedRules));
     },
     switchToCorrectionsTrigger,
     previousDayStats,

--- a/lib/editor-page/__tests__/use-installed-rule-metas.test.ts
+++ b/lib/editor-page/__tests__/use-installed-rule-metas.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for loadInstalledRuleMetas — the rule-meta source feeding the inspector
+ * correction-mode dropdown (#1817 left the inspector path unwired).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { buildModeRuleConfigsFromRules } from "@/lib/linting/mode-rule-configs";
+
+// isElectronRenderer is mocked so the pure loader runs outside Electron.
+vi.mock("@/lib/utils/runtime-env", () => ({
+  isElectronRenderer: () => true,
+}));
+
+import { loadInstalledRuleMetas } from "../use-installed-rule-metas";
+
+interface FakeRulesetsApi {
+  listInstalled: ReturnType<typeof vi.fn>;
+  readModule: ReturnType<typeof vi.fn>;
+}
+
+function setRulesetsApi(api: FakeRulesetsApi | undefined): void {
+  (window as unknown as { electronAPI?: { rulesets?: FakeRulesetsApi } }).electronAPI = api
+    ? { rulesets: api }
+    : undefined;
+}
+
+afterEach(() => {
+  setRulesetsApi(undefined);
+  vi.restoreAllMocks();
+});
+
+describe("loadInstalledRuleMetas", () => {
+  beforeEach(() => setRulesetsApi(undefined));
+
+  it("returns [] when the rulesets API is unavailable", async () => {
+    expect(await loadInstalledRuleMetas()).toEqual([]);
+  });
+
+  it("flattens rules across all installed rulesets and keeps mode metadata", async () => {
+    setRulesetsApi({
+      listInstalled: vi.fn(async () => [
+        { id: "pack-a", version: "1.0.0", tag: null },
+        { id: "pack-b", version: "1.0.0", tag: null },
+      ]),
+      readModule: vi.fn(async (id: string) =>
+        id === "pack-a"
+          ? {
+              ok: true,
+              id,
+              tag: null,
+              code: "",
+              manifest: {
+                rules: [
+                  { ruleId: "a-1", applicableModes: ["novel"], defaultConfig: { severity: "error" } },
+                  { ruleId: "a-2", applicableModes: ["official"] },
+                ],
+              },
+            }
+          : {
+              ok: true,
+              id,
+              tag: null,
+              code: "",
+              manifest: { rules: [{ ruleId: "b-1", applicableModes: ["novel", "official"] }] },
+            },
+      ),
+    });
+
+    const metas = await loadInstalledRuleMetas();
+    expect(metas.map((m) => m.ruleId).sort()).toEqual(["a-1", "a-2", "b-1"]);
+
+    // The metas must drive buildModeRuleConfigsFromRules correctly (the actual fix).
+    const novel = buildModeRuleConfigsFromRules("novel", metas);
+    expect(novel["a-1"].enabled).toBe(true);
+    expect(novel["a-1"].severity).toBe("error");
+    expect(novel["a-2"].enabled).toBe(false);
+    expect(novel["b-1"].enabled).toBe(true);
+    // Complete map: switching to a mode disables non-member rules, not drops them.
+    expect(Object.keys(novel).sort()).toEqual(["a-1", "a-2", "b-1"]);
+  });
+
+  it("skips rulesets that failed to load and rules without a string ruleId", async () => {
+    setRulesetsApi({
+      listInstalled: vi.fn(async () => [
+        { id: "ok", version: "1.0.0", tag: null },
+        { id: "bad", version: "1.0.0", tag: null },
+      ]),
+      readModule: vi.fn(async (id: string) =>
+        id === "ok"
+          ? {
+              ok: true,
+              id,
+              tag: null,
+              code: "",
+              manifest: {
+                rules: [
+                  { ruleId: "ok-1", applicableModes: ["novel"] },
+                  { applicableModes: ["novel"] }, // malformed: no ruleId
+                ],
+              },
+            }
+          : { ok: false, id, reason: "verification failed" },
+      ),
+    });
+
+    const metas = await loadInstalledRuleMetas();
+    expect(metas.map((m) => m.ruleId)).toEqual(["ok-1"]);
+  });
+
+  it("returns [] (never throws) when the API rejects", async () => {
+    setRulesetsApi({
+      listInstalled: vi.fn(async () => {
+        throw new Error("ipc boom");
+      }),
+      readModule: vi.fn(),
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(await loadInstalledRuleMetas()).toEqual([]);
+  });
+});

--- a/lib/editor-page/__tests__/use-installed-rule-metas.test.ts
+++ b/lib/editor-page/__tests__/use-installed-rule-metas.test.ts
@@ -52,7 +52,11 @@ describe("loadInstalledRuleMetas", () => {
               code: "",
               manifest: {
                 rules: [
-                  { ruleId: "a-1", applicableModes: ["novel"], defaultConfig: { severity: "error" } },
+                  {
+                    ruleId: "a-1",
+                    applicableModes: ["novel"],
+                    defaultConfig: { severity: "error" },
+                  },
                   { ruleId: "a-2", applicableModes: ["official"] },
                 ],
               },

--- a/lib/editor-page/use-installed-rule-metas.ts
+++ b/lib/editor-page/use-installed-rule-metas.ts
@@ -1,0 +1,97 @@
+"use client";
+
+/**
+ * Loads the per-rule metadata (`ruleId` + `applicableModes` + `defaultConfig`)
+ * of every installed external ruleset for the editor page, so the inspector's
+ * correction-mode dropdown can derive the full per-rule config map on switch
+ * (see {@link buildModeRuleConfigsFromRules}).
+ *
+ * #1817 fixed the settings `ModeSelector` (which sources rules from
+ * `useRulesetStatus`), but the inspector dropdown lives in `app/page.tsx` and
+ * had no rule list, so switching modes there still wiped every rule to {}.
+ * This hook supplies that list. It deliberately does NOT call `checkUpdate`
+ * (no network) — it only reads the installed manifests already on disk.
+ *
+ * Electron only: the rulesets API is exposed by the desktop preload bridge.
+ * On Web there are no external rulesets, so this returns an empty array.
+ */
+
+import { useEffect, useState } from "react";
+
+import type { ModeRuleMetaInput } from "@/lib/linting/mode-rule-configs";
+import { isElectronRenderer } from "@/lib/utils/runtime-env";
+
+interface ManifestRule {
+  ruleId: string;
+  applicableModes?: string[];
+  defaultConfig?: { enabled?: boolean; severity?: string; skipDialogue?: boolean };
+}
+
+function getRulesetsAPI(): NonNullable<Window["electronAPI"]>["rulesets"] | undefined {
+  return (window as Window & { electronAPI?: Window["electronAPI"] }).electronAPI?.rulesets;
+}
+
+/**
+ * Read and flatten the rule metas of every installed external ruleset.
+ * Pure (no React) so it can be unit-tested and reused. Returns [] on Web or
+ * when the rulesets API is unavailable.
+ */
+export async function loadInstalledRuleMetas(): Promise<ModeRuleMetaInput[]> {
+  if (!isElectronRenderer()) return [];
+  const api = getRulesetsAPI();
+  if (!api) return [];
+  try {
+    const installed = await api.listInstalled();
+    const mods = await Promise.all(installed.map((r) => api.readModule(r.id)));
+    const out: ModeRuleMetaInput[] = [];
+    for (const mod of mods) {
+      if (!mod || !mod.ok) continue;
+      const manifest = mod.manifest as { rules?: ManifestRule[] };
+      for (const rule of manifest.rules ?? []) {
+        if (!rule || typeof rule.ruleId !== "string") continue;
+        out.push({
+          ruleId: rule.ruleId,
+          applicableModes: rule.applicableModes,
+          defaultConfig: rule.defaultConfig,
+        });
+      }
+    }
+    return out;
+  } catch (err) {
+    console.error("[useInstalledRuleMetas] failed to load rule metas", err);
+    return [];
+  }
+}
+
+/**
+ * Returns the flattened rule metas of every installed external ruleset,
+ * refreshing when packs are installed/updated/uninstalled.
+ */
+export function useInstalledRuleMetas(): ModeRuleMetaInput[] {
+  const isElectron = isElectronRenderer();
+  const [metas, setMetas] = useState<ModeRuleMetaInput[]>([]);
+
+  // Initial load on mount.
+  useEffect(() => {
+    let cancelled = false;
+    loadInstalledRuleMetas().then((next) => {
+      if (!cancelled) setMetas(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Reload when the installed ruleset set changes.
+  useEffect(() => {
+    if (!isElectron) return;
+    const api = getRulesetsAPI();
+    if (!api) return;
+    const unsubscribe = api.onChanged(() => {
+      loadInstalledRuleMetas().then(setMetas);
+    });
+    return unsubscribe;
+  }, [isElectron]);
+
+  return metas;
+}


### PR DESCRIPTION
## 概要
#1817 で校正モード切替の退行を修正したが、**インスペクタのモード `<select>`（ユーザーが実際に使う UI）と空 config の初期化が未対応**だったため、依然として検出0件が再現していた。その残課題を dev の方式（`buildModeRuleConfigsFromRules`）に乗せて補完する。

## #1817 の残り欠落
1. `app/page.tsx` の `onCorrectionModeChange`（インスペクタの「小説」ドロップダウン）は死蔵の `LINT_PRESETS[*].configs`（空 `{}`）を送ったままで、切り替えると全ルールを空で上書き → 検出0件
2. 既に空 config 化されたユーザー（本不具合の被害者）は再読込しても 0件のまま（初期化経路なし）

## 修正
- `useInstalledRuleMetas` / `loadInstalledRuleMetas`：インストール済み外部ルールセットの manifest からルールメタ（`ruleId`/`applicableModes`/`defaultConfig`）を取得。`checkUpdate` を呼ばずネットワーク不使用（常時マウントされるページ向け）
- インスペクタの `onCorrectionModeChange` を `buildModeRuleConfigsFromRules` に配線（#1817 の設定 ModeSelector と同一ロジック）
- `lintingRuleConfigs` が空のとき、現モードのルールマップで自動初期化（**空のときのみ**＝既存ユーザー設定は非破壊）
- `loadInstalledRuleMetas` のユニットテスト追加（flatten / 失敗ルールセットskip / 例外時 [] / mode マップ生成）

## 検証（自動・手動テスト不要）
- `npx tsc --noEmit`：pass
- `npx eslint`（変更ファイル）：0 errors / 0 warnings
- `npm run check:boundaries`：valid
- `npx vitest run`：**1877 passed / 159 files**

関連 issue なし