### PR TITLE
fix(editor): gate [[blank]]/no-break/kern on mdiExtensionsEnabled (#1886)

### DIFF
--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -255,17 +255,18 @@ export default function MilkdownEditor({
       }
 
       // MDI extensions: conditionally loaded
-      // NOTE: enableNoBreak / enableKern are not explicitly passed here, so
-      //   they default to `true` (always enabled, even in .md files).
-      //   enableMdiBreak is explicitly gated on mdiExtensionsEnabled so that
-      //   `[[br]]` is only active in .mdi files. Aligning nobreak/kern with
-      //   the same gating is tracked separately.
+      // All MDI macro families are gated on mdiExtensionsEnabled (true only
+      // for .mdi files) so that .txt/.md content containing [[blank]],
+      // [[no-break:...]], [[kern:...:...]] etc. is preserved byte-for-byte
+      // and not stripped/altered by the serializer (#1886).
       editor = editor.use(
         japaneseNovel({
           isVertical,
           showManuscriptLine: false,
           enableRuby: mdiExtensionsEnabled,
           enableTcy: mdiExtensionsEnabled,
+          enableNoBreak: mdiExtensionsEnabled,
+          enableKern: mdiExtensionsEnabled,
           enableMdiBreak: mdiExtensionsEnabled,
           // .txt: characters like *, #, ** are literal — copy must bypass
           // markdown stripping / MDI conversion (P2-A).

--- a/packages/milkdown-plugin-japanese-novel/__tests__/mdi-macro-gating-1886.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/mdi-macro-gating-1886.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Regression test for #1886:
+ * [[blank]], [[no-break:...]], [[kern:...:...]] macros must NOT be parsed/stripped
+ * when editing .txt or .md files (mdiExtensionsEnabled = false).
+ * Only .mdi files (enableMdiBreak = true) should activate MDI parsing.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { Editor, rootCtx, defaultValueCtx, editorViewCtx } from "@milkdown/core";
+import { commonmark } from "@milkdown/preset-commonmark";
+import type { EditorView } from "@milkdown/prose/view";
+import { japaneseNovel } from "../index";
+import { remarkMdiBlankPlugin, remarkNoBreakPlugin, remarkKernPlugin } from "../syntax";
+
+// ---------------------------------------------------------------------------
+// Pure remark-plugin unit tests (no full editor mount needed)
+// ---------------------------------------------------------------------------
+
+type TextNode = { type: "text"; value: string };
+type Paragraph = { type: "paragraph"; children: TextNode[] };
+type Root = { type: "root"; children: Paragraph[] };
+
+function makeTree(paragraphText: string): Root {
+  return {
+    type: "root",
+    children: [{ type: "paragraph", children: [{ type: "text", value: paragraphText }] }],
+  };
+}
+
+function runBlankPlugin(tree: Root, opts?: { enable?: boolean }): Root {
+  const factory = remarkMdiBlankPlugin as unknown as (o?: {
+    enable?: boolean;
+  }) => (t: Root) => void;
+  factory(opts)(tree);
+  return tree;
+}
+
+function runNoBreakPlugin(tree: Root, opts?: { enable?: boolean }): Root {
+  const factory = remarkNoBreakPlugin as unknown as (o?: { enable?: boolean }) => (t: Root) => void;
+  factory(opts)(tree);
+  return tree;
+}
+
+function runKernPlugin(tree: Root, opts?: { enable?: boolean }): Root {
+  const factory = remarkKernPlugin as unknown as (o?: { enable?: boolean }) => (t: Root) => void;
+  factory(opts)(tree);
+  return tree;
+}
+
+describe("Issue #1886 — remarkMdiBlankPlugin disabled for non-MDI files", () => {
+  it("[[blank]] paragraph is NOT converted when enable=false (.txt/.md mode)", () => {
+    const tree = runBlankPlugin(makeTree("[[blank]]"), { enable: false });
+    // Must remain a plain paragraph — not a blankParagraph node that strips content
+    expect(tree.children[0]!.type).toBe("paragraph");
+    expect(tree.children[0]!.children).toHaveLength(1);
+    expect((tree.children[0]!.children[0] as TextNode).value).toBe("[[blank]]");
+  });
+
+  it("[[blank]] paragraph IS converted when enabled (.mdi mode)", () => {
+    const tree = runBlankPlugin(makeTree("[[blank]]"), { enable: true });
+    const node = tree.children[0]! as unknown as { type: string; children: unknown[] };
+    expect(node.type).toBe("blankParagraph");
+    expect(node.children).toHaveLength(0);
+  });
+});
+
+describe("Issue #1886 — remarkNoBreakPlugin disabled for non-MDI files", () => {
+  it("[[no-break:ABC]] is preserved verbatim when enable=false (.txt/.md mode)", () => {
+    const tree = runNoBreakPlugin(makeTree("前[[no-break:ABC]]後"), { enable: false });
+    expect(tree.children[0]!.type).toBe("paragraph");
+    expect(tree.children[0]!.children).toHaveLength(1);
+    // The full literal text must survive unchanged
+    expect((tree.children[0]!.children[0] as TextNode).value).toBe("前[[no-break:ABC]]後");
+  });
+
+  it("[[no-break:ABC]] IS parsed when enabled (.mdi mode)", () => {
+    const tree = runNoBreakPlugin(makeTree("前[[no-break:ABC]]後"), { enable: true });
+    // The text node is split into text + nobreak + text
+    expect(tree.children[0]!.children.length).toBeGreaterThan(1);
+    const types = tree.children[0]!.children.map((n) => (n as { type: string }).type);
+    expect(types).toContain("nobreak");
+  });
+});
+
+describe("Issue #1886 — remarkKernPlugin disabled for non-MDI files", () => {
+  it("[[kern:0.5em:wide]] is preserved verbatim when enable=false (.txt/.md mode)", () => {
+    const tree = runKernPlugin(makeTree("前[[kern:0.5em:wide]]後"), { enable: false });
+    expect(tree.children[0]!.type).toBe("paragraph");
+    expect(tree.children[0]!.children).toHaveLength(1);
+    expect((tree.children[0]!.children[0] as TextNode).value).toBe("前[[kern:0.5em:wide]]後");
+  });
+
+  it("[[kern:0.5em:wide]] IS parsed when enabled (.mdi mode)", () => {
+    const tree = runKernPlugin(makeTree("前[[kern:0.5em:wide]]後"), { enable: true });
+    // The text node is split — kern node appears
+    expect(tree.children[0]!.children.length).toBeGreaterThan(1);
+    const types = tree.children[0]!.children.map((n) => (n as { type: string }).type);
+    expect(types).toContain("kern");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full editor mount: textContent of parse tree must preserve macros for non-MDI
+// ---------------------------------------------------------------------------
+
+const mountedRoots: HTMLElement[] = [];
+afterEach(() => {
+  mountedRoots.forEach((r) => r.remove());
+  mountedRoots.length = 0;
+});
+
+/**
+ * Mounts an editor with MDI disabled (mirrors .txt / .md mode) and returns the
+ * textContent of every top-level node (reflecting what the change listener would
+ * emit for `tab.content` via the `updated` path in plain-text mode, or the
+ * clipboard serializer fallback).
+ */
+async function collectTextNonMdi(source: string): Promise<string> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  mountedRoots.push(root);
+
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, source);
+    })
+    .use(commonmark)
+    .use(
+      japaneseNovel({
+        isVertical: false,
+        showManuscriptLine: false,
+        enableRuby: false,
+        enableTcy: false,
+        enableNoBreak: false,
+        enableKern: false,
+        enableMdiBreak: false,
+        plainText: false,
+      }),
+    )
+    .create();
+
+  let collectedText = "";
+  editor.action((ctx) => {
+    const view = ctx.get(editorViewCtx);
+    const lines: string[] = [];
+    view.state.doc.forEach((node) => {
+      lines.push(node.textContent);
+    });
+    collectedText = lines.join("\n");
+  });
+
+  await editor.destroy();
+  return collectedText;
+}
+
+/**
+ * Mounts an editor with MDI enabled (mirrors .mdi mode) and returns the
+ * textContent of every top-level node.
+ */
+async function collectTextMdi(source: string): Promise<string> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  mountedRoots.push(root);
+
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, root);
+      ctx.set(defaultValueCtx, source);
+    })
+    .use(commonmark)
+    .use(
+      japaneseNovel({
+        isVertical: false,
+        showManuscriptLine: false,
+        enableRuby: true,
+        enableTcy: true,
+        enableNoBreak: true,
+        enableKern: true,
+        enableMdiBreak: true,
+        plainText: false,
+      }),
+    )
+    .create();
+
+  let collectedText = "";
+  editor.action((ctx) => {
+    const view: EditorView = ctx.get(editorViewCtx);
+    const lines: string[] = [];
+    view.state.doc.forEach((node) => {
+      lines.push(node.textContent);
+    });
+    collectedText = lines.join("\n");
+  });
+
+  await editor.destroy();
+  return collectedText;
+}
+
+describe("Issue #1886 — full editor: MDI macros preserved as text in non-MDI mode", () => {
+  it("[[blank]] paragraph text is preserved in non-MDI mode (not silently removed)", async () => {
+    // Without the fix, [[blank]] is parsed as a blankParagraph node whose textContent
+    // is empty, so tab.content loses the marker on every save.
+    const text = await collectTextNonMdi("段落A\n\n[[blank]]\n\n段落B");
+    expect(text).toContain("[[blank]]");
+    expect(text).toContain("段落A");
+    expect(text).toContain("段落B");
+  });
+
+  it("[[no-break:ABC]] text survives in non-MDI mode (not stripped to ABC)", async () => {
+    // Without the fix, [[no-break:ABC]] is parsed as a nobreak node whose textContent
+    // is "ABC", dropping the macro wrapper on save.
+    const text = await collectTextNonMdi("前[[no-break:ABC]]後");
+    expect(text).toContain("[[no-break:ABC]]");
+    expect(text).not.toMatch(/^前ABC後$/m);
+  });
+
+  it("[[kern:0.5em:wide]] text survives in non-MDI mode (not stripped to wide)", async () => {
+    // Without the fix, [[kern:0.5em:wide]] is parsed as a kern node whose textContent
+    // is "wide", dropping the macro wrapper on save.
+    const text = await collectTextNonMdi("前[[kern:0.5em:wide]]後");
+    expect(text).toContain("[[kern:0.5em:wide]]");
+    expect(text).not.toMatch(/^前wide後$/m);
+  });
+
+  it("[[blank]] IS parsed as an empty node in .mdi mode (feature still works)", async () => {
+    // The .mdi path must not regress: blankParagraph node has no textContent.
+    const text = await collectTextMdi("段落A\n\n[[blank]]\n\n段落B");
+    // In MDI mode [[blank]] becomes an empty paragraph — no literal marker in text output.
+    expect(text).not.toContain("[[blank]]");
+    expect(text).toContain("段落A");
+    expect(text).toContain("段落B");
+  });
+
+  it("[[no-break:ABC]] IS converted to a nobreak atom in .mdi mode (macro syntax gone)", async () => {
+    const text = await collectTextMdi("前[[no-break:ABC]]後");
+    // The nobreak node is an atom (attrs-only, no textContent children).
+    // The macro syntax must be gone — only the surrounding text survives as textContent.
+    expect(text).not.toContain("[[no-break:");
+    // textContent of atom nodes is empty; surrounding text still present.
+    expect(text).toContain("前");
+    expect(text).toContain("後");
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/index.ts
@@ -80,10 +80,13 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     () => remarkMdiBreakPlugin as (o?: { enable?: boolean }) => (tree: unknown) => void,
     { enable: enableMdiBreak },
   );
+  // Gate [[blank]] parsing on the same flag as other MDI block macros so that
+  // .txt/.md files containing literal "[[blank]]" are not consumed and deleted
+  // on save (#1886). enableMdiBreak carries the mdiExtensionsEnabled signal.
   const remarkMdiBlank = $remark(
     "japaneseNovelMdiBlank",
     () => remarkMdiBlankPlugin as (o?: { enable?: boolean }) => (tree: unknown) => void,
-    { enable: true },
+    { enable: enableMdiBreak },
   );
   const remarkHeadingAnchor = $remark(
     "japaneseNovelHeadingAnchor",
@@ -135,8 +138,7 @@ export function japaneseNovel(options: JapaneseNovelOptions = {}): MilkdownPlugi
     ...(enableMdiBreak ? [remarkMdiBreak, mdibreakSchema] : []),
     ...(enableNoBreak ? [remarkNoBreak, nobreakSchema] : []),
     ...(enableKern ? [remarkKern, kernSchema] : []),
-    remarkMdiBlank,
-    blankParagraphSchema,
+    ...(enableMdiBreak ? [remarkMdiBlank, blankParagraphSchema] : []),
     remarkHeadingAnchor,
     headingAnchorSchema,
     headingIdFixerPlugin,


### PR DESCRIPTION
## 概要

`.txt` / `.md` ファイルで `[[blank]]`・`[[no-break:...]]`・`[[kern:...:...]]` が MDI マクロとして解釈され、保存時に内容が削除・破壊されるバグを修正します。

### 根本原因

- `MilkdownEditor.tsx` の `japaneseNovel()` 呼び出しで `enableNoBreak` / `enableKern` を明示していなかったため、デフォルト値 `true` が使われていた
- `packages/milkdown-plugin-japanese-novel/index.ts` で `remarkMdiBlankPlugin` が `{ enable: true }` で無条件登録されていた
- 結果、`.txt`/`.md` でも MDI パーサーが動作し、`[[blank]]` → 空ノード（内容消失）・`[[no-break:ABC]]` → "ABC" のみ・`[[kern:...:wide]]` → "wide" のみ に変換されて保存

### 修正内容

**`components/editor/MilkdownEditor.tsx`**
- `japaneseNovel()` に `enableNoBreak: mdiExtensionsEnabled`・`enableKern: mdiExtensionsEnabled` を追加
- コメントを更新（"tracked separately" を解消）

**`packages/milkdown-plugin-japanese-novel/index.ts`**
- `remarkMdiBlankPlugin` の `enable` を `enableMdiBreak`（= `mdiExtensionsEnabled`）でゲート
- `blankParagraphSchema` も同フラグで条件付きロード（パーサーが無効なら schema 登録も不要）

## テスト計画

- [x] `npx vitest run packages/milkdown-plugin-japanese-novel/__tests__/` — 92 tests passed (11 新規追加)
- [x] `npm run type-check` — clean
- [x] `npx eslint` (変更ファイル) — clean
- [x] `npm run check:boundaries` — clean

### 追加した回帰テスト（`mdi-macro-gating-1886.test.ts`）

- remark プラグインレベル: `enable=false` 時に各マクロが変換されないことを確認（6件）
- フルエディタマウント: 非 MDI モードで `[[blank]]`・`[[no-break:ABC]]`・`[[kern:...:...]]` が textContent に保持されることを確認（3件）
- `.mdi` モードのリグレッション: 各マクロが正常にパースされることを確認（2件）

## リグレッションリスク

- `.mdi` ファイルへの影響なし（`enableMdiBreak=true` → 動作変化なし）
- `.md` ファイルへの影響: `[[blank]]`/`[[no-break:...]]`/`[[kern:...:...]]` が今後はリテラルテキストとして扱われる（正しい挙動）

Closes #1886
Refs #1895