### PR TITLE
fix(search): 検索中コンテンツ編集でカーソルが誤位置へジャンプする問題を修正 (#1857)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -544,12 +544,28 @@ export default function EditorPage() {
     content,
   ]);
 
+  // #1857: 明示的ナビゲーション（次へ/前へ/結果クリック）のたびに増加するカウンター。
+  // コンテンツ編集で matches が再計算されても nonce は変わらないため、
+  // useSearchHighlight 内でカーソル誤移動が起きない。
+  const [searchNavigationNonce, setSearchNavigationNonce] = useState(0);
+
+  // 明示的ナビゲーション専用ハンドラー。setCurrentMatchIndex と同時に nonce を増やす。
+  // setSearchTerm（検索語変更時リセット）は直接 setCurrentMatchIndex を呼ぶためナビゲーションとして扱わない。
+  const handleNavigateToMatch = useCallback(
+    (index: number | ((prev: number) => number)) => {
+      setCurrentMatchIndex(index);
+      setSearchNavigationNonce((n) => n + 1);
+    },
+    [setCurrentMatchIndex],
+  );
+
   useSearchHighlight({
     editorView: editorViewInstance,
     matches: searchMatches,
     currentMatchIndex,
     searchTerm,
     isSearchVisible,
+    navigationNonce: searchNavigationNonce,
   });
 
   // フローティング検索窓は <main> のトップレベル（dockview パネル外）でレンダリングし、
@@ -1349,7 +1365,7 @@ export default function EditorPage() {
     onExcludeCommentsChange: setExcludeComments,
     onSearchTargetChange: setSearchTarget,
     onSelectionOnlyChange: setSelectionOnly,
-    onCurrentMatchIndexChange: setCurrentMatchIndex,
+    onCurrentMatchIndexChange: handleNavigateToMatch,
     onCloseSearchResults: handleCloseSearchResults,
     editorViewInstance,
     dictionarySearchTrigger,
@@ -1566,7 +1582,7 @@ export default function EditorPage() {
           isSearchDialogOpen,
           onSearchTermChange: setSearchTerm,
           onCaseSensitiveChange: setCaseSensitive,
-          onCurrentMatchIndexChange: setCurrentMatchIndex,
+          onCurrentMatchIndexChange: handleNavigateToMatch,
           onOpenSearchDialog: openSearchDialog,
           onCloseSearchDialog: closeSearchDialog,
           onToggleSearchDialog: toggleSearchDialog,

--- a/lib/editor-page/__tests__/use-search-highlight.test.tsx
+++ b/lib/editor-page/__tests__/use-search-highlight.test.tsx
@@ -65,6 +65,7 @@ function Harness(props: {
   currentMatchIndex: number;
   searchTerm: string;
   isSearchVisible: boolean;
+  navigationNonce?: number;
 }) {
   useSearchHighlight({
     editorView: props.view,
@@ -72,6 +73,7 @@ function Harness(props: {
     currentMatchIndex: props.currentMatchIndex,
     searchTerm: props.searchTerm,
     isSearchVisible: props.isSearchVisible,
+    navigationNonce: props.navigationNonce ?? 0,
   });
   return null;
 }
@@ -161,5 +163,114 @@ describe("useSearchHighlight – destroyed view (#1507)", () => {
         );
       });
     }).not.toThrow();
+  });
+});
+
+describe("useSearchHighlight – navigation vs content-edit separation (#1857)", () => {
+  /**
+   * Bug: with the search dialog open, every content edit caused matches to be
+   * recomputed (new array reference), which re-triggered the decoration effect
+   * and also dispatched a TextSelection — jumping the cursor to the current
+   * match position instead of leaving it where the user was typing.
+   *
+   * Fix: TextSelection / centerEditorPosition now only fire when navigationNonce
+   * changes (i.e. on explicit 次へ/前へ/結果クリック), not on every matches update.
+   *
+   * Note: A full ProseMirror integration test (placing the cursor at a specific
+   * position, typing, then asserting the cursor stayed) would require a real DOM
+   * with Milkdown mounted. This unit test exercises the separation at the hook
+   * boundary by asserting that TextSelection.create is NOT called when only
+   * matches changes (simulating content-edit-triggered recompute), and IS called
+   * when navigationNonce increments (simulating explicit navigation).
+   */
+
+  it("does NOT move selection when matches change due to content edit (nonce unchanged)", async () => {
+    const { TextSelection } = await import("@milkdown/prose/state");
+    const { view } = makeView(true);
+    const initialMatches: SearchMatch[] = [{ from: 5, to: 8 }];
+
+    // Initial render: search is open, nonce=0, no prior navigation.
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={initialMatches}
+          currentMatchIndex={0}
+          searchTerm="foo"
+          isSearchVisible={true}
+          navigationNonce={0}
+        />,
+      );
+    });
+
+    // Reset the mock so we can check calls from this point on.
+    vi.mocked(TextSelection.create).mockClear();
+
+    // Simulate content edit: matches array is replaced (new reference, same logical
+    // match) but navigationNonce stays at 0.
+    const updatedMatches: SearchMatch[] = [{ from: 5, to: 8 }];
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={updatedMatches}
+          currentMatchIndex={0}
+          searchTerm="foo"
+          isSearchVisible={true}
+          navigationNonce={0}
+        />,
+      );
+    });
+
+    // TextSelection.create must NOT have been called — cursor stays where the
+    // user was typing, not jumping to the match position.
+    expect(TextSelection.create).not.toHaveBeenCalled();
+  });
+
+  it("DOES move selection when navigationNonce increments (explicit 次へ/前へ)", async () => {
+    const { TextSelection } = await import("@milkdown/prose/state");
+    const { view } = makeView(true);
+    const matches: SearchMatch[] = [
+      { from: 5, to: 8 },
+      { from: 20, to: 23 },
+    ];
+
+    // Initial render at nonce=0 (no prior navigation recorded).
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={matches}
+          currentMatchIndex={0}
+          searchTerm="foo"
+          isSearchVisible={true}
+          navigationNonce={0}
+        />,
+      );
+    });
+
+    vi.mocked(TextSelection.create).mockClear();
+
+    // User clicks 次へ: currentMatchIndex advances and navigationNonce increments.
+    act(() => {
+      root.render(
+        <Harness
+          view={view}
+          matches={matches}
+          currentMatchIndex={1}
+          searchTerm="foo"
+          isSearchVisible={true}
+          navigationNonce={1}
+        />,
+      );
+    });
+
+    // TextSelection.create MUST have been called with the new match position.
+    expect(TextSelection.create).toHaveBeenCalledTimes(1);
+    expect(TextSelection.create).toHaveBeenCalledWith(
+      expect.anything(),
+      matches[1].from,
+      matches[1].from,
+    );
   });
 });

--- a/lib/editor-page/use-search-highlight.ts
+++ b/lib/editor-page/use-search-highlight.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Decoration, type EditorView } from "@milkdown/prose/view";
 import { TextSelection } from "@milkdown/prose/state";
 import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
@@ -24,6 +24,13 @@ interface UseSearchHighlightParams {
   /** いずれかの検索 UI（フローティング窓 or サイドパネル）が表示中か。
    *  false になったら（＝両方とも非表示）ハイライトを消す。 */
   isSearchVisible: boolean;
+  /**
+   * #1857: 次へ/前へ/結果クリックなど明示的なユーザーナビゲーションのたびに
+   * インクリメントされるカウンター。このカウンターが変化した時のみ
+   * TextSelection とスクロールを実行する。コンテンツ編集で matches が
+   * 再計算されても navigationNonce は変わらないため、カーソル誤移動が起きない。
+   */
+  navigationNonce: number;
 }
 
 /**
@@ -34,7 +41,9 @@ interface UseSearchHighlightParams {
  * 責務:
  *  1. `isEditorViewAlive` で破棄済み view をガード（#1507）
  *  2. 検索 UI が非表示 or 検索語が空 → decorations を空 dispatch してクリア
- *  3. それ以外 → 全マッチをハイライト（current は強調クラス）＋現在マッチへスクロール
+ *  3. それ以外 → 全マッチをハイライト（current は強調クラス）
+ *  4. #1857: TextSelection とスクロールは navigationNonce が変化した時のみ実行
+ *     （コンテンツ編集で matches が再計算されてもカーソル位置を上書きしない）
  */
 export function useSearchHighlight({
   editorView,
@@ -42,7 +51,14 @@ export function useSearchHighlight({
   currentMatchIndex,
   searchTerm,
   isSearchVisible,
+  navigationNonce,
 }: UseSearchHighlightParams): void {
+  // navigationNonce が最後に処理されたときの値を追跡する。
+  // 初期値を -1 にして最初の明示的ナビゲーションを確実に捕捉する。
+  const lastNavigationNonceRef = useRef(-1);
+
+  // Effect 1: デコレーション更新。matches/searchTerm/可視状態が変わるたびに実行。
+  // TextSelection とスクロールは実行しない（#1857）。
   useEffect(() => {
     if (!isEditorViewAlive(editorView)) return;
     const { state, dispatch } = editorView;
@@ -69,21 +85,31 @@ export function useSearchHighlight({
     } catch {
       // #1507: view が検索中に破棄された — decorations も一緒に消える
     }
-
-    // 現在のマッチを画面中央へ。選択も移動して連続ナビを自然にする。
-    const current = matches[currentMatchIndex];
-    if (current) {
-      try {
-        const view = editorView;
-        view.dispatch(
-          view.state.tr.setSelection(
-            TextSelection.create(view.state.doc, current.from, current.from),
-          ),
-        );
-        centerEditorPosition(view, current.from);
-      } catch {
-        // 破棄済み view ではスクロール不要
-      }
-    }
   }, [editorView, matches, currentMatchIndex, searchTerm, isSearchVisible]);
+
+  // Effect 2: 明示的ナビゲーション時のみ選択移動＋スクロール（#1857）。
+  // navigationNonce が変化した時だけ実行される。コンテンツ編集で matches が
+  // 再計算されても nonce は変わらないため、カーソルが誤位置へ飛ばない。
+  // matches と currentMatchIndex は deps に含めるが、lastNavigationNonceRef
+  // ガードにより nonce が変化した時のみ実際に処理される。
+  useEffect(() => {
+    if (navigationNonce === lastNavigationNonceRef.current) return;
+    lastNavigationNonceRef.current = navigationNonce;
+
+    if (!isEditorViewAlive(editorView)) return;
+
+    const current = matches[currentMatchIndex];
+    if (!current) return;
+
+    try {
+      editorView.dispatch(
+        editorView.state.tr.setSelection(
+          TextSelection.create(editorView.state.doc, current.from, current.from),
+        ),
+      );
+      centerEditorPosition(editorView, current.from);
+    } catch {
+      // 破棄済み view ではスクロール不要
+    }
+  }, [navigationNonce, editorView, matches, currentMatchIndex]);
 }


### PR DESCRIPTION
## 概要

**データ破損リスクあり（P1）**: 検索ダイアログを開いたまま本文を編集すると、毎回カーソルが現在の検索一致位置へ強制移動し、その後の入力が誤った位置へ挿入されるバグを修正。

Closes #1857

## 根本原因

`useSearchHighlight` のエフェクトがデコレーション更新と選択移動（TextSelection + scroll）を1つのエフェクトで行っており、deps に `matches` が含まれていた。コンテンツ編集で `matches` が新しい配列として再計算されるたびにエフェクトが再実行され、`TextSelection.create` とスクロールが発火していた。

## 修正内容

`lib/editor-page/use-search-highlight.ts` を2エフェクトに分割：

- **Effect 1 (デコレーション)**: `matches / searchTerm / isSearchVisible` 変化で実行。TextSelection・スクロールは実行しない。
- **Effect 2 (ナビゲーション)**: `navigationNonce` が変化した時のみ実行。コンテンツ編集では nonce が変わらないためカーソルは動かない。

`app/page.tsx` に `handleNavigateToMatch` を追加し、SearchDialog・SearchResults の `onCurrentMatchIndexChange` を差し替え。次へ/前へ/結果クリック時のみ nonce をインクリメントする。

## 変更ファイル（3件）

| ファイル | 変更内容 |
|---|---|
| `lib/editor-page/use-search-highlight.ts` | エフェクト分割、`navigationNonce` パラメータ追加 |
| `app/page.tsx` | `searchNavigationNonce` state 追加、`handleNavigateToMatch` 追加、2箇所の `onCurrentMatchIndexChange` を差し替え |
| `lib/editor-page/__tests__/use-search-highlight.test.tsx` | `Harness` に `navigationNonce` 追加、#1857 リグレッションテスト2件追加 |

## テスト計画

- [x] `npx vitest run lib/editor-page/__tests__/use-search-highlight.test.tsx` — 6件全通過
- [x] `npm run type-check` — エラーなし
- [x] `npx eslint` 対象ファイル — エラー・警告なし
- [ ] 手動確認: 検索ダイアログを開いた状態で本文を編集し、カーソル位置が保持されることを確認
- [ ] 手動確認: 次へ/前へボタンで検索結果間を移動できることを確認

## リグレッションテストの注意

ProseMirror を実際にマウントした統合テスト（カーソル位置の数値アサート）は jsdom 上では困難なため、フック境界でのユニットテストとして実装：
- `TextSelection.create` がコンテンツ編集（nonce 不変）時に呼ばれないことを検証
- `TextSelection.create` が明示的ナビゲーション（nonce 変化）時に正しい位置で呼ばれることを検証

## レビュアー注意事項

**データ破損リスクあり**: このバグは入力文字が意図しない位置へ挿入される可能性があるため P1 扱い。Effect 2 の deps に `matches` と `currentMatchIndex` が含まれているが、`lastNavigationNonceRef` ガードにより nonce が変化した時のみ実際の選択移動処理が実行される点を確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)