### PR TITLE
fix(tab-manager): popout/background tab content sync recomputes isDirty (#1876)

### DIFF
--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -267,7 +267,7 @@ export function useDockviewAdapter({
   // effect to re-run (which would duplicate addPanel calls).
   const [layoutReadyTick, setLayoutReadyTick] = useState(0);
 
-  const { tabs, activeTabId, switchTab, closeTab, cloneTab, updateTab } = tabManager;
+  const { tabs, activeTabId, switchTab, closeTab, cloneTab, updateTab, setTabContent } = tabManager;
 
   // Latest-state refs so the mount-only handleDockviewReady closure (and the
   // dockview event subscriptions it registers) never read stale first-render
@@ -678,13 +678,18 @@ export function useDockviewAdapter({
       // and apply to the editor view only for the active tab.
       for (const tab of tabs) {
         if (tab.id === data.bufferId && isEditorTab(tab)) {
-          // Update tab state in memory regardless of active/inactive status
-          updateTab(tab.id, { content: data.content });
+          // Use setTabContent so isDirty is correctly recomputed for background
+          // tabs (updateTab is a shallow merge that skips dirty recomputation,
+          // causing popout edits to be silently lost — #1876).
+          if (tab.id === activeTabId) {
+            // Active tab: drive the editor view (ProseMirror) which will
+            // propagate back to tab state via setContent.
+            tabSetContent(data.content);
+          } else {
+            // Background tab: update content and recompute isDirty directly.
+            setTabContent(tab.id, data.content);
+          }
         }
-      }
-      // Apply to editor view (ProseMirror) only when the active tab matches
-      if (data.bufferId === activeTabId) {
-        tabSetContent(data.content);
       }
     });
 
@@ -696,7 +701,7 @@ export function useDockviewAdapter({
       if (typeof unsubSync === "function") unsubSync();
       if (typeof unsubClose === "function") unsubClose();
     };
-  }, [activeTabId, tabs, tabSetContent, updateTab]);
+  }, [activeTabId, tabs, tabSetContent, updateTab, setTabContent]);
 
   // Broadcast content changes to other windows (editor tabs only)
   useEffect(() => {

--- a/lib/tab-manager/__tests__/set-tab-content-dirty.test.ts
+++ b/lib/tab-manager/__tests__/set-tab-content-dirty.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression test for #1876: non-active (background/popout) tab content sync
+ * must recompute isDirty rather than performing a shallow updateTab merge.
+ *
+ * The production fix lives in useTabState.setTabContent().
+ * We extract the pure updater logic and test it without React.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import type { TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
+import { createNewTab } from "@/lib/tab-manager/types";
+
+// ---------------------------------------------------------------------------
+// Pure updater — mirrors setTabContent's setTabs functional updater
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors the setTabs updater inside useTabState.setTabContent().
+ * Tests the core logic in isolation from the React hook lifecycle.
+ */
+function applySetTabContent(tabs: TabState[], tabId: string, newContent: string): TabState[] {
+  return tabs.map((tab): TabState => {
+    if (tab.id !== tabId || !isEditorTab(tab)) return tab;
+    const dirty = newContent !== tab.lastSavedContent;
+    return {
+      ...tab,
+      content: newContent,
+      isDirty: dirty,
+      isPreview: dirty ? false : tab.isPreview,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("setTabContent — background/popout dirty recomputation (#1876)", () => {
+  it("marks a non-active tab dirty when content differs from lastSavedContent", () => {
+    const saved = "saved content";
+    const tab = createNewTab(saved);
+    // Simulate a save: lastSavedContent matches content, isDirty=false
+    expect(tab.isDirty).toBe(false);
+
+    // Popout window edits the content
+    const edited = "edited in popout";
+    const [updated] = applySetTabContent([tab], tab.id, edited).filter(isEditorTab);
+
+    expect(updated.content).toBe(edited);
+    expect(updated.isDirty).toBe(true);
+  });
+
+  it("keeps isDirty=false when content matches lastSavedContent (no real change)", () => {
+    const saved = "identical content";
+    const tab = createNewTab(saved);
+
+    const [updated] = applySetTabContent([tab], tab.id, saved).filter(isEditorTab);
+
+    expect(updated.content).toBe(saved);
+    expect(updated.isDirty).toBe(false);
+  });
+
+  it("promotes a preview tab to fixed when content changes", () => {
+    const tab = createNewTab("original");
+    // Force isPreview=true to simulate a preview tab
+    const previewTab = { ...tab, isPreview: true };
+
+    const [updated] = applySetTabContent([previewTab], previewTab.id, "changed").filter(
+      isEditorTab,
+    );
+
+    expect(updated.isDirty).toBe(true);
+    expect(updated.isPreview).toBe(false);
+  });
+
+  it("leaves a preview tab as preview when content is unchanged", () => {
+    const saved = "unchanged";
+    const tab = createNewTab(saved);
+    const previewTab = { ...tab, isPreview: true };
+
+    const [updated] = applySetTabContent([previewTab], previewTab.id, saved).filter(isEditorTab);
+
+    expect(updated.isDirty).toBe(false);
+    expect(updated.isPreview).toBe(true);
+  });
+
+  it("does not affect other tabs in the array", () => {
+    const tabA = createNewTab("content A");
+    const tabB = createNewTab("content B");
+
+    const result = applySetTabContent([tabA, tabB], tabA.id, "new content for A");
+    const [, bResult] = result.filter(isEditorTab);
+
+    // tabB must be untouched (same reference)
+    expect(bResult).toBe(tabB);
+  });
+
+  it("old updateTab shallow merge would NOT set isDirty (regression guard)", () => {
+    // Demonstrate the pre-fix broken behaviour: updateTab was called with
+    // { content: newContent } which does NOT recompute isDirty.
+    const saved = "saved content";
+    const tab = createNewTab(saved);
+
+    // Broken pre-fix path: shallow merge only sets content
+    const broken: TabState[] = [tab].map((t) => {
+      if (t.id !== tab.id || !isEditorTab(t)) return t;
+      return { ...t, content: "popout edit" }; // no isDirty update!
+    });
+    const [brokenTab] = broken.filter(isEditorTab);
+
+    // isDirty would remain false — the bug
+    expect(brokenTab.isDirty).toBe(false);
+    expect(brokenTab.content).toBe("popout edit");
+
+    // Fixed path correctly marks dirty
+    const [fixedTab] = applySetTabContent([tab], tab.id, "popout edit").filter(isEditorTab);
+    expect(fixedTab.isDirty).toBe(true);
+    expect(fixedTab.content).toBe("popout edit");
+  });
+});

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -220,6 +220,7 @@ export function useTabManager(options?: {
     openDiffTab: tabState.openDiffTab,
     forceCloseTab: tabState.forceCloseTab,
     updateTab: tabState.updateTab,
+    setTabContent: tabState.setTabContent,
 
     // Close-tab dialog
     pendingCloseTabId: tabState.pendingCloseTabId,

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -69,6 +69,12 @@ export interface UseTabManagerReturn {
    * Used by diff tab conflict resolution to update source tab content.
    */
   updateTab: (tabId: TabId, updates: Partial<EditorTabState>) => void;
+  /**
+   * Set content on any tab by id, correctly recomputing isDirty.
+   * Unlike updateTab() (shallow merge that skips dirty recomputation),
+   * this helper is safe for background/popout content sync.
+   */
+  setTabContent: (tabId: TabId, newContent: string) => void;
 
   // Close-tab unsaved warning flow
   pendingCloseTabId: TabId | null;

--- a/lib/tab-manager/use-tab-state.ts
+++ b/lib/tab-manager/use-tab-state.ts
@@ -34,6 +34,12 @@ export interface UseTabStateReturn extends TabManagerCore {
   lastSaveWasAuto: boolean;
   /** Update a single tab by id. */
   updateTab: (tabId: TabId, updates: Partial<EditorTabState>) => void;
+  /**
+   * Set content on any tab by id, correctly recomputing isDirty.
+   * Unlike updateTab() (shallow merge that skips dirty recomputation),
+   * this helper mirrors setContent() logic for background/popout tabs.
+   */
+  setTabContent: (tabId: TabId, newContent: string) => void;
   /** Find a tab by its file path. */
   findTabByPath: (path: string) => EditorTabState | undefined;
 
@@ -137,6 +143,22 @@ export function useTabState(): UseTabStateReturn {
       prev.map((tab): TabState => {
         if (tab.id !== tabId || !isEditorTab(tab)) return tab;
         return { ...tab, ...updates };
+      }),
+    );
+  }, []);
+
+  const setTabContent = useCallback((tabId: TabId, newContent: string) => {
+    setTabs((prev) =>
+      prev.map((tab): TabState => {
+        if (tab.id !== tabId || !isEditorTab(tab)) return tab;
+        const dirty = newContent !== tab.lastSavedContent;
+        return {
+          ...tab,
+          content: newContent,
+          isDirty: dirty,
+          // Promote preview tab to fixed when edited
+          isPreview: dirty ? false : tab.isPreview,
+        };
       }),
     );
   }, []);
@@ -375,6 +397,7 @@ export function useTabState(): UseTabStateReturn {
 
     // Helpers
     updateTab,
+    setTabContent,
     findTabByPath,
 
     // Tab CRUD


### PR DESCRIPTION
## 概要

非アクティブタブ（バックグラウンド・popout ウィンドウ）のバッファ同期で `isDirty` が正しく再計算されず、未保存のまま編集内容が失われる P0 バグを修正。

Closes #1876

### 根本原因

`use-dockview-adapter.ts` の `onBufferSync` コールバックが、バックグラウンドタブに対して `updateTab(id, { content })` を呼んでいた。これは浅いマージで `isDirty` を再計算しないため、バックグラウンドタブが `isDirty=false` のまま残り、auto-save がスキップして編集内容が失われる。

### 修正

1. **`lib/tab-manager/use-tab-state.ts`**: `setTabContent(tabId, newContent)` ヘルパーを追加。`setContent()` と同じ `isDirty` 再計算ロジック（`newContent !== tab.lastSavedContent`）を任意のタブ ID に対して適用。
2. **`lib/tab-manager/types.ts`**: `UseTabManagerReturn` に `setTabContent` を追加。
3. **`lib/tab-manager/index.ts`**: `setTabContent` を公開インターフェースから返す。
4. **`lib/dockview/use-dockview-adapter.ts`**: `onBufferSync` でバックグラウンドタブに `setTabContent` を使用（アクティブタブは従来通り `tabSetContent` でエディタビューを駆動）。

> 注: `setTabContent` ヘルパーは兄弟 PR #1877 での再利用を想定して公開インターフェースに追加。

## テスト計画

- [x] `lib/tab-manager/__tests__/set-tab-content-dirty.test.ts` を新規追加（6 テスト）
  - バックグラウンドタブのコンテンツ変更で `isDirty=true` になること
  - `lastSavedContent` と一致する場合は `isDirty=false` を維持すること
  - プレビュータブが固定タブに昇格すること
  - 他タブが影響を受けないこと
  - 旧 `updateTab` 浅いマージが `isDirty` を設定しないことのリグレッションガード
- [x] `npm run type-check` — pass
- [x] `npx vitest run lib/tab-manager/__tests__/` — 20 ファイル 204 テスト pass
- [x] ESLint — 新規 warning なし（既存 warning は pre-existing）
- [x] `npm run check:boundaries` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)