### PR TITLE
fix(editor): 書式解除の混在選択バグ修正・縦横切替で未保存コンテンツが失われるバグ修正

### DIFF
--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -134,6 +134,9 @@ export default function MilkdownEditor({
   const isElectron = typeof window !== "undefined" && isElectronRenderer();
   // 初期内容はマウント時に固定（ファイル切り替えでコンポーネントが再マウントされたときだけ変わる）
   const initialContentRef = useRef<string>(initialContent);
+  // 最新コンテンツを追跡する。isVertical 切替でエディタが再構築されたとき、
+  // 未保存の変更を保持するために initialContentRef の代わりに使う（#426）。
+  const currentContentRef = useRef<string>(initialContent);
   const onChangeRef = useRef(onChange);
   const onInsertTextRef = useRef(onInsertText);
   const onLintIssuesUpdatedRef = useRef(onLintIssuesUpdated);
@@ -191,7 +194,7 @@ export default function MilkdownEditor({
 
   const { get } = useEditor(
     (root) => {
-      const value = initialContentRef.current;
+      const value = currentContentRef.current;
       let editor = Editor.make()
         .config(nord)
         .config((ctx) => {
@@ -210,10 +213,13 @@ export default function MilkdownEditor({
               doc.forEach((node) => {
                 lines.push(node.textContent);
               });
-              onChangeRef.current?.(lines.join("\n"));
+              const content = lines.join("\n");
+              currentContentRef.current = content;
+              onChangeRef.current?.(content);
             });
           } else {
             ctx.get(listenerCtx).markdownUpdated((_ctx, markdown) => {
+              currentContentRef.current = markdown;
               onChangeRef.current?.(markdown);
             });
           }

--- a/lib/editor-page/__tests__/clear-formatting.test.ts
+++ b/lib/editor-page/__tests__/clear-formatting.test.ts
@@ -88,4 +88,42 @@ describe("clearFormatting", () => {
     clearFormatting(view);
     expect(view.state.doc.toJSON()).toEqual(before);
   });
+
+  it("#1828: 見出し・引用・リスト・段落の混在選択を全て標準段落に戻す", async () => {
+    const md = "## Mixed Heading\n\n> **Mixed Bold Quote**\n\n- *Mixed Italic List*\n\nPlain Control";
+    const { view } = await makeView(md);
+
+    // 文書全体を選択して書式解除
+    selectAllAndClear(view);
+
+    // 全トップレベルノードが paragraph になっていること
+    view.state.doc.forEach((node) => {
+      expect(node.type.name).toBe("paragraph");
+    });
+
+    // インラインマークがゼロになっていること
+    let markCount = 0;
+    view.state.doc.descendants((node) => {
+      markCount += node.marks.length;
+    });
+    expect(markCount).toBe(0);
+
+    // テキスト内容が保持されていること
+    const text = view.state.doc.textContent;
+    expect(text).toContain("Mixed Heading");
+    expect(text).toContain("Mixed Bold Quote");
+    expect(text).toContain("Mixed Italic List");
+    expect(text).toContain("Plain Control");
+  });
+
+  it("#1828: 見出し＋引用の混在選択（段落ネスト）を標準段落に戻す", async () => {
+    const { view } = await makeView("# タイトル\n\n> 引用テキスト");
+    selectAllAndClear(view);
+    view.state.doc.forEach((node) => {
+      expect(node.type.name).toBe("paragraph");
+    });
+    const text = view.state.doc.textContent;
+    expect(text).toContain("タイトル");
+    expect(text).toContain("引用テキスト");
+  });
 });

--- a/lib/editor-page/__tests__/clear-formatting.test.ts
+++ b/lib/editor-page/__tests__/clear-formatting.test.ts
@@ -90,7 +90,8 @@ describe("clearFormatting", () => {
   });
 
   it("#1828: 見出し・引用・リスト・段落の混在選択を全て標準段落に戻す", async () => {
-    const md = "## Mixed Heading\n\n> **Mixed Bold Quote**\n\n- *Mixed Italic List*\n\nPlain Control";
+    const md =
+      "## Mixed Heading\n\n> **Mixed Bold Quote**\n\n- *Mixed Italic List*\n\nPlain Control";
     const { view } = await makeView(md);
 
     // 文書全体を選択して書式解除

--- a/lib/editor-page/clear-formatting.ts
+++ b/lib/editor-page/clear-formatting.ts
@@ -1,49 +1,65 @@
-import { setBlockType, lift } from "@milkdown/prose/commands";
-import { liftListItem } from "@milkdown/prose/schema-list";
+import { liftTarget } from "@milkdown/prose/transform";
 import type { EditorView } from "@milkdown/prose/view";
-
-/** lift 系コマンドを変化が無くなるまで反復実行する（多重ネスト対策）。上限付き。 */
-function repeat(
-  view: EditorView,
-  command: (state: EditorView["state"], dispatch: EditorView["dispatch"]) => boolean,
-): void {
-  for (let i = 0; i < 16; i += 1) {
-    if (!command(view.state, view.dispatch)) break;
-  }
-}
 
 /**
  * 選択範囲を標準本文（段落・装飾なし）に戻す。
  *
- * Milkdown には単一の「書式解除」コマンドが無いため、ProseMirror を直接操作する。
- * 1) インラインマーク（太字・斜体・取り消し線・コード等）をすべて除去
- * 2) 見出し・コードブロック等のテキストブロックを標準段落へ変換
- * 3) リスト項目を段落へ引き上げ（list_item は generic lift では解除できないため専用コマンド）
- * 4) 引用などの残りのラッパーから段落を引き上げる
+ * 1) インラインマーク（太字・斜体等）をすべて除去
+ * 2) 各ブロックを個別処理：見出し等のテキストブロックを段落へ変換し、
+ *    引用・リスト等のラッパーから引き上げる
  *
  * 選択が空の場合は何もしない。
+ *
+ * 混在選択（見出し＋引用＋リスト＋段落）でも正しく動作するよう、
+ * 選択全体に対して liftListItem/lift を一括適用する代わりに、
+ * ノードを個別に走査して per-node の Transform 操作を行う。
+ * 各操作は同一 transaction に集約し、dispatch は一度だけ。
  */
 export function clearFormatting(view: EditorView): void {
   if (view.state.selection.empty) return;
 
-  // 1) インラインマークをすべて除去
   const { from, to } = view.state.selection;
-  view.dispatch(view.state.tr.removeMark(from, to));
+  const { state } = view;
+  const { schema } = state;
+  const paragraph = schema.nodes.paragraph;
+  const tr = state.tr;
 
-  // 2) テキストブロックを標準段落へ変換
-  const paragraph = view.state.schema.nodes.paragraph;
-  if (paragraph) {
-    setBlockType(paragraph)(view.state, view.dispatch);
-  }
+  // 1) インラインマークをすべて除去（位置変化なし）
+  tr.removeMark(from, to);
 
-  // 3) リスト項目を引き上げてリストから抜ける
-  const listItem = view.state.schema.nodes.list_item;
-  if (listItem) {
-    repeat(view, liftListItem(listItem));
-  }
+  // 2) ノードを個別に変換・引き上げ
+  // オリジナル doc を走査し、tr.mapping / tr.doc で現在位置を追跡する。
+  // TipTap の clearNodes と同様の per-node アプローチ。
+  state.doc.nodesBetween(from, to, (node, pos) => {
+    if (node.isText) return;
 
-  // 4) 引用などの残りのラッパーを解除
-  repeat(view, lift);
+    // テキストブロック（見出し・コードブロック等）を段落へ変換
+    if (paragraph && node.isTextblock && node.type !== paragraph) {
+      try {
+        tr.setNodeMarkup(tr.mapping.map(pos), paragraph, {}, []);
+      } catch {
+        // 前の操作で位置が無効になった場合はスキップ
+      }
+    }
 
+    // ラッパー（引用・リスト・リスト項目）から引き上げる
+    try {
+      const mappedPos = tr.mapping.map(pos);
+      const mappedEnd = tr.mapping.map(pos + node.nodeSize);
+      const $from = tr.doc.resolve(mappedPos);
+      const $to = tr.doc.resolve(mappedEnd);
+      const range = $from.blockRange($to);
+      if (!range) return;
+
+      const depth = liftTarget(range);
+      if (depth != null) {
+        tr.lift(range, depth);
+      }
+    } catch {
+      // 前の lift で位置が変化した場合はスキップ
+    }
+  });
+
+  view.dispatch(tr.scrollIntoView());
   view.focus();
 }


### PR DESCRIPTION
## Summary

- **#1828 書式解除の混在選択バグ**: 見出し・引用・リスト・段落が混在する選択に対して「標準本文に戻す」を実行すると、引用とリストのブロック構造が残っていた。`liftListItem`/`lift` コマンドは選択全体を対象とするため、混在選択では blockRange の共通祖先が見つからず `false` を返す。per-node アプローチ（TipTap の `clearNodes` と同方式）に変更し、各ノードに対して `tr.mapping` で位置を追跡しながら `tr.lift` を個別に適用することで修正。
- **#426 縦横切替で未保存コンテンツ消失**: `isVertical` が変わると `useEditor` がエディタを再構築するが、`defaultValueCtx` に `initialContentRef.current`（マウント時の内容）を渡していたため、未保存の変更が失われていた。`currentContentRef` で最新コンテンツを追跡し、再構築時にそれを使うことで修正。

## Changes

| ファイル | 変更内容 |
|---|---|
| `lib/editor-page/clear-formatting.ts` | per-node 方式の書式解除に全面書き換え |
| `lib/editor-page/__tests__/clear-formatting.test.ts` | 混在選択の回帰テスト 2 件追加 |
| `components/editor/MilkdownEditor.tsx` | `currentContentRef` でコンテンツを追跡、再構築時に使用 |

## Test plan

- [ ] `npm run test -- --run lib/editor-page/__tests__/clear-formatting.test.ts` → 7件全パス
- [ ] 見出し・引用・リスト・段落を混在させた文書で「標準本文に戻す」を実行 → 全ブロックが段落になること
- [ ] テキストを入力（未保存のまま）→ 縦横切替 → 入力内容が保持されていること
- [ ] 既存の書式解除（単一見出し・引用のみ・リストのみ）が引き続き動作すること

Closes #1828
Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)