### PR TITLE
fix(history-panel): card keydown guard with e.target===e.currentTarget (#1853)

### DIFF
--- a/components/HistoryPanel/SnapshotItem.tsx
+++ b/components/HistoryPanel/SnapshotItem.tsx
@@ -55,7 +55,11 @@ export default function SnapshotItem({
         if (!isLoadingDiff) onCompare(snapshot);
       }}
       onKeyDown={(e) => {
-        if ((e.key === "Enter" || e.key === " ") && !isLoadingDiff) {
+        if (
+          (e.key === "Enter" || e.key === " ") &&
+          !isLoadingDiff &&
+          e.target === e.currentTarget
+        ) {
           e.preventDefault();
           onCompare(snapshot);
         }

--- a/components/HistoryPanel/__tests__/SnapshotItem-keyboard-guard.test.tsx
+++ b/components/HistoryPanel/__tests__/SnapshotItem-keyboard-guard.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Regression test for #1853: keyboard Enter/Space on nested buttons
+ * must NOT fire onCompare on the parent card.
+ *
+ * Root cause: the card role="button" had an onKeyDown that unconditionally
+ * called onCompare when Enter or Space was pressed, even when the event
+ * originated from a nested button (bookmark / menu toggle). The fix guards
+ * with `e.target === e.currentTarget` so only direct card focus triggers compare.
+ *
+ * The test renders a minimal component that mirrors SnapshotItem's keydown
+ * shape to keep the test free of heavy dependency mocks (icons, DiffIndicator,
+ * storage services, etc.), following the project's existing inline-mirror pattern.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+// Minimal mirror of SnapshotItem's keyboard guard shape
+function SnapshotCard({
+  onCompare,
+  onToggleBookmark,
+  onMenuToggle,
+  isLoadingDiff = false,
+}: {
+  onCompare: () => void;
+  onToggleBookmark: () => void;
+  onMenuToggle: () => void;
+  isLoadingDiff?: boolean;
+}) {
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-testid="card"
+      onClick={() => {
+        if (!isLoadingDiff) onCompare();
+      }}
+      onKeyDown={(e) => {
+        if (
+          (e.key === "Enter" || e.key === " ") &&
+          !isLoadingDiff &&
+          e.target === e.currentTarget
+        ) {
+          e.preventDefault();
+          onCompare();
+        }
+      }}
+    >
+      <button
+        data-testid="bookmark-btn"
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleBookmark();
+        }}
+      >
+        ブックマーク
+      </button>
+      <button
+        data-testid="menu-btn"
+        onClick={(e) => {
+          e.stopPropagation();
+          onMenuToggle();
+        }}
+      >
+        メニュー
+      </button>
+    </div>
+  );
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+describe("#1853 regression — nested button keyboard events must not fire onCompare", () => {
+  it("Enter on bookmark button calls onToggleBookmark and does NOT call onCompare", () => {
+    const onCompare = vi.fn();
+    const onToggleBookmark = vi.fn();
+    const onMenuToggle = vi.fn();
+
+    act(() => {
+      root.render(
+        <SnapshotCard
+          onCompare={onCompare}
+          onToggleBookmark={onToggleBookmark}
+          onMenuToggle={onMenuToggle}
+        />,
+      );
+    });
+
+    const bookmarkBtn = container.querySelector(
+      "[data-testid='bookmark-btn']",
+    ) as HTMLButtonElement;
+
+    act(() => {
+      bookmarkBtn.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onCompare).not.toHaveBeenCalled();
+  });
+
+  it("Space on bookmark button does NOT call onCompare", () => {
+    const onCompare = vi.fn();
+
+    act(() => {
+      root.render(
+        <SnapshotCard onCompare={onCompare} onToggleBookmark={vi.fn()} onMenuToggle={vi.fn()} />,
+      );
+    });
+
+    const bookmarkBtn = container.querySelector(
+      "[data-testid='bookmark-btn']",
+    ) as HTMLButtonElement;
+
+    act(() => {
+      bookmarkBtn.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    });
+
+    expect(onCompare).not.toHaveBeenCalled();
+  });
+
+  it("Enter on menu button does NOT call onCompare", () => {
+    const onCompare = vi.fn();
+
+    act(() => {
+      root.render(
+        <SnapshotCard onCompare={onCompare} onToggleBookmark={vi.fn()} onMenuToggle={vi.fn()} />,
+      );
+    });
+
+    const menuBtn = container.querySelector("[data-testid='menu-btn']") as HTMLButtonElement;
+
+    act(() => {
+      menuBtn.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onCompare).not.toHaveBeenCalled();
+  });
+
+  it("Space on menu button does NOT call onCompare", () => {
+    const onCompare = vi.fn();
+
+    act(() => {
+      root.render(
+        <SnapshotCard onCompare={onCompare} onToggleBookmark={vi.fn()} onMenuToggle={vi.fn()} />,
+      );
+    });
+
+    const menuBtn = container.querySelector("[data-testid='menu-btn']") as HTMLButtonElement;
+
+    act(() => {
+      menuBtn.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    });
+
+    expect(onCompare).not.toHaveBeenCalled();
+  });
+
+  it("Enter directly on the card itself DOES call onCompare", () => {
+    const onCompare = vi.fn();
+
+    act(() => {
+      root.render(
+        <SnapshotCard onCompare={onCompare} onToggleBookmark={vi.fn()} onMenuToggle={vi.fn()} />,
+      );
+    });
+
+    const card = container.querySelector("[data-testid='card']") as HTMLDivElement;
+
+    act(() => {
+      card.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onCompare).toHaveBeenCalledTimes(1);
+  });
+
+  it("Space directly on the card itself DOES call onCompare", () => {
+    const onCompare = vi.fn();
+
+    act(() => {
+      root.render(
+        <SnapshotCard onCompare={onCompare} onToggleBookmark={vi.fn()} onMenuToggle={vi.fn()} />,
+      );
+    });
+
+    const card = container.querySelector("[data-testid='card']") as HTMLDivElement;
+
+    act(() => {
+      card.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    });
+
+    expect(onCompare).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter on card does NOT call onCompare when isLoadingDiff is true", () => {
+    const onCompare = vi.fn();
+
+    act(() => {
+      root.render(
+        <SnapshotCard
+          onCompare={onCompare}
+          onToggleBookmark={vi.fn()}
+          onMenuToggle={vi.fn()}
+          isLoadingDiff={true}
+        />,
+      );
+    });
+
+    const card = container.querySelector("[data-testid='card']") as HTMLDivElement;
+
+    act(() => {
+      card.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+
+    expect(onCompare).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

履歴パネルのスナップショットカードで、ブックマークボタン・メニューボタンにフォーカスして Enter/Space を押すと、親カードの `onKeyDown` にイベントが伝播して誤って差分表示（`onCompare`）が呼び出されるバグを修正します。

### 変更内容

`SnapshotItem.tsx` の親カード `onKeyDown` に `e.target === e.currentTarget` ガードを追加。カード本体にフォーカスがある場合のみ Enter/Space で差分表示を開くよう制限します。

マウスクリックの動作は既に正しく（内部ボタンは `onClick` で `stopPropagation` 済み）、今回の修正はキーボード操作のみが対象です。

Closes #1853

## テスト計画

- [x] リグレッションテスト追加: `components/HistoryPanel/__tests__/SnapshotItem-keyboard-guard.test.tsx`
  - ブックマークボタンにフォーカスして Enter/Space → `onCompare` は呼ばれない
  - メニューボタンにフォーカスして Enter/Space → `onCompare` は呼ばれない
  - カード本体にフォーカスして Enter/Space → `onCompare` が1回呼ばれる
  - `isLoadingDiff=true` 時はカード本体でも `onCompare` を呼ばない
  - 計 7 テスト、全 pass 確認済み
- [x] `npm run type-check` — pass
- [x] `npx eslint` 対象ファイル — 警告なし
- [x] `npm run check:boundaries` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)