### PR TITLE
fix(linting): 校正ルールセット worker 起動失敗の main-thread フォールバック＋「すべて無効」修正 (#1831, #1832)

### DIFF
--- a/components/settings/linting/RulesetList.tsx
+++ b/components/settings/linting/RulesetList.tsx
@@ -15,6 +15,7 @@ import {
 import RulesetCard from "./RulesetCard";
 import type { RulesetCardRule } from "./RulesetCard";
 import type { UseRulesetStatusReturn } from "./useRulesetStatus";
+import { buildBulkConfig, collectAllRuleIds } from "./bulk-toggle";
 
 interface RulesetListProps {
   lintingRuleConfigs: Record<
@@ -60,23 +61,29 @@ export default function RulesetList({
     [lintingRuleConfigs, onLintingRuleConfigsBatchChange],
   );
 
+  // 表示中の全ルール ID（内蔵 LINT_RULES_META + 外部ルールセット）を収集する。
+  // 内蔵ルールゼロ化後はルールが外部ルールセット (rulesetStatus.rulesets) から
+  // 供給されるため、LINT_RULES_META だけを回すと一括操作が空振りする (#1832)。
+  const allRuleIds = useCallback(
+    (): string[] =>
+      collectAllRuleIds(
+        LINT_RULES_META.map((rule) => rule.id),
+        rulesetStatus?.rulesets,
+      ),
+    [rulesetStatus],
+  );
+
   const handleEnableAll = useCallback(() => {
-    const next: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }> =
-      {};
-    for (const rule of LINT_RULES_META) {
-      next[rule.id] = { ...getConfig(rule.id, lintingRuleConfigs), enabled: true };
-    }
-    onLintingRuleConfigsBatchChange(next);
-  }, [lintingRuleConfigs, onLintingRuleConfigsBatchChange]);
+    onLintingRuleConfigsBatchChange(
+      buildBulkConfig(lintingRuleConfigs, allRuleIds(), true, getConfig),
+    );
+  }, [lintingRuleConfigs, onLintingRuleConfigsBatchChange, allRuleIds]);
 
   const handleDisableAll = useCallback(() => {
-    const next: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }> =
-      {};
-    for (const rule of LINT_RULES_META) {
-      next[rule.id] = { ...getConfig(rule.id, lintingRuleConfigs), enabled: false };
-    }
-    onLintingRuleConfigsBatchChange(next);
-  }, [lintingRuleConfigs, onLintingRuleConfigsBatchChange]);
+    onLintingRuleConfigsBatchChange(
+      buildBulkConfig(lintingRuleConfigs, allRuleIds(), false, getConfig),
+    );
+  }, [lintingRuleConfigs, onLintingRuleConfigsBatchChange, allRuleIds]);
 
   const handleResetDefaults = useCallback(() => {
     onLintingRuleConfigsBatchChange({ ...LINT_DEFAULT_CONFIGS });

--- a/components/settings/linting/__tests__/bulk-toggle.test.ts
+++ b/components/settings/linting/__tests__/bulk-toggle.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the bulk enable/disable helpers (#1832).
+ *
+ * Regression: after built-in rules were zeroed, "すべて無効 / すべて有効"
+ * iterated only the empty LINT_RULES_META, so external-ruleset rules were
+ * never toggled (the buttons silently no-op'd).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { buildBulkConfig, collectAllRuleIds, type RuleConfig } from "../bulk-toggle";
+
+const getConfig = (ruleId: string, configs: Record<string, RuleConfig>): RuleConfig =>
+  configs[ruleId] ?? { enabled: true, severity: "warning" };
+
+describe("collectAllRuleIds (#1832)", () => {
+  it("includes external ruleset rule ids even when built-ins are empty", () => {
+    const ids = collectAllRuleIds(
+      [],
+      [{ rules: [{ ruleId: "a" }, { ruleId: "b" }] }, { rules: [{ ruleId: "c" }] }],
+    );
+    expect(ids).toEqual(["a", "b", "c"]);
+  });
+
+  it("merges built-in and external ids", () => {
+    const ids = collectAllRuleIds(["builtin-1"], [{ rules: [{ ruleId: "ext-1" }] }]);
+    expect(ids).toEqual(["builtin-1", "ext-1"]);
+  });
+
+  it("handles undefined rulesetStatus (Web)", () => {
+    expect(collectAllRuleIds(["x"], undefined)).toEqual(["x"]);
+  });
+});
+
+describe("buildBulkConfig (#1832)", () => {
+  const current: Record<string, RuleConfig> = {
+    a: { enabled: true, severity: "warning" },
+    b: { enabled: true, severity: "error" },
+    c: { enabled: true, severity: "warning" },
+  };
+
+  it("disables every collected rule id (the core #1832 bug)", () => {
+    const next = buildBulkConfig(current, ["a", "b", "c"], false, getConfig);
+    expect(next.a.enabled).toBe(false);
+    expect(next.b.enabled).toBe(false);
+    expect(next.c.enabled).toBe(false);
+  });
+
+  it("preserves severity / skipDialogue when toggling", () => {
+    const withSkip: Record<string, RuleConfig> = {
+      a: { enabled: true, severity: "error", skipDialogue: true },
+    };
+    const next = buildBulkConfig(withSkip, ["a"], false, getConfig);
+    expect(next.a).toEqual({ enabled: false, severity: "error", skipDialogue: true });
+  });
+
+  it("enables every collected rule id", () => {
+    const allOff: Record<string, RuleConfig> = {
+      a: { enabled: false, severity: "warning" },
+    };
+    const next = buildBulkConfig(allOff, ["a", "b"], true, getConfig);
+    expect(next.a.enabled).toBe(true);
+    expect(next.b.enabled).toBe(true);
+  });
+
+  it("does not mutate the input config", () => {
+    buildBulkConfig(current, ["a"], false, getConfig);
+    expect(current.a.enabled).toBe(true);
+  });
+
+  it("is a no-op on rule ids when the list is empty (documents the old bug)", () => {
+    const next = buildBulkConfig(current, [], false, getConfig);
+    expect(next.a.enabled).toBe(true); // unchanged — exactly what went wrong pre-#1832
+  });
+});

--- a/components/settings/linting/bulk-toggle.ts
+++ b/components/settings/linting/bulk-toggle.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure helpers for the "すべて有効 / すべて無効" bulk actions in RulesetList.
+ *
+ * Extracted so the rule-id collection can be unit-tested without React.
+ * Before #1832 the bulk handlers iterated only the (now-empty) built-in
+ * `LINT_RULES_META`, so they silently no-op'd once all rules moved to
+ * external rulesets.
+ */
+
+import type { Severity } from "@/lib/linting/types";
+
+export interface RuleConfig {
+  enabled: boolean;
+  severity: Severity;
+  skipDialogue?: boolean;
+}
+
+interface RulesetLike {
+  rules: ReadonlyArray<{ ruleId: string }>;
+}
+
+/**
+ * Collect every rule id currently shown in the settings panel:
+ * built-in (`LINT_RULES_META`) ∪ external rulesets. Order is built-ins
+ * first, then rulesets in listing order; duplicates are preserved by the
+ * caller's map semantics (last write wins, which is idempotent here).
+ */
+export function collectAllRuleIds(
+  builtInRuleIds: ReadonlyArray<string>,
+  rulesets: ReadonlyArray<RulesetLike> | undefined,
+): string[] {
+  const ids = [...builtInRuleIds];
+  if (rulesets) {
+    for (const rs of rulesets) {
+      for (const rule of rs.rules) {
+        ids.push(rule.ruleId);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Build the replacement config map for a bulk enable/disable: start from the
+ * current configs (preserving severity/skipDialogue and any unlisted rules)
+ * and set `enabled` on every collected rule id.
+ */
+export function buildBulkConfig(
+  current: Readonly<Record<string, RuleConfig>>,
+  ruleIds: ReadonlyArray<string>,
+  enabled: boolean,
+  getConfig: (ruleId: string, configs: Record<string, RuleConfig>) => RuleConfig,
+): Record<string, RuleConfig> {
+  const next: Record<string, RuleConfig> = { ...current };
+  for (const ruleId of ruleIds) {
+    next[ruleId] = { ...getConfig(ruleId, next), enabled };
+  }
+  return next;
+}

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
@@ -7,7 +7,7 @@
  * dispose-before-READY path.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 import { RuleRunnerProxy } from "../rule-runner-proxy";
 import {
@@ -18,6 +18,16 @@ import {
   WorkerStaleError,
 } from "../protocol";
 import type { LintIssue } from "@/lib/linting/types";
+import { makeModule } from "@/lib/linting/registry/__tests__/ruleset-fixtures";
+
+// Mock only the blob-import helper — jsdom/node can't `import(blob:)`.
+// `buildRulesetRunner` / `createIsolatedRulesetContext` stay real so the
+// main-thread fallback genuinely builds and runs rules.
+vi.mock("../build-ruleset-runner", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../build-ruleset-runner")>();
+  return { ...actual, importRulesetModule: vi.fn() };
+});
+import { importRulesetModule } from "../build-ruleset-runner";
 
 // ----------------------------------------------------------------
 // Fake Worker
@@ -228,27 +238,29 @@ describe("RuleRunnerProxy", () => {
     proxy.dispose();
   });
 
-  it("uncorrelated ERROR before READY rejects readyPromise so subsequent runBatch fails fast instead of hanging", async () => {
+  it("uncorrelated ERROR before READY falls back to main-thread linting instead of hanging (#1831)", async () => {
     const proxy = makeProxy();
-    // Do NOT emit READY. Send an uncorrelated ERROR (worker startup
-    // failed before posting READY).
+    // Do NOT emit READY. Send an uncorrelated ERROR (worker startup failed —
+    // e.g. file:// null-origin chunk resolution in packaged Electron).
     fakeWorker.emit({
       type: "ERROR",
       error: { name: "WorkerError", message: "init failed" },
     });
 
-    // The proxy is now in a poisoned state. Any new runBatch must
-    // reject promptly via the rejected readyPromise rather than hang.
-    const next = await proxy
-      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
-      .catch((e) => e);
-    expect(next).toBeInstanceOf(Error);
-    expect((next as Error).message).toBe("init failed");
+    // The proxy now runs on the main thread. runBatch resolves (no rulesets
+    // loaded → empty) rather than rejecting or hanging.
+    const resp = await proxy.runBatch({
+      paragraphs: [{ text: "テスト", index: 0 }],
+      mode: "per-paragraph",
+      version: 1,
+    });
+    expect(resp.perParagraph.size).toBe(0);
+    expect(fakeWorker.terminated).toBe(true);
 
     proxy.dispose();
   });
 
-  it("uncorrelated ERROR after READY poisons the proxy so subsequent runBatch fails fast", async () => {
+  it("uncorrelated ERROR after READY falls back to main-thread linting (#1831)", async () => {
     const proxy = makeProxy();
     emitReady();
 
@@ -257,29 +269,30 @@ describe("RuleRunnerProxy", () => {
       error: { name: "WorkerError", message: "post-ready boom" },
     });
 
-    const next = await proxy
-      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
-      .catch((e) => e);
-    expect(next).toBeInstanceOf(Error);
-    expect((next as Error).message).toBe("post-ready boom");
-    // poison() terminates the worker.
+    const resp = await proxy.runBatch({
+      paragraphs: [{ text: "テスト", index: 0 }],
+      mode: "per-paragraph",
+      version: 1,
+    });
+    expect(resp.perParagraph.size).toBe(0);
     expect(fakeWorker.terminated).toBe(true);
 
     proxy.dispose();
   });
 
-  it("worker.onerror poisons the proxy so subsequent runBatch fails fast", async () => {
+  it("worker.onerror falls back to main-thread linting (#1831)", async () => {
     const proxy = makeProxy();
     emitReady();
 
     // Simulate the underlying Worker emitting an `error` event.
     fakeWorker.onerror?.(new ErrorEvent("error", { message: "worker crashed" }));
 
-    const next = await proxy
-      .runBatch({ paragraphs: [], mode: "per-paragraph", version: 1 })
-      .catch((e) => e);
-    expect(next).toBeInstanceOf(Error);
-    expect((next as Error).message).toBe("worker crashed");
+    const resp = await proxy.runBatch({
+      paragraphs: [{ text: "テスト", index: 0 }],
+      mode: "per-paragraph",
+      version: 1,
+    });
+    expect(resp.perParagraph.size).toBe(0);
     expect(fakeWorker.terminated).toBe(true);
 
     proxy.dispose();
@@ -431,5 +444,115 @@ describe("RuleRunnerProxy", () => {
     if (last?.type !== "RUN_BATCH") throw new Error("unreachable");
     expect(last.paragraphs[0].tokens).toBeUndefined();
     proxy.dispose();
+  });
+
+  // ----------------------------------------------------------------
+  // Main-thread fallback rule execution (#1831)
+  //
+  // When the worker can't start (packaged Electron file:// null-origin),
+  // the proxy imports every loaded ruleset on the main thread and runs
+  // them there. The fixture rule flags the full-width "！".
+  // ----------------------------------------------------------------
+
+  describe("main-thread fallback (#1831)", () => {
+    beforeEach(() => {
+      vi.mocked(importRulesetModule).mockReset();
+    });
+
+    it("applies a ruleset loaded before the worker fails on the main thread", async () => {
+      vi.mocked(importRulesetModule).mockResolvedValue(
+        makeModule({ id: "com.example.bang", ruleIds: ["bang-rule"] }),
+      );
+
+      const proxy = makeProxy();
+      // Load the ruleset while the worker is still (apparently) starting.
+      const loadPromise = proxy.loadRuleset("com.example.bang", "/* code */");
+
+      // Worker startup fails → fallback kicks in and resolves the load.
+      fakeWorker.emit({
+        type: "ERROR",
+        error: { name: "WorkerError", message: "startup failed" },
+      });
+
+      const loadResult = await loadPromise;
+      expect(loadResult.ok).toBe(true);
+
+      const resp = await proxy.runBatch({
+        paragraphs: [{ text: "これはダメ！", index: 0 }],
+        mode: "per-paragraph",
+        version: 1,
+      });
+      const issues = resp.perParagraph.get(0);
+      expect(issues?.length).toBe(1);
+      expect(issues?.[0].ruleId).toBe("bang-rule");
+      expect(fakeWorker.terminated).toBe(true);
+
+      proxy.dispose();
+    });
+
+    it("loads a ruleset on the main thread after fallback is already active", async () => {
+      vi.mocked(importRulesetModule).mockResolvedValue(
+        makeModule({ id: "com.example.bang", ruleIds: ["bang-rule"] }),
+      );
+
+      const proxy = makeProxy();
+      // Trigger fallback first (no rulesets yet).
+      fakeWorker.onerror?.(new ErrorEvent("error", { message: "crash" }));
+
+      const loadResult = await proxy.loadRuleset("com.example.bang", "/* code */");
+      expect(loadResult.ok).toBe(true);
+      expect(loadResult.ruleIds).toContain("bang-rule");
+
+      const resp = await proxy.runBatch({
+        paragraphs: [{ text: "わっ！", index: 0 }],
+        mode: "per-paragraph",
+        version: 1,
+      });
+      expect(resp.perParagraph.get(0)?.[0].ruleId).toBe("bang-rule");
+
+      proxy.dispose();
+    });
+
+    it("honors disable config in the fallback runner", async () => {
+      vi.mocked(importRulesetModule).mockResolvedValue(
+        makeModule({ id: "com.example.bang", ruleIds: ["bang-rule"] }),
+      );
+
+      const proxy = makeProxy();
+      fakeWorker.onerror?.(new ErrorEvent("error", { message: "crash" }));
+      await proxy.loadRuleset("com.example.bang", "/* code */");
+
+      // Disable the rule — fallback runner must respect it.
+      proxy.setConfig("bang-rule", { enabled: false, severity: "warning" });
+
+      const resp = await proxy.runBatch({
+        paragraphs: [{ text: "ダメ！", index: 0 }],
+        mode: "per-paragraph",
+        version: 1,
+      });
+      expect(resp.perParagraph.size).toBe(0);
+
+      proxy.dispose();
+    });
+
+    it("unloads a ruleset from the fallback runner", async () => {
+      vi.mocked(importRulesetModule).mockResolvedValue(
+        makeModule({ id: "com.example.bang", ruleIds: ["bang-rule"] }),
+      );
+
+      const proxy = makeProxy();
+      fakeWorker.onerror?.(new ErrorEvent("error", { message: "crash" }));
+      await proxy.loadRuleset("com.example.bang", "/* code */");
+      await proxy.unloadRuleset("com.example.bang");
+
+      const resp = await proxy.runBatch({
+        paragraphs: [{ text: "ダメ！", index: 0 }],
+        mode: "per-paragraph",
+        version: 1,
+      });
+      expect(resp.perParagraph.size).toBe(0);
+
+      proxy.dispose();
+    });
   });
 });

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/build-ruleset-runner.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/build-ruleset-runner.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared ruleset-runner builder.
+ *
+ * Both the lint Web Worker (`linting.worker.ts`) and the main-thread
+ * fallback inside `RuleRunnerProxy` build a `RuleRunner` from
+ * legacy rules ∪ loaded external ruleset modules. Keeping the logic in
+ * one place ensures the fallback produces byte-for-byte the same rule set
+ * the worker would have — critical for #1831 where the worker fails to
+ * start in packaged Electron (file:// → `location.origin === "null"`
+ * breaks the Turbopack worker bootstrap's `new URL(chunk, origin)`).
+ */
+
+import { RuleRunner } from "@/lib/linting/rule-runner";
+import { RulesetRegistry } from "@/lib/linting/registry/ruleset-registry";
+import { createRulesetContext } from "@/lib/linting/registry/ruleset-context-factory";
+import type { RulesetContext } from "@/lib/linting/sdk/ruleset-context";
+import type { RulesetModule } from "@/lib/linting/sdk/ruleset-types";
+import type { LintRule, LintRuleConfig } from "@/lib/linting/types";
+
+/** A DictLike that always returns empty — external L2 rules requiring dict:genji are gated off. */
+const NO_OP_DICT = {
+  async lookupBatch(_terms: string[]): Promise<Map<string, never>> {
+    return new Map<string, never>();
+  },
+  async has(_term: string): Promise<boolean> {
+    return false;
+  },
+};
+
+/**
+ * Build the isolated RulesetContext used to instantiate external rules
+ * without dictionary access. Matches the worker's NO_OP dict environment so
+ * the main-thread fallback yields identical results (no dict:genji rules).
+ */
+export function createIsolatedRulesetContext(): RulesetContext {
+  return createRulesetContext({
+    dictHealth: { state: "not-installed" },
+    dict: NO_OP_DICT,
+    requirements: new Map([["dict:genji", false]]),
+  });
+}
+
+export interface BuildRulesetRunnerInput {
+  /** Legacy (built-in, JSON-driven) rules — always registered first. */
+  legacyRules: LintRule[];
+  /** Currently-loaded external ruleset modules. */
+  externals: Iterable<RulesetModule>;
+  /** Context used to instantiate external rules. */
+  ctx: RulesetContext;
+  /** Base guideline-map entries (legacy part) merged with external additions. */
+  baseGuidelineMapEntries: ReadonlyArray<[string, string | undefined]>;
+  /** Last-known per-rule configs replayed onto the rebuilt runner. */
+  configs: ReadonlyMap<string, LintRuleConfig>;
+  /** Last-known active guideline ids replayed onto the rebuilt runner. */
+  activeGuidelines: string[] | null;
+}
+
+/**
+ * Build a fresh `RuleRunner = legacyRules ∪ external rules`, replaying the
+ * supplied configs/guidelines. Throws if external rule instantiation throws;
+ * callers must keep their previous runner on failure (failure isolation).
+ */
+export function buildRulesetRunner(input: BuildRulesetRunnerInput): {
+  runner: RuleRunner;
+  ruleGuidelineMap: Map<string, string | undefined>;
+} {
+  const runner = new RuleRunner();
+
+  // 1. Legacy rules.
+  for (const rule of input.legacyRules) {
+    runner.registerRule(rule);
+  }
+
+  // 2. External rules via a fresh registry so each rebuild is independent.
+  const registry = new RulesetRegistry();
+  for (const mod of input.externals) {
+    registry.registerExternal(mod, "folder");
+  }
+  for (const rule of registry.buildRules(input.ctx)) {
+    runner.registerRule(rule);
+  }
+
+  // 3. Merge guideline maps: legacy base + external additions.
+  const mergedGuidelineMap = new Map<string, string | undefined>(input.baseGuidelineMapEntries);
+  for (const [ruleId, guidelineId] of registry.buildRuleGuidelineMap()) {
+    mergedGuidelineMap.set(ruleId, guidelineId);
+  }
+  runner.setGuidelineMap(mergedGuidelineMap);
+
+  // 4. Replay configs + active guidelines.
+  for (const [ruleId, config] of input.configs) {
+    runner.setConfig(ruleId, config);
+  }
+  runner.setActiveGuidelines(input.activeGuidelines);
+
+  return { runner, ruleGuidelineMap: mergedGuidelineMap };
+}
+
+/**
+ * Import an external ruleset module from its source code via a blob URL.
+ * Used on the main thread (renderer) for the fallback path and inside the
+ * worker. The blob URL is always revoked.
+ */
+export async function importRulesetModule(code: string): Promise<RulesetModule> {
+  const blob = new Blob([code], { type: "text/javascript" });
+  const url = URL.createObjectURL(blob);
+  try {
+    // webpackIgnore: true is REQUIRED — the bundler must not resolve this
+    // runtime blob: URI at build time.
+    return (await import(/* webpackIgnore: true */ url)).default as RulesetModule;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
@@ -19,8 +19,12 @@ import { RULE_GUIDELINE_MAP } from "@/lib/linting/lint-presets";
 import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
 import { isMorphologicalDocumentLintRule, isMorphologicalLintRule } from "@/lib/linting/types";
 import { RulesetRegistry } from "@/lib/linting/registry/ruleset-registry";
-import { createRulesetContext } from "@/lib/linting/registry/ruleset-context-factory";
 import type { RulesetModule } from "@/lib/linting/sdk/ruleset-types";
+import {
+  buildRulesetRunner,
+  createIsolatedRulesetContext,
+  importRulesetModule,
+} from "./build-ruleset-runner";
 import type {
   RulesetLoadWarning,
   SerializedIssueMap,
@@ -50,24 +54,6 @@ const legacyRules = buildLegacyRules();
 /** Map from ruleset id → loaded module (only successfully-loaded modules). */
 const loadedExternals = new Map<string, RulesetModule>();
 
-/**
- * A no-op DictLike used when building the worker-local RulesetContext.
- * The worker has no access to window.electronAPI, so dictionary lookups
- * always return empty results. Rules that require dict:genji will be
- * disabled by the registry's requirement gate.
- */
-const NO_OP_DICT = {
-  async lookupBatch(_terms: string[]): Promise<Map<string, never>> {
-    return new Map<string, never>();
-  },
-  async has(_term: string): Promise<boolean> {
-    return false;
-  },
-};
-
-/** Not-ready health snapshot for worker-local context construction. */
-const NOT_READY_HEALTH = { state: "not-installed" as const };
-
 /** Last-known config snapshot, replayed onto rebuilt runners. */
 const lastConfigs = new Map<string, LintRuleConfig>();
 /** Last-known active guidelines, replayed onto rebuilt runners. */
@@ -83,46 +69,14 @@ let lastGuidelineMapEntries: Array<[string, string | undefined]> = Array.from(
 
 /** Build a fresh RuleRunner = legacy ∪ all currently-loaded external rules. */
 function buildRunner(): { runner: RuleRunner; ruleGuidelineMap: Map<string, string | undefined> } {
-  const newRunner = new RuleRunner();
-
-  // 1. Register legacy rules.
-  for (const rule of legacyRules) {
-    newRunner.registerRule(rule);
-  }
-
-  // 2. Register externals via a fresh registry so each rebuild is independent.
-  const registry = new RulesetRegistry();
-  for (const mod of loadedExternals.values()) {
-    registry.registerExternal(mod, "folder");
-  }
-
-  const ctx = createRulesetContext({
-    dictHealth: NOT_READY_HEALTH,
-    dict: NO_OP_DICT,
-    requirements: new Map([["dict:genji", false]]),
+  return buildRulesetRunner({
+    legacyRules,
+    externals: loadedExternals.values(),
+    ctx: createIsolatedRulesetContext(),
+    baseGuidelineMapEntries: lastGuidelineMapEntries,
+    configs: lastConfigs,
+    activeGuidelines: lastGuidelines,
   });
-
-  const externalRules = registry.buildRules(ctx);
-  for (const rule of externalRules) {
-    newRunner.registerRule(rule);
-  }
-
-  // 3. Merge guideline maps: legacy base + external additions.
-  const mergedGuidelineMap = new Map<string, string | undefined>(lastGuidelineMapEntries);
-  for (const [ruleId, guidelineId] of registry.buildRuleGuidelineMap()) {
-    mergedGuidelineMap.set(ruleId, guidelineId);
-  }
-  newRunner.setGuidelineMap(mergedGuidelineMap);
-
-  // 4. Replay last-known configs.
-  for (const [ruleId, config] of lastConfigs) {
-    newRunner.setConfig(ruleId, config);
-  }
-
-  // 5. Replay last-known active guidelines.
-  newRunner.setActiveGuidelines(lastGuidelines);
-
-  return { runner: newRunner, ruleGuidelineMap: mergedGuidelineMap };
 }
 
 // Initial runner (no externals yet).
@@ -251,15 +205,8 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
 // -------------------------------------------------------------------------
 
 async function handleLoadRuleset(correlationId: number, id: string, code: string): Promise<void> {
-  let url: string | null = null;
   try {
-    const blob = new Blob([code], { type: "text/javascript" });
-    url = URL.createObjectURL(blob);
-    // webpackIgnore: true is REQUIRED — the bundler must not try to resolve
-    // this dynamic import at build time. The URL is a runtime blob: URI.
-    const mod = (await import(/* webpackIgnore: true */ url)).default as RulesetModule;
-    URL.revokeObjectURL(url);
-    url = null;
+    const mod = await importRulesetModule(code);
 
     // Register into a temporary registry for validation (quarantine check).
     const tempRegistry = new RulesetRegistry();
@@ -313,14 +260,6 @@ async function handleLoadRuleset(correlationId: number, id: string, code: string
       hasMorphologicalRules: runnerHasRegisteredMorphRules(runner),
     });
   } catch (err) {
-    // Ensure blob URL is always revoked even on error.
-    if (url !== null) {
-      try {
-        URL.revokeObjectURL(url);
-      } catch {
-        // ignore
-      }
-    }
     const detail = err instanceof Error ? err.message : String(err);
     const warnings: RulesetLoadWarning[] = [
       {

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
@@ -15,8 +15,14 @@ import {
   isMorphologicalDocumentLintRule,
   isMorphologicalLintRule,
 } from "@/lib/linting/types";
-import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
+import type { LintIssue, LintRule, LintRuleConfig } from "@/lib/linting/types";
+import type { RulesetModule } from "@/lib/linting/sdk/ruleset-types";
 
+import {
+  buildRulesetRunner,
+  createIsolatedRulesetContext,
+  importRulesetModule,
+} from "./build-ruleset-runner";
 import {
   WorkerDisposedError,
   WorkerStaleError,
@@ -83,14 +89,35 @@ export class RuleRunnerProxy implements RuleRunnerLike {
 
   private ready = false;
   private disposed = false;
-  /**
-   * Non-null once the worker has hit a fatal failure (uncorrelated
-   * ERROR, `onerror`, `messageerror`). Set on either the pre-READY or
-   * post-READY path. Once set, the proxy is poisoned: `runBatch` and
-   * other API calls fail fast with this error instead of attempting
-   * to talk to a dead worker.
-   */
-  private fatalError: Error | null = null;
+
+  // ----------------------------------------------------------------
+  // Main-thread fallback state (#1831)
+  //
+  // In packaged Electron the app is served from file://, so the worker's
+  // `location.origin` is the string "null" and the Turbopack worker
+  // bootstrap's `new URL(chunk, location.origin)` throws — the worker never
+  // reaches READY. Rather than poisoning the proxy (which left ALL linting
+  // dead once built-in rules were zeroed), we fall back to running every
+  // rule on the main thread. The renderer CAN blob-import ruleset modules
+  // even when the file:// worker cannot resolve its chunks.
+  // ----------------------------------------------------------------
+  private fallbackActive = false;
+  private fallbackRunner: RuleRunner | null = null;
+  private fallbackBuild: Promise<void> | null = null;
+  /** Legacy (built-in, non-morph) rules hosted by the fallback runner — mirrors the worker. */
+  private readonly fallbackLegacyRules: LintRule[];
+  /** id → source code of every load request, retained so the fallback can rebuild. */
+  private readonly loadedCodes = new Map<string, string>();
+  /** id → imported module (populated on the main thread once in fallback). */
+  private readonly fallbackModules = new Map<string, RulesetModule>();
+  /** Last-known per-rule configs, replayed onto the fallback runner. */
+  private readonly lastConfigs = new Map<string, LintRuleConfig>();
+  /** Last-known active guideline ids, replayed onto the fallback runner. */
+  private lastActiveGuidelines: string[] | null = null;
+  /** Last-known guideline-map entries (legacy base), replayed onto the fallback runner. */
+  private lastGuidelineMapEntries: Array<[string, string | undefined]> = Array.from(
+    RULE_GUIDELINE_MAP.entries(),
+  );
 
   /** Promise that resolves once the worker has posted READY. */
   readonly readyPromise: Promise<void>;
@@ -109,9 +136,16 @@ export class RuleRunnerProxy implements RuleRunnerLike {
 
     // 2. Pre-compute worker capability flags from rule metadata so
     //    `hasDocumentRules()` can answer synchronously.
-    this.workerHasDocumentRules = createJsonDrivenRules().some(
+    const jsonRules = createJsonDrivenRules();
+    this.workerHasDocumentRules = jsonRules.some(
       (r) =>
         isDocumentLintRule(r) && !isMorphologicalLintRule(r) && !isMorphologicalDocumentLintRule(r),
+    );
+
+    // Non-morph legacy rules the worker would host — reused by the
+    // main-thread fallback so it produces the same rule set (#1831).
+    this.fallbackLegacyRules = jsonRules.filter(
+      (r) => !isMorphologicalLintRule(r) && !isMorphologicalDocumentLintRule(r),
     );
 
     // 3. Spin up the worker.
@@ -137,7 +171,12 @@ export class RuleRunnerProxy implements RuleRunnerLike {
 
   setConfig(ruleId: string, config: LintRuleConfig): void {
     if (this.disposed) return;
+    this.lastConfigs.set(ruleId, config);
     this.mainRunner.setConfig(ruleId, config);
+    if (this.fallbackActive) {
+      this.fallbackRunner?.setConfig(ruleId, config);
+      return;
+    }
     this.send({
       type: "SET_CONFIG",
       correlationId: this.nextId(),
@@ -148,7 +187,12 @@ export class RuleRunnerProxy implements RuleRunnerLike {
 
   setActiveGuidelines(guidelines: string[] | null): void {
     if (this.disposed) return;
+    this.lastActiveGuidelines = guidelines;
     this.mainRunner.setActiveGuidelines(guidelines);
+    if (this.fallbackActive) {
+      this.fallbackRunner?.setActiveGuidelines(guidelines);
+      return;
+    }
     this.send({
       type: "SET_ACTIVE_GUIDELINES",
       correlationId: this.nextId(),
@@ -158,7 +202,12 @@ export class RuleRunnerProxy implements RuleRunnerLike {
 
   setGuidelineMap(map: Map<string, string | undefined>): void {
     if (this.disposed) return;
+    this.lastGuidelineMapEntries = Array.from(map.entries());
     this.mainRunner.setGuidelineMap(map);
+    if (this.fallbackActive) {
+      this.fallbackRunner?.setGuidelineMap(map);
+      return;
+    }
     this.send({
       type: "SET_GUIDELINE_MAP",
       correlationId: this.nextId(),
@@ -185,11 +234,11 @@ export class RuleRunnerProxy implements RuleRunnerLike {
   // ----------------------------------------------------------------
 
   async runBatch(req: RunBatchRequest): Promise<RunBatchResponse> {
-    if (this.fatalError) {
-      throw this.fatalError;
-    }
     if (this.disposed) {
       throw new WorkerDisposedError();
+    }
+    if (this.fallbackActive) {
+      return this.runBatchFallback(req);
     }
 
     // Track the latest version requested so older responses can be filtered.
@@ -280,8 +329,13 @@ export class RuleRunnerProxy implements RuleRunnerLike {
    * On failure the worker's existing runner is left intact (failure isolation).
    */
   async loadRuleset(id: string, code: string): Promise<RulesetLoadResult> {
-    if (this.fatalError) throw this.fatalError;
     if (this.disposed) throw new WorkerDisposedError();
+    // Retain the source so the fallback can (re)build the main-thread runner.
+    this.loadedCodes.set(id, code);
+
+    if (this.fallbackActive) {
+      return this.loadRulesetMainThread(id, code);
+    }
 
     const correlationId = this.nextId();
     const result = new Promise<RulesetLoadResult>((resolve, reject) => {
@@ -298,8 +352,21 @@ export class RuleRunnerProxy implements RuleRunnerLike {
    * The worker rebuilds the runner from legacy + remaining externals.
    */
   async unloadRuleset(id: string): Promise<RulesetLoadResult> {
-    if (this.fatalError) throw this.fatalError;
     if (this.disposed) throw new WorkerDisposedError();
+    this.loadedCodes.delete(id);
+
+    if (this.fallbackActive) {
+      if (this.fallbackBuild) {
+        try {
+          await this.fallbackBuild;
+        } catch {
+          /* build never rejects */
+        }
+      }
+      this.fallbackModules.delete(id);
+      this.rebuildFallbackRunner();
+      return { ok: true, ruleIds: [], warnings: [] };
+    }
 
     const correlationId = this.nextId();
     const result = new Promise<RulesetLoadResult>((resolve, reject) => {
@@ -418,11 +485,9 @@ export class RuleRunnerProxy implements RuleRunnerLike {
             return;
           }
         } else {
-          // Uncorrelated worker failure — treat as fatal. Reject every
-          // pending request, reject readyPromise if startup hadn't
-          // completed, and poison the proxy so future `runBatch()`
-          // calls fail fast instead of posting into a dead worker.
-          this.poison(err);
+          // Uncorrelated worker failure (e.g. startup crash). Switch to the
+          // main-thread fallback instead of killing linting entirely (#1831).
+          void this.enterFallback(err).catch(() => {});
         }
         return;
       }
@@ -434,35 +499,158 @@ export class RuleRunnerProxy implements RuleRunnerLike {
   }
 
   private handleWorkerError(e: ErrorEvent | Error): void {
-    const err = e instanceof Error ? e : new Error(e.message ?? String(e));
-    this.poison(err);
+    const err =
+      e instanceof Error ? e : new Error(e.message ? String(e.message) : "Lint worker error");
+    void this.enterFallback(err).catch(() => {});
   }
 
+  // ----------------------------------------------------------------
+  // Main-thread fallback (#1831)
+  // ----------------------------------------------------------------
+
   /**
-   * Mark the proxy as fatally broken: reject every pending request and
-   * `readyPromise` (if startup hadn't completed), terminate the worker,
-   * and remember the error so subsequent API calls fail fast instead
-   * of hanging.
+   * The worker is unusable (failed to start / crashed). Tear it down and
+   * rebuild every loaded ruleset on the main thread so linting keeps working.
    */
-  private poison(err: Error): void {
-    if (this.fatalError) return;
-    this.fatalError = err;
-    for (const entry of this.pending.values()) {
-      entry.reject(err);
-    }
-    this.pending.clear();
-    for (const entry of this.pendingRulesets.values()) {
-      entry.reject(err);
-    }
-    this.pendingRulesets.clear();
-    this.preReadyBuffer.length = 0;
-    if (!this.ready) {
-      this.rejectReady(err);
-    }
-    if (!this.disposed) {
-      this.disposed = true;
+  private async enterFallback(err: Error): Promise<void> {
+    if (this.fallbackActive || this.disposed) return;
+    this.fallbackActive = true;
+    console.warn("[lint] worker unavailable — falling back to main-thread linting:", err.message);
+
+    try {
       this.worker.terminate();
+    } catch {
+      /* ignore */
     }
+
+    // In-flight batches can't be salvaged (their paragraphs aren't retained);
+    // reject them as stale so the lint pipeline re-runs through the fallback.
+    const staleErr = new WorkerStaleError();
+    for (const entry of this.pending.values()) entry.reject(staleErr);
+    this.pending.clear();
+    this.preReadyBuffer.length = 0;
+
+    // Build the fallback runner (imports every recorded ruleset module).
+    this.fallbackBuild = this.buildFallbackRunner();
+
+    // Unblock anything awaiting worker startup so it proceeds to the fallback.
+    if (!this.ready) {
+      this.ready = true;
+      this.resolveReady();
+    }
+
+    // Resolve pending ruleset requests once the fallback is built.
+    const pendingRs = Array.from(this.pendingRulesets.values());
+    this.pendingRulesets.clear();
+    try {
+      await this.fallbackBuild;
+    } catch {
+      /* buildFallbackRunner never rejects */
+    }
+    for (const entry of pendingRs) {
+      entry.resolve({ ok: true, ruleIds: [], warnings: [] });
+    }
+  }
+
+  /** Import every recorded ruleset on the main thread, then build the runner. */
+  private async buildFallbackRunner(): Promise<void> {
+    for (const [id, code] of this.loadedCodes) {
+      if (this.fallbackModules.has(id)) continue;
+      try {
+        this.fallbackModules.set(id, await importRulesetModule(code));
+      } catch (e) {
+        console.error(`[lint] fallback failed to import ruleset "${id}":`, e);
+      }
+    }
+    this.rebuildFallbackRunner();
+  }
+
+  /** (Re)build the fallback runner from the currently-imported modules. */
+  private rebuildFallbackRunner(): void {
+    try {
+      const { runner } = buildRulesetRunner({
+        legacyRules: this.fallbackLegacyRules,
+        externals: this.fallbackModules.values(),
+        ctx: createIsolatedRulesetContext(),
+        baseGuidelineMapEntries: this.lastGuidelineMapEntries,
+        configs: this.lastConfigs,
+        activeGuidelines: this.lastActiveGuidelines,
+      });
+      this.fallbackRunner = runner;
+      this.workerHasMorphRules = runnerHasRegisteredMorphRules(runner);
+    } catch (e) {
+      console.error("[lint] fallback runner build failed:", e);
+    }
+  }
+
+  /** Load a single ruleset into the (already-active) fallback runner. */
+  private async loadRulesetMainThread(id: string, code: string): Promise<RulesetLoadResult> {
+    if (this.fallbackBuild) {
+      try {
+        await this.fallbackBuild;
+      } catch {
+        /* build never rejects */
+      }
+    }
+    try {
+      const mod = await importRulesetModule(code);
+      this.fallbackModules.set(id, mod);
+      this.rebuildFallbackRunner();
+      const ruleIds = (mod.manifest?.rules ?? []).map((r) => r.ruleId);
+      return { ok: true, ruleIds, warnings: [] };
+    } catch (e) {
+      return {
+        ok: false,
+        ruleIds: [],
+        warnings: [
+          {
+            code: "load-failed",
+            messageJa: "ルールセットの読み込みに失敗しました",
+            detail: e instanceof Error ? e.message : String(e),
+          },
+        ],
+      };
+    }
+  }
+
+  /** Run a batch entirely on the main thread (worker unavailable). */
+  private async runBatchFallback(req: RunBatchRequest): Promise<RunBatchResponse> {
+    if (this.fallbackBuild) {
+      try {
+        await this.fallbackBuild;
+      } catch {
+        /* build never rejects */
+      }
+    }
+    if (req.version > this.latestRequestedVersion) {
+      this.latestRequestedVersion = req.version;
+    }
+
+    // Built-in morph rules (real dict) run via the existing main runner.
+    const { mainPerParagraph, mainDocument } = this.runMainMorph(req);
+
+    const runner = this.fallbackRunner;
+    if (req.runWorker === false || !runner) {
+      return { perParagraph: mainPerParagraph, document: mainDocument };
+    }
+
+    const runPer = req.mode === "per-paragraph" || req.mode === "both";
+    const runDoc = req.mode === "document" || req.mode === "both";
+
+    const fbPerParagraph = new Map<number, LintIssue[]>();
+    if (runPer) {
+      for (const p of req.paragraphs) {
+        const issues = p.tokens ? runner.runAllWithTokens(p.text, p.tokens) : runner.runAll(p.text);
+        if (issues.length > 0) fbPerParagraph.set(p.index, issues);
+      }
+    }
+    const fbDocument: Map<number, LintIssue[]> =
+      runDoc && runner.hasDocumentRules() ? runner.runDocument(req.paragraphs) : new Map();
+
+    return {
+      perParagraph: mergeIssueMaps(mainPerParagraph, fbPerParagraph),
+      document: mergeIssueMaps(mainDocument, fbDocument),
+    };
   }
 
   private runMainMorph(req: RunBatchRequest): {
@@ -508,6 +696,13 @@ export class RuleRunnerProxy implements RuleRunnerLike {
 // ------------------------------------------------------------------
 // Helpers
 // ------------------------------------------------------------------
+
+/** Whether a runner hosts at least one registered morphological rule (ignoring enabled state). */
+function runnerHasRegisteredMorphRules(r: RuleRunner): boolean {
+  return r
+    .getRegisteredRules()
+    .some((rule) => isMorphologicalLintRule(rule) || isMorphologicalDocumentLintRule(rule));
+}
 
 function deserialize(entries: SerializedIssueMap): Map<number, LintIssue[]> {
   const map = new Map<number, LintIssue[]>();

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -57,7 +57,22 @@ export const LEGACY_PACKAGE_IMPORTS = new Map([
   ],
   [
     "packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts",
-    new Set(["@/lib/linting/types", "@/lib/nlp-client/types"]),
+    new Set([
+      "@/lib/linting/registry/__tests__/ruleset-fixtures",
+      "@/lib/linting/types",
+      "@/lib/nlp-client/types",
+    ]),
+  ],
+  [
+    "packages/milkdown-plugin-japanese-novel/linting-plugin/worker/build-ruleset-runner.ts",
+    new Set([
+      "@/lib/linting/registry/ruleset-context-factory",
+      "@/lib/linting/registry/ruleset-registry",
+      "@/lib/linting/rule-runner",
+      "@/lib/linting/sdk/ruleset-context",
+      "@/lib/linting/sdk/ruleset-types",
+      "@/lib/linting/types",
+    ]),
   ],
   [
     "packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts",
@@ -81,6 +96,7 @@ export const LEGACY_PACKAGE_IMPORTS = new Map([
       "@/lib/linting/lint-presets",
       "@/lib/linting/rule-registry",
       "@/lib/linting/rule-runner",
+      "@/lib/linting/sdk/ruleset-types",
       "@/lib/linting/types",
     ]),
   ],


### PR DESCRIPTION
## 概要

親テスト計画 #1825 で検出された 2 件の不合格バグを修正。

### #1831 (P0) — packaged Electron で公式6ルールセットが全滅
**根本原因**: packaged Electron は `output: "export"` + file:// 配信のため、lint worker の `location.origin` が文字列 `"null"` になる。Turbopack の worker bootstrap が `new URL(chunk, location.origin)` でチャンク URL を解決するが、`"null"` を base にすると throw し、**worker が READY に到達しない**。内蔵ルールゼロ化 (#1809) 後は全ルールが外部 ruleset 経由のため、校正検出全体が利用不能になっていた。`Error: [object Event]` は worker 起動失敗→`onerror`(プレーン Event)→proxy が poison→全 `loadRuleset` が reject、の連鎖。

**修正**: `RuleRunnerProxy` を poison ではなく **main-thread フォールバック**へ切替。worker が起動失敗/クラッシュしたら、読み込み済みの全 ruleset を renderer 側で blob import し、メインスレッドの `RuleRunner` で実行する。これは #1820（project-search worker）と同じ graceful degradation 方針。worker と fallback で同一ルールセットを構築するため、`buildRunner` ロジックを `build-ruleset-runner.ts` に共有抽出。

> 注: renderer の `import(blob:)` は worker bootstrap の相対URL解決とは別経路（絶対 blob: URL のネイティブ動的 import）のため、worker が失敗する file:// 環境でも動作が期待できる。packaged 実機での最終確認はベータ配信で行う。

### #1832 (P1) — 「すべて無効」が no-op
**根本原因**: 内蔵ルールゼロ化後、ルールは外部 ruleset から供給されるのに `handleEnableAll` / `handleDisableAll` が空の `LINT_RULES_META` だけを回していた。「すべて有効」もフォールバック既定 `enabled:true` で動いて見えていただけ。

**修正**: `collectAllRuleIds` で内蔵＋外部の全ルール ID を集約。純粋ロジックを `bulk-toggle.ts` に抽出。

## テスト
- `proxy.test.ts`: worker 起動失敗→フォールバック、fallback runner でのルール実行 / config 反映 / unload を検証（`importRulesetModule` をモック）。旧 poison テスト3件をフォールバック挙動へ更新。
- `bulk-toggle.test.ts`: `collectAllRuleIds` が外部 ruleset を含むこと、`buildBulkConfig` の disable / enable / severity 保持 / 非破壊を検証。
- 全 1912 テスト pass / type-check / ESLint 0 error / import boundaries valid / `bundle:electron` + electron static export OK。

Closes #1831
Closes #1832