### PR TITLE
fix(layout): 右インスペクタの境界線を 2px・明色化して確実に視認可能に

### DIFF
--- a/shared/ui/ResizablePanel.tsx
+++ b/shared/ui/ResizablePanel.tsx
@@ -88,12 +88,13 @@ export default function ResizablePanel({
       className={clsx(
         "relative flex-shrink-0",
         !isResizing && "transition-all duration-300 ease-in-out",
-        // 右インスペクタは隣に ActivityBar のような背景ブロックが無く、
-        // border-border(rgb 45,45,45) では暗いエディタ背景(rgb 8,8,8)に
-        // 紛れて境界線が見えない。左ナビゲーションと同等に視認できるよう、
-        // より明瞭な border-border-secondary(rgb 60,60,60) を用いる。
+        // 左ナビゲーション側は ActivityBar(bg-background-tertiary rgb 30,30,30)の
+        // 背景ブロックが境界を明瞭にするが、右インスペクタは隣接ブロックが無く
+        // 1px の border-border(rgb 45,45,45)は暗いエディタ背景(rgb 8,8,8)に紛れて
+        // 「境界線が無い」ように見える。右側は 2px かつより明るい
+        // border-border-secondary(rgb 60,60,60)で明確な縦線にして左右の視認性を揃える。
         !isCollapsed &&
-          (side === "right" ? "border-l border-border-secondary" : "border-r border-border"),
+          (side === "right" ? "border-l-2 border-border-secondary" : "border-r border-border"),
         className,
       )}
       style={{ width: isCollapsed ? "0px" : `${width}px` }}


### PR DESCRIPTION
## 概要

#1848 の追加対応。右インスペクタとエディタの境界線が「まだ出てこない」との報告（dev 反映後も視認できず）を受け、境界線を確実に視認できる強さに修正します。

## 根本原因（深掘り）

- このアプリで明確に見える区切り（エディタツールバー等）は `bg-background-secondary`（rgb 18,18,18）の**塗り**で視認性を得ている。**単独の 1px border** は元来薄い
- 左側は `ActivityBar`（`bg-background-tertiary` rgb 30,30,30）の背景ブロックが境界を明瞭にしているが、右インスペクタには隣接ブロックが無い
- インスペクタは子要素（ファイル情報・校正カード・統計カード等）が `bg-background-secondary` を多用するため、aside 自体の背景塗りは内部階層を壊す → 不可
- 結果、#1848 の `border-l border-border-secondary`（1px@60）でもエディタ背景（rgb 8,8,8）に対して薄く、境界線が出ていなかった

## 修正

`shared/ui/ResizablePanel.tsx` の右パネル境界を **`border-l-2 border-border-secondary`（2px・rgb 60,60,60）** の明確な縦線に変更。左パネルは ActivityBar に隣接し十分な視認性があるため従来どおり。

実レンダリング比較（`1px@45` → `2px@60`）で視認性が明確に向上することを確認済み。

## 検証

- `npx tsc --noEmit` → pass（exit 0）
- 実ブラウザでのトークン値レンダリング比較で 2px@60 が明確な縦線として視認できることを確認
- 影響範囲は ResizablePanel の右パネルのみ

## 補足

QA 用パッケージ版アプリは再ビルドしないと本修正は反映されません（dev の最新を pull → リビルド／再起動が必要）。

## 関連 issue

関連 issue なし