### PR TITLE
fix(data-preservation): Codex 独立レビュー指摘8件を修正（#1839/#1840 後続）

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,10 @@ import CreateProjectWizard from "@/components/CreateProjectWizard";
 import PermissionPrompt from "@/components/PermissionPrompt";
 import WebSunsetNotice from "@/components/WebSunsetNotice";
 import { useRubyTcy } from "@/lib/editor-page/use-ruby-tcy";
+import {
+  subscribeWindowActivity,
+  getWindowActivitySnapshot,
+} from "@/lib/editor-page/window-activity";
 import { useLintHandlers } from "@/lib/editor-page/use-lint-handlers";
 import { useTabManager } from "@/lib/tab-manager";
 import { useUnsavedWarning } from "@/lib/hooks/use-unsaved-warning";
@@ -293,6 +297,25 @@ export default function EditorPage() {
   const flushActiveEditorRef = useRef<(() => string | null) | null>(null);
   const registerFlush = useCallback((flush: (() => string | null) | null) => {
     flushActiveEditorRef.current = flush;
+  }, []);
+
+  // #1840 (Codex F-02 mitigation): the dirty/clean decision on close/quit reads
+  // `tab.isDirty`, which lags the live editor by the 200ms listener debounce.
+  // Flush the live content whenever the window loses focus or becomes hidden
+  // (e.g. the user clicks away, or the in-app update dialog steals focus before
+  // "今すぐ再起動"), so `tab.content`/`isDirty` are current before any close
+  // decision. This only syncs state (never loses data). The full fix — a main →
+  // renderer close-preflight that flushes before deciding — is tracked separately.
+  useEffect(() => {
+    let prev = getWindowActivitySnapshot();
+    return subscribeWindowActivity((next) => {
+      const lostFocus = prev.isWindowFocused && !next.isWindowFocused;
+      const becameHidden = prev.isDocumentVisible && !next.isDocumentVisible;
+      prev = next;
+      if (lostFocus || becameHidden) {
+        flushActiveEditorRef.current?.();
+      }
+    });
   }, []);
 
   const tabManager = useTabManager({

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -397,13 +397,12 @@ export default function MilkdownEditor({
           result = ctx.get(serializerCtx)(doc);
         }
       });
-      // 安全策（#1840 / レビュー Finding 2）: 縦横切替などでエディタが再マウント中、
-      // 空の初期 doc が一瞬シリアライズされて "" を返すことがある。実コンテンツが
-      // 残っている状態で "" を返すと、呼び出し側がファイルを空で上書きしてしまう。
-      // その場合は null を返してフォールバック（既存 tab.content を保持）させる。
-      if (result === "" && currentContentRef.current !== "") {
-        return null;
-      }
+      // 注（#1840 / Codex F-01）: ここに来た時点で editor.action は editorViewCtx を
+      // 解決できている＝EditorView は ready。ready な view の doc は内容の単一の
+      // 真実なので、result === "" は「本当に空」を意味する（ユーザーの全削除など）。
+      // よって "" を異常値として弾かない。未 ready 時は上の ctx.get が throw して
+      // catch 節で null を返し、呼び出し側が既存 tab.content にフォールバックする。
+      // 再マウント過渡は registerFlush(null)（登録が一旦 null）でも保護される。
       if (result != null && result !== currentContentRef.current) {
         // ライブ値を ref と親 state に反映し、後続の isDirty 再計算も正しくする。
         currentContentRef.current = result;

--- a/electron/window-manager.js
+++ b/electron/window-manager.js
@@ -123,8 +123,24 @@ async function createWindow({ showWelcome = false, hasPendingFile = false } = {}
 
   // ウィンドウ終了前に状態をフラッシュする（未保存の場合はダイアログも表示）
   let isHandlingClose = false;
+
+  // #1839 (Codex F-04): 保存失敗で renderer が closeAborted を送ったら、通常 close
+  // 経路でも isHandlingClose を戻す。これがないと 2 回目の close が「処理中」とみなされ
+  // 確認なしで閉じてしまう（実 close は destroy 経由なので close イベントは常に prevent）。
+  const onWindowCloseAborted = (event) => {
+    if (!newWindow.isDestroyed() && event.sender === newWindow.webContents) {
+      isHandlingClose = false;
+    }
+  };
+  ipcMain.on(SYSTEM_CHANNELS.send.closeAborted, onWindowCloseAborted);
+
   newWindow.on("close", (event) => {
-    if (isHandlingClose) return;
+    // 実際のクローズは saveDoneAndClose → win.destroy() 経由のみ。close イベントは
+    // 常に prevent し、処理中（isHandlingClose）の再入もブロックする（Codex F-04）。
+    if (isHandlingClose) {
+      event.preventDefault();
+      return;
+    }
     event.preventDefault();
     isHandlingClose = true;
 
@@ -162,6 +178,7 @@ async function createWindow({ showWelcome = false, hasPendingFile = false } = {}
 
   // ウィンドウ閉鎖時にセットから削除
   newWindow.on("closed", () => {
+    ipcMain.removeListener(SYSTEM_CHANNELS.send.closeAborted, onWindowCloseAborted);
     allWindows.delete(newWindow);
     if (mainWindow === newWindow) {
       mainWindow = allWindows.values().next().value || null;
@@ -284,14 +301,16 @@ async function _handleWindowBeforeQuit(win) {
       const result = await waitForCloseOrAbort();
       if (result === "aborted") return true;
     } else {
-      // 「保存しない」: フラッシュのみ依頼し、destroy を待つ
+      // 「保存しない」: フラッシュのみ依頼し、destroy を待つ。renderer ハング等で
+      // timeout/abort したら安全側で quit を中止する（Codex F-05）。
       win.webContents.send(SYSTEM_CHANNELS.event.requestFlushStateBeforeClose);
-      await waitForCloseOrAbort();
+      if ((await waitForCloseOrAbort()) === "aborted") return true;
     }
   } else {
-    // clean: フラッシュのみ依頼し、destroy を待つ
+    // clean: フラッシュのみ依頼し、destroy を待つ。clean 判定が debounce 遅延で
+    // 誤っている可能性もあるため、timeout/abort は安全側で quit を中止（Codex F-05/F-02）。
     win.webContents.send(SYSTEM_CHANNELS.event.requestFlushStateBeforeClose);
-    await waitForCloseOrAbort();
+    if ((await waitForCloseOrAbort()) === "aborted") return true;
   }
 
   return false;

--- a/lib/services/__tests__/history-store.test.ts
+++ b/lib/services/__tests__/history-store.test.ts
@@ -29,6 +29,12 @@ import type { VFSDirectoryHandle, VFSFileHandle } from "@/lib/vfs/types";
 /** Flat map of full path → content */
 const fileStore = new Map<string, string>();
 
+/**
+ * Test hook: when set, called at the start of getFileHandle. Throwing from it
+ * simulates a getFileHandle/backup failure for specific file names (Codex F-07).
+ */
+let getFileHandleHook: ((fileName: string, options?: { create?: boolean }) => void) | null = null;
+
 function createMockFileHandle(name: string, dirPath: string): VFSFileHandle {
   const fullPath = dirPath ? `${dirPath}/${name}` : name;
   return {
@@ -54,6 +60,7 @@ function createMockDirectoryHandle(name: string, path: string): VFSDirectoryHand
     path,
     getFileHandle: vi.fn(
       async (fileName: string, options?: { create?: boolean }): Promise<VFSFileHandle> => {
+        getFileHandleHook?.(fileName, options);
         const fullPath = path ? `${path}/${fileName}` : fileName;
         if (!fileStore.has(fullPath) && !options?.create) {
           throw new Error(`File not found: ${fullPath}`);
@@ -108,6 +115,7 @@ describe("HistoryStore", () => {
 
   beforeEach(() => {
     fileStore.clear();
+    getFileHandleHook = null;
     store = new HistoryStore();
     vi.unstubAllGlobals();
   });
@@ -151,8 +159,8 @@ describe("HistoryStore", () => {
       expect(result.snapshots[0].id).toBe("a");
     });
 
-    // Issue #1844 / T-3: corrupt index.json must self-heal
-    it("backs up corrupt index.json to index.json.corrupt.bak and returns a default index", async () => {
+    // Issue #1844 / T-3: corrupt index.json must self-heal (backup → regenerate)
+    it("backs up corrupt index.json (timestamped) and returns/regenerates a default index", async () => {
       const corruptContent = "NOT_VALID_JSON{{{";
       fileStore.set(".illusions/history/index.json", corruptContent);
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -163,14 +171,16 @@ describe("HistoryStore", () => {
       expect(result.snapshots).toEqual([]);
       expect(result.maxSnapshots).toBe(100);
 
-      // Backup file was created with the original corrupt content
-      const backupKey = ".illusions/history/index.json.corrupt.bak";
-      expect(fileStore.has(backupKey)).toBe(true);
-      expect(fileStore.get(backupKey)).toBe(corruptContent);
+      // A timestamped backup file was created with the original corrupt content
+      // (Codex F-07: generational name instead of fixed .corrupt.bak).
+      const backupKey = [...fileStore.keys()].find((k) =>
+        /\.illusions\/history\/index\.json\.corrupt\.\d+\.bak$/.test(k),
+      );
+      expect(backupKey).toBeDefined();
+      expect(fileStore.get(backupKey!)).toBe(corruptContent);
 
-      // A fresh valid index.json was written
+      // A fresh valid index.json was written (backup succeeded → regenerate)
       const regeneratedKey = ".illusions/history/index.json";
-      expect(fileStore.has(regeneratedKey)).toBe(true);
       const regenerated = JSON.parse(fileStore.get(regeneratedKey)!) as { snapshots: unknown[] };
       expect(regenerated.snapshots).toEqual([]);
 
@@ -180,6 +190,39 @@ describe("HistoryStore", () => {
       );
 
       warnSpy.mockRestore();
+    });
+
+    // Codex F-07: if the backup write fails, the corrupt index.json must NOT be
+    // overwritten (preserve snapshot metadata for manual recovery).
+    it("does NOT overwrite corrupt index.json when the backup write fails", async () => {
+      const corruptContent = "NOT_VALID_JSON{{{";
+      fileStore.set(".illusions/history/index.json", corruptContent);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      // Make creating the backup file throw.
+      getFileHandleHook = (fileName) => {
+        if (fileName.includes(".corrupt.")) {
+          throw new Error("backup failed");
+        }
+      };
+
+      const result = await store.loadIndex();
+
+      // Still returns an in-memory default so the app works this session
+      expect(result.snapshots).toEqual([]);
+
+      // The original corrupt index.json is preserved (NOT overwritten)
+      expect(fileStore.get(".illusions/history/index.json")).toBe(corruptContent);
+
+      // No backup was written
+      const backupKey = [...fileStore.keys()].find((k) => k.includes(".corrupt."));
+      expect(backupKey).toBeUndefined();
+
+      expect(errorSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
     });
 
     it("a second loadIndex after corruption succeeds and returns valid index", async () => {

--- a/lib/services/history-store.ts
+++ b/lib/services/history-store.ts
@@ -80,26 +80,36 @@ export class HistoryStore {
       parsed = JSON.parse(content) as HistoryIndex;
     } catch (err) {
       console.warn(
-        "[HistoryStore] index.json が破損しています。index.json.corrupt.bak にバックアップし、デフォルト値で再生成します。",
+        "[HistoryStore] index.json が破損しています。バックアップ成功時のみデフォルト値で再生成します。",
         err,
       );
+      // Codex F-07: バックアップに失敗したら元 index.json を上書きしない。上書きすると
+      // snapshot メタデータが完全に失われ、ファイルが残っても履歴 UI から復元不能になる。
+      // 世代を残すため timestamp 付きバックアップ名を使う。
+      let backedUp = false;
       try {
         const historyDir = await this.getHistoryDirectory();
-        // Overwrite (not timestamp-based) so we never accumulate stale backups.
-        // 固定サフィックスで上書きし、古いバックアップが溜まらないようにする。
         const backupHandle = await historyDir.getFileHandle(
-          `${HISTORY_INDEX_FILENAME}.corrupt.bak`,
+          `${HISTORY_INDEX_FILENAME}.corrupt.${Date.now()}.bak`,
           { create: true },
         );
         await backupHandle.write(content);
+        backedUp = true;
       } catch (backupErr) {
-        console.error("[HistoryStore] index.json のバックアップに失敗しました:", backupErr);
+        console.error(
+          "[HistoryStore] index.json のバックアップに失敗しました。破損 index は上書きせず保持します:",
+          backupErr,
+        );
       }
       const defaultIndex = createDefaultHistoryIndex();
-      try {
-        await this.saveIndex(defaultIndex);
-      } catch (saveErr) {
-        console.error("[HistoryStore] デフォルト index.json の保存に失敗しました:", saveErr);
+      // バックアップ成功時のみ既存 index を default で再生成（自己修復）。失敗時は
+      // 破損 index をディスクに残し（手動復旧用）、当セッションはメモリ上の default で動く。
+      if (backedUp) {
+        try {
+          await this.saveIndex(defaultIndex);
+        } catch (saveErr) {
+          console.error("[HistoryStore] デフォルト index.json の保存に失敗しました:", saveErr);
+        }
       }
       return defaultIndex;
     }

--- a/lib/storage/__tests__/electron-storage-manager.test.ts
+++ b/lib/storage/__tests__/electron-storage-manager.test.ts
@@ -36,6 +36,8 @@ function createFakeBetterSqlite3(tables: Partial<Record<TableName, FakeRow[]>> =
     recent_files: tables.recent_files ?? [],
     recent_projects: tables.recent_projects ?? [],
     kv_store: [],
+    // Codex F-06: quarantine table for corrupt records (raw data preserved before delete)
+    corrupt_records: [],
   };
 
   /**
@@ -80,7 +82,21 @@ function createFakeBetterSqlite3(tables: Partial<Record<TableName, FakeRow[]>> =
   const prepareReal = (sql: string) => {
     const stmt = {
       run: vi.fn((...args: unknown[]): void => {
-        if (/DELETE FROM app_state/.test(sql)) {
+        if (/INSERT INTO corrupt_records/.test(sql)) {
+          // Codex F-06: capture quarantined raw data (source_table, record_id, data, ts)
+          const [source_table, record_id, data, quarantined_at] = args as [
+            string,
+            string,
+            string,
+            number,
+          ];
+          store.corrupt_records.push({
+            source_table,
+            record_id,
+            data,
+            quarantined_at,
+          } as unknown as FakeRow);
+        } else if (/DELETE FROM app_state/.test(sql)) {
           store.app_state = [];
         } else if (/DELETE FROM editor_buffer/.test(sql)) {
           store.editor_buffer = [];
@@ -291,6 +307,34 @@ describe("ElectronStorageManager — corrupt JSON recovery", () => {
         expect.stringContaining("editor_buffer"),
         expect.any(SyntaxError),
       );
+
+      warnSpy.mockRestore();
+    });
+
+    // Codex F-06: the raw corrupt editor_buffer (unsaved crash-recovery draft)
+    // must be quarantined before deletion, not destroyed.
+    it("quarantines the raw corrupt editor_buffer data before deleting it", () => {
+      const corruptRaw = '{"content":"未保存の本文",,,BROKEN';
+      const fakeDb = createFakeBetterSqlite3({
+        editor_buffer: [{ id: "editor_buffer", data: corruptRaw, updated_at: 7 }],
+      });
+      const manager = createManagerWithFakeDb(fakeDb);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = manager.loadEditorBuffer();
+
+      expect(result).toBeNull();
+      // Deleted from editor_buffer…
+      expect(fakeDb.store.editor_buffer).toHaveLength(0);
+      // …but the raw body is preserved in quarantine for recovery.
+      const quarantined = fakeDb.store.corrupt_records as unknown as Array<{
+        source_table: string;
+        record_id: string;
+        data: string;
+      }>;
+      expect(quarantined).toHaveLength(1);
+      expect(quarantined[0].source_table).toBe("editor_buffer");
+      expect(quarantined[0].data).toBe(corruptRaw);
 
       warnSpy.mockRestore();
     });

--- a/lib/storage/electron-storage-manager.ts
+++ b/lib/storage/electron-storage-manager.ts
@@ -203,6 +203,41 @@ export class ElectronStorageManager {
   }
 
   /**
+   * 破損 JSON レコードを削除する前に、生データを corrupt_records へ隔離する
+   * （Codex F-06）。特に editor_buffer はクラッシュ回復用の未保存下書きであり、
+   * 末尾の余分な 1 文字などで JSON.parse が失敗しても本文は復旧可能なことが多い。
+   * 復旧の最後の砦を消さないよう、削除と隔離を同一トランザクションで行う。
+   *
+   * sourceTable は自コード内のリテラル（app_state / recent_files / editor_buffer /
+   * recent_projects）のみを渡す前提（外部入力ではないため SQL 連結は安全）。
+   */
+  private quarantineAndDelete(sourceTable: string, recordId: string, rawData: string): void {
+    const db = this.ensureInitialized();
+    try {
+      db.exec(
+        `CREATE TABLE IF NOT EXISTS corrupt_records (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          source_table TEXT NOT NULL,
+          record_id TEXT,
+          data TEXT NOT NULL,
+          quarantined_at INTEGER NOT NULL
+        )`,
+      );
+      runInTransaction(db, () => {
+        db.prepare(
+          "INSERT INTO corrupt_records (source_table, record_id, data, quarantined_at) VALUES (?, ?, ?, ?)",
+        ).run(sourceTable, recordId, rawData, Date.now());
+        db.prepare(`DELETE FROM ${sourceTable} WHERE id = ?`).run(recordId);
+      });
+    } catch (err) {
+      console.error(
+        `[ElectronStorageManager] 破損レコードの隔離に失敗しました (${sourceTable}/${recordId}):`,
+        err,
+      );
+    }
+  }
+
+  /**
    * アプリ状態を読み込む
    */
   loadAppState(): AppState | null {
@@ -213,20 +248,14 @@ export class ElectronStorageManager {
     try {
       return JSON.parse(row.data) as AppState;
     } catch (err) {
-      // Corrupt app_state record: delete it so every subsequent startup starts clean.
-      // app_state が破損している場合はレコードを削除してセルフヒールする。
+      // Corrupt app_state record: quarantine then delete so every subsequent
+      // startup starts clean without destroying the raw data (Codex F-06).
+      // app_state が破損している場合は隔離してから削除しセルフヒールする。
       console.warn(
-        "[ElectronStorageManager] app_state の JSON が破損しています。レコードを削除してデフォルト状態に戻します。",
+        "[ElectronStorageManager] app_state の JSON が破損しています。隔離してデフォルト状態に戻します。",
         err,
       );
-      try {
-        db.prepare("DELETE FROM app_state WHERE id = ?").run("app_state");
-      } catch (deleteErr) {
-        console.error(
-          "[ElectronStorageManager] 破損した app_state レコードの削除に失敗しました:",
-          deleteErr,
-        );
-      }
+      this.quarantineAndDelete("app_state", "app_state", row.data);
       return null;
     }
   }
@@ -278,20 +307,13 @@ export class ElectronStorageManager {
       try {
         results.push(JSON.parse(row.data) as RecentFile);
       } catch (err) {
-        // Corrupt recent_files row: remove it so the next load is clean.
-        // 破損した recent_files 行を削除してセルフヒールする。
+        // Corrupt recent_files row: quarantine then remove (Codex F-06).
+        // 破損した recent_files 行を隔離してから削除しセルフヒールする。
         console.warn(
-          `[ElectronStorageManager] recent_files(id=${row.id}) の JSON が破損しています。レコードを削除します。`,
+          `[ElectronStorageManager] recent_files(id=${row.id}) の JSON が破損しています。隔離して削除します。`,
           err,
         );
-        try {
-          db.prepare("DELETE FROM recent_files WHERE id = ?").run(row.id);
-        } catch (deleteErr) {
-          console.error(
-            "[ElectronStorageManager] 破損した recent_files レコードの削除に失敗しました:",
-            deleteErr,
-          );
-        }
+        this.quarantineAndDelete("recent_files", row.id, row.data);
       }
     }
     return results;
@@ -338,20 +360,15 @@ export class ElectronStorageManager {
     try {
       return JSON.parse(row.data) as EditorBuffer;
     } catch (err) {
-      // Corrupt editor_buffer record: delete it so the next load starts clean.
-      // 破損した editor_buffer レコードを削除してセルフヒールする。
+      // Corrupt editor_buffer = unsaved crash-recovery draft. Quarantine the raw
+      // data BEFORE deleting so a recoverable body isn't destroyed (Codex F-06).
+      // editor_buffer はクラッシュ回復用の未保存下書き。本文を失わないよう、削除前に
+      // 生データを隔離する。
       console.warn(
-        "[ElectronStorageManager] editor_buffer の JSON が破損しています。レコードを削除します。",
+        "[ElectronStorageManager] editor_buffer の JSON が破損しています。生データを隔離してから削除します。",
         err,
       );
-      try {
-        db.prepare("DELETE FROM editor_buffer WHERE id = ?").run("editor_buffer");
-      } catch (deleteErr) {
-        console.error(
-          "[ElectronStorageManager] 破損した editor_buffer レコードの削除に失敗しました:",
-          deleteErr,
-        );
-      }
+      this.quarantineAndDelete("editor_buffer", "editor_buffer", row.data);
       return null;
     }
   }
@@ -425,20 +442,13 @@ export class ElectronStorageManager {
       try {
         results.push(JSON.parse(row.data) as { id: string; rootPath: string; name: string });
       } catch (err) {
-        // Corrupt recent_projects row: remove it so the next load is clean.
-        // 破損した recent_projects 行を削除してセルフヒールする。
+        // Corrupt recent_projects row: quarantine then remove (Codex F-06).
+        // 破損した recent_projects 行を隔離してから削除しセルフヒールする。
         console.warn(
-          `[ElectronStorageManager] recent_projects(id=${row.id}) の JSON が破損しています。レコードを削除します。`,
+          `[ElectronStorageManager] recent_projects(id=${row.id}) の JSON が破損しています。隔離して削除します。`,
           err,
         );
-        try {
-          db.prepare("DELETE FROM recent_projects WHERE id = ?").run(row.id);
-        } catch (deleteErr) {
-          console.error(
-            "[ElectronStorageManager] 破損した recent_projects レコードの削除に失敗しました:",
-            deleteErr,
-          );
-        }
+        this.quarantineAndDelete("recent_projects", row.id, row.data);
       }
     }
     return results;

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -83,6 +83,7 @@ export function useTabManager(options?: {
     pendingCloseTabId: tabState.pendingCloseTabId,
     setPendingCloseTabId: tabState.setPendingCloseTabId,
     forceCloseTab: tabState.forceCloseTab,
+    flushActiveEditorRef: options?.flushActiveEditorRef,
     tryCreateSnapshot: fileIO.tryCreateSnapshot,
   });
 

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -192,10 +192,21 @@ export function useAutoSave(params: UseAutoSaveParams): void {
       });
     }
 
+    // M-3 (Codex F-08): suspend — main も suspend を broadcast しているので購読し、
+    // スリープ直前に dirty タブを即フラッシュする。スリープ中の電源断/強制再起動で
+    // 最後の自動保存以降の入力が失われるのを防ぐ。
+    let unsubscribeSuspend: (() => void) | null = null;
+    if (powerAPI?.onSuspend) {
+      unsubscribeSuspend = powerAPI.onSuspend(() => {
+        runAutoSave();
+      });
+    }
+
     return () => {
       unsubscribe();
       unsubscribeResume?.();
       unsubscribeLockScreen?.();
+      unsubscribeSuspend?.();
       if (autoSaveTimerRef.current) {
         clearInterval(autoSaveTimerRef.current);
         autoSaveTimerRef.current = null;

--- a/lib/tab-manager/use-close-dialog.ts
+++ b/lib/tab-manager/use-close-dialog.ts
@@ -21,6 +21,12 @@ export interface UseCloseDialogParams extends TabManagerCore {
   /** Force-close a tab without dirty check. */
   forceCloseTab: (tabId: TabId) => void;
   /**
+   * Ref holding the active editor's on-demand live-content flush (#1840 /
+   * Codex F-03). When the tab being closed is the active tab, flush before
+   * saving so the close-save doesn't persist debounce-lagged content.
+   */
+  flushActiveEditorRef?: React.MutableRefObject<(() => string | null) | null>;
+  /**
    * Create a history snapshot with the given type (project mode only).
    * B1 fix: caller supplies correct SnapshotType.
    */
@@ -57,11 +63,13 @@ export interface UseCloseDialogReturn {
 export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogReturn {
   const {
     tabsRef,
+    activeTabIdRef,
     setTabs,
     isProjectRef,
     pendingCloseTabId,
     setPendingCloseTabId,
     forceCloseTab,
+    flushActiveEditorRef,
     tryCreateSnapshot,
   } = params;
 
@@ -82,8 +90,19 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
       return;
     }
 
+    // #1840 (Codex F-03): if closing the active tab, flush the live editor
+    // content first so we don't persist debounce-lagged content. flush() returns
+    // null when not applicable/ready, so we fall back to tab.content.
+    let tabToSave = tab;
+    if (tab.id === activeTabIdRef.current && flushActiveEditorRef?.current) {
+      const live = flushActiveEditorRef.current();
+      if (live != null && live !== tab.content) {
+        tabToSave = { ...tab, content: live };
+      }
+    }
+
     const outcome = await executeTabSave({
-      tab,
+      tab: tabToSave,
       isProject: isProjectRef.current,
       tabsRef,
       setTabs,
@@ -114,6 +133,8 @@ export function useCloseDialog(params: UseCloseDialogParams): UseCloseDialogRetu
     pendingCloseTabId,
     forceCloseTab,
     tabsRef,
+    activeTabIdRef,
+    flushActiveEditorRef,
     setTabs,
     isProjectRef,
     setPendingCloseTabId,


### PR DESCRIPTION
## 概要

beta `v1.2.20-beta.20260620.140801`（#1847）発行後の **Codex 独立レビュー**で検出したデータ損失/フェイルオープン 8 件を修正。うち **F-01 は #1840 で混入した退行**（私の空ガードが意図的な全削除を旧本文へ戻す）。

type-check 0 error / vitest **1950 pass** / lint 0 error。

## 修正一覧

| ID | 重大度 | 内容 |
|---|---|---|
| F-01 | CRITICAL(退行) | `flushContent` の空ガード撤去。ready な EditorView の `""` は正当な全削除。未 ready は throw→null フォールバック、再マウント過渡は `registerFlush(null)` で保護 |
| F-02 | CRITICAL(緩和) | 終了/quit の dirty 判定が debounce 遅延の `isDirty` を読む問題に、blur/hidden 時のライブ flush で `tab.content`/`isDirty` を最新化。完全な close-preflight は後続 |
| F-03 | CRITICAL | タブ「保存して閉じる」(`use-close-dialog`) もアクティブタブを flush してから保存 |
| F-04 | CRITICAL | 通常 close で保存失敗(`closeAborted`)後に `isHandlingClose` を戻し、2回目 close の確認迂回を解消。close は常に prevent |
| F-05 | CRITICAL | quit の clean/「保存しない」経路も `waitForCloseOrAbort` 結果を検査し timeout/abort なら中止（fail-open 解消） |
| F-06 | HIGH | 破損レコード（特に editor_buffer のクラッシュ回復下書き）を削除前に `corrupt_records` へ隔離（同一トランザクション） |
| F-07 | HIGH | history index バックアップ失敗時は元 index を上書きしない。バックアップ名を timestamp 付き世代式に |
| F-08 | MED | `suspend` 購読でスリープ直前に dirty タブを即フラッシュ |

## テスト
- type-check: 0 error / vitest: 1950 passed / lint: 0 error
- 新規: storage 隔離（quarantine）テスト、history バックアップ失敗テスト

## レビュー対応方針
F-05 (latent split-pane) 等の議論を含む Codex 全指摘を評価し、データ保全側に倒して採用。

Refs #1837, #1839, #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)