### PR TITLE
fix(editor): 表示設定変更直後の入力文字消失を修正 (#1885)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -123,6 +123,20 @@ export default function EditorPage() {
     setEditorKey((prev) => prev + 1);
   }, []);
 
+  // #1840 / #1885: holds the active editor's on-demand live-content flush.
+  // Declared early so incrementEditorKeyWithFlush (used by useEditorSettings)
+  // can close over it. MilkdownEditor registers itself via registerFlush below.
+  const flushActiveEditorRef = useRef<(() => string | null) | null>(null);
+
+  // #1885: display-setting changes that trigger incrementEditorKey() remount the
+  // editor, cancelling the Milkdown listener's 200ms debounce and losing the last
+  // typed characters. Flush live content into React state first so the new editor
+  // instance initialises with currentContentRef containing the latest keystrokes.
+  const incrementEditorKeyWithFlush = useCallback(() => {
+    flushActiveEditorRef.current?.();
+    incrementEditorKey();
+  }, [incrementEditorKey]);
+
   // Ref for dockview layout flush — populated after useDockviewPersistence,
   // consumed by useTabManager's close handler via stable callback.
   const flushLayoutStateRef = useRef<(() => Promise<void>) | undefined>(undefined);
@@ -145,7 +159,7 @@ export default function EditorPage() {
     handlers: settingsHandlers,
     setters: settingsSetters,
     settingsHydrated,
-  } = useEditorSettings(incrementEditorKey);
+  } = useEditorSettings(incrementEditorKeyWithFlush);
   const {
     fontScale,
     lineHeight,
@@ -290,11 +304,9 @@ export default function EditorPage() {
     triggerSwitchToCorrections,
   } = panelHandlers;
 
-  // #1840: holds the active editor's on-demand live-content flush. Save flows
-  // call it right before persisting so they never write debounce-lagged content.
-  // The mounted MilkdownEditor (only the active dockview panel renders one)
-  // registers itself here; unmount clears it.
-  const flushActiveEditorRef = useRef<(() => string | null) | null>(null);
+  // #1840: save flows call flushActiveEditorRef right before persisting so they
+  // never write debounce-lagged content. The mounted MilkdownEditor registers
+  // itself here; unmount clears it. (Ref declared early above for #1885.)
   const registerFlush = useCallback((flush: (() => string | null) | null) => {
     flushActiveEditorRef.current = flush;
   }, []);

--- a/lib/editor-page/__tests__/use-display-settings-flush.test.ts
+++ b/lib/editor-page/__tests__/use-display-settings-flush.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression test for #1885: display-setting changes (e.g. font scale, line
+ * height) that trigger an editor remount must flush the live ProseMirror
+ * content before calling incrementEditorKey().
+ *
+ * Root cause: the Milkdown plugin-listener debounces its onChange call by
+ * 200 ms. If a setting handler calls incrementEditorKey() directly, the editor
+ * unmounts before the debounce fires, so the last typed characters are lost.
+ *
+ * Fix (app/page.tsx): useEditorSettings receives incrementEditorKeyWithFlush
+ * instead of bare incrementEditorKey. The wrapper calls
+ * flushActiveEditorRef.current?.() first, which synchronously serialises the
+ * live ProseMirror doc and calls setContent() before the remount.
+ *
+ * This test unit-tests the handler ordering with a mock flush ref and a mock
+ * increment function. A full editor-remount integration test is impractical
+ * without a real browser runtime (#1896 tracks UI-test verification).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Helper: replicate the incrementEditorKeyWithFlush factory from page.tsx
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors the logic from app/page.tsx:
+ *
+ *   const incrementEditorKeyWithFlush = useCallback(() => {
+ *     flushActiveEditorRef.current?.();
+ *     incrementEditorKey();
+ *   }, [incrementEditorKey]);
+ */
+function makeIncrementWithFlush(
+  flushRef: { current: (() => string | null) | null },
+  increment: () => void,
+): () => void {
+  return () => {
+    flushRef.current?.();
+    increment();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("incrementEditorKeyWithFlush (#1885)", () => {
+  it("calls flush before incrementEditorKey", () => {
+    const callOrder: string[] = [];
+
+    const flushRef: { current: (() => string | null) | null } = {
+      current: () => {
+        callOrder.push("flush");
+        return "flushed content";
+      },
+    };
+    const increment = vi.fn(() => {
+      callOrder.push("increment");
+    });
+
+    const incrementWithFlush = makeIncrementWithFlush(flushRef, increment);
+    incrementWithFlush();
+
+    expect(callOrder).toEqual(["flush", "increment"]);
+    expect(increment).toHaveBeenCalledOnce();
+  });
+
+  it("still calls incrementEditorKey when no flush is registered (null ref)", () => {
+    const flushRef: { current: (() => string | null) | null } = { current: null };
+    const increment = vi.fn();
+
+    const incrementWithFlush = makeIncrementWithFlush(flushRef, increment);
+    incrementWithFlush();
+
+    expect(increment).toHaveBeenCalledOnce();
+  });
+
+  it("does not call a stale flush after the editor unmounts (ref cleared to null)", () => {
+    const flush = vi.fn(() => null);
+    const flushRef: { current: (() => string | null) | null } = { current: flush };
+    const increment = vi.fn();
+
+    const incrementWithFlush = makeIncrementWithFlush(flushRef, increment);
+
+    // Simulate editor unmount clearing the ref (MilkdownEditor's cleanup)
+    flushRef.current = null;
+
+    incrementWithFlush();
+
+    expect(flush).not.toHaveBeenCalled();
+    expect(increment).toHaveBeenCalledOnce();
+  });
+
+  it("captures the content returned by flush before remounting", () => {
+    const LIVE_CONTENT = "最新のコンテンツ";
+    let capturedContent: string | null = null;
+
+    const flushRef: { current: (() => string | null) | null } = {
+      current: () => {
+        capturedContent = LIVE_CONTENT;
+        return LIVE_CONTENT;
+      },
+    };
+    const increment = vi.fn();
+
+    const incrementWithFlush = makeIncrementWithFlush(flushRef, increment);
+    incrementWithFlush();
+
+    // flush must have written content before increment triggers remount
+    expect(capturedContent).toBe(LIVE_CONTENT);
+    expect(increment).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## 概要

表示設定（フォントサイズ・行間・段落間隔など）変更直後に文字が消える P1 バグを修正。

### 根本原因

`useEditorSettings` が `incrementEditorKey` をそのまま受け取り、表示設定ハンドラが直接呼び出していた。`incrementEditorKey()` は React の editorKey をインクリメントしてエディタを再マウントするが、Milkdown の `plugin-listener` は onChange を **200ms デバウンス** で発火する。再マウントによりデバウンスタイマーがキャンセルされ、その間に入力した文字が `tab.content` に反映されないまま消失していた（#1837 と同系統）。

### 修正内容

`app/page.tsx` で `incrementEditorKeyWithFlush` を追加し、`useEditorSettings` に渡す。

```ts
const incrementEditorKeyWithFlush = useCallback(() => {
  flushActiveEditorRef.current?.();  // ProseMirror doc を即時シリアライズ → setContent()
  incrementEditorKey();              // エディタ再マウント
}, [incrementEditorKey]);
```

`flushActiveEditorRef.current` は既存の #1840 インフラ（`MilkdownEditor` が登録する `flushContent`）を再利用する。フォント・行間・段落間隔・テキストインデント・文字数など `incrementEditorKey` を呼ぶ全ての表示設定ハンドラに自動適用される。

### 変更ファイル数

2 ファイル（`app/page.tsx` + 回帰テスト）

## テスト計画

- [x] ユニットテスト追加: `lib/editor-page/__tests__/use-display-settings-flush.test.ts`
  - flush が increment より先に呼ばれることを検証（モック flush ref + モック increment）
  - flush が null のとき increment だけ呼ばれることを検証（ref クリア後の動作）
  - 4 ケース全パス
- [x] `npm run type-check` パス
- [x] `npx eslint app/page.tsx lib/editor-page/__tests__/use-display-settings-flush.test.ts` パス

### 回帰テスト注記

Playwright での E2E 検証（文字入力 → 設定変更 → 文字が残存）はタイミング依存のため別 issue #1896 で追跡。本 PR のユニットテストは flush-before-increment の **順序保証** を検証している。

Closes #1885
Refs #1896