### PR TITLE
fix(linting): 設定「すべて更新」/再ダウンロードに進捗・完了トーストを追加 (#1838)

### DIFF
--- a/components/settings/linting/useRulesetStatus.ts
+++ b/components/settings/linting/useRulesetStatus.ts
@@ -3,6 +3,12 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
+import {
+  showRulesetSyncProgress,
+  notifyRulesetSyncSummary,
+  notifyRulesetSyncError,
+} from "@/lib/services/ruleset-sync-feedback";
+import { notificationManager } from "@/lib/services/notification-manager";
 
 /** Matches RulesetManifest from the SDK — only the fields the UI needs. */
 export interface RulesetRuleMeta {
@@ -144,8 +150,19 @@ export function useRulesetStatus(): UseRulesetStatusReturn {
     if (!isElectron) return;
     const api = getRulesetsAPI();
     if (!api) return;
-    await api.sync();
-    await refresh();
+    // 進捗→完了サマリーのトーストは起動時自動更新と共有（#1838: 設定側の
+    // 「すべて更新」/再ダウンロードがトーストを出さない退行の修正）。
+    const progressId = showRulesetSyncProgress();
+    try {
+      const summary = await api.sync();
+      notifyRulesetSyncSummary(summary);
+    } catch (err) {
+      console.error("[useRulesetStatus] sync failed", err);
+      notifyRulesetSyncError(err);
+    } finally {
+      notificationManager.dismiss(progressId);
+      await refresh();
+    }
   }, [isElectron, refresh]);
 
   const uninstall = useCallback(

--- a/lib/services/__tests__/ruleset-sync-feedback.test.ts
+++ b/lib/services/__tests__/ruleset-sync-feedback.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for the shared ruleset-sync toast helpers (#1838).
+ *
+ * Regression: the settings「すべて更新」/ 再ダウンロードボタン（useRulesetStatus.sync）
+ * showed no progress/completion toast — only the startup auto-update path did.
+ * These helpers centralize the feedback so both paths stay in sync.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { showMessage, dismiss, success, warning, error } = vi.hoisted(() => ({
+  showMessage: vi.fn(() => "toast-id"),
+  dismiss: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { showMessage, dismiss, success, warning, error },
+}));
+
+import {
+  RULESET_SYNC_PROGRESS_MESSAGE,
+  showRulesetSyncProgress,
+  notifyRulesetSyncSummary,
+  notifyRulesetSyncError,
+} from "@/lib/services/ruleset-sync-feedback";
+
+describe("ruleset-sync-feedback", () => {
+  beforeEach(() => {
+    showMessage.mockClear();
+    dismiss.mockClear();
+    success.mockClear();
+    warning.mockClear();
+    error.mockClear();
+  });
+
+  it("shows a persistent progress toast and returns its id", () => {
+    const id = showRulesetSyncProgress();
+    expect(id).toBe("toast-id");
+    expect(showMessage).toHaveBeenCalledWith(RULESET_SYNC_PROGRESS_MESSAGE, {
+      type: "info",
+      duration: 0,
+    });
+  });
+
+  it("reports the installed count on success", () => {
+    notifyRulesetSyncSummary([
+      { status: "installed" },
+      { status: "up-to-date" },
+      { status: "installed" },
+    ]);
+    expect(success).toHaveBeenCalledWith("校正ルールセットを更新しました（2 件）。");
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when nothing was installed", () => {
+    notifyRulesetSyncSummary([{ status: "up-to-date" }, { status: "skipped" }]);
+    expect(success).not.toHaveBeenCalled();
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it("warns when some packs fail", () => {
+    notifyRulesetSyncSummary([{ status: "installed" }, { status: "error" }]);
+    expect(warning).toHaveBeenCalledWith(
+      "校正ルールセットを更新しました（1 件）。1 件は失敗しました。",
+    );
+    expect(success).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a missing/non-array summary", () => {
+    notifyRulesetSyncSummary(undefined);
+    expect(success).not.toHaveBeenCalled();
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast", () => {
+    notifyRulesetSyncError(new Error("boom"));
+    expect(error).toHaveBeenCalledWith("校正ルールセットの更新に失敗しました：boom");
+  });
+});

--- a/lib/services/ruleset-sync-feedback.ts
+++ b/lib/services/ruleset-sync-feedback.ts
@@ -1,0 +1,55 @@
+/**
+ * 校正ルールセット `sync()`（全公式ルールセットの差分ダウンロード）の共有トースト表示。
+ *
+ * 同じ `sync()` を呼ぶ経路が 2 つある:
+ * - 起動時自動更新 / 手動「更新」ボタン … `startup-checks/ruleset-update-check.ts`
+ * - 設定「すべて更新」/ 再ダウンロード … `useRulesetStatus.sync()`
+ *
+ * どちらも進捗トースト → 完了サマリーという同じ UX を出すべきなので、メッセージと
+ * 要約ロジックをここに集約する（#1838: 設定側ボタンがトーストを出さない退行の修正）。
+ */
+import { notificationManager } from "./notification-manager";
+
+export const RULESET_SYNC_PROGRESS_MESSAGE = "校正ルールセットを更新中...";
+
+interface RulesetSyncResultLike {
+  status: "installed" | "up-to-date" | "skipped" | "error";
+}
+
+/**
+ * 進捗トーストを表示し、`id` を返す。完了後に `dismiss(id)` すること。
+ */
+export function showRulesetSyncProgress(): string {
+  return notificationManager.showMessage(RULESET_SYNC_PROGRESS_MESSAGE, {
+    type: "info",
+    duration: 0,
+  });
+}
+
+/**
+ * `sync()` の結果を要約してトーストを出す。1 件も更新が無ければ静かに閉じる。
+ */
+export function notifyRulesetSyncSummary(
+  summary: readonly RulesetSyncResultLike[] | undefined,
+): void {
+  const installed = Array.isArray(summary)
+    ? summary.filter((s) => s.status === "installed").length
+    : 0;
+  const failed = Array.isArray(summary) ? summary.filter((s) => s.status === "error").length : 0;
+  if (failed > 0) {
+    notificationManager.warning(
+      `校正ルールセットを更新しました（${installed} 件）。${failed} 件は失敗しました。`,
+    );
+  } else if (installed > 0) {
+    notificationManager.success(`校正ルールセットを更新しました（${installed} 件）。`);
+  }
+}
+
+/**
+ * `sync()` の失敗をエラートーストで表示する。
+ */
+export function notifyRulesetSyncError(err: unknown): void {
+  notificationManager.error(
+    `校正ルールセットの更新に失敗しました：${err instanceof Error ? err.message : String(err)}`,
+  );
+}

--- a/lib/services/startup-checks/ruleset-update-check.ts
+++ b/lib/services/startup-checks/ruleset-update-check.ts
@@ -17,6 +17,11 @@
  */
 import { getStorageService } from "@/lib/storage/storage-service";
 import { notificationManager } from "../notification-manager";
+import {
+  showRulesetSyncProgress,
+  notifyRulesetSyncSummary,
+  notifyRulesetSyncError,
+} from "../ruleset-sync-feedback";
 import type { StartupCheck, StartupNotice } from "../startup-check-queue";
 
 interface RulesetUpdateInfo {
@@ -42,47 +47,30 @@ function getElectronRulesets(): ElectronRulesetsApi | undefined {
     ?.rulesets;
 }
 
-const SYNC_MESSAGE = "校正ルールセットを更新中...";
-
 /**
  * `sync()`（全公式ルールセットの差分ダウンロード）を進捗トースト付きで実行する。
  * 自動更新・手動「更新」ボタンの両方から使う。完了時にインストール件数を要約表示し、
  * 1 件も更新が無ければ静かに閉じる。worker への再読み込みは main 側の `changed`
  * イベント → subscribeRulesetChanges が担うため、ここでは行わない。
+ *
+ * トースト表示は設定「すべて更新」（useRulesetStatus.sync）と共有する（#1838）。
  */
 export function runRulesetSync(): void {
   const api = getElectronRulesets();
   if (!api?.sync) return;
 
-  const progressId = notificationManager.showMessage(SYNC_MESSAGE, {
-    type: "info",
-    duration: 0,
-  });
+  const progressId = showRulesetSyncProgress();
 
   api
     .sync()
     .then((summary) => {
       notificationManager.dismiss(progressId);
-      const installed = Array.isArray(summary)
-        ? summary.filter((s) => s.status === "installed").length
-        : 0;
-      const failed = Array.isArray(summary)
-        ? summary.filter((s) => s.status === "error").length
-        : 0;
-      if (failed > 0) {
-        notificationManager.warning(
-          `校正ルールセットを更新しました（${installed} 件）。${failed} 件は失敗しました。`,
-        );
-      } else if (installed > 0) {
-        notificationManager.success(`校正ルールセットを更新しました（${installed} 件）。`);
-      }
+      notifyRulesetSyncSummary(summary);
     })
     .catch((err: unknown) => {
       notificationManager.dismiss(progressId);
       console.warn("[ruleset-update-check] sync failed:", err);
-      notificationManager.error(
-        `校正ルールセットの更新に失敗しました：${err instanceof Error ? err.message : String(err)}`,
-      );
+      notifyRulesetSyncError(err);
     });
 }
 


### PR DESCRIPTION
## 概要

校正ルールセット設定の **「すべて更新」** ボタンと各ルールセットの **「再ダウンロード」** は `useRulesetStatus.sync()`（= `api.sync()` + `refresh()`）を呼ぶだけで、進捗トーストも完了トーストも出さなかった。ユーザーには更新が走ったのか・完了したのかが分からず、無反応に見えていた（#1838 / #1825 D-3・D-4）。

進捗「校正ルールセットを更新中...」と完了サマリー「校正ルールセットを更新しました（N 件）。」は**起動時自動更新 (`runRulesetSync`) が既に出していた**ため、メッセージと要約ロジックを共有ヘルパに抽出し、起動時・設定 UI の両経路で同一 UX を保証する。

## 変更点

- `lib/services/ruleset-sync-feedback.ts` 新設
  - `showRulesetSyncProgress()` / `notifyRulesetSyncSummary()` / `notifyRulesetSyncError()`
- `useRulesetStatus.sync()` を進捗 → 完了/失敗トースト付きに変更（`handleUpdateAll` と `onRedownload` の両方が恩恵を受ける）
- `runRulesetSync()` を共有ヘルパ利用へリファクタ（**挙動不変**）
- 共有ヘルパの単体テスト追加（成功件数 / 沈黙 / 失敗件数 / エラー）

## 検証

- `vitest run` 全 **1948 passed**（新規 6 件含む）、`tsc --noEmit` 0 errors、`eslint` 0 errors
- **dev Electron 実機 UI テスト**（`/Applications/Illusions.app` 不使用）:
  - gendai タグを v0.1.0 に下げ `updateAvailable=true` を確認
  - 設定 → 校正 → 「すべて更新（1）」クリック
  - トースト捕捉: `校正ルールセットを更新中...` → `校正ルールセットを更新しました（1 件）。`
  - **D-3 progress toast: PASS / D-4 completion toast: PASS**

Closes #1838