### PR TITLE
feat(linting): 幻辞 辞書外語 校正ルールセット + dict:genji prewarm 配線 (#1628)

### DIFF
--- a/electron/official-rulesets.js
+++ b/electron/official-rulesets.js
@@ -46,6 +46,11 @@ const OFFICIAL_RULESETS = Object.freeze([
     owner: "illusions-lab",
     repo: "illusions-ruleset-jtf-style-guide",
   }),
+  Object.freeze({
+    id: "com.illusions-lab.genji-vocab",
+    owner: "illusions-lab",
+    repo: "illusions-ruleset-genji-vocab",
+  }),
 ]);
 
 module.exports = { OFFICIAL_RULESETS };

--- a/lib/dict/__tests__/dict-access.test.ts
+++ b/lib/dict/__tests__/dict-access.test.ts
@@ -138,6 +138,27 @@ describe("DictAccess (#1624)", () => {
       await access.lookupBatch(["雪", "雪", ""]);
       expect(lookupBatch).toHaveBeenCalledWith(["雪"]);
     });
+
+    it("does NOT record an I/O error as a miss (leaves terms unresolved, re-queries next time)", async () => {
+      // A transient IPC failure must never become a cached `{ found: false }` —
+      // otherwise the 辞書外語 lint rule would flag every word and the poisoned
+      // negative would persist across keystrokes. Regression for the prewarm fix.
+      const lookupBatch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("ipc boom"))
+        .mockResolvedValueOnce([{ entry: "雪", found: true }]);
+      setElectronDict({ lookupBatch, verify: vi.fn(), getStatus: vi.fn() });
+      const access = await importFresh();
+
+      // First call fails: the term must be ABSENT from the result, not `{found:false}`.
+      const first = await access.lookupBatch(["雪"]);
+      expect(first.has("雪")).toBe(false);
+
+      // The failure was not cached, so a second call actually re-queries and resolves.
+      const second = await access.lookupBatch(["雪"]);
+      expect(second.get("雪")).toEqual({ found: true });
+      expect(lookupBatch).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe("has()", () => {

--- a/lib/dict/dict-access.ts
+++ b/lib/dict/dict-access.ts
@@ -166,12 +166,17 @@ class DictAccess {
   ): Promise<void> {
     for (let i = 0; i < misses.length; i += LOCAL_BATCH_CHUNK) {
       const chunk = misses.slice(i, i + LOCAL_BATCH_CHUNK);
-      let rows: Array<{ entry: string } & DictLookup> = [];
+      let rows: Array<{ entry: string } & DictLookup>;
       try {
         rows = await dict.lookupBatch(chunk);
       } catch (err) {
+        // A transient IPC error must NOT be recorded as "these words are absent":
+        // leave the chunk unresolved (callers see no entry → treat as unknown,
+        // never as out-of-dictionary) and let the next pass re-query. Caching a
+        // synthetic MISS here would both poison the LRU and make the 辞書外語
+        // lint rule flag every word until the dictionary is re-downloaded.
         console.warn("[dict-access] local lookupBatch failed:", err);
-        rows = [];
+        continue;
       }
 
       const found = new Set<string>();
@@ -182,7 +187,8 @@ class DictAccess {
         out.set(entry, lookup);
         found.add(entry);
       }
-      // Cache negatives so repeated analysis doesn't re-query absent words.
+      // Cache negatives so repeated analysis doesn't re-query absent words. Only
+      // safe after a SUCCESSFUL query — a genuine miss, not an I/O failure.
       for (const t of chunk) {
         if (!found.has(t)) {
           this.cache.set(t, MISS);
@@ -204,8 +210,11 @@ class DictAccess {
     try {
       map = await GenjiApiBackend.lookupBatchRemote(capped);
     } catch (err) {
+      // Same fail-safe as the local path: a network error must not be cached as
+      // "absent". Leave the terms unresolved so a later request can retry and so
+      // no consumer mistakes an I/O failure for an out-of-dictionary word.
       console.warn("[dict-access] remote lookupBatch failed:", err);
-      map = new Map();
+      return;
     }
 
     for (const t of capped) {

--- a/lib/linting/__tests__/dict-candidate-terms.test.ts
+++ b/lib/linting/__tests__/dict-candidate-terms.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+
+import { collectDictCandidateTerms, dictCandidateTerm } from "@/lib/linting/dict-candidate-terms";
+import type { Token } from "@/lib/nlp-client/types";
+
+/** Build a token with sensible defaults. */
+function tok(partial: Partial<Token> & { surface: string; pos: string }): Token {
+  return {
+    pos_detail_1: undefined,
+    pos_detail_2: undefined,
+    pos_detail_3: undefined,
+    basic_form: partial.surface,
+    reading: undefined,
+    start: 0,
+    end: partial.surface.length,
+    ...partial,
+  } as Token;
+}
+
+describe("dictCandidateTerm", () => {
+  it("returns the surface for a general noun", () => {
+    expect(dictCandidateTerm(tok({ surface: "辞書", pos: "名詞", pos_detail_1: "一般" }))).toBe(
+      "辞書",
+    );
+  });
+
+  it("includes proper nouns by default (uses surface)", () => {
+    const t = tok({ surface: "幾田花", pos: "名詞", pos_detail_1: "固有名詞" });
+    expect(dictCandidateTerm(t)).toBe("幾田花");
+    expect(dictCandidateTerm(t, { includeProperNouns: false })).toBeNull();
+  });
+
+  it("uses basic_form for conjugated verbs/adjectives", () => {
+    expect(
+      dictCandidateTerm(
+        tok({ surface: "走っ", pos: "動詞", pos_detail_1: "自立", basic_form: "走る" }),
+      ),
+    ).toBe("走る");
+    expect(
+      dictCandidateTerm(
+        tok({ surface: "美しく", pos: "形容詞", pos_detail_1: "自立", basic_form: "美しい" }),
+      ),
+    ).toBe("美しい");
+  });
+
+  it("falls back to surface when basic_form is missing/unknown", () => {
+    expect(
+      dictCandidateTerm(
+        tok({ surface: "ググる", pos: "動詞", pos_detail_1: "自立", basic_form: "*" }),
+      ),
+    ).toBe("ググる");
+  });
+
+  it("skips verbs/adjectives when includeVerbsAdjectives is false", () => {
+    const t = tok({ surface: "走っ", pos: "動詞", pos_detail_1: "自立", basic_form: "走る" });
+    expect(dictCandidateTerm(t, { includeVerbsAdjectives: false })).toBeNull();
+  });
+
+  it.each([
+    ["数", tok({ surface: "三", pos: "名詞", pos_detail_1: "数" })],
+    ["代名詞", tok({ surface: "それ", pos: "名詞", pos_detail_1: "代名詞" })],
+    ["非自立", tok({ surface: "こと", pos: "名詞", pos_detail_1: "非自立" })],
+    ["接尾", tok({ surface: "たち", pos: "名詞", pos_detail_1: "接尾" })],
+  ])("excludes auxiliary noun subtype %s", (_label, t) => {
+    expect(dictCandidateTerm(t)).toBeNull();
+  });
+
+  it.each([
+    ["助詞", tok({ surface: "は", pos: "助詞", pos_detail_1: "係助詞" })],
+    ["助動詞", tok({ surface: "だ", pos: "助動詞" })],
+    ["記号", tok({ surface: "。", pos: "記号", pos_detail_1: "句点" })],
+  ])("skips non-content part of speech %s", (_label, t) => {
+    expect(dictCandidateTerm(t)).toBeNull();
+  });
+
+  it("skips pure-ASCII tokens (English, digits, symbols)", () => {
+    expect(
+      dictCandidateTerm(tok({ surface: "hello", pos: "名詞", pos_detail_1: "固有名詞" })),
+    ).toBeNull();
+    expect(dictCandidateTerm(tok({ surface: "123", pos: "名詞", pos_detail_1: "数" }))).toBeNull();
+  });
+
+  it("respects minLength", () => {
+    const t = tok({ surface: "木", pos: "名詞", pos_detail_1: "一般" });
+    expect(dictCandidateTerm(t, { minLength: 1 })).toBe("木");
+    expect(dictCandidateTerm(t, { minLength: 2 })).toBeNull();
+  });
+});
+
+describe("collectDictCandidateTerms", () => {
+  it("dedupes across tokens and drops non-candidates", () => {
+    const tokens: Token[] = [
+      tok({ surface: "辞書", pos: "名詞", pos_detail_1: "一般" }),
+      tok({ surface: "は", pos: "助詞", pos_detail_1: "係助詞" }),
+      tok({ surface: "辞書", pos: "名詞", pos_detail_1: "一般" }), // dup
+      tok({ surface: "走っ", pos: "動詞", pos_detail_1: "自立", basic_form: "走る" }),
+    ];
+    expect(collectDictCandidateTerms(tokens).sort()).toEqual(["走る", "辞書"]);
+  });
+
+  it("returns an empty list for no candidate tokens", () => {
+    expect(
+      collectDictCandidateTerms([tok({ surface: "、", pos: "記号", pos_detail_1: "読点" })]),
+    ).toEqual([]);
+  });
+});

--- a/lib/linting/dict-candidate-terms.ts
+++ b/lib/linting/dict-candidate-terms.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared content-word → dictionary-headword extraction.
+ *
+ * The "辞書外語" (out-of-dictionary) lint rule runs in the worker but its
+ * membership data must be prewarmed on the renderer (where `getDictAccess()`
+ * works). The renderer therefore extracts the SAME candidate headwords the rule
+ * will query, batch-looks-them-up, and ships the result as a snapshot.
+ *
+ * IMPORTANT: the external ruleset (illusions-lab/illusions-ruleset-genji-vocab)
+ * vendors a byte-identical copy of this logic in its rule. They MUST stay in
+ * sync — if the renderer extracts a different headword than the rule queries,
+ * the rule simply finds no snapshot entry and skips that token (a false
+ * negative, never a false positive). Keep the selection rules below stable.
+ */
+import type { Token } from "@/lib/nlp-client/types";
+
+export interface DictCandidateOptions {
+  /** Include 固有名詞 (proper nouns: names, places). Default true. */
+  includeProperNouns?: boolean;
+  /** Include 動詞/形容詞 (matched by basic form). Default true. */
+  includeVerbsAdjectives?: boolean;
+  /** Skip headwords shorter than this (in code points). Default 1. */
+  minLength?: number;
+}
+
+/** 名詞 subtypes that are never meaningful dictionary headwords. */
+const EXCLUDED_NOUN_DETAILS = new Set(["数", "代名詞", "非自立", "接尾", "特殊"]);
+/** 動詞/形容詞 subtypes that are auxiliary, not real lexical entries. */
+const EXCLUDED_VERB_ADJ_DETAILS = new Set(["非自立", "接尾"]);
+
+const ALL_ASCII = /^[\x00-\x7F]+$/;
+
+function isValidHeadword(key: string, minLength: number): boolean {
+  if (key.length === 0 || key === "*") return false;
+  if ([...key].length < minLength) return false;
+  // Pure ASCII (English words, digits, punctuation, kaomoji) are not Genji
+  // headwords — skip them so they never get flagged.
+  if (ALL_ASCII.test(key)) return false;
+  return true;
+}
+
+/**
+ * The dictionary headword this token should be looked up under, or `null` if the
+ * token is not a checkable content word.
+ *
+ * - 名詞 → surface form (`surface`).
+ * - 動詞 / 形容詞 → basic form (`basic_form`), falling back to surface.
+ */
+export function dictCandidateTerm(token: Token, opts: DictCandidateOptions = {}): string | null {
+  const includeProperNouns = opts.includeProperNouns ?? true;
+  const includeVerbsAdjectives = opts.includeVerbsAdjectives ?? true;
+  const minLength = opts.minLength ?? 1;
+  const detail = token.pos_detail_1;
+
+  if (token.pos === "名詞") {
+    if (detail && EXCLUDED_NOUN_DETAILS.has(detail)) return null;
+    if (!includeProperNouns && detail === "固有名詞") return null;
+    const key = token.surface;
+    return isValidHeadword(key, minLength) ? key : null;
+  }
+
+  if (includeVerbsAdjectives && (token.pos === "動詞" || token.pos === "形容詞")) {
+    if (detail && EXCLUDED_VERB_ADJ_DETAILS.has(detail)) return null;
+    const base = token.basic_form && token.basic_form !== "*" ? token.basic_form : token.surface;
+    return isValidHeadword(base, minLength) ? base : null;
+  }
+
+  return null;
+}
+
+/** Deduplicated list of dictionary headwords to prewarm for a set of tokens. */
+export function collectDictCandidateTerms(
+  tokens: ReadonlyArray<Token>,
+  opts: DictCandidateOptions = {},
+): string[] {
+  const seen = new Set<string>();
+  for (const token of tokens) {
+    const term = dictCandidateTerm(token, opts);
+    if (term) seen.add(term);
+  }
+  return [...seen];
+}

--- a/lib/linting/registry/ruleset-context-factory.ts
+++ b/lib/linting/registry/ruleset-context-factory.ts
@@ -15,7 +15,7 @@ import {
   AbstractMorphologicalLintRule,
 } from "../base-rule";
 import { ENGINE_API_VERSION } from "../sdk/ruleset-types";
-import type { RulesetBases, RulesetContext } from "../sdk/ruleset-context";
+import type { RulesetBases, RulesetContext, DictToolkit } from "../sdk/ruleset-context";
 import { createDictToolkit, createToolkit, type DictLike } from "../toolkit";
 
 const BASES: RulesetBases = {
@@ -29,6 +29,12 @@ const BASES: RulesetBases = {
 export interface BuildContextOptions {
   dictHealth: GenjiHealth;
   dict: DictLike;
+  /**
+   * Use this prebuilt dictionary toolkit instead of constructing one from
+   * `dictHealth`/`dict`. The lint pipeline passes a persistent snapshot-backed
+   * toolkit here so per-batch prewarm data survives runner rebuilds.
+   */
+  dictToolkit?: DictToolkit;
   /** Override the resolved requirement satisfaction map. Defaults from dict health. */
   requirements?: ReadonlyMap<string, boolean>;
   engineApi?: number;
@@ -36,7 +42,7 @@ export interface BuildContextOptions {
 
 /** Build a context from explicit dependency state (test-friendly). */
 export function createRulesetContext(opts: BuildContextOptions): RulesetContext {
-  const dictToolkit = createDictToolkit(opts.dictHealth, opts.dict);
+  const dictToolkit = opts.dictToolkit ?? createDictToolkit(opts.dictHealth, opts.dict);
   const toolkit = createToolkit(dictToolkit);
   const requirements =
     opts.requirements ?? new Map<string, boolean>([["dict:genji", dictToolkit.ready]]);

--- a/lib/linting/sdk/ruleset-context.ts
+++ b/lib/linting/sdk/ruleset-context.ts
@@ -93,6 +93,22 @@ export interface DictToolkit {
   lookupBatch(terms: string[]): Promise<Map<string, DictLookup>>;
   /** Whether a headword exists. Returns false when not ready. */
   has(term: string): Promise<boolean>;
+  /**
+   * Synchronous membership check against the current prewarmed snapshot.
+   *
+   * The lint pipeline is synchronous (`lint`/`lintWithTokens` return arrays, not
+   * promises), but dictionary I/O is async. A rule that needs dictionary access
+   * therefore declares the terms it will query via {@link DictPrewarmRule.collectDictTerms};
+   * the pipeline batch-fetches them (`lookupBatch`) and installs a snapshot just
+   * before the rule runs. `hasCached`/`lookupCached` read that snapshot.
+   *
+   * Returns `false`/`undefined` when the dictionary is not ready OR the term was
+   * not prewarmed — so a rule that fails to declare a term simply gets no hit
+   * (it never false-positives on a missing snapshot).
+   */
+  hasCached(term: string): boolean;
+  /** Synchronous projection lookup against the current prewarmed snapshot. */
+  lookupCached(term: string): DictLookup | undefined;
 }
 
 /** Shared detector library. Centralizes logic so rules stay declarative-ish. */

--- a/lib/linting/toolkit/__tests__/dict-toolkit.test.ts
+++ b/lib/linting/toolkit/__tests__/dict-toolkit.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 
-import { createDictToolkit } from "../dict-toolkit";
+import { createDictToolkit, createSnapshotDictToolkit } from "../dict-toolkit";
 import type { GenjiHealth } from "@/lib/dict/dict-access";
 
 function spyDict() {
@@ -34,4 +34,76 @@ describe("createDictToolkit", () => {
       expect(dict.has).not.toHaveBeenCalled();
     },
   );
+
+  it("never reports cached membership (no prewarm snapshot)", () => {
+    const tk = createDictToolkit({ state: "ready" } as GenjiHealth, spyDict());
+    expect(tk.hasCached("猫")).toBe(false);
+    expect(tk.lookupCached("猫")).toBeUndefined();
+  });
+});
+
+describe("createSnapshotDictToolkit", () => {
+  it("starts not-ready with an empty snapshot", () => {
+    const tk = createSnapshotDictToolkit();
+    expect(tk.ready).toBe(false);
+    expect(tk.state).toBe("unknown");
+    expect(tk.hasCached("猫")).toBe(false);
+    expect(tk.lookupCached("猫")).toBeUndefined();
+  });
+
+  it("reads installed snapshot membership synchronously when ready", () => {
+    const tk = createSnapshotDictToolkit();
+    tk.setSnapshot(
+      [
+        ["猫", { found: true, reading: "ネコ" }],
+        ["みゃお", { found: false }],
+      ],
+      true,
+    );
+    expect(tk.ready).toBe(true);
+    expect(tk.state).toBe("ready");
+    // Present headword.
+    expect(tk.hasCached("猫")).toBe(true);
+    expect(tk.lookupCached("猫")).toEqual({ found: true, reading: "ネコ" });
+    // Prewarmed-but-absent headword: distinguishable from "not prewarmed".
+    expect(tk.hasCached("みゃお")).toBe(false);
+    expect(tk.lookupCached("みゃお")).toEqual({ found: false });
+    // Not prewarmed at all → undefined (rule must skip, never flag).
+    expect(tk.lookupCached("未照合")).toBeUndefined();
+  });
+
+  it("treats a not-ready snapshot as no prewarm (rules no-op)", () => {
+    const tk = createSnapshotDictToolkit();
+    // ready=false even though entries are present (dict not installed).
+    tk.setSnapshot([["猫", { found: true }]], false);
+    expect(tk.ready).toBe(false);
+    expect(tk.hasCached("猫")).toBe(false);
+    expect(tk.lookupCached("猫")).toBeUndefined();
+  });
+
+  it("clearSnapshot returns to the not-prewarmed state", () => {
+    const tk = createSnapshotDictToolkit();
+    tk.setSnapshot([["猫", { found: true }]], true);
+    tk.clearSnapshot();
+    expect(tk.ready).toBe(false);
+    expect(tk.hasCached("猫")).toBe(false);
+    expect(tk.lookupCached("猫")).toBeUndefined();
+  });
+
+  it("replaces the snapshot per batch (no stale carryover)", () => {
+    const tk = createSnapshotDictToolkit();
+    tk.setSnapshot([["猫", { found: true }]], true);
+    expect(tk.lookupCached("猫")).toEqual({ found: true });
+    // Next batch covers different terms; the old term is no longer prewarmed.
+    tk.setSnapshot([["犬", { found: true }]], true);
+    expect(tk.lookupCached("犬")).toEqual({ found: true });
+    expect(tk.lookupCached("猫")).toBeUndefined();
+  });
+
+  it("has no live async dictionary connection (always empty)", async () => {
+    const tk = createSnapshotDictToolkit();
+    tk.setSnapshot([["猫", { found: true }]], true);
+    expect(await tk.has("猫")).toBe(false);
+    expect((await tk.lookupBatch(["猫"])).size).toBe(0);
+  });
 });

--- a/lib/linting/toolkit/dict-toolkit.ts
+++ b/lib/linting/toolkit/dict-toolkit.ts
@@ -8,7 +8,7 @@
  * Japanese warning (see ruleset-registry).
  */
 import type { DictLookup } from "@/lib/dict/dict-types";
-import type { GenjiHealth } from "@/lib/dict/dict-access";
+import type { GenjiHealth, GenjiHealthState } from "@/lib/dict/dict-access";
 import type { DictToolkit } from "../sdk/ruleset-context";
 
 /** Minimal dictionary surface needed by the toolkit (injectable for tests). */
@@ -17,12 +17,39 @@ export interface DictLike {
   has(term: string): Promise<boolean>;
 }
 
+/** A serialized prewarm snapshot entry pair. Structured-clone friendly. */
+export type DictSnapshotEntry = readonly [string, DictLookup];
+
+/**
+ * A {@link DictToolkit} whose synchronous `hasCached`/`lookupCached` read a
+ * prewarmed snapshot that the lint pipeline installs per batch.
+ *
+ * `setSnapshot` is internal to the pipeline — rules only ever see the narrower
+ * {@link DictToolkit}. The lint pass is synchronous but dictionary I/O is async,
+ * so the renderer prewarms membership for the batch (via
+ * `getDictAccess().lookupBatch`) and ships it here.
+ */
+export interface DictToolkitInternal extends DictToolkit {
+  /**
+   * Install the snapshot for the upcoming synchronous lint pass.
+   * @param entries term → projection pairs (misses included as `{ found: false }`).
+   * @param ready whether the dictionary is actually usable; when false every
+   *   `hasCached`/`lookupCached` reports "not prewarmed" so rules no-op.
+   */
+  setSnapshot(entries: ReadonlyArray<DictSnapshotEntry>, ready: boolean): void;
+  /** Drop the current snapshot (returns to the not-prewarmed state). */
+  clearSnapshot(): void;
+}
+
 const EMPTY: ReadonlyMap<string, DictLookup> = new Map();
 
 /**
  * Build a {@link DictToolkit} bound to a resolved health snapshot. Pass the
  * already-fetched `health` so the toolkit is synchronous to construct and the
  * `ready` flag is stable for the lifetime of a ruleset build.
+ *
+ * This variant has no prewarm snapshot, so `hasCached`/`lookupCached` always
+ * report "not prewarmed" (false / undefined).
  */
 export function createDictToolkit(health: GenjiHealth, dict: DictLike): DictToolkit {
   const ready = health.state === "ready";
@@ -36,6 +63,59 @@ export function createDictToolkit(health: GenjiHealth, dict: DictLike): DictTool
     async has(term: string): Promise<boolean> {
       if (!ready) return false;
       return dict.has(term);
+    },
+    hasCached(): boolean {
+      return false;
+    },
+    lookupCached(): DictLookup | undefined {
+      return undefined;
+    },
+  };
+}
+
+/**
+ * Build a snapshot-backed {@link DictToolkitInternal} for the lint pipeline.
+ *
+ * It holds no async dictionary connection (the worker/fallback can't reach the
+ * Electron dict IPC); the async `lookupBatch`/`has` therefore return empty. All
+ * real membership data arrives through {@link DictToolkitInternal.setSnapshot},
+ * which the renderer fills per batch from `getDictAccess()`.
+ *
+ * `ready` reflects the most recent `setSnapshot(_, ready)` — before any snapshot
+ * it is `false`, so a dict rule built against this toolkit no-ops until the
+ * renderer confirms the dictionary is usable AND has prewarmed the batch.
+ */
+export function createSnapshotDictToolkit(): DictToolkitInternal {
+  let snapshot = new Map<string, DictLookup>();
+  let ready = false;
+  return {
+    get ready(): boolean {
+      return ready;
+    },
+    get state(): GenjiHealthState {
+      return ready ? "ready" : "unknown";
+    },
+    async lookupBatch(): Promise<Map<string, DictLookup>> {
+      return new Map(EMPTY);
+    },
+    async has(): Promise<boolean> {
+      return false;
+    },
+    hasCached(term: string): boolean {
+      if (!ready) return false;
+      return snapshot.get(term)?.found ?? false;
+    },
+    lookupCached(term: string): DictLookup | undefined {
+      if (!ready) return undefined;
+      return snapshot.get(term);
+    },
+    setSnapshot(entries: ReadonlyArray<DictSnapshotEntry>, isReady: boolean): void {
+      snapshot = new Map(entries);
+      ready = isReady;
+    },
+    clearSnapshot(): void {
+      snapshot = new Map();
+      ready = false;
     },
   };
 }

--- a/lib/linting/toolkit/index.ts
+++ b/lib/linting/toolkit/index.ts
@@ -24,8 +24,8 @@ export { detectUnits } from "./unit-detector";
 export { matchWordList, escapeRegExp } from "./word-list";
 export { dedupe, defaultIssueKey } from "./dedupe";
 export { posFilter, isPos } from "./pos-filter";
-export { createDictToolkit } from "./dict-toolkit";
-export type { DictLike } from "./dict-toolkit";
+export { createDictToolkit, createSnapshotDictToolkit } from "./dict-toolkit";
+export type { DictLike, DictToolkitInternal, DictSnapshotEntry } from "./dict-toolkit";
 
 /** Build a legacy JsonRuleMeta from ruleset metadata (constructor boilerplate). */
 export function toJsonRuleMeta(rule: RulesetRuleMeta, manifest: RulesetManifest): JsonRuleMeta {

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -16,6 +16,8 @@ import type { IgnoredCorrection } from "@/lib/project/project-types";
 import { LRUCache } from "@/shared/lib/lru-cache";
 import { hashString } from "@/shared/lib/hash-string";
 import { getAtomOffset, collectParagraphs } from "../shared/paragraph-helpers";
+import { getDictAccess } from "@/lib/dict/dict-access";
+import { collectDictCandidateTerms } from "@/lib/linting/dict-candidate-terms";
 import type {
   LintingPluginState,
   LintingPluginOptions,
@@ -23,6 +25,7 @@ import type {
   RuleRunnerLike,
 } from "./types";
 import { isSilentCancelError } from "./worker/protocol";
+import type { DictSnapshotPayload } from "./worker/protocol";
 
 export const lintingKey = new PluginKey<LintingPluginState>("linting");
 
@@ -306,6 +309,36 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
 
           if (version !== processingVersion) return;
 
+          // Prewarm dictionary membership for dict:genji rules. The lint pass is
+          // synchronous but dictionary I/O is async, so we look up every
+          // candidate headword here (the renderer, where getDictAccess() is
+          // reachable) and ship the result with the batch. Most-inclusive
+          // options are used so the snapshot is a superset of whatever the rule
+          // queries regardless of its config (undeclared terms simply skip).
+          let dictPayload: DictSnapshotPayload | undefined;
+          if (currentRuleRunner.hasDictRules()) {
+            const terms = new Set<string>();
+            for (const tokens of tokensByText.values()) {
+              for (const term of collectDictCandidateTerms(tokens)) terms.add(term);
+            }
+            try {
+              const access = getDictAccess();
+              const health = await access.getHealth();
+              if (version !== processingVersion) return;
+              const ready = health.state === "ready";
+              let entries: DictSnapshotPayload["entries"] = [];
+              if (ready && terms.size > 0) {
+                const map = await access.lookupBatch([...terms]);
+                if (version !== processingVersion) return;
+                entries = [...map.entries()];
+              }
+              dictPayload = { ready, entries };
+            } catch (err) {
+              console.error("[Linting] dictionary prewarm failed:", err);
+              dictPayload = { ready: false, entries: [] };
+            }
+          }
+
           // Build the per-paragraph batch (uncached only). The runner
           // will route through the worker for L1 + main thread for L2
           // morph; results merge transparently.
@@ -325,6 +358,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
                 paragraphs: perParaInputs,
                 mode: "per-paragraph",
                 version,
+                dict: dictPayload,
               });
               if (version !== processingVersion) return;
               for (const p of uncachedParagraphs) {
@@ -353,6 +387,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
                 paragraphs: docInputs,
                 mode: "document",
                 version,
+                dict: dictPayload,
               });
               if (version !== processingVersion) return;
               documentIssueCache = resp.document;

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/build-ruleset-runner.dict.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/build-ruleset-runner.dict.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Integration test for the dict:genji snapshot path.
+ *
+ * Builds a runner from a fake L2 ruleset that flags out-of-dictionary nouns,
+ * exactly as the real `illusions-ruleset-genji-vocab` rule does: it reads
+ * `ctx.toolkit.dict.lookupCached` and only flags terms that were prewarmed AND
+ * absent. Verifies requirement gating, the per-batch snapshot, and the
+ * fail-safe (no flags when the dictionary is not ready / a term was not
+ * prewarmed).
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  anyRulesetRequiresDict,
+  buildRulesetRunner,
+  createIsolatedRulesetContext,
+  rulesetRequiresDict,
+} from "../build-ruleset-runner";
+import { createSnapshotDictToolkit } from "@/lib/linting/toolkit";
+import { ENGINE_API_VERSION } from "@/lib/linting/sdk/ruleset-types";
+import type { RulesetContext } from "@/lib/linting/sdk/ruleset-context";
+import type { RulesetManifest, RulesetModule } from "@/lib/linting/sdk/ruleset-types";
+import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
+import type { Token } from "@/lib/nlp-client/types";
+
+function noun(surface: string, start: number): Token {
+  return {
+    surface,
+    pos: "名詞",
+    pos_detail_1: "一般",
+    basic_form: surface,
+    start,
+    end: start + surface.length,
+  } as Token;
+}
+
+/** A fake L2 ruleset whose rule mirrors the real genji-vocab out-of-dict rule. */
+function makeDictL2Module(): RulesetModule {
+  const manifest: RulesetManifest = {
+    id: "com.test.genji-vocab",
+    name: "test",
+    nameJa: "幻辞テスト",
+    version: "1.0.0",
+    engineApi: ENGINE_API_VERSION,
+    license: "MIT",
+    maintainerEmail: "test@example.com",
+    requires: [{ kind: "dict", dictId: "genji" }],
+    guidelines: [],
+    rules: [
+      {
+        ruleId: "out-of-dict",
+        nameJa: "辞書外語",
+        descriptionJa: "辞書外語",
+        level: "L2",
+        defaultConfig: { enabled: true, severity: "info" },
+        applicableModes: [],
+        docs: { positiveExample: "a", negativeExample: "b", sourceReference: "c" },
+        requires: [{ kind: "dict", dictId: "genji" }],
+      },
+    ],
+  };
+
+  return {
+    manifest,
+    createRules(ctx: RulesetContext) {
+      const { AbstractMorphologicalLintRule } = ctx.bases;
+      const { dict } = ctx.toolkit;
+      class OutOfDict extends AbstractMorphologicalLintRule {
+        readonly id = "out-of-dict";
+        readonly name = "out-of-dict";
+        readonly nameJa = "辞書外語";
+        readonly description = "辞書外語";
+        readonly descriptionJa = "辞書外語";
+        readonly level = "L2" as const;
+        readonly defaultConfig: LintRuleConfig = { enabled: true, severity: "info" };
+        lintWithTokens(
+          _text: string,
+          tokens: ReadonlyArray<Token>,
+          config: LintRuleConfig,
+        ): LintIssue[] {
+          if (!config.enabled || !dict.ready) return [];
+          const out: LintIssue[] = [];
+          for (const t of tokens) {
+            if (t.pos !== "名詞") continue;
+            const lk = dict.lookupCached(t.surface);
+            if (lk !== undefined && lk.found === false) {
+              out.push({
+                ruleId: this.id,
+                severity: config.severity,
+                message: `out-of-dict: ${t.surface}`,
+                messageJa: `辞書外語: ${t.surface}`,
+                from: t.start,
+                to: t.end,
+              });
+            }
+          }
+          return out;
+        }
+      }
+      return [new OutOfDict()];
+    },
+  };
+}
+
+function buildRunner(dict = createSnapshotDictToolkit()) {
+  const mod = makeDictL2Module();
+  const { runner } = buildRulesetRunner({
+    legacyRules: [],
+    externals: [mod],
+    ctx: createIsolatedRulesetContext(dict),
+    baseGuidelineMapEntries: [],
+    configs: new Map(),
+    activeGuidelines: null,
+  });
+  return { runner, dict };
+}
+
+describe("rulesetRequiresDict", () => {
+  it("detects a ruleset-level dict requirement", () => {
+    expect(rulesetRequiresDict(makeDictL2Module())).toBe(true);
+    expect(anyRulesetRequiresDict([makeDictL2Module()])).toBe(true);
+  });
+});
+
+describe("dict:genji snapshot execution", () => {
+  // 「猫」が辞書内、「ニャオ」が辞書外。
+  const tokens = [noun("猫", 0), noun("ニャオ", 1)];
+
+  it("registers + enables the dict L2 rule (requirement satisfied via snapshot path)", () => {
+    const { runner } = buildRunner();
+    expect(runner.getRegisteredRules().some((r) => r.id === "out-of-dict")).toBe(true);
+    expect(runner.getEnabledRules().some((r) => r.id === "out-of-dict")).toBe(true);
+  });
+
+  it("flags only prewarmed-and-absent headwords when ready", () => {
+    const { runner, dict } = buildRunner();
+    dict.setSnapshot(
+      [
+        ["猫", { found: true }],
+        ["ニャオ", { found: false }],
+      ],
+      true,
+    );
+    const issues = runner.runAllWithTokens("猫ニャオ", tokens);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].ruleId).toBe("out-of-dict");
+    expect(issues[0].messageJa).toBe("辞書外語: ニャオ");
+    expect([issues[0].from, issues[0].to]).toEqual([1, 4]);
+  });
+
+  it("no-ops when the dictionary is not ready (no false positives)", () => {
+    const { runner, dict } = buildRunner();
+    // Entries present but ready=false (dict not installed).
+    dict.setSnapshot(
+      [
+        ["猫", { found: true }],
+        ["ニャオ", { found: false }],
+      ],
+      false,
+    );
+    expect(runner.runAllWithTokens("猫ニャオ", tokens)).toHaveLength(0);
+  });
+
+  it("no-ops when no snapshot was installed for the batch", () => {
+    const { runner } = buildRunner();
+    expect(runner.runAllWithTokens("猫ニャオ", tokens)).toHaveLength(0);
+  });
+
+  it("skips terms that were not prewarmed (never flags undeclared words)", () => {
+    const { runner, dict } = buildRunner();
+    // Only 猫 prewarmed; ニャオ absent from the snapshot entirely.
+    dict.setSnapshot([["猫", { found: true }]], true);
+    expect(runner.runAllWithTokens("猫ニャオ", tokens)).toHaveLength(0);
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/proxy.test.ts
@@ -374,6 +374,7 @@ describe("RuleRunnerProxy", () => {
       ruleIds: ["ex-morph-1"],
       warnings: [],
       hasMorphologicalRules: true,
+      hasDictRules: false,
     });
     await loadPromise;
 
@@ -410,6 +411,7 @@ describe("RuleRunnerProxy", () => {
       ruleIds: ["ex-morph-1"],
       warnings: [],
       hasMorphologicalRules: true,
+      hasDictRules: false,
     });
     await loadPromise;
     expect(proxy.hasMorphologicalRules()).toBe(true);
@@ -426,6 +428,7 @@ describe("RuleRunnerProxy", () => {
       ruleIds: [],
       warnings: [],
       hasMorphologicalRules: false,
+      hasDictRules: false,
     });
     await unloadPromise;
 

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/build-ruleset-runner.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/build-ruleset-runner.ts
@@ -14,10 +14,11 @@ import { RuleRunner } from "@/lib/linting/rule-runner";
 import { RulesetRegistry } from "@/lib/linting/registry/ruleset-registry";
 import { createRulesetContext } from "@/lib/linting/registry/ruleset-context-factory";
 import type { RulesetContext } from "@/lib/linting/sdk/ruleset-context";
+import type { DictToolkitInternal } from "@/lib/linting/toolkit";
 import type { RulesetModule } from "@/lib/linting/sdk/ruleset-types";
 import type { LintRule, LintRuleConfig } from "@/lib/linting/types";
 
-/** A DictLike that always returns empty — external L2 rules requiring dict:genji are gated off. */
+/** A DictLike that always returns empty — async dict access is unreachable here. */
 const NO_OP_DICT = {
   async lookupBatch(_terms: string[]): Promise<Map<string, never>> {
     return new Map<string, never>();
@@ -28,15 +29,22 @@ const NO_OP_DICT = {
 };
 
 /**
- * Build the isolated RulesetContext used to instantiate external rules
- * without dictionary access. Matches the worker's NO_OP dict environment so
- * the main-thread fallback yields identical results (no dict:genji rules).
+ * Build the isolated RulesetContext used to instantiate external rules.
+ *
+ * Pass `dictToolkit` (a persistent snapshot-backed toolkit) to enable
+ * `dict:genji` rules: the renderer prewarms membership per batch and installs it
+ * via `dictToolkit.setSnapshot`, so the rule reads `dict.hasCached/lookupCached`
+ * synchronously. The requirement is marked satisfied because the snapshot path
+ * supplies the data — the rule itself no-ops when `dict.ready` is false (dict
+ * not installed / batch not prewarmed). Without `dictToolkit` the context has no
+ * dictionary and `dict:genji` rules stay gated off (legacy behavior).
  */
-export function createIsolatedRulesetContext(): RulesetContext {
+export function createIsolatedRulesetContext(dictToolkit?: DictToolkitInternal): RulesetContext {
   return createRulesetContext({
     dictHealth: { state: "not-installed" },
     dict: NO_OP_DICT,
-    requirements: new Map([["dict:genji", false]]),
+    dictToolkit,
+    requirements: new Map([["dict:genji", dictToolkit != null]]),
   });
 }
 
@@ -111,4 +119,26 @@ export async function importRulesetModule(code: string): Promise<RulesetModule> 
   } finally {
     URL.revokeObjectURL(url);
   }
+}
+
+/**
+ * Whether a ruleset declares a Genji dictionary requirement — at the ruleset
+ * level OR on any individual rule. Read straight from `manifest` (no code
+ * execution), so it is safe to call before/after building rules.
+ */
+export function rulesetRequiresDict(mod: RulesetModule): boolean {
+  const manifest = mod?.manifest;
+  if (!manifest) return false;
+  const hasDictReq = (reqs: ReadonlyArray<{ kind: string }> | undefined): boolean =>
+    Array.isArray(reqs) && reqs.some((r) => r?.kind === "dict");
+  if (hasDictReq(manifest.requires)) return true;
+  return (manifest.rules ?? []).some((r) => hasDictReq(r.requires));
+}
+
+/** Whether any module in the iterable requires the Genji dictionary. */
+export function anyRulesetRequiresDict(mods: Iterable<RulesetModule>): boolean {
+  for (const mod of mods) {
+    if (rulesetRequiresDict(mod)) return true;
+  }
+  return false;
 }

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/linting.worker.ts
@@ -20,7 +20,9 @@ import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
 import { isMorphologicalDocumentLintRule, isMorphologicalLintRule } from "@/lib/linting/types";
 import { RulesetRegistry } from "@/lib/linting/registry/ruleset-registry";
 import type { RulesetModule } from "@/lib/linting/sdk/ruleset-types";
+import { createSnapshotDictToolkit } from "@/lib/linting/toolkit";
 import {
+  anyRulesetRequiresDict,
   buildRulesetRunner,
   createIsolatedRulesetContext,
   importRulesetModule,
@@ -67,16 +69,28 @@ let lastGuidelineMapEntries: Array<[string, string | undefined]> = Array.from(
 // Active runner (swapped on successful rebuild)
 // -------------------------------------------------------------------------
 
+/**
+ * Persistent snapshot-backed dictionary toolkit. Survives runner rebuilds so the
+ * per-batch prewarm installed on RUN_BATCH stays valid for the rules that closed
+ * over it. Built once; the renderer fills it via `setSnapshot`.
+ */
+const workerDict = createSnapshotDictToolkit();
+
 /** Build a fresh RuleRunner = legacy ∪ all currently-loaded external rules. */
 function buildRunner(): { runner: RuleRunner; ruleGuidelineMap: Map<string, string | undefined> } {
   return buildRulesetRunner({
     legacyRules,
     externals: loadedExternals.values(),
-    ctx: createIsolatedRulesetContext(),
+    ctx: createIsolatedRulesetContext(workerDict),
     baseGuidelineMapEntries: lastGuidelineMapEntries,
     configs: lastConfigs,
     activeGuidelines: lastGuidelines,
   });
+}
+
+/** Whether any loaded ruleset requires the Genji dictionary. */
+function hasDictRules(): boolean {
+  return anyRulesetRequiresDict(loadedExternals.values());
 }
 
 // Initial runner (no externals yet).
@@ -156,7 +170,15 @@ self.onmessage = (event: MessageEvent<WorkerRequest>) => {
         runner.setGuidelineMap(new Map(msg.entries));
         return;
       case "RUN_BATCH": {
-        const { correlationId, version, paragraphs, mode } = msg;
+        const { correlationId, version, paragraphs, mode, dict } = msg;
+        // Install the prewarmed dictionary snapshot for this batch (or clear it
+        // when absent) so `dict:genji` rules read fresh per-batch membership and
+        // never a stale snapshot from a previous run.
+        if (dict) {
+          workerDict.setSnapshot(dict.entries, dict.ready);
+        } else {
+          workerDict.clearSnapshot();
+        }
         const perParagraph = new Map<number, LintIssue[]>();
         const runPer = mode === "per-paragraph" || mode === "both";
         const runDoc = mode === "document" || mode === "both";
@@ -228,6 +250,7 @@ async function handleLoadRuleset(correlationId: number, id: string, code: string
         ruleIds: [],
         warnings,
         hasMorphologicalRules: runnerHasRegisteredMorphRules(runner),
+        hasDictRules: hasDictRules(),
       });
       return;
     }
@@ -258,6 +281,7 @@ async function handleLoadRuleset(correlationId: number, id: string, code: string
       ruleIds,
       warnings: allWarnings,
       hasMorphologicalRules: runnerHasRegisteredMorphRules(runner),
+      hasDictRules: hasDictRules(),
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
@@ -277,6 +301,7 @@ async function handleLoadRuleset(correlationId: number, id: string, code: string
       ruleIds: [],
       warnings,
       hasMorphologicalRules: runnerHasRegisteredMorphRules(runner),
+      hasDictRules: hasDictRules(),
     });
   }
 }
@@ -298,6 +323,7 @@ function handleUnloadRuleset(correlationId: number, id: string): void {
       ruleIds: [],
       warnings: [],
       hasMorphologicalRules: runnerHasRegisteredMorphRules(runner),
+      hasDictRules: hasDictRules(),
     });
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
@@ -315,6 +341,7 @@ function handleUnloadRuleset(correlationId: number, id: string): void {
         },
       ],
       hasMorphologicalRules: runnerHasRegisteredMorphRules(runner),
+      hasDictRules: hasDictRules(),
     });
   }
 }

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts
@@ -10,6 +10,25 @@
 
 import type { LintIssue, LintRuleConfig } from "@/lib/linting/types";
 import type { Token } from "@/lib/nlp-client/types";
+import type { DictLookup } from "@/lib/dict/dict-types";
+
+/**
+ * Prewarmed dictionary membership for one batch.
+ *
+ * The lint pass is synchronous but dictionary I/O is async, so the renderer
+ * looks up every candidate headword in the batch (where `getDictAccess()` is
+ * reachable) and ships the result here. `dict:genji` rules read it synchronously
+ * via `ctx.toolkit.dict.hasCached/lookupCached`.
+ *
+ * `entries` includes misses (`{ found: false }`) so the rule can distinguish
+ * "looked up, absent → flag" from "not looked up → skip". `ready` is false when
+ * the dictionary is not usable (not installed / web fallback / corrupt), in
+ * which case the rule no-ops.
+ */
+export interface DictSnapshotPayload {
+  ready: boolean;
+  entries: Array<[string, DictLookup]>;
+}
 
 // -------------------------------------------------------------------------
 // Plugin-facing surface
@@ -32,6 +51,12 @@ export interface RuleRunnerLike {
    * paragraphs in addition to the uncached set.
    */
   hasMorphologicalDocumentRules(): boolean;
+  /**
+   * True iff at least one loaded ruleset requires the Genji dictionary. The
+   * decoration plugin uses this to decide whether to prewarm dictionary
+   * membership and attach a {@link DictSnapshotPayload} to each batch.
+   */
+  hasDictRules(): boolean;
   /** Execute one batched lint pass. */
   runBatch(req: RunBatchRequest): Promise<RunBatchResponse>;
   /**
@@ -83,6 +108,12 @@ export interface RunBatchRequest {
    * Defaults to `true`.
    */
   runWorker?: boolean;
+  /**
+   * Prewarmed dictionary membership for this batch. Present only when a loaded
+   * ruleset requires the dictionary (`hasDictRules()`); the rule reads it via
+   * `ctx.toolkit.dict.hasCached/lookupCached`.
+   */
+  dict?: DictSnapshotPayload;
 }
 
 export interface RunBatchResponse {
@@ -141,6 +172,12 @@ export type WorkerEvent =
        * tokens start flowing before the main thread sends SET_CONFIG.
        */
       hasMorphologicalRules: boolean;
+      /**
+       * Whether any currently-loaded ruleset requires the Genji dictionary.
+       * Drives the proxy's `hasDictRules()` so the decoration plugin prewarms
+       * membership and ships a {@link DictSnapshotPayload} per batch.
+       */
+      hasDictRules: boolean;
     };
 
 /** Main → worker requests. */
@@ -172,6 +209,8 @@ export type WorkerRequest =
        */
       paragraphs: ReadonlyArray<{ text: string; index: number; tokens?: ReadonlyArray<Token> }>;
       mode: BatchMode;
+      /** Prewarmed dictionary membership; present only when `hasDictRules()`. */
+      dict?: DictSnapshotPayload;
     }
   | {
       /** Load (or reload) an external ruleset by injecting its ESM source. */

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
@@ -17,8 +17,10 @@ import {
 } from "@/lib/linting/types";
 import type { LintIssue, LintRule, LintRuleConfig } from "@/lib/linting/types";
 import type { RulesetModule } from "@/lib/linting/sdk/ruleset-types";
+import { createSnapshotDictToolkit, type DictToolkitInternal } from "@/lib/linting/toolkit";
 
 import {
+  anyRulesetRequiresDict,
   buildRulesetRunner,
   createIsolatedRulesetContext,
   importRulesetModule,
@@ -80,6 +82,19 @@ export class RuleRunnerProxy implements RuleRunnerLike {
    * and forwards those tokens to the worker in RUN_BATCH.
    */
   private workerHasMorphRules = false;
+
+  /**
+   * Whether the worker currently hosts at least one ruleset that requires the
+   * Genji dictionary. Updated on every RULESET_LOADED event. Drives
+   * `hasDictRules()` so the decoration plugin prewarms membership.
+   */
+  private workerHasDictRules = false;
+
+  /**
+   * Persistent snapshot-backed dictionary toolkit for the main-thread fallback
+   * runner. Survives fallback rebuilds; `runBatchFallback` fills it per batch.
+   */
+  private readonly fallbackDict: DictToolkitInternal = createSnapshotDictToolkit();
 
   private nextCorrelationId = 1;
   private latestRequestedVersion = 0;
@@ -229,6 +244,13 @@ export class RuleRunnerProxy implements RuleRunnerLike {
     return this.mainRunner.hasMorphologicalDocumentRules();
   }
 
+  hasDictRules(): boolean {
+    if (this.fallbackActive) {
+      return anyRulesetRequiresDict(this.fallbackModules.values());
+    }
+    return this.workerHasDictRules;
+  }
+
   // ----------------------------------------------------------------
   // RuleRunnerLike — async batch execution
   // ----------------------------------------------------------------
@@ -317,6 +339,9 @@ export class RuleRunnerProxy implements RuleRunnerLike {
         ? req.paragraphs.map((p) => ({ text: p.text, index: p.index, tokens: p.tokens }))
         : req.paragraphs.map((p) => ({ text: p.text, index: p.index })),
       mode: req.mode,
+      // Ship prewarmed dictionary membership only when the worker hosts a
+      // dict-requiring ruleset; keeps the structured-clone payload minimal.
+      dict: this.workerHasDictRules ? req.dict : undefined,
     });
 
     return workerResponse;
@@ -460,6 +485,7 @@ export class RuleRunnerProxy implements RuleRunnerLike {
         // rules. This drives both `hasMorphologicalRules()` (so the
         // decoration plugin tokenizes) and token forwarding in RUN_BATCH.
         this.workerHasMorphRules = evt.hasMorphologicalRules;
+        this.workerHasDictRules = evt.hasDictRules;
         const entry = this.pendingRulesets.get(evt.correlationId);
         if (entry) {
           this.pendingRulesets.delete(evt.correlationId);
@@ -571,7 +597,7 @@ export class RuleRunnerProxy implements RuleRunnerLike {
       const { runner } = buildRulesetRunner({
         legacyRules: this.fallbackLegacyRules,
         externals: this.fallbackModules.values(),
-        ctx: createIsolatedRulesetContext(),
+        ctx: createIsolatedRulesetContext(this.fallbackDict),
         baseGuidelineMapEntries: this.lastGuidelineMapEntries,
         configs: this.lastConfigs,
         activeGuidelines: this.lastActiveGuidelines,
@@ -632,6 +658,14 @@ export class RuleRunnerProxy implements RuleRunnerLike {
     const runner = this.fallbackRunner;
     if (req.runWorker === false || !runner) {
       return { perParagraph: mainPerParagraph, document: mainDocument };
+    }
+
+    // Install the prewarmed dictionary snapshot (or clear it) so dict:genji
+    // rules hosted by the fallback runner read fresh per-batch membership.
+    if (req.dict) {
+      this.fallbackDict.setSnapshot(req.dict.entries, req.dict.ready);
+    } else {
+      this.fallbackDict.clearSnapshot();
     }
 
     const runPer = req.mode === "per-paragraph" || req.mode === "both";

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -30,7 +30,9 @@ export const LEGACY_PACKAGE_IMPORTS = new Map([
   [
     "packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts",
     new Set([
+      "@/lib/dict/dict-access",
       "@/lib/linting",
+      "@/lib/linting/dict-candidate-terms",
       "@/lib/nlp-client/types",
       "@/lib/project/project-types",
       "@/shared/lib/hash-string",
@@ -64,6 +66,16 @@ export const LEGACY_PACKAGE_IMPORTS = new Map([
     ]),
   ],
   [
+    "packages/milkdown-plugin-japanese-novel/linting-plugin/worker/__tests__/build-ruleset-runner.dict.test.ts",
+    new Set([
+      "@/lib/linting/sdk/ruleset-context",
+      "@/lib/linting/sdk/ruleset-types",
+      "@/lib/linting/toolkit",
+      "@/lib/linting/types",
+      "@/lib/nlp-client/types",
+    ]),
+  ],
+  [
     "packages/milkdown-plugin-japanese-novel/linting-plugin/worker/build-ruleset-runner.ts",
     new Set([
       "@/lib/linting/registry/ruleset-context-factory",
@@ -71,6 +83,7 @@ export const LEGACY_PACKAGE_IMPORTS = new Map([
       "@/lib/linting/rule-runner",
       "@/lib/linting/sdk/ruleset-context",
       "@/lib/linting/sdk/ruleset-types",
+      "@/lib/linting/toolkit",
       "@/lib/linting/types",
     ]),
   ],
@@ -83,12 +96,13 @@ export const LEGACY_PACKAGE_IMPORTS = new Map([
       "@/lib/linting/rule-registry",
       "@/lib/linting/rule-runner",
       "@/lib/linting/sdk/ruleset-types",
+      "@/lib/linting/toolkit",
       "@/lib/linting/types",
     ]),
   ],
   [
     "packages/milkdown-plugin-japanese-novel/linting-plugin/worker/protocol.ts",
-    new Set(["@/lib/linting/types", "@/lib/nlp-client/types"]),
+    new Set(["@/lib/dict/dict-types", "@/lib/linting/types", "@/lib/nlp-client/types"]),
   ],
   [
     "packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts",
@@ -97,6 +111,7 @@ export const LEGACY_PACKAGE_IMPORTS = new Map([
       "@/lib/linting/rule-registry",
       "@/lib/linting/rule-runner",
       "@/lib/linting/sdk/ruleset-types",
+      "@/lib/linting/toolkit",
       "@/lib/linting/types",
     ]),
   ],


### PR DESCRIPTION
## 概要

幻辞（Genji）辞書に**未収録の語**を形態素解析（L2）で検出する校正ルールセットを新設し、
本体の校正パイプラインで機能するよう **dict:genji の prewarm 配線**を追加した。

- ルールセット本体は別リポジトリ（1 repo = 1 ruleset 方針）:
  **[illusions-lab/illusions-ruleset-genji-vocab](https://github.com/illusions-lab/illusions-ruleset-genji-vocab)** （v0.1.0 リリース済み）
- 本 PR は **illusions 本体側**の SDK 拡張・パイプライン配線・公式登録。

Closes #1628

## 設計（同期 lint × 非同期辞書 I/O の橋渡し）

校正実行は**同期**（`runAllWithTokens`/`lintWithTokens`）だが辞書 I/O は**非同期**。
そこで renderer（`getDictAccess()` が使える decoration-plugin）が**バッチ前に辞書メンバーシップを
prewarm** し、`DictSnapshotPayload {ready, entries}` を `RUN_BATCH` で worker / main-thread fallback へ配送。
worker 側は永続スナップショット dict に `setSnapshot` してから同期 lint を実行する。

ルールは **「prewarm 済みかつ未収録」**の語だけをフラグ（`lookupCached(t)===undefined` ならスキップ）。
→ prewarm 漏れは false-negative にしかならず、**誤検出（false positive）はゼロ**。

## 安全性

- **既存ルールセット（dict 非依存の公式6件）は挙動完全不変** — 新経路はすべて `hasDictRules()` /
  `requires:dict` でガードし、dict ルールが無い限り従来と同一ペイロード・同一実行。
- 辞書未インストール／破損／Web フォールバック時は `dict.ready=false` → ルールが **no-op**（全語を辞書外と誤判定しない）。
- スナップショットは毎バッチ set/clear（stale 防止）。set→同期実行間に `await` なし（race なし）。

## 主な変更

| ファイル | 変更 |
| --- | --- |
| `lib/linting/sdk/ruleset-context.ts` | `DictToolkit` に同期 `hasCached`/`lookupCached` を追加 |
| `lib/linting/toolkit/dict-toolkit.ts` | `createSnapshotDictToolkit`（snapshot 方式の DictToolkitInternal）|
| `lib/linting/dict-candidate-terms.ts` | 内容語抽出（名詞/動詞/形容詞・固有名詞含む）共有ロジック |
| `…/decoration-plugin.ts` | バッチ前の辞書 prewarm + `req.dict` 配送 |
| `…/worker/{protocol,linting.worker,rule-runner-proxy,build-ruleset-runner}.ts` | snapshot 配送・永続 dict・requires:dict 充足 |
| `electron/official-rulesets.js` | `com.illusions-lab.genji-vocab` を公式（自動DL）登録 |

## テスト

- 新規ユニット: `dict-toolkit`（snapshot）/ `dict-candidate-terms` / `build-ruleset-runner.dict`（gating・per-batch・fail-safe）
- **全 1979 件 green**、`type-check` clean、`bundle:electron` 成功、`check-import-boundaries` 通過
- ルールセット repo 側: 13 ユニット（通常＋エッジ）green、`v0.1.0` リリース成功

## 検証（手動）

1. 起動時に `genji-vocab` が `~/.illusions/rulesets/` へ自動DL される
2. 校正設定で「幻辞 辞書照合」を有効化
3. 辞書外の造語/誤字を含む文 → 当該語に **info（青波線）**。収録語のみ → 指摘なし
4. 辞書を未インストール/破損状態にする → 当該ルールは無検出（誤検出しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)