### PR TITLE
fix(linting): Web 版で校正ルール0件時に「デスクトップ版で利用」を明示 (#1833)

### DIFF
--- a/components/inspector/CorrectionsPanel.tsx
+++ b/components/inspector/CorrectionsPanel.tsx
@@ -17,6 +17,7 @@ import clsx from "clsx";
 
 import { LINT_RULE_CATEGORIES } from "@/lib/linting/lint-presets";
 import { CORRECTION_MODE_IDS, CORRECTION_MODES } from "@/lib/linting/correction-modes";
+import { isElectronRenderer } from "@/lib/utils/runtime-env";
 import type { CorrectionModeId } from "@/lib/linting/correction-config";
 import { DEFAULT_POS_COLORS } from "@/packages/milkdown-plugin-japanese-novel/pos-highlight/pos-colors";
 import InfoTooltip from "./InfoTooltip";
@@ -260,6 +261,10 @@ export default function CorrectionsPanel({
     { value: "warning", label: "警告", icon: <AlertTriangle className="w-3.5 h-3.5" /> },
     { value: "info", label: "情報", icon: <Info className="w-3.5 h-3.5" /> },
   ];
+
+  // Web 版には校正ルールが供給されない（ルールセットはデスクトップ版のみ）。
+  // 0 件を「問題なし」と誤認させないよう、空状態で desktop-only を明示する (#1833)。
+  const isElectron = isElectronRenderer();
 
   /** Render a flat list of issue cards */
   const renderFlatList = (): React.JSX.Element => (
@@ -564,9 +569,21 @@ export default function CorrectionsPanel({
 
           {/* Issue list */}
           {filteredIssues.length === 0 ? (
-            <div className="pt-4 text-center">
-              <p className="text-sm text-foreground-tertiary">問題は検出されませんでした</p>
-            </div>
+            !isElectron ? (
+              <div className="pt-4 text-center">
+                <p className="text-sm text-foreground-secondary">
+                  校正ルールはデスクトップ版で利用できます
+                </p>
+                <p className="mt-1 text-xs text-foreground-tertiary">
+                  Web
+                  版には校正ルールセットが含まれていません。デスクトップ版で公式ルールセットをインストールすると校正が利用できます。
+                </p>
+              </div>
+            ) : (
+              <div className="pt-4 text-center">
+                <p className="text-sm text-foreground-tertiary">問題は検出されませんでした</p>
+              </div>
+            )
           ) : sortMode === "category" ? (
             renderGroupedList()
           ) : (

--- a/components/settings/LintingSettings.tsx
+++ b/components/settings/LintingSettings.tsx
@@ -141,7 +141,7 @@ function LintingSettingsInner({
         {/* Web fallback note */}
         {!isElectron && (
           <p className="text-xs text-foreground-tertiary mt-3">
-            ルールセットの管理はデスクトップ版で利用できます
+            校正ルールはデスクトップ版で利用できます（Web 版にはルールセットが含まれていません）
           </p>
         )}
       </div>


### PR DESCRIPTION
## 概要

#1825 J-1 で検出された #1833 の対応。Web 版は外部ルールセットが供給されず校正ルールが 0 件のため、校正を有効化しても検出結果が常に 0 件になり、インスペクタが「問題は検出されませんでした」と表示して「文章に問題なし」と誤認させていた。

## 方針

ユーザー判断により、**Web は当面「デスクトップ版で利用」表示に留める**。Web での実ルール供給（バンドル / CORS 対応 API）は #1835 で追跡。

## 変更

- **CorrectionsPanel**: Web(`!isElectron`) かつ検出 0 件のとき「校正ルールはデスクトップ版で利用できます」＋補足を表示。Electron では従来どおり「問題は検出されませんでした」。
- **LintingSettings**: Web フォールバック注記を「ルールセットの管理は…」→「校正ルールはデスクトップ版で利用できます（Web 版にはルールセットが含まれていません）」へ拡張。

## テスト
- type-check / ESLint / prettier / 既存 component テスト90件 pass。
- 純 presentational 変更（リポジトリに @testing-library/react 不在のため render テストは追加せず、既存方針に準拠）。

Closes #1833
Refs #1825, #1835