### PR TITLE
fix(settings): 設定モーダルにフォーカストラップとaria-dialog属性を追加 (#1851)

### DIFF
--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -12,6 +12,22 @@ import { resolveLegacyCategory, type SettingsCategory } from "./settings/setting
 
 export type { SettingsCategory } from "./settings/settings-category";
 
+/** Focusable element selectors — intentionally conservative */
+const FOCUSABLE_SELECTORS = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(", ");
+
+function getFocusableElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)).filter(
+    (el) => !el.closest("[inert]") && getComputedStyle(el).display !== "none",
+  );
+}
+
 interface SettingsModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -29,6 +45,9 @@ export default function SettingsModal({ isOpen, onClose, initialCategory }: Sett
     resolveLegacyCategory(initialCategory, { isElectron }),
   );
   const modalRef = useRef<HTMLDivElement>(null);
+  /** Element that had focus before the modal opened — restored on close. */
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const headingId = "settings-modal-heading";
 
   useEffect(() => {
     if (isOpen && initialCategory) {
@@ -36,6 +55,7 @@ export default function SettingsModal({ isOpen, onClose, initialCategory }: Sett
     }
   }, [isOpen, initialCategory, isElectron]);
 
+  // Body scroll lock
   useEffect(() => {
     if (isOpen) {
       document.body.style.overflow = "hidden";
@@ -45,15 +65,96 @@ export default function SettingsModal({ isOpen, onClose, initialCategory }: Sett
     }
   }, [isOpen]);
 
+  // Capture return-focus target and move focus into modal on open;
+  // restore focus to that target on close.
   useEffect(() => {
-    function handleEscape(e: KeyboardEvent): void {
-      if (e.key === "Escape" && isOpen) {
-        onClose();
+    if (isOpen) {
+      returnFocusRef.current = document.activeElement as HTMLElement | null;
+
+      // Move initial focus to the modal panel after render
+      const frame = requestAnimationFrame(() => {
+        if (modalRef.current) {
+          const first = getFocusableElements(modalRef.current)[0];
+          if (first) {
+            first.focus();
+          } else {
+            modalRef.current.focus();
+          }
+        }
+      });
+
+      return () => cancelAnimationFrame(frame);
+    } else {
+      // Restore focus when modal closes
+      if (returnFocusRef.current && typeof returnFocusRef.current.focus === "function") {
+        returnFocusRef.current.focus();
+        returnFocusRef.current = null;
       }
     }
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isOpen]);
+
+  // Focus trap: Tab / Shift+Tab cycle inside the modal.
+  // Escape closes the modal.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKeyDown(e: KeyboardEvent): void {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+      if (!modalRef.current) return;
+
+      const focusable = getFocusableElements(modalRef.current);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey) {
+        if (active === first || !modalRef.current.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last || !modalRef.current.contains(active)) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
   }, [isOpen, onClose]);
+
+  // Mark background siblings as inert while the modal is open so that
+  // pointer events and AT cannot reach them.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const overlay = document.querySelector<HTMLElement>("[data-settings-modal-overlay]");
+    if (!overlay) return;
+
+    const siblings: HTMLElement[] = [];
+    let node = overlay.parentElement?.firstChild;
+    while (node) {
+      if (node !== overlay && node instanceof HTMLElement) {
+        node.setAttribute("inert", "");
+        siblings.push(node);
+      }
+      node = node.nextSibling;
+    }
+
+    return () => {
+      for (const el of siblings) {
+        el.removeAttribute("inert");
+      }
+    };
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
@@ -69,18 +170,25 @@ export default function SettingsModal({ isOpen, onClose, initialCategory }: Sett
 
   return (
     <div
+      data-settings-modal-overlay=""
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
       onClick={handleOverlayClick}
     >
       <div
         ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        tabIndex={-1}
         className={clsx(
           "relative w-full h-[80vh] mx-4 rounded-xl bg-background-elevated shadow-xl border border-border flex flex-col transition-[max-width] duration-200",
           isWide ? "max-w-6xl" : "max-w-4xl",
         )}
       >
         <div className="flex-shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
-          <h2 className="text-lg font-medium text-foreground">設定</h2>
+          <h2 id={headingId} className="text-lg font-medium text-foreground">
+            設定
+          </h2>
           <button
             onClick={onClose}
             className="p-1 rounded hover:bg-hover text-foreground-secondary hover:text-foreground transition-colors"

--- a/components/__tests__/SettingsModal-focus-trap.test.tsx
+++ b/components/__tests__/SettingsModal-focus-trap.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * Regression tests for SettingsModal accessible dialog (#1851)
+ *
+ * Verifies:
+ * - role="dialog" and aria-modal="true" are present
+ * - Focus moves into the modal on open
+ * - Tab from last focusable wraps to first (focus trap)
+ * - Shift+Tab from first focusable wraps to last
+ * - Background siblings become inert while modal is open
+ * - Focus is returned to the originating element on close
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+// SettingsModal depends on several sub-modules — mock heavy ones.
+vi.mock("@/lib/utils/runtime-env", () => ({
+  isElectronRenderer: () => false,
+}));
+
+vi.mock("@/components/settings/nav-config", () => ({
+  buildSettingsNavConfig: () => [],
+}));
+
+vi.mock("@/components/settings/tab-registry", () => ({
+  buildSettingsTabRegistry: () => ({
+    account: {
+      component: () => React.createElement("div", { "data-testid": "tab-content" }, "タブ内容"),
+      wide: false,
+    },
+  }),
+}));
+
+vi.mock("@/components/settings/settings-category", () => ({
+  resolveLegacyCategory: (_cat: unknown) => "account",
+}));
+
+vi.mock("@/components/settings/primitives", () => ({
+  SettingsNav: ({
+    "aria-label": ariaLabel,
+  }: {
+    "aria-label"?: string;
+    groups: unknown[];
+    active: unknown;
+    onSelect: (cat: unknown) => void;
+  }) =>
+    React.createElement(
+      "nav",
+      { "aria-label": ariaLabel, "data-testid": "settings-nav" },
+      React.createElement("button", { "data-testid": "nav-btn" }, "アカウント"),
+    ),
+}));
+
+import SettingsModal from "../SettingsModal";
+
+let root: Root;
+let container: HTMLDivElement;
+
+function fireKeyDown(key: string, shiftKey = false): void {
+  const event = new KeyboardEvent("keydown", { key, shiftKey, bubbles: true });
+  document.dispatchEvent(event);
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("SettingsModal – accessible dialog (#1851)", () => {
+  it("renders with role=dialog and aria-modal=true when open", async () => {
+    await act(async () => {
+      root.render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    });
+
+    const dialog = document.querySelector("[role='dialog']");
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("aria-labelledby points to the 設定 heading", async () => {
+    await act(async () => {
+      root.render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    });
+
+    const dialog = document.querySelector("[role='dialog']");
+    const labelledById = dialog?.getAttribute("aria-labelledby");
+    expect(labelledById).toBeTruthy();
+
+    const heading = document.getElementById(labelledById!);
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toBe("設定");
+  });
+
+  it("moves focus into the modal when opened", async () => {
+    // Place a trigger button outside the modal
+    const triggerBtn = document.createElement("button");
+    triggerBtn.textContent = "設定を開く";
+    document.body.appendChild(triggerBtn);
+    triggerBtn.focus();
+    expect(document.activeElement).toBe(triggerBtn);
+
+    await act(async () => {
+      root.render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    });
+
+    // Wait for requestAnimationFrame-based focus shift
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+
+    const dialog = document.querySelector<HTMLElement>("[role='dialog']");
+    expect(dialog?.contains(document.activeElement)).toBe(true);
+  });
+
+  it("focus trap: Tab from last focusable wraps to first", async () => {
+    await act(async () => {
+      root.render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    });
+
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+
+    const dialog = document.querySelector<HTMLElement>("[role='dialog']");
+    const focusable = dialog
+      ? Array.from(
+          dialog.querySelectorAll<HTMLElement>(
+            "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
+          ),
+        )
+      : [];
+
+    expect(focusable.length).toBeGreaterThan(0);
+
+    // Focus the last element
+    const last = focusable[focusable.length - 1];
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    // Tab should wrap to first
+    fireKeyDown("Tab", false);
+
+    expect(document.activeElement).toBe(focusable[0]);
+  });
+
+  it("focus trap: Shift+Tab from first focusable wraps to last", async () => {
+    await act(async () => {
+      root.render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    });
+
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+
+    const dialog = document.querySelector<HTMLElement>("[role='dialog']");
+    const focusable = dialog
+      ? Array.from(
+          dialog.querySelectorAll<HTMLElement>(
+            "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])",
+          ),
+        )
+      : [];
+
+    expect(focusable.length).toBeGreaterThan(0);
+
+    // Focus the first element
+    const first = focusable[0];
+    first.focus();
+    expect(document.activeElement).toBe(first);
+
+    // Shift+Tab should wrap to last
+    fireKeyDown("Tab", true);
+
+    expect(document.activeElement).toBe(focusable[focusable.length - 1]);
+  });
+
+  it("background sibling receives inert attribute while modal is open", async () => {
+    // Render the modal first so the overlay element is created
+    await act(async () => {
+      root.render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    });
+
+    // Find the overlay element and its parent to add a sibling there
+    const overlay = document.querySelector<HTMLElement>("[data-settings-modal-overlay]");
+    expect(overlay).not.toBeNull();
+
+    const overlayParent = overlay!.parentElement!;
+    const background = document.createElement("div");
+    background.setAttribute("data-testid", "background");
+    overlayParent.appendChild(background);
+
+    // Re-render to trigger the effect with the new sibling
+    await act(async () => {
+      root.render(<SettingsModal isOpen={false} onClose={() => {}} />);
+    });
+    await act(async () => {
+      root.render(<SettingsModal isOpen={true} onClose={() => {}} />);
+    });
+
+    // The background sibling of the overlay should be inert
+    expect(background.hasAttribute("inert")).toBe(true);
+
+    background.remove();
+  });
+
+  it("restores focus to originating element on close", async () => {
+    const triggerBtn = document.createElement("button");
+    triggerBtn.textContent = "設定を開く";
+    document.body.appendChild(triggerBtn);
+    triggerBtn.focus();
+
+    const onClose = vi.fn();
+
+    // Open
+    await act(async () => {
+      root.render(<SettingsModal isOpen={true} onClose={onClose} />);
+    });
+
+    await act(async () => {
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    });
+
+    // Close
+    await act(async () => {
+      root.render(<SettingsModal isOpen={false} onClose={onClose} />);
+    });
+
+    expect(document.activeElement).toBe(triggerBtn);
+  });
+
+  it("Escape key calls onClose", async () => {
+    const onClose = vi.fn();
+
+    await act(async () => {
+      root.render(<SettingsModal isOpen={true} onClose={onClose} />);
+    });
+
+    fireKeyDown("Escape");
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders nothing when isOpen is false", async () => {
+    await act(async () => {
+      root.render(<SettingsModal isOpen={false} onClose={() => {}} />);
+    });
+
+    const dialog = document.querySelector("[role='dialog']");
+    expect(dialog).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- `role="dialog"`, `aria-modal="true"`, `aria-labelledby` を設定モーダルパネルに追加
- モーダルオープン時に最初のフォーカス可能要素へフォーカスを移動（`requestAnimationFrame` 経由）
- Tab / Shift+Tab をモーダル内でトラップ（最後→最初、最初→最後のサイクリング）
- 背面の兄弟要素に `inert` 属性を付与してポインターイベントと AT のアクセスをブロック
- クローズ時に元のフォーカス先（設定ボタン等）へフォーカスを復元

## Test plan

- [ ] 設定モーダルを開いたとき、フォーカスがモーダル内の最初の要素に移動する
- [ ] Tab キーでモーダル内をサイクルし、最後の要素からは最初の要素に戻る
- [ ] Shift+Tab で最初の要素から最後の要素に戻る
- [ ] 背面の Activity Bar ボタン等に Tab で到達できないことを確認
- [ ] Escape でモーダルを閉じると、設定ボタンにフォーカスが戻る
- [ ] `npm run type-check` pass
- [ ] `npx vitest run components/__tests__/SettingsModal-focus-trap.test.tsx` — 9 tests pass

## Regression test added

`components/__tests__/SettingsModal-focus-trap.test.tsx` — 9 テストケース（role/aria属性、初期フォーカス、Tab/Shift+Tabトラップ、inert付与、フォーカス復元、Escapeキー）

Closes #1851

🤖 Generated with [Claude Code](https://claude.com/claude-code)