### PR TITLE
fix(stats): サブフォルダ内ファイルの前日比を basename → フルパス修正 (#1891)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1192,7 +1192,10 @@ export default function EditorPage() {
   const charCount = visibleTextCharCount;
 
   // --- Previous day comparison ---
-  const previousDayStats = usePreviousDayStats(currentFile?.name, isProjectMode(editorMode));
+  const previousDayStats = usePreviousDayStats(
+    currentFile?.path ?? undefined,
+    isProjectMode(editorMode),
+  );
 
   // --- Linting hook ---
   const {

--- a/lib/editor-page/__tests__/use-previous-day-stats.test.ts
+++ b/lib/editor-page/__tests__/use-previous-day-stats.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Regression test for #1891:
+ * usePreviousDayStats must look up snapshots by FULL path, not basename.
+ *
+ * Root cause: app/page.tsx was passing currentFile?.name (basename) instead
+ * of currentFile?.path (full path) to usePreviousDayStats.  historyService
+ * keys snapshots by full path, so sub-folder files ("chapters/main.mdi")
+ * never matched the basename "main.mdi" and the previous-day comparison
+ * was always empty.
+ *
+ * Fix: page.tsx now passes currentFile?.path. This test verifies that
+ * getSnapshots is called with a full path containing a directory separator,
+ * and that the hook surfaces the correct previous-day stats.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Mock history service
+// ---------------------------------------------------------------------------
+
+// A snapshot stamped as "yesterday" relative to the test run time.
+function yesterdayTs(): number {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return d.getTime();
+}
+
+const YESTERDAY_CONTENT = "昨日の本文";
+
+type MockGetSnapshots = ReturnType<typeof vi.fn>;
+type MockGetSnapshotContent = ReturnType<typeof vi.fn>;
+
+let mockGetSnapshots: MockGetSnapshots;
+let mockGetSnapshotContent: MockGetSnapshotContent;
+
+vi.mock("@/lib/services/history-service", () => ({
+  getHistoryService: () => ({
+    getSnapshots: mockGetSnapshots,
+    getSnapshotContent: mockGetSnapshotContent,
+  }),
+}));
+
+// computeTextStatistics is used to derive charCount from the snapshot content.
+// We mock it to return a fixed value so the test stays simple.
+vi.mock("@/lib/editor-page/text-statistics", () => ({
+  computeTextStatistics: (_content: string) => ({
+    visibleTextCharCount: 5,
+    manuscriptPages: 1,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import the hook AFTER mocks are registered
+// ---------------------------------------------------------------------------
+
+import { usePreviousDayStats } from "../use-previous-day-stats";
+import type { PreviousDayStats } from "../use-previous-day-stats";
+
+// ---------------------------------------------------------------------------
+// Minimal host component to capture hook output
+// ---------------------------------------------------------------------------
+
+interface HostProps {
+  sourceFile: string | undefined;
+  enabled: boolean;
+  onResult: (stats: PreviousDayStats | null) => void;
+}
+
+function HookHost({ sourceFile, enabled, onResult }: HostProps): null {
+  const stats = usePreviousDayStats(sourceFile, enabled);
+  // Call onResult every render so tests can inspect the latest value.
+  onResult(stats);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("usePreviousDayStats (#1891 regression)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let lastResult: PreviousDayStats | null;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+
+    lastResult = null;
+
+    const snapshotId = "snap-001";
+
+    mockGetSnapshots = vi.fn().mockResolvedValue([
+      {
+        id: snapshotId,
+        sourcePath: "chapters/main.mdi",
+        timestamp: yesterdayTs(),
+        type: "auto",
+        characterCount: YESTERDAY_CONTENT.length,
+        filename: "chapters__main.mdi.[yesterday].__auto__.history",
+        displayName: "main.mdi",
+        fileSize: YESTERDAY_CONTENT.length,
+        checksum: "abc",
+      },
+    ]);
+
+    mockGetSnapshotContent = vi.fn().mockResolvedValue(YESTERDAY_CONTENT);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  // -----------------------------------------------------------------------
+  // #1891: sub-folder full path must reach getSnapshots
+  // -----------------------------------------------------------------------
+
+  it("サブフォルダのフルパスで getSnapshots を呼び出し、前日比が返る (regression #1891)", async () => {
+    const fullPath = "chapters/main.mdi";
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        React.createElement(HookHost, {
+          sourceFile: fullPath,
+          enabled: true,
+          onResult: (s) => {
+            lastResult = s;
+          },
+        }),
+      );
+    });
+
+    // Wait for async effect to settle
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // getSnapshots must have been called with the FULL path, not "main.mdi"
+    expect(mockGetSnapshots).toHaveBeenCalledWith(fullPath);
+    expect(mockGetSnapshots).not.toHaveBeenCalledWith("main.mdi");
+
+    // The hook should surface a non-null result (snapshot found)
+    expect(lastResult).not.toBeNull();
+    expect(lastResult!.charCount).toBe(5);
+  });
+
+  it("basename だけでは getSnapshots が空を返し、前日比は null になる (basename-keyed bug 再現)", async () => {
+    // Return empty for basename; non-empty for full path.
+    mockGetSnapshots = vi.fn().mockImplementation(async (path?: string) => {
+      // Simulate the bug: snapshots are keyed by full path; basename lookup returns []
+      if (path === "main.mdi") return [];
+      return [
+        {
+          id: "snap-002",
+          sourcePath: "chapters/main.mdi",
+          timestamp: yesterdayTs(),
+          type: "auto",
+          characterCount: 5,
+          filename: "chapters__main.mdi.[yesterday].__auto__.history",
+          displayName: "main.mdi",
+          fileSize: 5,
+          checksum: "abc",
+        },
+      ];
+    });
+
+    // Passing only basename (old bug)
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        React.createElement(HookHost, {
+          sourceFile: "main.mdi",
+          enabled: true,
+          onResult: (s) => {
+            lastResult = s;
+          },
+        }),
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // With basename, no snapshot is found => null
+    expect(lastResult).toBeNull();
+  });
+
+  it("enabled=false のときは getSnapshots を呼ばない", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        React.createElement(HookHost, {
+          sourceFile: "chapters/main.mdi",
+          enabled: false,
+          onResult: (s) => {
+            lastResult = s;
+          },
+        }),
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetSnapshots).not.toHaveBeenCalled();
+    expect(lastResult).toBeNull();
+  });
+
+  it("sourceFile=undefined のときは getSnapshots を呼ばない", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        React.createElement(HookHost, {
+          sourceFile: undefined,
+          enabled: true,
+          onResult: (s) => {
+            lastResult = s;
+          },
+        }),
+      );
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetSnapshots).not.toHaveBeenCalled();
+    expect(lastResult).toBeNull();
+  });
+});

--- a/lib/editor-page/use-previous-day-stats.ts
+++ b/lib/editor-page/use-previous-day-stats.ts
@@ -61,7 +61,9 @@ function findPreviousDaySnapshot(snapshots: SnapshotEntry[]): SnapshotEntry | nu
  * 昨日の文字数を取得するフック。
  * 履歴サービスから昨日の最後のスナップショットを取得する。
  *
- * @param sourceFile - Source file name to filter snapshots (e.g. "main.mdi")
+ * @param sourceFile - Full source path to filter snapshots (e.g. "chapters/main.mdi").
+ *   Must be the full path, not just the basename, to correctly match snapshots for
+ *   files in sub-directories (#1891).
  * @param enabled - Whether the hook should fetch data (requires project mode)
  */
 export function usePreviousDayStats(


### PR DESCRIPTION
## 概要

- `app/page.tsx` が `usePreviousDayStats` に `currentFile?.name`（basename）を渡していた
- 履歴サービスはスナップショットをフルパスでキー管理するため、サブフォルダ内ファイル（例: `chapters/main.mdi`）では `"main.mdi"` で検索しても一致せず、前日比が常に空になっていた
- `currentFile?.path ?? undefined`（フルパス）を渡すよう修正し、`HistoryPanel` / `activeFilePath` と同じ参照に統一

## 変更ファイル（2件）

- `app/page.tsx` — `usePreviousDayStats` 呼び出しを `currentFile?.name` → `currentFile?.path ?? undefined` に修正
- `lib/editor-page/use-previous-day-stats.ts` — JSDoc を更新（フルパス受け取りを明記）
- `lib/editor-page/__tests__/use-previous-day-stats.test.ts` — リグレッションテスト 4 件を新規追加

## テスト計画

- [x] `npx vitest run lib/editor-page/__tests__/use-previous-day-stats.test.ts` — 4/4 passed
  - サブフォルダのフルパスで `getSnapshots` が呼ばれること
  - basename のみでは前日比が null になること（旧バグ再現）
  - `enabled=false` / `sourceFile=undefined` では呼ばれないこと
- [x] `npm run type-check` — clean (0 errors)
- [x] `npx eslint` — 0 errors (既存 warning 1 件は pre-existing)

## リグレッション回避

`getSnapshots` に渡すパスを basename から full-path に変更するだけの最小修正。
`HistoryPanel` はもともと `activeFilePath`（フルパス）を使用しており、今回の修正でその挙動と統一された。

Closes #1891