### PR TITLE
fix(BubbleMenu): 非選択時にメニューをアンマウントし Tab 順序・A11Y ツリーから除外 (#1855)

### DIFF
--- a/components/BubbleMenu.tsx
+++ b/components/BubbleMenu.tsx
@@ -141,7 +141,7 @@ export default function BubbleMenu({
       className={clsx(
         "fixed z-50 bg-background-elevated rounded-lg shadow-lg border border-border flex gap-1 p-1 transition-opacity duration-100",
         isVertical ? "flex-col items-center" : "items-center",
-        selectionState.hasSelection ? "opacity-100" : "opacity-0 pointer-events-none",
+        "opacity-100",
       )}
       style={{
         top: `${position.top}px`,
@@ -209,7 +209,9 @@ export default function BubbleMenu({
     </div>
   );
 
-  // Render via portal to document.body to escape dockview's transform context
-  if (!mounted) return null;
+  // Render via portal to document.body to escape dockview's transform context.
+  // Do not render when there is no selection — keeps hidden buttons out of the
+  // accessibility tree and Tab order (#1855).
+  if (!mounted || !selectionState.hasSelection) return null;
   return createPortal(menu, document.body);
 }

--- a/components/__tests__/BubbleMenu-a11y.test.tsx
+++ b/components/__tests__/BubbleMenu-a11y.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Regression test for BubbleMenu accessibility bug (#1855).
+ *
+ * When there is no text selection the BubbleMenu must NOT appear in the DOM —
+ * it was previously rendered offscreen with opacity-0/pointer-events-none, which
+ * left all format buttons in the Tab order and accessibility tree.
+ */
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { createRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import BubbleMenu from "../BubbleMenu";
+import type { EditorSelectionState } from "@/lib/editor-page/use-selection-tracking";
+
+let root: Root;
+
+const noSelection: EditorSelectionState = {
+  hasSelection: false,
+  selectionCount: 0,
+  isCollapsed: true,
+  from: 0,
+  to: 0,
+  startCoords: null,
+  endCoords: null,
+  rangeRect: null,
+  pointerClientY: null,
+};
+
+const withSelection: EditorSelectionState = {
+  hasSelection: true,
+  selectionCount: 5,
+  isCollapsed: false,
+  from: 10,
+  to: 15,
+  startCoords: { top: 100, left: 100, right: 200, bottom: 120 },
+  endCoords: { top: 100, left: 200, right: 300, bottom: 120 },
+  rangeRect: { top: 100, left: 100, right: 300, bottom: 120 },
+  pointerClientY: 110,
+};
+
+beforeEach(() => {
+  root = createRoot(document.body);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.innerHTML = "";
+});
+
+function renderBubble(selectionState: EditorSelectionState) {
+  const scrollRef = createRef<HTMLDivElement | null>() as React.RefObject<HTMLDivElement | null>;
+  act(() => {
+    root.render(
+      <BubbleMenu
+        selectionState={selectionState}
+        scrollContainerRef={scrollRef}
+        onFormat={() => {}}
+      />,
+    );
+  });
+}
+
+describe("BubbleMenu アクセシビリティ (#1855)", () => {
+  it("テキスト未選択時、フォーマットボタンが DOM に存在しない", () => {
+    renderBubble(noSelection);
+
+    // No buttons must be in the DOM when there is no selection
+    const buttons = document.body.querySelectorAll("button");
+    expect(buttons.length).toBe(0);
+  });
+
+  it("テキスト未選択時、太字ボタンが見つからない", () => {
+    renderBubble(noSelection);
+
+    const boldBtn = Array.from(document.body.querySelectorAll("button")).find(
+      (el) => el.getAttribute("title") === "太字",
+    );
+    expect(boldBtn).toBeUndefined();
+  });
+
+  it("テキスト選択時、フォーマットボタンが DOM に存在する", () => {
+    renderBubble(withSelection);
+
+    const buttons = document.body.querySelectorAll("button");
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it("テキスト選択時、太字ボタンが見つかる", () => {
+    renderBubble(withSelection);
+
+    const boldBtn = Array.from(document.body.querySelectorAll("button")).find(
+      (el) => el.getAttribute("title") === "太字",
+    );
+    expect(boldBtn).toBeDefined();
+  });
+
+  it("選択解除後、ボタンが DOM から除去される", async () => {
+    const scrollRef = createRef<HTMLDivElement | null>() as React.RefObject<HTMLDivElement | null>;
+
+    // First render with selection
+    await act(async () => {
+      root.render(
+        <BubbleMenu
+          selectionState={withSelection}
+          scrollContainerRef={scrollRef}
+          onFormat={() => {}}
+        />,
+      );
+    });
+
+    let buttons = document.body.querySelectorAll("button");
+    expect(buttons.length).toBeGreaterThan(0);
+
+    // Then render without selection
+    await act(async () => {
+      root.render(
+        <BubbleMenu
+          selectionState={noSelection}
+          scrollContainerRef={scrollRef}
+          onFormat={() => {}}
+        />,
+      );
+    });
+
+    buttons = document.body.querySelectorAll("button");
+    expect(buttons.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- 選択がない場合 `BubbleMenu` を DOM からアンマウントし、フォーマットボタンが Tab 順序・スクリーンリーダーのアクセシビリティツリーに残らないよう修正 (#1855)
- 従来の `opacity-0 pointer-events-none` によるオフスクリーン配置を廃止し、`hasSelection` が `false` の場合は `null` を返すよう変更
- リグレッションテスト `components/__tests__/BubbleMenu-a11y.test.tsx` を追加（5ケース）

## Root cause

`BubbleMenu.tsx` の末尾で `if (!mounted) return null` していたが `hasSelection` チェックがなく、選択なし時も全ボタンが DOM に残っていた。`opacity-0 pointer-events-none` はマウス操作のみをブロックし Tab・スクリーンリーダーには無効。

## Files changed

- `components/BubbleMenu.tsx` — 選択なし時に `null` を返す（2行変更）
- `components/__tests__/BubbleMenu-a11y.test.tsx` — リグレッションテスト追加

## Test plan

- [x] `npx vitest run components/__tests__/BubbleMenu-a11y.test.tsx` — 5 tests passed
- [x] `npm run type-check` — エラーなし
- [x] `npm run check:boundaries` — 違反なし
- [ ] 手動: エディタでテキストを選択 → BubbleMenu 表示、選択解除 → BubbleMenu 非表示・Tab 不到達を確認

Closes #1855

🤖 Generated with [Claude Code](https://claude.com/claude-code)