### PR TITLE
fix(search): 検索パネル5バグ修正 (#1820-#1824)

### DIFF
--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -575,8 +575,11 @@ export default function SearchResults({
             <OptionCheckbox
               label="選択範囲のみ"
               checked={selectionOnly}
-              onChange={onSelectionOnlyChange}
-              disabled={!hasSelection || scope !== "current"}
+              onChange={(checked) => {
+                if (checked && scope !== "current") setScope("current");
+                onSelectionOnlyChange(checked);
+              }}
+              disabled={!hasSelection}
             />
             {projectSearchEnabled && (
               <label className="flex items-center justify-between gap-2">

--- a/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
+++ b/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
@@ -117,7 +117,6 @@ describe("findSearchMatches enhanced search", () => {
     const oldForm = findSearchMatches(source, "旧体", { normalizeVariants: true });
     const expanded = findSearchMatches(source, "平成", { normalizeVariants: true });
 
-
     expect(kana[0].text).toBe("カタカナ");
     expect(width[0].text).toBe("ＡＢＣ");
     expect(halfWidthKana[0].text).toBe("ｶﾞ");

--- a/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
+++ b/lib/editor-page/__tests__/find-search-matches-enhanced.test.ts
@@ -22,10 +22,12 @@ const schema = new Schema({
       content: "inline*",
       toDOM: () => ["p", 0] as [string, number],
     },
+    // Production schema: content:"inline*" (textblock), NOT atom.
+    // Matches packages/milkdown-plugin-japanese-novel/nodes/blank-paragraph.ts.
     blankParagraph: {
       group: "block",
-      atom: true,
-      toDOM: () => ["p"],
+      content: "inline*",
+      toDOM: () => ["p", { class: "mdi-blank" }, 0] as [string, Record<string, string>, number],
     },
     text: { group: "inline" },
     hardbreak: {
@@ -34,6 +36,14 @@ const schema = new Schema({
       selectable: false,
       leafText: () => "\n",
       toDOM: () => ["br"],
+    },
+    // Milkdown preset-commonmark html inline atom (stores raw HTML including <!-- --> comments).
+    html: {
+      group: "inline",
+      inline: true,
+      atom: true,
+      attrs: { value: { default: "" } },
+      toDOM: () => ["span"] as [string],
     },
     ruby: atomNode({ base: { default: "" }, text: { default: "" } }, "ruby"),
     tcy: atomNode({ value: { default: "" } }, "span"),
@@ -107,12 +117,22 @@ describe("findSearchMatches enhanced search", () => {
     const oldForm = findSearchMatches(source, "旧体", { normalizeVariants: true });
     const expanded = findSearchMatches(source, "平成", { normalizeVariants: true });
 
+
     expect(kana[0].text).toBe("カタカナ");
     expect(width[0].text).toBe("ＡＢＣ");
     expect(halfWidthKana[0].text).toBe("ｶﾞ");
     expect(oldForm[0].text).toBe("舊體");
     expect(expanded[0].text).toBe("㍻");
     expect(expanded[0].to - expanded[0].from).toBe(1);
+  });
+
+  it("equates IVS variant 髙 (U+9AD9) with 高 (U+9AD8) when normalizeVariants is on (#1821)", () => {
+    const source = doc(paragraph(schema.text("髙橋さんと高田さん")));
+
+    const matches = findSearchMatches(source, "高", { normalizeVariants: true });
+    expect(matches).toHaveLength(2);
+    expect(matches[0].text).toBe("髙");
+    expect(matches[1].text).toBe("高");
   });
 
   it("searches ruby base and reading without making either directly replaceable", () => {
@@ -150,6 +170,49 @@ describe("findSearchMatches enhanced search", () => {
     expect(findSearchMatches(source, "12", {})).toHaveLength(1);
     expect(findSearchMatches(source, "0.5em", {})).toEqual([]);
     expect(findSearchMatches(source, "blank", {})).toEqual([]);
+  });
+
+  it("does not count blankParagraph in paragraphNumber to match UI counter (#1823)", () => {
+    const source = doc(
+      paragraph(schema.text("段落A")),
+      schema.node("blankParagraph"),
+      paragraph(schema.text("段落B")),
+    );
+
+    // 「段落」は両段落にヒットするが、blankParagraph は段落番号を消費しない。
+    const matches = findSearchMatches(source, "段落", {});
+    expect(matches).toHaveLength(2);
+    expect(matches[0]).toMatchObject({ paragraphNumber: 1 });
+    expect(matches[1]).toMatchObject({ paragraphNumber: 2 });
+
+    // blankParagraph に検索語が存在しても段落番号は加算されない（空白行は番号なし）。
+    const source2 = doc(
+      paragraph(schema.text("前")),
+      schema.node("blankParagraph", null, [schema.text("blank内")]),
+      paragraph(schema.text("後")),
+    );
+    const matches2 = findSearchMatches(source2, "後", {});
+    expect(matches2[0]).toMatchObject({ paragraphNumber: 2 });
+  });
+
+  it("includes html comment node content when excludeComments is false (#1822)", () => {
+    const source = doc(
+      paragraph(
+        schema.text("前"),
+        schema.node("html", { value: "<!-- 注釈 -->" }),
+        schema.text("後"),
+      ),
+    );
+
+    // デフォルト（excludeComments: true）ではコメント内にマッチしない
+    expect(findSearchMatches(source, "注釈", {})).toHaveLength(0);
+    // excludeComments: false でコメント内もマッチする
+    const matches = findSearchMatches(source, "注釈", { excludeComments: false });
+    expect(matches).toMatchObject([{ source: "comment", replaceable: false }]);
+    // 通常の html ノード（コメントでない）はコメント扱いしない
+    expect(findSearchMatches(source, "前", { excludeComments: false })).toMatchObject([
+      { source: "text", replaceable: true },
+    ]);
   });
 
   it("finds text spanning an atom with exact ProseMirror bounds and blocks replacement", () => {

--- a/lib/editor-page/__tests__/project-search-worker-client.test.ts
+++ b/lib/editor-page/__tests__/project-search-worker-client.test.ts
@@ -59,17 +59,24 @@ describe("ProjectSearchWorkerClient", () => {
     await expect(pending).rejects.toThrow("disposed");
   });
 
-  it("poisons the client after a worker crash", async () => {
+  it("falls back to synchronous matching after a worker crash", async () => {
     const worker = new FakeWorker();
     const client = new ProjectSearchWorkerClient(() => worker as unknown as Worker);
     const pending = client.matchDocument("first", ".mdi", "first", {});
 
-    worker.onerror?.(new ErrorEvent("error", { message: "worker crashed" }));
+    // Worker が起動失敗した際は保留中リクエストを同期で履行し、以降も同期モードへ移行する。
+    worker.onerror?.(new ErrorEvent("error", { message: "worker failed to load" }));
 
-    await expect(pending).rejects.toThrow("worker crashed");
+    // pending request is fulfilled synchronously via findRawDocumentMatches
+    await expect(pending).resolves.toMatchObject({
+      matches: [expect.objectContaining({ source: "text", rawFrom: 0, rawTo: 5 })],
+    });
+    // subsequent requests also resolve synchronously without using the worker
     const afterCrash = client.matchDocument("second", ".mdi", "second", {});
     expect(worker.received).toHaveLength(1);
-    await expect(afterCrash).rejects.toThrow("worker crashed");
+    await expect(afterCrash).resolves.toMatchObject({
+      matches: [expect.objectContaining({ source: "text", rawFrom: 0, rawTo: 6 })],
+    });
     expect(worker.terminated).toBe(true);
   });
 });

--- a/lib/editor-page/find-search-matches.ts
+++ b/lib/editor-page/find-search-matches.ts
@@ -113,7 +113,10 @@ export function findSearchMatches(
     if (!node.isTextblock) return;
 
     const isHeading = node.type.name === "heading";
-    if (!isHeading) paragraphNumber += 1;
+    // blankParagraph (MDI [[blank]]) は CSS counter-increment: paragraph から除外
+    // されているため、UI 側の段落番号と一致させるためここでも数えない。
+    const isBlankParagraph = node.type.name === "blankParagraph";
+    if (!isHeading && !isBlankParagraph) paragraphNumber += 1;
 
     const bodyProjection = createBodyProjection(node, pos + 1, options.excludeComments);
     const metadata = {
@@ -239,9 +242,19 @@ function createBodyProjection(
 }
 
 function getCommentText(node: Node): string | null {
-  if (node.type.name !== "comment" && node.type.name !== "htmlComment") return null;
-  const value = node.attrs.value ?? node.attrs.text ?? node.textContent;
-  return typeof value === "string" ? value.replace(/^<!--\s*|\s*-->$/g, "") : "";
+  if (node.type.name === "comment" || node.type.name === "htmlComment") {
+    const value = node.attrs.value ?? node.attrs.text ?? node.textContent;
+    return typeof value === "string" ? value.replace(/^<!--\s*|\s*-->$/g, "") : "";
+  }
+  // Milkdown の commonmark preset は HTML 構文（<!-- ... --> を含む）を
+  // attrs.value に生テキストを持つ "html" inline atom ノードとして格納する。
+  if (node.type.name === "html") {
+    const raw = typeof node.attrs.value === "string" ? (node.attrs.value as string).trim() : "";
+    if (/^<!--[\s\S]*-->$/.test(raw)) {
+      return raw.replace(/^<!--\s*|\s*-->$/g, "");
+    }
+  }
+  return null;
 }
 
 function createRubyReadingProjections(

--- a/lib/editor-page/japanese-variant-normalization.ts
+++ b/lib/editor-page/japanese-variant-normalization.ts
@@ -10,6 +10,11 @@ const SHINJITAI_BY_KYUJITAI = new Map(
     .map(([shinjitai, kyujitai]) => [kyujitai, shinjitai] as const),
 );
 
+// CJK variant characters absent from the kyujitai package that nonetheless
+// appear in Japanese text and should be equated in fuzzy search.
+// 髙 (U+9AD9) is a common alternate form of 高 (U+9AD8) used in personal names.
+const EXTRA_VARIANTS: ReadonlyMap<string, string> = new Map([["髙", "高"]]);
+
 /**
  * Normalizes width, kana script, and old character forms for search comparison.
  * The kyujitai table is maintained by the `kyujitai` package rather than in
@@ -24,7 +29,8 @@ export function normalizeJapaneseSearchVariants(text: string): string {
       codePoint >= 0x30a1 && codePoint <= 0x30f6
         ? String.fromCodePoint(codePoint - 0x60)
         : character;
-    normalized += SHINJITAI_BY_KYUJITAI.get(kana) ?? kana;
+    const mapped = SHINJITAI_BY_KYUJITAI.get(kana) ?? EXTRA_VARIANTS.get(kana) ?? kana;
+    normalized += mapped;
   }
 
   return normalized;

--- a/lib/editor-page/project-search-worker-client.ts
+++ b/lib/editor-page/project-search-worker-client.ts
@@ -1,4 +1,5 @@
 import type { SearchOptions } from "./find-search-matches";
+import { findRawDocumentMatches } from "./project-search";
 import type { ProjectDocumentMatcher, RawDocumentSearchResult } from "./project-search";
 
 export interface ProjectSearchWorkerRequest {
@@ -28,6 +29,10 @@ const defaultWorkerFactory: ProjectSearchWorkerFactory = () =>
   new Worker(new URL("./project-search.worker.ts", import.meta.url), { type: "module" });
 
 interface PendingMatch {
+  content: string;
+  fileType: string;
+  searchTerm: string;
+  options: SearchOptions;
   resolve: (result: RawDocumentSearchResult) => void;
   reject: (error: Error) => void;
 }
@@ -37,15 +42,18 @@ export class ProjectSearchWorkerClient {
   private readonly pending = new Map<number, PendingMatch>();
   private nextId = 1;
   private disposed = false;
-  private fatalError: Error | null = null;
+  private useFallback = false;
 
   readonly matchDocument: ProjectDocumentMatcher = (content, fileType, searchTerm, options) => {
-    if (this.fatalError) return Promise.reject(this.fatalError);
+    // Worker が起動失敗した場合はメインスレッドの同期実装で処理する。
+    if (this.useFallback) {
+      return Promise.resolve(findRawDocumentMatches(content, fileType, searchTerm, options));
+    }
     if (this.disposed) return Promise.reject(new Error("Project search worker is disposed"));
 
     const id = this.nextId++;
     const result = new Promise<RawDocumentSearchResult>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
+      this.pending.set(id, { content, fileType, searchTerm, options, resolve, reject });
     });
     this.worker.postMessage({
       type: "MATCH_DOCUMENT",
@@ -75,28 +83,34 @@ export class ProjectSearchWorkerClient {
       error.name = message.error.name;
       pending.reject(error);
     };
-    this.worker.onerror = (event) => {
-      this.poison(new Error(event.message || "Project search worker failed"));
+    this.worker.onerror = () => {
+      // Worker URL の解決失敗（Electron パッケージ版など）を検知したら同期モードへ切替。
+      // 保留中のリクエストはメインスレッドで同期実行して履行する。
+      this.useFallback = true;
+      this.worker.terminate();
+      const snapshot = new Map(this.pending);
+      this.pending.clear();
+      for (const [, item] of snapshot) {
+        try {
+          item.resolve(findRawDocumentMatches(item.content, item.fileType, item.searchTerm, item.options));
+        } catch (error) {
+          item.reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      }
     };
   }
 
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    this.rejectAll(new Error("Project search worker is disposed"));
-    this.worker.terminate();
+    if (!this.useFallback) {
+      this.rejectAll(new Error("Project search worker is disposed"));
+      this.worker.terminate();
+    }
   }
 
   private rejectAll(error: Error): void {
     for (const pending of this.pending.values()) pending.reject(error);
     this.pending.clear();
-  }
-
-  private poison(error: Error): void {
-    if (this.fatalError) return;
-    this.fatalError = error;
-    this.disposed = true;
-    this.rejectAll(error);
-    this.worker.terminate();
   }
 }

--- a/lib/editor-page/project-search-worker-client.ts
+++ b/lib/editor-page/project-search-worker-client.ts
@@ -92,7 +92,9 @@ export class ProjectSearchWorkerClient {
       this.pending.clear();
       for (const [, item] of snapshot) {
         try {
-          item.resolve(findRawDocumentMatches(item.content, item.fileType, item.searchTerm, item.options));
+          item.resolve(
+            findRawDocumentMatches(item.content, item.fileType, item.searchTerm, item.options),
+          );
         } catch (error) {
           item.reject(error instanceof Error ? error : new Error(String(error)));
         }


### PR DESCRIPTION
## Summary

- **#1820** Worker クラッシュ時のフォールバック: `ProjectSearchWorkerClient` が `onerror` でメインスレッドの同期実装へ自動切替（Electron パッケージ版で Worker URL が解決できない問題）
- **#1821** 異体字正規化: `EXTRA_VARIANTS` マップを追加し、kyujitai パッケージ未収録の髙 (U+9AD9) → 高 (U+9AD8) 変換に対応
- **#1822** コメント除外: Milkdown の `"html"` inline atom ノード（`<!-- ... -->` を格納）を `getCommentText` で正しく検出
- **#1823** 段落番号ずれ: `blankParagraph` を `paragraphNumber` のカウント対象から除外し、UI の CSS カウンターと整合
- **#1824** 「選択範囲のみ」常時 disabled: 選択なし時のみ無効化し、チェック時にスコープを自動で「現在のファイル」へ切替

## Changes

| ファイル | 変更内容 |
|---|---|
| `lib/editor-page/japanese-variant-normalization.ts` | `EXTRA_VARIANTS` マップ追加（#1821） |
| `lib/editor-page/find-search-matches.ts` | `blankParagraph` カウント除外 + html コメント検出（#1822, #1823） |
| `lib/editor-page/project-search-worker-client.ts` | Worker クラッシュ → 同期フォールバック（#1820） |
| `components/SearchResults.tsx` | 「選択範囲のみ」disabled 条件修正 + 自動スコープ切替（#1824） |
| `lib/editor-page/__tests__/find-search-matches-enhanced.test.ts` | 回帰テスト3件追加（#1821/#1822/#1823） |
| `lib/editor-page/__tests__/project-search-worker-client.test.ts` | フォールバック動作テスト更新（#1820） |

## Test plan

- [ ] 39テスト（36既存 + 3新規）全通過確認済み
- [ ] 髙橋 で検索 → normalizeVariants ON で2件ヒット（髙 と 高）
- [ ] `<!-- コメント -->` ノードで「コメントを除外」ON/OFF 切替確認
- [ ] [[blank]] を含むドキュメントで段落番号が UI カウンターと一致
- [ ] テキスト選択後「選択範囲のみ」が有効になることを確認

Closes #1820
Closes #1821
Closes #1822
Closes #1823
Closes #1824

🤖 Generated with [Claude Code](https://claude.com/claude-code)