### PR TITLE
fix(search-dialog): 検索ダイアログのドラッグ位置をビューポートにクランプし画面外操作不能を修正 (#1852)

### DIFF
--- a/components/SearchDialog.tsx
+++ b/components/SearchDialog.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { Search, X, ChevronUp, ChevronDown, List } from "lucide-react";
-import { computeAnchorPos } from "@/lib/search-dialog/compute-anchor-pos";
+import { computeAnchorPos, clampDragPos } from "@/lib/search-dialog/compute-anchor-pos";
 import type { SearchMatch } from "@/lib/editor-page/find-search-matches";
 
 const DIALOG_WIDTH = 320; // w-80 と一致させる
@@ -93,6 +93,38 @@ export default function SearchDialog({
     }
   }, [isOpen]);
 
+  // ウィンドウリサイズ時にドラッグ位置を再クランプし、ダイアログが
+  // 操作不能な位置に取り残されないようにする。
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleResize = () => {
+      setDragOffset((prev) => {
+        if (prev === null) return prev;
+        const dialogEl = dialogRef.current;
+        const dialogSize = dialogEl
+          ? { width: dialogEl.offsetWidth, height: dialogEl.offsetHeight }
+          : { width: DIALOG_WIDTH, height: 0 };
+        return clampDragPos(prev, dialogSize, window.innerWidth, window.innerHeight);
+      });
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [isOpen]);
+
+  // ダイアログが開いている間はグローバル keydown で Escape を捕捉する。
+  // dialog の onKeyDown だけだとフォーカスがエディタ側に移った後に Escape が
+  // 効かなくなるため、document レベルで補完する。
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleGlobalKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleGlobalKeyDown);
+    return () => document.removeEventListener("keydown", handleGlobalKeyDown);
+  }, [isOpen, onClose]);
+
   const handleDragMouseDown = useCallback((e: React.MouseEvent) => {
     // Don't initiate drag from interactive elements
     if ((e.target as HTMLElement).closest("button, input, label, a")) return;
@@ -115,7 +147,12 @@ export default function SearchDialog({
       }
       const dx = ev.clientX - dragStart.current.mouseX;
       const dy = ev.clientY - dragStart.current.mouseY;
-      setDragOffset({ x: dragStart.current.elX + dx, y: dragStart.current.elY + dy });
+      const rawPos = { x: dragStart.current.elX + dx, y: dragStart.current.elY + dy };
+      const dialogEl = dialogRef.current;
+      const dialogSize = dialogEl
+        ? { width: dialogEl.offsetWidth, height: dialogEl.offsetHeight }
+        : { width: DIALOG_WIDTH, height: 0 };
+      setDragOffset(clampDragPos(rawPos, dialogSize, window.innerWidth, window.innerHeight));
     };
 
     const handleMouseUp = () => {

--- a/lib/search-dialog/__tests__/compute-anchor-pos.test.ts
+++ b/lib/search-dialog/__tests__/compute-anchor-pos.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { computeAnchorPos } from "../compute-anchor-pos";
+import { computeAnchorPos, clampDragPos } from "../compute-anchor-pos";
 
 const DIALOG_WIDTH = 320;
 const PADDING = 16;
@@ -37,5 +37,60 @@ describe("computeAnchorPos", () => {
   it("returns top with padding/2 offset from the anchor top", () => {
     const pos = computeAnchorPos({ top: 0, right: 800 }, 1000, DIALOG_WIDTH, PADDING);
     expect(pos.top).toBe(8);
+  });
+});
+
+describe("clampDragPos", () => {
+  const VIEWPORT_W = 1440;
+  const VIEWPORT_H = 900;
+  const DIALOG_SIZE = { width: 320, height: 200 };
+  const MIN_VISIBLE = 44; // default
+
+  it("leaves a position that is already fully in-viewport unchanged", () => {
+    const pos = clampDragPos({ x: 100, y: 100 }, DIALOG_SIZE, VIEWPORT_W, VIEWPORT_H);
+    expect(pos.x).toBe(100);
+    expect(pos.y).toBe(100);
+  });
+
+  it("clamps far bottom-right drag back into viewport (header/close button visible)", () => {
+    // ダイアログを画面右下の遥か外にドラッグした場合
+    const pos = clampDragPos({ x: 99999, y: 99999 }, DIALOG_SIZE, VIEWPORT_W, VIEWPORT_H);
+    // x ≤ viewportWidth - minVisibleHeight
+    expect(pos.x).toBeLessThanOrEqual(VIEWPORT_W - MIN_VISIBLE);
+    // y ≤ viewportHeight - minVisibleHeight
+    expect(pos.y).toBeLessThanOrEqual(VIEWPORT_H - MIN_VISIBLE);
+  });
+
+  it("clamps far top-left drag so top edge never goes above viewport", () => {
+    // ダイアログを画面左上の遥か外にドラッグした場合
+    const pos = clampDragPos({ x: -99999, y: -99999 }, DIALOG_SIZE, VIEWPORT_W, VIEWPORT_H);
+    // y は 0 未満にならない
+    expect(pos.y).toBeGreaterThanOrEqual(0);
+    // x は -(dialogWidth - minVisibleHeight) 以上（左端は一部画面外 OK）
+    expect(pos.x).toBeGreaterThanOrEqual(-(DIALOG_SIZE.width - MIN_VISIBLE));
+  });
+
+  it("re-clamps correctly after window shrinks (resize regression)", () => {
+    // 大きいウィンドウでドラッグ → ウィンドウ縮小後に再クランプ
+    const originalPos = { x: 1200, y: 700 }; // 元は 1440×900 内で有効
+    const smallViewportW = 800;
+    const smallViewportH = 500;
+    const pos = clampDragPos(originalPos, DIALOG_SIZE, smallViewportW, smallViewportH);
+    expect(pos.x).toBeLessThanOrEqual(smallViewportW - MIN_VISIBLE);
+    expect(pos.y).toBeLessThanOrEqual(smallViewportH - MIN_VISIBLE);
+    expect(pos.y).toBeGreaterThanOrEqual(0);
+  });
+
+  it("uses provided minVisibleHeight to keep header accessible", () => {
+    const customMin = 56;
+    const pos = clampDragPos(
+      { x: 99999, y: 99999 },
+      DIALOG_SIZE,
+      VIEWPORT_W,
+      VIEWPORT_H,
+      customMin,
+    );
+    expect(pos.x).toBeLessThanOrEqual(VIEWPORT_W - customMin);
+    expect(pos.y).toBeLessThanOrEqual(VIEWPORT_H - customMin);
   });
 });

--- a/lib/search-dialog/compute-anchor-pos.ts
+++ b/lib/search-dialog/compute-anchor-pos.ts
@@ -14,6 +14,18 @@ export interface AnchorPos {
   readonly right: number;
 }
 
+/** ドラッグ後の絶対座標 (left/top) をクランプするための入力。 */
+export interface DragPos {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** ダイアログのサイズ。 */
+export interface DialogSize {
+  readonly width: number;
+  readonly height: number;
+}
+
 /**
  * Compute the top-right anchor position for the dialog.
  *
@@ -33,4 +45,35 @@ export function computeAnchorPos(
   const maxRight = Math.max(padding, viewportWidth - dialogWidth - padding);
   const clampedRight = Math.max(minRight, Math.min(maxRight, rawRight));
   return { top: rect.top + padding / 2, right: clampedRight };
+}
+
+/**
+ * Clamp a dragged dialog position so that the header/close button remains
+ * accessible within the viewport.
+ *
+ * ヘッダー行の高さ分（minVisibleHeight）は常に viewport 内に留まるように
+ * top/left をクランプする。右端・下端は dialogWidth/Height 全体が飛び出さない
+ * ようにクランプする。
+ *
+ * @param pos ドラッグで算出した絶対座標 (left, top)
+ * @param dialogSize ダイアログの実サイズ (px)
+ * @param viewportWidth window.innerWidth
+ * @param viewportHeight window.innerHeight
+ * @param minVisibleHeight ヘッダー行の高さ — この分は必ず viewport 内に残す (px, default 44)
+ */
+export function clampDragPos(
+  pos: DragPos,
+  dialogSize: DialogSize,
+  viewportWidth: number,
+  viewportHeight: number,
+  minVisibleHeight = 44,
+): DragPos {
+  const minX = -(dialogSize.width - minVisibleHeight);
+  const maxX = viewportWidth - minVisibleHeight;
+  const minY = 0;
+  const maxY = viewportHeight - minVisibleHeight;
+  return {
+    x: Math.max(minX, Math.min(maxX, pos.x)),
+    y: Math.max(minY, Math.min(maxY, pos.y)),
+  };
 }


### PR DESCRIPTION
## Summary

- `lib/search-dialog/compute-anchor-pos.ts` に純関数 `clampDragPos()` を追加し、ダイアログがヘッダー/閉じるボタンを含む最低限の領域を常に viewport 内に保つようクランプ
- `components/SearchDialog.tsx` のドラッグ mousemove ハンドラでクランプを適用し、画面外へのドラッグを防止
- `window resize` イベントで `dragOffset` を再クランプし、ウィンドウ縮小後の取り残しを防止
- `document keydown` で Escape をグローバル捕捉し、フォーカスがエディタに移った後もダイアログを閉じられるよう修正

Closes #1852

## Test plan

- [ ] `npx vitest run lib/search-dialog/__tests__/compute-anchor-pos.test.ts` — 10 件パス（既存 5 件 + 新規 5 件）
- [ ] `npm run type-check` — エラーなし
- [ ] `npx eslint components/SearchDialog.tsx lib/search-dialog/compute-anchor-pos.ts lib/search-dialog/__tests__/compute-anchor-pos.test.ts` — エラーなし
- [ ] 手動: 検索ダイアログを右端・下端・左上へドラッグしてもヘッダーが viewport 内に残ることを確認
- [ ] 手動: ダイアログを移動後にエディタをクリックして Escape キーを押すとダイアログが閉じることを確認

## Regression test added

`lib/search-dialog/__tests__/compute-anchor-pos.test.ts` に `clampDragPos` の 5 件の回帰テストを追加（far bottom-right、far top-left、resize 後再クランプ、カスタム minVisibleHeight、in-viewport 無変化）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)