### PR TITLE
fix(export): [[blank]] 不使用の空白行を 印刷/PDF/DOCX/EPUB で保持（TXT パリティ）

### DIFF
--- a/lib/export/__tests__/blank-paragraph-export.test.ts
+++ b/lib/export/__tests__/blank-paragraph-export.test.ts
@@ -4,6 +4,7 @@ import { mdiToHtml } from "@/lib/export/mdi-to-html";
 import { mdiToPlainText } from "@/lib/export/txt-exporter";
 import { generateDocxBlob } from "@/lib/export/docx-exporter";
 import { buildEpubFiles } from "@/lib/export/epub-shared";
+import { promoteBlankRunsToMarkers } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 
 describe("html exporter — [[blank]] paragraph handling", () => {
   it("[[blank]] → <p></p>", () => {
@@ -336,5 +337,101 @@ describe("export — non-.mdi preserves literal editor HTML (Codex P3)", () => {
       expect(documentXml).not.toContain("&lt;p&gt;");
       expect(documentXml).toContain("本文");
     });
+  });
+});
+
+// Regression for #1826: author-intentional blank lines (Enter-key empty
+// paragraphs, NO [[blank]] macro) were preserved in TXT but collapsed in
+// HTML/PDF/print/DOCX/EPUB. The fix promotes the 2nd+ blank line in a run to a
+// [[blank]] marker for ".mdi" exports, matching TXT's collapseBlankLines rule
+// (1st blank = structural separator, rest = preserved). All paths must reach
+// TXT parity. Synthetic fixtures only — no manuscript content.
+describe("export — plain blank lines (no [[blank]] macro) preserved at TXT parity (#1826)", () => {
+  // 第一場 then 3 blank lines then 第二場 → TXT keeps 2 (1st is the structural
+  // paragraph separator). HTML/DOCX/EPUB must keep the same 2 blank paragraphs.
+  const SRC = "第一場\n\n\n\n第二場";
+
+  it("txt (reference): keeps exactly 2 intentional blank lines", () => {
+    const lines = mdiToPlainText(SRC, ".mdi").split("\n");
+    const aIdx = lines.findIndex((l) => l.includes("第一場"));
+    const bIdx = lines.findIndex((l) => l.includes("第二場"));
+    const blanks = lines.slice(aIdx + 1, bIdx).filter((l) => l.trim() === "").length;
+    expect(blanks).toBe(2);
+  });
+
+  it("html (.mdi): 2 empty <p></p> between the two scenes — TXT parity", () => {
+    const html = mdiToHtml(SRC, { bodyOnly: true, fileType: ".mdi" });
+    const count = (html.match(/<p><\/p>/g) ?? []).length;
+    expect(count).toBe(2);
+    // The U+E000 sentinel must not leak
+    expect(html).not.toContain(String.fromCharCode(0xe000));
+    expect(html).not.toContain("[[blank]]");
+  });
+
+  it("docx (.mdi): 4 total <w:p> (第一場 + 2 blanks + 第二場) — TXT parity", async () => {
+    const blob = await generateDocxBlob(SRC, {
+      metadata: { title: "novel.mdi", language: "ja" },
+      fileType: ".mdi",
+    });
+    const unzipped = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+    const documentXml = strFromU8(unzipped["word/document.xml"]!);
+    const pCount = (documentXml.match(/<w:p[\s>]/g) ?? []).length;
+    expect(pCount).toBe(4);
+    expect(documentXml).not.toContain("[[blank]]");
+  });
+
+  it("epub (.mdi): 2 empty <p></p> in chapter xhtml — TXT parity", () => {
+    const files = buildEpubFiles(`# 第一章\n\n${SRC}`, {
+      metadata: { title: "novel.mdi", language: "ja" },
+      fileType: ".mdi",
+    });
+    const chapter = files.get("OEBPS/chapter-1.xhtml") as string;
+    const count = (chapter.match(/<p><\/p>/g) ?? []).length;
+    expect(count).toBe(2);
+    expect(chapter).not.toContain("[[blank]]");
+  });
+
+  it("html (.mdi): a SINGLE blank line is a structural separator — no spurious <p></p>", () => {
+    const html = mdiToHtml("第一場\n\n第二場", { bodyOnly: true, fileType: ".mdi" });
+    expect(html).not.toContain("<p></p>");
+  });
+
+  it("docx (.mdi): a SINGLE blank line → 2 <w:p> only (no extra blank paragraph)", async () => {
+    const blob = await generateDocxBlob("第一場\n\n第二場", {
+      metadata: { title: "novel.mdi", language: "ja" },
+      fileType: ".mdi",
+    });
+    const unzipped = unzipSync(new Uint8Array(await blob.arrayBuffer()));
+    const documentXml = strFromU8(unzipped["word/document.xml"]!);
+    const pCount = (documentXml.match(/<w:p[\s>]/g) ?? []).length;
+    expect(pCount).toBe(2);
+  });
+
+  it(".md scope guard: plain blank lines stay collapsed (CommonMark / DATA-LOSS)", () => {
+    // For .md the standard Markdown semantics apply — extra blank lines collapse.
+    const html = mdiToHtml(SRC, { bodyOnly: true, fileType: ".md" });
+    expect(html).not.toContain("<p></p>");
+  });
+});
+
+describe("promoteBlankRunsToMarkers (#1826 helper)", () => {
+  it("promotes the 2nd+ blank line in a run to [[blank]] markers", () => {
+    expect(promoteBlankRunsToMarkers("A\n\n\n\nB")).toBe("A\n\n[[blank]]\n\n[[blank]]\n\nB");
+  });
+
+  it("a single blank line stays a structural separator (no marker)", () => {
+    expect(promoteBlankRunsToMarkers("A\n\nB")).toBe("A\n\nB");
+  });
+
+  it("trims leading/trailing blank runs (matches collapseBlankLines)", () => {
+    expect(promoteBlankRunsToMarkers("\n\n\nA\n\nB\n\n\n")).toBe("A\n\nB");
+  });
+
+  it("leaves an existing [[blank]] marker untouched (no double promotion)", () => {
+    expect(promoteBlankRunsToMarkers("A\n\n[[blank]]\n\nB")).toBe("A\n\n[[blank]]\n\nB");
+  });
+
+  it("handles content with no blank runs", () => {
+    expect(promoteBlankRunsToMarkers("A\nB\nC")).toBe("A\nB\nC");
   });
 });

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -22,6 +22,7 @@ import {
   replaceMdiWithRubyText,
   MDI_BREAK_RE,
   isMdiBlankParagraphLine,
+  promoteBlankRunsToMarkers,
 } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import type { ExportMetadata } from "./types";
 import {
@@ -68,10 +69,15 @@ function buildDocxDocument(content: string, options: DocxExportOptions): Documen
   //   `fromRawText` so NO editor-HTML normalization runs — literal `<br />`,
   //   `<p>x</p>`, `\[\[blank]]` are preserved verbatim (DATA-LOSS guard).
   const fileType = options.fileType ?? ".mdi";
-  const normalized =
+  const rawNormalized =
     fileType === ".mdi"
       ? MdiDocument.fromEditorOutput(content, { fileType: ".mdi" }).toRawText()
       : MdiDocument.fromRawText(content).toRawText();
+  // Promote author-intentional blank lines into [[blank]] markers so the
+  // paragraph loop emits empty <w:p> for them instead of collapsing — TXT
+  // parity (#1826). Scoped to ".mdi" (see mdi-to-html.ts for rationale).
+  const normalized =
+    fileType === ".mdi" ? promoteBlankRunsToMarkers(rawNormalized) : rawNormalized;
   const paragraphs = parseMarkdownToDocxParagraphs(normalized, settings, fontConfig);
 
   // Page dimensions (swap for landscape)

--- a/lib/export/docx-exporter.ts
+++ b/lib/export/docx-exporter.ts
@@ -76,8 +76,7 @@ function buildDocxDocument(content: string, options: DocxExportOptions): Documen
   // Promote author-intentional blank lines into [[blank]] markers so the
   // paragraph loop emits empty <w:p> for them instead of collapsing — TXT
   // parity (#1826). Scoped to ".mdi" (see mdi-to-html.ts for rationale).
-  const normalized =
-    fileType === ".mdi" ? promoteBlankRunsToMarkers(rawNormalized) : rawNormalized;
+  const normalized = fileType === ".mdi" ? promoteBlankRunsToMarkers(rawNormalized) : rawNormalized;
   const paragraphs = parseMarkdownToDocxParagraphs(normalized, settings, fontConfig);
 
   // Page dimensions (swap for landscape)

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -17,6 +17,7 @@ import {
   MDI_KERN_AMOUNT_RE,
   MDI_BLANK_RE,
   MdiDocument,
+  promoteBlankRunsToMarkers,
 } from "@/packages/milkdown-plugin-japanese-novel/mdi-document";
 import { PAGE_DIMENSIONS } from "./pdf-export-settings";
 
@@ -269,10 +270,17 @@ export function mdiToHtml(
   // leaks as literal text into PDF/EPUB/print output. TXT/DOCX already normalize
   // this way via MdiDocument — this brings the HTML pipeline to parity.
   const fileType = options?.fileType ?? ".mdi";
-  const normalized =
+  const rawNormalized =
     fileType === ".mdi"
       ? MdiDocument.fromEditorOutput(markdown, { fileType: ".mdi" }).toRawText()
       : MdiDocument.fromRawText(markdown).toRawText();
+  // Promote author-intentional blank lines (Enter-key empty paragraphs, no
+  // [[blank]] macro) into explicit [[blank]] markers so markdown-it does not
+  // collapse them — TXT already preserves these, this brings HTML/PDF/EPUB to
+  // parity (#1826). Scoped to ".mdi": .md/.txt keep CommonMark collapse and the
+  // DATA-LOSS guard (#1608). Markers feed the existing sentinel path below.
+  const normalized =
+    fileType === ".mdi" ? promoteBlankRunsToMarkers(rawNormalized) : rawNormalized;
   // Pre-process: replace [[blank]] paragraph markers with a U+E000 PUA sentinel.
   // markdown-it will wrap the sentinel in <p>…</p>; we swap it for an empty <p></p> after rendering.
   const BLANK_SENTINEL = "";

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -279,8 +279,7 @@ export function mdiToHtml(
   // collapse them — TXT already preserves these, this brings HTML/PDF/EPUB to
   // parity (#1826). Scoped to ".mdi": .md/.txt keep CommonMark collapse and the
   // DATA-LOSS guard (#1608). Markers feed the existing sentinel path below.
-  const normalized =
-    fileType === ".mdi" ? promoteBlankRunsToMarkers(rawNormalized) : rawNormalized;
+  const normalized = fileType === ".mdi" ? promoteBlankRunsToMarkers(rawNormalized) : rawNormalized;
   // Pre-process: replace [[blank]] paragraph markers with a U+E000 PUA sentinel.
   // markdown-it will wrap the sentinel in <p>…</p>; we swap it for an empty <p></p> after rendering.
   const BLANK_SENTINEL = "";

--- a/packages/milkdown-plugin-japanese-novel/mdi-document.ts
+++ b/packages/milkdown-plugin-japanese-novel/mdi-document.ts
@@ -363,6 +363,50 @@ function collapseBlankLines(text: string): string {
   return result.join("\n");
 }
 
+/**
+ * Promote author-intentional blank lines into explicit `[[blank]]` paragraph
+ * markers. The inverse companion of {@link collapseBlankLines}: in a run of N
+ * consecutive blank lines between content, the 1st is the structural Markdown
+ * paragraph separator (kept as one blank line) and lines 2..N are author-
+ * intentional, each emitted as a `[[blank]]` paragraph.
+ *
+ * The TXT export already preserves these via {@link collapseBlankLines}; HTML
+ * (markdown-it) and DOCX collapse them. Running the canonical text through this
+ * before those pipelines brings them to TXT parity, because every exporter
+ * already renders `[[blank]]` correctly (HTML → `<p></p>`, DOCX → empty `<w:p>`).
+ *
+ * Existing `[[blank]]` lines (non-blank text) pass through untouched — no double
+ * promotion. Leading/trailing blank runs are dropped, matching collapseBlankLines.
+ */
+export function promoteBlankRunsToMarkers(text: string): string {
+  const lines = text.split("\n");
+  const out: string[] = [];
+  let blankRun = 0;
+  let seenContent = false;
+
+  for (const line of lines) {
+    if (line.trim() === "") {
+      blankRun++;
+      continue;
+    }
+
+    if (seenContent && blankRun > 0) {
+      out.push(""); // 1st blank: structural paragraph separator
+      for (let k = 1; k < blankRun; k++) {
+        // 2nd+ blank: author-intentional → explicit blank paragraph
+        out.push(MDI_BLANK_MARKER);
+        out.push("");
+      }
+    }
+
+    out.push(line);
+    seenContent = true;
+    blankRun = 0;
+  }
+
+  return out.join("\n");
+}
+
 // ---------------------------------------------------------------------------
 // Editor-output normalization (string-level sanitize before persisting)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`[[blank]]` マクロを使わず Enter で作った空白行（空段落）が、**印刷 / PDF / DOCX / EPUB** で消えていた（**TXT のみ保持**）。本 PR で全エクスポート経路を TXT とパリティに揃える。

Closes #1826

## 根本原因

TXT の正準ルール = `mdi-document.ts` の `collapseBlankLines()`:
> 連続空行の **1 本目 = 構造的な段落区切り（出力しない）／ 2 本目以降 = 作者意図として保持**。

- **HTML 系**（`mdi-to-html.ts` → markdown-it）: markdown-it が連続空行を CommonMark 仕様どおり畳むため、`[[blank]]` 以外の空段落が全消失。
- **DOCX**（`docx-exporter.ts`）: `parseMarkdownToDocxParagraphs` が空行を段落区切りに畳み、`[[blank]]` のみ空 `<w:p>` 化。

## 修正

TXT が既に持つルールを共有ヘルパ `promoteBlankRunsToMarkers` として切り出し、**連続空行の 2 本目以降を `[[blank]]` マーカーへ昇格**させる。各 exporter は既に `[[blank]]` を正しく描画できる（HTML→`<p></p>` / DOCX→空 `<w:p>` / EPUB→HTML 経由）ため、昇格させるだけで全経路が修正される。

- `packages/.../mdi-document.ts`: `promoteBlankRunsToMarkers` 追加・export
- `lib/export/mdi-to-html.ts`: 正規化直後（`.mdi` のみ）に適用 → **PDF / 印刷 / EPUB 自動修正**
- `lib/export/docx-exporter.ts`: DOCX 段落生成前に適用
- **スコープ**: `.mdi` のみ。`.md`/`.txt` は CommonMark 畳み込み＋DATA-LOSS 保護（#1608）を維持

## 検証

`第一場\n\n\n\n第二場`（空行3本）→ TXT は 2 本保持。修正後：

| 経路 | 結果 |
|---|---|
| TXT（基準） | 空行 2 |
| HTML / PDF / 印刷 | 空 `<p></p>` 2 ✅ |
| DOCX | `<w:p>` 4（第一場+空2+第二場）✅ |
| EPUB | 空 `<p></p>` 2 ✅ |

- 全経路パリティテスト＋単一空行の誤注入防止＋`.md` スコープガード＋ヘルパ単体テストを追加
- `npx vitest run lib/export` → **147 passed**
- `npm run type-check` / `lint` / `check:boundaries` → 全 green
- 合成 PDF(HTML)/DOCX/EPUB を `/tmp` に出力し独立 grep で検証（実原稿不使用）

> 注: 合成フィクスチャのみ使用。実原稿には未接触。PDF プレビュー/印刷ウィンドウ等の Electron ネイティブ描画は未目視（出力コンテンツレベルで検証済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)