### PR TITLE
fix(file-type): 大文字・混在拡張子と Save As の fileType 更新を修正 (#1887 #1871)

### DIFF
--- a/lib/project/project-service.ts
+++ b/lib/project/project-service.ts
@@ -564,8 +564,9 @@ export class ProjectService {
    * ファイル名からサポートされた拡張子を抽出する。
    */
   private getFileExtension(fileName: string): SupportedFileExtension {
-    if (fileName.endsWith(".mdi")) return ".mdi";
-    if (fileName.endsWith(".md")) return ".md";
+    const lower = fileName.toLowerCase();
+    if (lower.endsWith(".mdi")) return ".mdi";
+    if (lower.endsWith(".md")) return ".md";
     return ".txt";
   }
 

--- a/lib/tab-manager/__tests__/infer-file-type.test.ts
+++ b/lib/tab-manager/__tests__/infer-file-type.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression tests for inferFileType (issues #1887 / #1871).
+ *
+ * #1887: upper-case and mixed-case extensions (.MD, .TXT, .Md, .Txt) must
+ * NOT fall through to ".mdi", which would enable MDI parsing and transform
+ * the file content.
+ *
+ * #1871: Save As fileType must be re-derived from the new filename; tested
+ * via executeTabSave in save-executor.test.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+import { inferFileType } from "@/lib/tab-manager/types";
+
+describe("inferFileType — case-insensitive extension detection (#1887)", () => {
+  // .md variants
+  it("lower-case .md → .md", () => {
+    expect(inferFileType("story.md")).toBe(".md");
+  });
+  it("upper-case .MD → .md (was broken: returned .mdi)", () => {
+    expect(inferFileType("story.MD")).toBe(".md");
+  });
+  it("mixed-case .Md → .md", () => {
+    expect(inferFileType("story.Md")).toBe(".md");
+  });
+  it("mixed-case .mD → .md", () => {
+    expect(inferFileType("story.mD")).toBe(".md");
+  });
+
+  // .txt variants
+  it("lower-case .txt → .txt", () => {
+    expect(inferFileType("notes.txt")).toBe(".txt");
+  });
+  it("upper-case .TXT → .txt (was broken: returned .mdi)", () => {
+    expect(inferFileType("notes.TXT")).toBe(".txt");
+  });
+  it("mixed-case .Txt → .txt", () => {
+    expect(inferFileType("notes.Txt")).toBe(".txt");
+  });
+  it("mixed-case .tXt → .txt", () => {
+    expect(inferFileType("notes.tXt")).toBe(".txt");
+  });
+
+  // .mdi variants — all map to .mdi
+  it("lower-case .mdi → .mdi", () => {
+    expect(inferFileType("novel.mdi")).toBe(".mdi");
+  });
+  it("upper-case .MDI → .mdi", () => {
+    expect(inferFileType("novel.MDI")).toBe(".mdi");
+  });
+  it("mixed-case .Mdi → .mdi", () => {
+    expect(inferFileType("novel.Mdi")).toBe(".mdi");
+  });
+
+  // Unknown extensions fall back to .mdi
+  it("unknown extension → .mdi (default)", () => {
+    expect(inferFileType("file.docx")).toBe(".mdi");
+  });
+  it("no extension → .mdi (default)", () => {
+    expect(inferFileType("README")).toBe(".mdi");
+  });
+
+  // Dotfiles and edge cases
+  it("filename with dots before extension → correct type", () => {
+    expect(inferFileType("my.story.v2.txt")).toBe(".txt");
+  });
+  it("filename with dots before extension → .md", () => {
+    expect(inferFileType("my.story.v2.MD")).toBe(".md");
+  });
+});

--- a/lib/tab-manager/__tests__/save-executor.test.ts
+++ b/lib/tab-manager/__tests__/save-executor.test.ts
@@ -678,3 +678,81 @@ describe("executeTabSave: failure and unmount handling", () => {
     expect(tryCreateSnapshot).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Save As fileType recompute (#1871)
+// ---------------------------------------------------------------------------
+
+describe("executeTabSave: Save As recomputes fileType from new descriptor (#1871)", () => {
+  it("changes fileType from .mdi to .txt when Save As targets a .txt file", async () => {
+    const tab = makeTab({ file: null, fileType: ".mdi", content: "本文" });
+    const h = makeHarness([tab]);
+    const newDescriptor: MdiFileDescriptor = {
+      path: "/p/export.txt",
+      handle: null,
+      name: "export.txt",
+    };
+    saveMdiFileMock.mockResolvedValue({ descriptor: newDescriptor, content: "本文" });
+
+    const outcome = await executeTabSave({
+      tab,
+      isProject: false,
+      tabsRef: h.tabsRef,
+      setTabs: h.setTabs,
+      tryCreateSnapshot: vi.fn(),
+      forceDialog: true,
+      recheckConflict: false,
+    });
+
+    expect(outcome.status).toBe("saved");
+    const updated = h.getTab("tab-1");
+    expect(updated.fileType).toBe(".txt");
+    expect(updated.file).toEqual(newDescriptor);
+  });
+
+  it("changes fileType from .txt to .mdi when Save As targets a .mdi file", async () => {
+    const tab = makeTab({
+      file: { path: "/p/notes.txt", handle: null, name: "notes.txt" },
+      fileType: ".txt",
+      content: "本文",
+    });
+    const h = makeHarness([tab]);
+    const newDescriptor: MdiFileDescriptor = {
+      path: "/p/novel.mdi",
+      handle: null,
+      name: "novel.mdi",
+    };
+    saveMdiFileMock.mockResolvedValue({ descriptor: newDescriptor, content: "本文" });
+
+    const outcome = await executeTabSave({
+      tab,
+      isProject: false,
+      tabsRef: h.tabsRef,
+      setTabs: h.setTabs,
+      tryCreateSnapshot: vi.fn(),
+      forceDialog: true,
+      recheckConflict: false,
+    });
+
+    expect(outcome.status).toBe("saved");
+    const updated = h.getTab("tab-1");
+    expect(updated.fileType).toBe(".mdi");
+    expect(updated.file).toEqual(newDescriptor);
+  });
+
+  it("keeps fileType unchanged for project-mode save (no descriptor update)", async () => {
+    const tab = makeTab({ fileType: ".mdi", content: "本文" });
+    const h = makeHarness([tab]);
+
+    await executeTabSave({
+      tab,
+      isProject: true,
+      tabsRef: h.tabsRef,
+      setTabs: h.setTabs,
+      tryCreateSnapshot: vi.fn(),
+    });
+
+    // Project mode does not change the file descriptor
+    expect(h.getTab("tab-1").fileType).toBe(".mdi");
+  });
+});

--- a/lib/tab-manager/save-executor.ts
+++ b/lib/tab-manager/save-executor.ts
@@ -23,6 +23,7 @@ import { saveMdiFile } from "../project/mdi-file";
 import { getProjectFileService } from "../services/project-file-service";
 import { suppressFileWatch } from "../services/file-watcher";
 import { acquireSaveLock, releaseSaveLock } from "./save-lock";
+import { inferFileType } from "./types";
 import { isEditorTab } from "./tab-types";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { MdiFileDescriptor } from "../project/mdi-file";
@@ -227,12 +228,15 @@ export async function executeTabSave(params: ExecuteTabSaveParams): Promise<Save
       setTabs((prev) =>
         prev.map((t) => {
           if (t.id !== tab.id || !isEditorTab(t)) return t;
+          // Recompute fileType from the new descriptor name (Save As may change extension).
+          const newFileType = descriptor ? inferFileType(descriptor.name) : t.fileType;
           const newIsDirty =
-            MdiDocument.fromEditorOutput(t.content, { fileType: t.fileType }).toRawText() !==
+            MdiDocument.fromEditorOutput(t.content, { fileType: newFileType }).toRawText() !==
             sanitized;
           return {
             ...t,
             ...(descriptor ? { file: descriptor } : null),
+            ...(descriptor ? { fileType: newFileType } : null),
             lastSavedContent: sanitized,
             isDirty: newIsDirty,
             lastSavedTime: Date.now(),

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -133,8 +133,9 @@ export function generateTabId(): TabId {
 }
 
 export function inferFileType(fileName: string): SupportedFileExtension {
-  if (fileName.endsWith(".md")) return ".md";
-  if (fileName.endsWith(".txt")) return ".txt";
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith(".md")) return ".md";
+  if (lower.endsWith(".txt")) return ".txt";
   return ".mdi";
 }
 


### PR DESCRIPTION
## 概要

- **#1887**: `inferFileType()` と `getFileExtension()` が大文字・混在拡張子（`.MD`/`.TXT`/`.Mdi` 等）を `.mdi` に誤判定し、MDI パーサでコンテンツを変形するバグを修正
- **#1871**: Save As で拡張子変更後も `fileType` が旧形式のまま残るバグを修正

## 変更内容

### `lib/tab-manager/types.ts` — `inferFileType()`
```typescript
// Before (case-sensitive):
if (fileName.endsWith(".md")) return ".md";
// After (case-insensitive):
const lower = fileName.toLowerCase();
if (lower.endsWith(".md")) return ".md";
```

### `lib/project/project-service.ts` — `getFileExtension()`
同様に `toLowerCase()` で統一。

### `lib/tab-manager/save-executor.ts` — `applySavedTabState()`
Save As 後に新しい descriptor 名から `fileType` を再計算:
```typescript
const newFileType = descriptor ? inferFileType(descriptor.name) : t.fileType;
```

## テスト計画

- [ ] `lib/tab-manager/__tests__/infer-file-type.test.ts` (14件): `.MD`/`.Md`/`.mD`/`.TXT`/`.Txt`/`.MDI` 等が正しい fileType を返すことを確認
- [ ] `lib/tab-manager/__tests__/save-executor.test.ts` に 3件追加: `.mdi`→`.txt`/`.txt`→`.mdi`/プロジェクトモードで fileType 不変を確認
- [ ] `npm run type-check` 通過
- [ ] `npx eslint` 警告なし
- [ ] `npm run check:boundaries` クリーン

## 退行リスク

- `inferFileType` は保存・開く・タブ生成の全経路で使用されるが、変更は `toLowerCase()` の追加のみ。小文字拡張子への既存の動作は変更なし。

Closes #1887
Closes #1871