### PR TITLE
fix(rulesets): 起動時自動syncで新規ルールセットを再起動なしで有効化

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -44,7 +44,7 @@ const { registerDictHandlers } = require("./ipc/dict-ipc");
 const { getDictManager } = require("./dict-manager");
 const { registerRulesetsHandlers } = require("./ipc/rulesets-ipc");
 const { getRulesetsManager } = require("./rulesets-manager");
-const { DICT_CHANNELS, POWER_CHANNELS } = require("./lib/ipc-channels");
+const { DICT_CHANNELS, POWER_CHANNELS, RULESETS_CHANNELS } = require("./lib/ipc-channels");
 
 process.on("uncaughtException", (err) => {
   console.error("[FATAL] Uncaught exception:", err);
@@ -267,7 +267,22 @@ app.whenReady().then(async () => {
       const summary = await getRulesetsManager().syncAllOfficial();
       const installed = summary.filter((s) => s.status === "installed");
       if (installed.length > 0) {
-        console.log("[Rulesets] auto-sync installed:", installed.map((s) => s.id).join(", "));
+        const ids = installed.map((s) => s.id);
+        console.log("[Rulesets] auto-sync installed:", ids.join(", "));
+        // Notify every open renderer so its lint worker (re)loads the freshly
+        // installed rulesets WITHOUT an app restart. The interactive sync IPC
+        // handler emits the same event; this closes the gap on first launch
+        // where a newly-added ruleset would otherwise stay inactive until the
+        // next start (the mount-time syncLoadedRulesets had already run before
+        // this delayed download finished, and nothing re-signaled the renderer).
+        for (const win of BrowserWindow.getAllWindows()) {
+          if (!win.isDestroyed()) {
+            win.webContents.send(RULESETS_CHANNELS.event.changed, {
+              reason: "installed",
+              ids,
+            });
+          }
+        }
       }
     } catch (err) {
       console.warn("[Rulesets] auto-sync failed:", err);


### PR DESCRIPTION
## 問題

起動時のサイレント自動 sync（`electron/main.js`）は新規公式ルールセットをディスクに安裝するが、`RULESETS_CHANNELS.event.changed` をレンダラーへ送っていなかった。

- レンダラー mount 時の `syncLoadedRulesets`（`use-linting.ts`）は一度だけ走り、その時点でディスクにある物を読んで `changed` を購読する。
- 起動時自動 sync は **6秒遅延**でダウンロード/安裝するが、その完了をレンダラーに通知しない。
- IPC 経由の手動 sync ハンドラ（`rulesets-ipc.js`）は `changed` を送るのに、起動時経路だけ抜けていた。

**結果**: 新規追加したルールセット（例: `genji-vocab`）は、既存ユーザーの初回起動でダウンロードされても **lint worker にロードされず、アプリを再起動するまで効かない**。

## 修正

起動時自動 sync で `installed` があれば、IPC ハンドラと同じく全ウィンドウの `webContents` へ `RULESETS_CHANNELS.event.changed`（`{reason:"installed", ids}`）を送信し、`subscribeRulesetChanges` が即時(再)ロードするようにした。

## 検証

実物の `RulesetsManager.syncAllOfficial()` を隔離 HOME で起動時 sync 経路に通し、`genji-vocab` が `status:"installed"`・全4ファイル on disk・`readModule` ok（code 3386B / tag v0.1.0）になることを確認。安裝半分は実行時に正常動作することを実証した上で、通知非対称（起動時 sync に `changed` 送信なし ⇔ IPC ハンドラにあり）を埋めた。

関連 issue なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)