### PR TITLE
fix(linting): 既存インストールの全ON config を起動時に現モードへ一度だけ移行

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,6 +45,7 @@ import { useLinting } from "@/lib/editor-page/use-linting";
 import { CORRECTION_MODES } from "@/lib/linting/correction-modes";
 import { buildModeRuleConfigsFromRules } from "@/lib/linting/mode-rule-configs";
 import { useInstalledRuleMetas } from "@/lib/editor-page/use-installed-rule-metas";
+import { useModeConfigMigration } from "@/lib/editor-page/use-mode-config-migration";
 import type { CorrectionModeId } from "@/lib/linting/correction-config";
 import { usePowerSaving } from "@/lib/editor-page/use-power-saving";
 import { useIgnoredCorrections } from "@/lib/editor-page/use-ignored-corrections";
@@ -139,6 +140,7 @@ export default function EditorPage() {
     settings,
     handlers: settingsHandlers,
     setters: settingsSetters,
+    settingsHydrated,
   } = useEditorSettings(incrementEditorKey);
   const {
     fontScale,
@@ -156,6 +158,7 @@ export default function EditorPage() {
     showSettingsModal,
     lintingEnabled,
     lintingRuleConfigs,
+    lintingModeConfigVersion,
     powerSaveMode,
     autoPowerSaveOnBattery,
     correctionConfig,
@@ -177,6 +180,7 @@ export default function EditorPage() {
     handleLintingEnabledChange,
     handleLintingRuleConfigChange,
     handleLintingRuleConfigsBatchChange,
+    handleLintingModeConfigVersionChange,
     handlePowerSaveModeChange,
     handleAutoPowerSaveOnBatteryChange,
     handleCorrectionConfigChange,
@@ -189,18 +193,20 @@ export default function EditorPage() {
   // per-rule config map from these, mirroring the settings ModeSelector (#1817).
   const loadedRules = useInstalledRuleMetas();
 
-  // After the external rulesets load, seed the rule config map for the current
-  // mode when nothing has been configured yet (fresh install, or a prior
-  // empty-config state left by the #1809/#1810 regression). Without this every
-  // rule stays disabled and nothing is detected until the user re-picks a mode.
-  // Guarded on an empty map so it never clobbers real user settings.
-  useEffect(() => {
-    if (loadedRules.length === 0) return;
-    if (Object.keys(lintingRuleConfigs).length > 0) return;
-    handleLintingRuleConfigsBatchChange(
-      buildModeRuleConfigsFromRules(correctionConfig.mode, loadedRules),
-    );
-  }, [loadedRules, lintingRuleConfigs, correctionConfig.mode, handleLintingRuleConfigsBatchChange]);
+  // One-time recovery: re-derive the rule-config map from the current mode for
+  // installs whose persisted config predates mode-aware derivation (fresh
+  // installs with an empty map, AND existing users left with a COMPLETE
+  // all-enabled map by the #1809/#1810 regression + "すべて有効"). Gated by a
+  // persisted version so it runs exactly once and never clobbers later manual
+  // edits. See use-mode-config-migration.ts.
+  useModeConfigMigration({
+    hydrated: settingsHydrated,
+    loadedRules,
+    currentMode: correctionConfig.mode,
+    configVersion: lintingModeConfigVersion,
+    applyConfigs: handleLintingRuleConfigsBatchChange,
+    setConfigVersion: handleLintingModeConfigVersionChange,
+  });
 
   // Derive a stable per-window key from the project root path (Electron project mode).
   // This key scopes tabs and dockview layout so multiple windows with different projects

--- a/lib/editor-page/__tests__/use-mode-config-migration.test.ts
+++ b/lib/editor-page/__tests__/use-mode-config-migration.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the one-time mode-config migration decision + derivation.
+ *
+ * The migration recovers installs whose persisted `lintingRuleConfigs` predates
+ * mode-aware derivation — notably existing users left with a COMPLETE
+ * all-enabled map (the #1809/#1810 regression + "すべて有効"), which the
+ * empty-config seed could not fix because no key was missing.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  MODE_CONFIG_MIGRATION_VERSION,
+  shouldRunModeConfigMigration,
+} from "../use-mode-config-migration";
+import { buildModeRuleConfigsFromRules } from "@/lib/linting/mode-rule-configs";
+import type { ModeRuleMetaInput } from "@/lib/linting/mode-rule-configs";
+
+describe("shouldRunModeConfigMigration", () => {
+  it("does not run before settings are hydrated", () => {
+    expect(shouldRunModeConfigMigration(false, 10, 0)).toBe(false);
+    expect(shouldRunModeConfigMigration(false, 10, undefined)).toBe(false);
+  });
+
+  it("does not run before any rules are loaded (Web / pre-load)", () => {
+    expect(shouldRunModeConfigMigration(true, 0, 0)).toBe(false);
+    expect(shouldRunModeConfigMigration(true, 0, undefined)).toBe(false);
+  });
+
+  it("runs when hydrated, rules loaded, and version is behind (0 / undefined)", () => {
+    expect(shouldRunModeConfigMigration(true, 1, 0)).toBe(true);
+    expect(shouldRunModeConfigMigration(true, 5, undefined)).toBe(true);
+  });
+
+  it("does not run again once the stored version has caught up", () => {
+    expect(shouldRunModeConfigMigration(true, 5, MODE_CONFIG_MIGRATION_VERSION)).toBe(false);
+    expect(shouldRunModeConfigMigration(true, 5, MODE_CONFIG_MIGRATION_VERSION + 1)).toBe(false);
+  });
+});
+
+describe("migration derivation (what the hook applies on run)", () => {
+  // A COMPLETE all-enabled map across two rulesets, mirroring the real-world
+  // regression artifact the migration must repair.
+  const rules: ModeRuleMetaInput[] = [
+    { ruleId: "gk-yotsugana", applicableModes: ["novel", "official", "blog", "academic", "sns"] },
+    { ruleId: "geh-katakana-trailing-choon", applicableModes: ["official", "blog", "academic"] },
+    { ruleId: "geh-gaisuu-arabic", applicableModes: ["official", "blog", "academic"] },
+  ];
+
+  it("re-derives a complete map that actually filters by the current mode", () => {
+    // Pretend the stored state was every rule enabled (regression artifact).
+    const novel = buildModeRuleConfigsFromRules("novel", rules);
+    // Full coverage: no rule dropped, so the replace contract holds.
+    expect(Object.keys(novel).sort()).toEqual([
+      "geh-gaisuu-arabic",
+      "geh-katakana-trailing-choon",
+      "gk-yotsugana",
+    ]);
+    // Novel keeps the correctness rule, disables the style-only rules.
+    expect(novel["gk-yotsugana"].enabled).toBe(true);
+    expect(novel["geh-katakana-trailing-choon"].enabled).toBe(false);
+    expect(novel["geh-gaisuu-arabic"].enabled).toBe(false);
+  });
+
+  it("derives a different result for a different mode (official enables style rules)", () => {
+    const official = buildModeRuleConfigsFromRules("official", rules);
+    expect(official["gk-yotsugana"].enabled).toBe(true);
+    expect(official["geh-katakana-trailing-choon"].enabled).toBe(true);
+    expect(official["geh-gaisuu-arabic"].enabled).toBe(true);
+  });
+});

--- a/lib/editor-page/use-ai-settings.ts
+++ b/lib/editor-page/use-ai-settings.ts
@@ -14,6 +14,8 @@ import { CORRECTION_MODES } from "@/lib/linting/correction-modes";
 export interface AiSettings {
   lintingEnabled: boolean;
   lintingRuleConfigs: Record<string, { enabled: boolean; severity: Severity }>;
+  /** One-time mode-config migration marker (see use-mode-config-migration.ts). */
+  lintingModeConfigVersion: number;
   characterExtractionBatchSize: number;
   characterExtractionConcurrency: number;
   powerSaveMode: boolean;
@@ -36,6 +38,8 @@ export interface AiSettingsHandlers {
   handleLintingRuleConfigsBatchChange: (
     configs: Record<string, { enabled: boolean; severity: Severity }>,
   ) => void;
+  /** Persist the one-time mode-config migration version. */
+  handleLintingModeConfigVersionChange: (version: number) => void;
   handleCharacterExtractionBatchSizeChange: (value: number) => void;
   handleCharacterExtractionConcurrencyChange: (value: number) => void;
   handlePowerSaveModeChange: (enabled: boolean) => Promise<void>;
@@ -69,6 +73,7 @@ export function useAiSettings(): UseAiSettingsResult {
   const [lintingRuleConfigs, setLintingRuleConfigs] = useState<
     Record<string, { enabled: boolean; severity: Severity }>
   >({});
+  const [lintingModeConfigVersion, setLintingModeConfigVersion] = useState(0);
   const [characterExtractionBatchSize, setCharacterExtractionBatchSize] = useState(3);
   const [characterExtractionConcurrency, setCharacterExtractionConcurrency] = useState(4);
   const [powerSaveMode, setPowerSaveMode] = useState(false);
@@ -121,6 +126,10 @@ export function useAiSettings(): UseAiSettingsResult {
         }
       }
       setLintingRuleConfigs(sanitized);
+    }
+
+    if (typeof appState.lintingModeConfigVersion === "number") {
+      setLintingModeConfigVersion(appState.lintingModeConfigVersion);
     }
 
     if (appState.powerSaveMode !== undefined) setPowerSaveMode(appState.powerSaveMode as boolean);
@@ -247,6 +256,13 @@ export function useAiSettings(): UseAiSettingsResult {
     [],
   );
 
+  const handleLintingModeConfigVersionChange = useCallback((version: number) => {
+    setLintingModeConfigVersion(version);
+    void persistAppState({ lintingModeConfigVersion: version }).catch((e) =>
+      console.error("Failed to persist lintingModeConfigVersion:", e),
+    );
+  }, []);
+
   const clearTempPowerSaveTimer = useCallback(() => {
     if (tempPowerSaveTimerRef.current !== null) {
       clearTimeout(tempPowerSaveTimerRef.current);
@@ -351,6 +367,7 @@ export function useAiSettings(): UseAiSettingsResult {
     aiSettings: {
       lintingEnabled,
       lintingRuleConfigs,
+      lintingModeConfigVersion,
       characterExtractionBatchSize,
       characterExtractionConcurrency,
       powerSaveMode,
@@ -369,6 +386,7 @@ export function useAiSettings(): UseAiSettingsResult {
       handleLintingEnabledChange,
       handleLintingRuleConfigChange,
       handleLintingRuleConfigsBatchChange,
+      handleLintingModeConfigVersionChange,
       handleCharacterExtractionBatchSizeChange,
       handleCharacterExtractionConcurrencyChange,
       handlePowerSaveModeChange,

--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { fetchAppState } from "@/lib/storage/app-state-manager";
 
@@ -54,6 +54,8 @@ export interface UseEditorSettingsResult {
   settings: EditorSettings;
   handlers: EditorSettingsHandlers;
   setters: EditorSettingsSetters;
+  /** True once persisted app state has been loaded into the sub-hooks. */
+  settingsHydrated: boolean;
 }
 
 /**
@@ -71,6 +73,12 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
   const { dictSettings, dictHandlers, applyPersistedDictSettings } = useDictSettings();
   const { updateSettings, updateHandlers, applyPersistedUpdateSettings } = useUpdateSettings();
 
+  // Flips true once persisted state has been applied, so downstream effects
+  // (e.g. the mode-config migration) can wait for the real values instead of
+  // acting on the initial defaults. Set even when there is no stored app state,
+  // since "nothing persisted" is itself a fully-resolved hydration outcome.
+  const [settingsHydrated, setSettingsHydrated] = useState(false);
+
   // Load persisted settings on mount
   useEffect(() => {
     let mounted = true;
@@ -78,17 +86,21 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
     const loadSettings = async () => {
       try {
         const appState = await fetchAppState();
-        if (!mounted || !appState) return;
+        if (!mounted) return;
 
-        applyPersistedDisplaySettings(appState as Record<string, unknown>);
-        applyPersistedAiSettings(appState as Record<string, unknown>);
-        applyPersistedDictSettings(appState as Record<string, unknown>);
-        applyPersistedUpdateSettings(appState as Record<string, unknown>);
+        if (appState) {
+          applyPersistedDisplaySettings(appState as Record<string, unknown>);
+          applyPersistedAiSettings(appState as Record<string, unknown>);
+          applyPersistedDictSettings(appState as Record<string, unknown>);
+          applyPersistedUpdateSettings(appState as Record<string, unknown>);
 
-        // Force editor rebuild to apply restored settings (e.g. custom font)
-        incrementEditorKey();
+          // Force editor rebuild to apply restored settings (e.g. custom font)
+          incrementEditorKey();
+        }
       } catch (error) {
         console.error("Failed to load settings:", error);
+      } finally {
+        if (mounted) setSettingsHydrated(true);
       }
     };
 
@@ -111,6 +123,7 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
     handleLintingEnabledChange: aiHandlers.handleLintingEnabledChange,
     handleLintingRuleConfigChange: aiHandlers.handleLintingRuleConfigChange,
     handleLintingRuleConfigsBatchChange: aiHandlers.handleLintingRuleConfigsBatchChange,
+    handleLintingModeConfigVersionChange: aiHandlers.handleLintingModeConfigVersionChange,
     handleCharacterExtractionBatchSizeChange: aiHandlers.handleCharacterExtractionBatchSizeChange,
     handleCharacterExtractionConcurrencyChange:
       aiHandlers.handleCharacterExtractionConcurrencyChange,
@@ -132,5 +145,6 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
     settings,
     handlers,
     setters: displaySetters,
+    settingsHydrated,
   };
 }

--- a/lib/editor-page/use-mode-config-migration.ts
+++ b/lib/editor-page/use-mode-config-migration.ts
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * One-time recovery of `lintingRuleConfigs` for installs whose persisted config
+ * predates mode-aware rule derivation.
+ *
+ * Background: the #1809/#1810 regression zeroed the built-in rule tables, and the
+ * "すべて有効" bulk toggle / broken mode switch left existing users with a
+ * COMPLETE all-enabled config map under the new external rule IDs. Neither the
+ * empty-config seed (#1818) nor a fill-missing pass can correct that — no key is
+ * missing, so on launch every rule stays enabled in every mode until the user
+ * re-picks a mode by hand.
+ *
+ * This migration re-derives the config from the *current* mode exactly once,
+ * gated by a persisted version, so the selected mode actually filters rules on
+ * the next launch without any manual action. It also covers fresh installs
+ * (empty config → seeded from mode).
+ *
+ * Deliberately a full replace (not merge): for these installs the stored map is
+ * a regression artifact, not curated per-rule state. After the version is
+ * bumped it never runs again, so later manual per-rule edits persist normally.
+ */
+
+import { useEffect } from "react";
+
+import type { CorrectionModeId } from "@/lib/linting/correction-config";
+import {
+  buildModeRuleConfigsFromRules,
+  type ModeRuleMetaInput,
+} from "@/lib/linting/mode-rule-configs";
+import type { Severity } from "@/lib/linting/types";
+
+/**
+ * Bump when the mode→config derivation changes in a way that warrants
+ * re-applying to existing installs.
+ * - v1: initial regression recovery (#1818 follow-up).
+ */
+export const MODE_CONFIG_MIGRATION_VERSION = 1;
+
+/**
+ * Pure guard so the run decision can be unit-tested without React. Migrate only
+ * once settings are hydrated (so the real persisted mode/version are known),
+ * rules are loaded (so the derived map is non-empty), and the stored version is
+ * behind the current one.
+ */
+export function shouldRunModeConfigMigration(
+  hydrated: boolean,
+  loadedRulesCount: number,
+  configVersion: number | undefined,
+): boolean {
+  return hydrated && loadedRulesCount > 0 && (configVersion ?? 0) < MODE_CONFIG_MIGRATION_VERSION;
+}
+
+export interface ModeConfigMigrationParams {
+  /** True once persisted app state has been loaded into the settings hooks. */
+  hydrated: boolean;
+  /** Rule metas of every installed ruleset (empty on Web / before load). */
+  loadedRules: readonly ModeRuleMetaInput[];
+  /** The current correction mode (already hydrated). */
+  currentMode: CorrectionModeId;
+  /** Persisted migration version (undefined / 0 = never migrated). */
+  configVersion: number | undefined;
+  /** Replace the whole rule-config map (handleLintingRuleConfigsBatchChange). */
+  applyConfigs: (
+    configs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>,
+  ) => void;
+  /** Persist the new migration version. */
+  setConfigVersion: (version: number) => void;
+}
+
+/**
+ * Runs {@link shouldRunModeConfigMigration} as an effect; when it fires, derives
+ * the per-rule config for the current mode and bumps the stored version.
+ */
+export function useModeConfigMigration(params: ModeConfigMigrationParams): void {
+  const { hydrated, loadedRules, currentMode, configVersion, applyConfigs, setConfigVersion } =
+    params;
+
+  useEffect(() => {
+    if (!shouldRunModeConfigMigration(hydrated, loadedRules.length, configVersion)) return;
+    applyConfigs(buildModeRuleConfigsFromRules(currentMode, loadedRules));
+    setConfigVersion(MODE_CONFIG_MIGRATION_VERSION);
+  }, [hydrated, loadedRules, currentMode, configVersion, applyConfigs, setConfigVersion]);
+}

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -82,6 +82,11 @@ export interface AppState {
     string,
     { enabled: boolean; severity: Severity; skipDialogue?: boolean }
   >;
+  /**
+   * One-time migration marker for mode-derived rule config recovery.
+   * undefined / 0 = never migrated. See `use-mode-config-migration.ts`.
+   */
+  lintingModeConfigVersion?: number;
 
   // オンラインAI API設定
   aiApiKey?: string;


### PR DESCRIPTION
## 背景

`#1817` / `#1818` で校正モード切替（Settings の ModeSelector・Inspector の CorrectionsPanel 両入口）は修正済み。しかし **既存インストールの起動時** に残る穴があった。

実機の永続化データを確認したところ：
- `correctionMode: official`
- `lintingRuleConfigs`: **69 ルールすべて enabled**（新外部ルール ID）

これは退行（`#1809`/`#1810` 内蔵ルールゼロ化）＋「すべて有効」操作で **完全な全 ON マップ** が永続化された状態。`#1818` の seed は **config が空のときだけ** 発火するため、このケースには効かず、**起動後にモードを手動で押し直すまで全モードで全ルールが有効なまま** になっていた（`buildModeRuleConfigsFromRules` の fill 系も「欠落ルールを埋める」だけなので 69 件すべて存在するこのケースは救えない）。

## 修正

永続バージョン `lintingModeConfigVersion` をゲートに、**一度だけ** 現モードから config を再導出する移行を追加。

- `lib/editor-page/use-mode-config-migration.ts`（新規）: 純関数 `shouldRunModeConfigMigration` + hook `useModeConfigMigration`
- ハイドレーション完了（`settingsHydrated`）後・ルールロード後にのみ実行 → 永続モード/バージョンを正しく参照
- **full replace**（退行アーティファクトを正規化）。移行後はバージョンが進むため二度と走らず、以降の手動編集は保持
- 空 config の新規インストールも同経路で seed（`#1818` の空 seed effect を置換）

### 変更ファイル
- `use-ai-settings.ts`: `lintingModeConfigVersion` 状態・永続化・ハンドラ
- `use-editor-settings.ts`: `settingsHydrated` を公開（hydration 完了シグナル）
- `app/page.tsx`: 空 seed effect → 移行 hook
- `storage-types.ts`: `lintingModeConfigVersion` キー

## テスト
- 判定ガード網羅（hydrated/rules/version の各分岐）＋ モード別導出（novel は style ルール無効・official は有効）
- ローカル: tsc ✅ / eslint ✅ / 全 1883 テスト ✅ / prettier ✅（本番ビルドは worktree の symlink node_modules を Turbopack が拒否するためローカル不可 → CI の Build ジョブで検証）

関連 issue なし（`#1817`/`#1818` の残課題）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)