### PR TITLE
fix(layout): 右インスペクタの境界線を左ナビゲーションと同等に視認可能化

### DIFF
--- a/shared/ui/ResizablePanel.tsx
+++ b/shared/ui/ResizablePanel.tsx
@@ -88,8 +88,12 @@ export default function ResizablePanel({
       className={clsx(
         "relative flex-shrink-0",
         !isResizing && "transition-all duration-300 ease-in-out",
-        !isCollapsed && (side === "right" ? "border-l" : "border-r"),
-        "border-border",
+        // 右インスペクタは隣に ActivityBar のような背景ブロックが無く、
+        // border-border(rgb 45,45,45) では暗いエディタ背景(rgb 8,8,8)に
+        // 紛れて境界線が見えない。左ナビゲーションと同等に視認できるよう、
+        // より明瞭な border-border-secondary(rgb 60,60,60) を用いる。
+        !isCollapsed &&
+          (side === "right" ? "border-l border-border-secondary" : "border-r border-border"),
         className,
       )}
       style={{ width: isCollapsed ? "0px" : `${width}px` }}


### PR DESCRIPTION
## 概要

右インスペクタパネルとエディタ領域の境界線が、左側のナビゲーションと比べて視認できないバグを修正します。

## 根本原因

- **左側**は `ActivityBar` が `bg-background-tertiary`（dark: rgb(30,30,30)）という明るい背景ブロックを持ち、`border-r border-border` と相まって**強い境界**を形成している
- **右側**インスペクタは隣接する背景ブロックが無く、`border-l border-border`（rgb(45,45,45)）の 1px 境界のみ。暗いエディタ背景（rgb(8,8,8)）に紛れて「境界線が無い」ように見えていた
- 経緯: #1798 でインスペクタ aside に境界線を追加 → #1801 で「二重ボーダー」として 1px の `border-border` に一本化した結果、再び視認性が低下していた

## 修正

`shared/ui/ResizablePanel.tsx` で、右パネル（`side="right"`）の境界色を、より明瞭な `border-border-secondary`（dark: rgb(60,60,60)）に変更。左パネルは `ActivityBar` に隣接して十分な視認性があるため `border-border` を維持し、左右の境界の「見え方」を揃えました。

## テスト

- `npx tsc --noEmit` → pass（exit 0）
- 境界色のトークン値（45 vs 60）レンダリング比較で視認性向上を確認
- ResizablePanel は左右パネルの2箇所のみで使用、border クラスを検証するテストは無し

## 関連 issue

関連 issue なし