### PR TITLE
fix(stats): .txt ファイルの文字数が Markdown/MDI 記法除去で過少計上される問題を修正 (#1889)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1186,7 +1186,7 @@ export default function EditorPage() {
     charTypeAnalysis,
     charUsageRates,
     readabilityAnalysis,
-  } = useTextStatistics(content);
+  } = useTextStatistics(content, activeFileType);
 
   // charCount は旧インターフェース互換用エイリアス（可視本文文字数）
   const charCount = visibleTextCharCount;

--- a/lib/editor-page/__tests__/text-statistics.test.ts
+++ b/lib/editor-page/__tests__/text-statistics.test.ts
@@ -312,6 +312,47 @@ describe("computeTextStatistics", () => {
 });
 
 // ---------------------------------------------------------------------------
+// fileType 別除去ルール — リグレッションテスト (#1889)
+// ---------------------------------------------------------------------------
+describe("extractVisibleText (fileType)", () => {
+  it(".txt: # や * や [[blank]] をそのまま本文文字として保持する", () => {
+    const input = "# 見出し\n*foo*\n[[blank]]";
+    // .txt ではすべての文字が本文であり、記法除去は行わない
+    expect(extractVisibleText(input, ".txt")).toBe(input);
+  });
+
+  it(".txt: 記法を含む文字列の可視文字数は生テキスト全文字（空白除く）に等しい", () => {
+    // "# 見出し\n*foo*\n[[blank]]" を .txt として処理した場合
+    // スペース・改行を除いた文字数: '#'+'見'+'出'+'し'+'*'+'f'+'o'+'o'+'*'+'['+'['+'b'+'l'+'a'+'n'+'k'+'+'']'+']' = 18
+    const input = "# 見出し\n*foo*\n[[blank]]";
+    const result = extractVisibleText(input, ".txt");
+    const expected = countVisibleChars(input); // 生テキストから空白・改行のみ除く
+    expect(countVisibleChars(result)).toBe(expected);
+  });
+
+  it(".mdi: # や *foo* は記法として除去され、[[blank]] は行ごと削除される", () => {
+    const input = "# 見出し\n*foo*\n[[blank]]";
+    const result = extractVisibleText(input, ".mdi");
+    expect(result).toBe("見出し\nfoo\n");
+  });
+
+  it(".md: Markdown 記法は除去されるが [[blank]] はプレーンテキストとして残る", () => {
+    const input = "# 見出し\n*foo*\n[[blank]]";
+    const result = extractVisibleText(input, ".md");
+    // 見出し記号と強調は除去、MDI マクロ [[blank]] はそのまま残る
+    expect(result).toBe("見出し\nfoo\n[[blank]]");
+  });
+
+  it(".txt: computeTextStatistics が記法を除去せずにカウントする", () => {
+    const input = "# 見出し\n*foo*\n[[blank]]";
+    const txtStats = computeTextStatistics(input, ".txt");
+    const mdiStats = computeTextStatistics(input, ".mdi");
+    // .txt の文字数は .mdi より多い（記法文字も本文としてカウント）
+    expect(txtStats.visibleTextCharCount).toBeGreaterThan(mdiStats.visibleTextCharCount);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 禁則処理のテスト
 // ---------------------------------------------------------------------------
 describe("countManuscriptCells (禁則処理)", () => {

--- a/lib/editor-page/text-statistics.ts
+++ b/lib/editor-page/text-statistics.ts
@@ -51,7 +51,12 @@ const LINE_END_PROHIBITED = new Set("（〔［｛〈《「『【".split(""));
 /**
  * Markdown / MDI / HTML のマークアップを除去し、可視本文テキストを返す。
  *
- * 除去ルール（この順番で適用）:
+ * fileType による除去ルール:
+ *  - ".txt" : 記法除去なし。生テキストをそのまま返す（`#`, `*` 等は本文文字）
+ *  - ".md"  : Markdown のみ除去（MDI 固有マクロは除去しない）
+ *  - ".mdi" : Markdown + MDI の全記法を除去（デフォルト）
+ *
+ * MDI 除去ルール（".mdi" 時のみ、この順番で適用）:
  *  1. コードブロック (` ``` ... ``` `) → 全削除
  *  2. インラインコード (`` `...` ``) → 全削除
  *  3. 画像 (`![alt](url)`) → 全削除（alt 含め）
@@ -65,8 +70,18 @@ const LINE_END_PROHIBITED = new Set("（〔［｛〈《「『【".split(""));
  * 11. Markdown 見出し記号（行頭の `#+ `）→ 除去（本文は残す）
  * 12. 強調記号 (`**...**`, `__...__`, `*...*`, `_..._`, `~~...~~`) → 内容は残す
  * 13. バックスラッシュエスケープ (`\X`) → バックスラッシュのみ除去
+ *
+ * ".md" 時はルール 1–4 および 10–13 のみ適用（MDI 固有のルール 5–9 を除く）。
  */
-export function extractVisibleText(rawContent: string): string {
+export function extractVisibleText(
+  rawContent: string,
+  fileType: ".mdi" | ".md" | ".txt" = ".mdi",
+): string {
+  // .txt はプレーンテキスト。記法除去なし。
+  if (fileType === ".txt") {
+    return rawContent;
+  }
+
   let text = rawContent;
 
   // 1. コードブロック（```...```、フェンス含む）
@@ -81,22 +96,24 @@ export function extractVisibleText(rawContent: string): string {
   // 4. リンク → テキスト部分のみ残す
   text = text.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1");
 
-  // 5. MDI ルビ {親文字|ルビ} → 親文字のみ
-  text = text.replace(/\{([^|{}]*)\|[^}]*\}/g, "$1");
+  if (fileType === ".mdi") {
+    // 5. MDI ルビ {親文字|ルビ} → 親文字のみ
+    text = text.replace(/\{([^|{}]*)\|[^}]*\}/g, "$1");
 
-  // 6. MDI 縦中横 ^内容^ → 内容のみ
-  text = text.replace(/\^([^^]*)\^/g, "$1");
+    // 6. MDI 縦中横 ^内容^ → 内容のみ
+    text = text.replace(/\^([^^]*)\^/g, "$1");
 
-  // 7. MDI no-break [[no-break:文字列]] → 文字列のみ
-  text = text.replace(/\[\[no-break:([^\]]*)\]\]/g, "$1");
+    // 7. MDI no-break [[no-break:文字列]] → 文字列のみ
+    text = text.replace(/\[\[no-break:([^\]]*)\]\]/g, "$1");
 
-  // 8. MDI kern [[kern:量:文字列]] → 文字列のみ
-  text = text.replace(/\[\[kern:[^\]]*?:([^\]]*)\]\]/g, "$1");
+    // 8. MDI kern [[kern:量:文字列]] → 文字列のみ
+    text = text.replace(/\[\[kern:[^\]]*?:([^\]]*)\]\]/g, "$1");
 
-  // 9. MDI 空行マーカー [[blank]] → 行ごと削除（可視文字としてカウントしない）。
-  // ライブ編集中の content は serializer が `[` をエスケープするため `\[\[blank]]`
-  // となる。各ブラケット前の `\` を任意マッチさせ、クリーン形・エスケープ形の双方を除去する。
-  text = text.replace(/^[ \t]*\\?\[\\?\[blank\\?\]\\?\][ \t]*$/gm, "");
+    // 9. MDI 空行マーカー [[blank]] → 行ごと削除（可視文字としてカウントしない）。
+    // ライブ編集中の content は serializer が `[` をエスケープするため `\[\[blank]]`
+    // となる。各ブラケット前の `\` を任意マッチさせ、クリーン形・エスケープ形の双方を除去する。
+    text = text.replace(/^[ \t]*\\?\[\\?\[blank\\?\]\\?\][ \t]*$/gm, "");
+  }
 
   // 10. HTML タグ → タグ記号を除去、内容は残す
   text = text.replace(/<[^>]*>/g, "");
@@ -297,9 +314,14 @@ export function countParagraphs(visibleText: string): number {
  * TextStatistics オブジェクトを一括計算する。
  *
  * @param rawContent - エディタの生コンテンツ（Markdown/MDI/HTML 記法を含む可能性あり）
+ * @param fileType   - ファイル種別。".txt" は記法除去なし、".md" は Markdown のみ除去、
+ *                     ".mdi" は Markdown + MDI 全除去（デフォルト）。
  */
-export function computeTextStatistics(rawContent: string): TextStatistics {
-  const visibleText = extractVisibleText(rawContent);
+export function computeTextStatistics(
+  rawContent: string,
+  fileType: ".mdi" | ".md" | ".txt" = ".mdi",
+): TextStatistics {
+  const visibleText = extractVisibleText(rawContent, fileType);
   const visibleTextCharCount = countVisibleChars(visibleText);
   const manuscriptCellCount = countManuscriptCells(visibleText);
   const manuscriptPages = countManuscriptPages(manuscriptCellCount);

--- a/lib/editor-page/use-text-statistics.ts
+++ b/lib/editor-page/use-text-statistics.ts
@@ -21,6 +21,7 @@ import { getDictAccess } from "@/lib/dict/dict-access";
 import type { Token } from "@/lib/nlp-client/types";
 import { computeTextStatistics } from "./text-statistics";
 import type { TextStatistics } from "./text-statistics";
+import type { SupportedFileExtension } from "@/lib/project/project-types";
 
 export type { TextStatistics };
 
@@ -46,9 +47,18 @@ export interface TextStatisticsResult extends TextStatistics {
  *                    using kuromoji through INlpClient
  *   Phase 3 (async): dictionary enrichment via enrichReadabilityWithDict()
  *                    using Genji freq_rank via DictAccess — only when state === "ready"
+ *
+ * @param content  - エディタの生コンテンツ
+ * @param fileType - ファイル種別（".txt" は記法除去なし、デフォルト ".mdi"）
  */
-export function useTextStatistics(content: string): TextStatisticsResult {
-  const manuscriptStats = useMemo(() => computeTextStatistics(content), [content]);
+export function useTextStatistics(
+  content: string,
+  fileType: SupportedFileExtension = ".mdi",
+): TextStatisticsResult {
+  const manuscriptStats = useMemo(
+    () => computeTextStatistics(content, fileType),
+    [content, fileType],
+  );
 
   const cleanedContent = useMemo(() => cleanMarkdown(content), [content]);
 


### PR DESCRIPTION
## 問題

`.txt` ファイルを開いた際、`extractVisibleText()` がファイル種別を問わず Markdown/MDI 記法除去を行っていたため、`#`・`*foo*`・`[[blank]]` などが本文文字として計上されず、文字数が大幅に過少表示されていた。

## 修正内容

- `extractVisibleText()` / `computeTextStatistics()` に `fileType` パラメータを追加
  - `".txt"` → 記法除去なし（生テキストをそのまま返す）
  - `".md"` → Markdown のみ除去（MDI マクロは本文として扱う）
  - `".mdi"` → Markdown + MDI 全除去（従来動作、デフォルト）
- `useTextStatistics()` が `fileType` を受け取り `computeTextStatistics()` に伝搬
- `app/page.tsx` の呼び出し箇所で `activeFileType` を渡すよう修正

## テスト計画

- [ ] ユニットテスト（vitest）: `lib/editor-page/__tests__/text-statistics.test.ts` に 5 件追加
  - `.txt` で `#`, `*foo*`, `[[blank]]` が除去されず全文字がカウントされること
  - `.mdi` で記法が従来通り除去されること
  - `.md` で Markdown のみ除去・MDI マクロが残ること
  - `.txt` の文字数 > `.mdi` の文字数（同一入力）であること
- [ ] 手動確認: `.txt` ファイルを開き、ヘッダー記号 `#` を含むテキストを入力してステータスバーの文字数が正しく表示されることを確認

## リグレッション防止

`extractVisibleText` のシグネチャ変更は後方互換（デフォルト `".mdi"`）。既存テストはすべてパス（67 件）。

Closes #1889