### PR TITLE
fix(updater): disable auto-update on dev/alpha channel builds

### DIFF
--- a/electron/__tests__/auto-updater.test.ts
+++ b/electron/__tests__/auto-updater.test.ts
@@ -46,6 +46,17 @@ describe("auto-updater.js — opt-in wiring", () => {
   it("opt-in 変更の即時反映 reevaluateUpdateChannel を公開する", () => {
     expect(autoUpdaterSrc).toMatch(/module\.exports\s*=\s*{[^}]*reevaluateUpdateChannel/);
   });
+
+  it("dev/alpha ビルドは app.getVersion() を純粋判定して auto-updater を無効化する", () => {
+    // 公開 Release を持たない dev/alpha 版で更新が走り、安定版/beta へ誤ダウングレード
+    // するのを防ぐ。純粋関数 isUnpublishedChannelVersion を app.getVersion() に適用する。
+    expect(autoUpdaterSrc).toMatch(/isUnpublishedChannelVersion\s*\(\s*app\.getVersion\(\)\s*\)/);
+    // setup と checkForUpdates と reevaluate の各所でガードに使われていること
+    expect(autoUpdaterSrc).toMatch(/if\s*\(\s*isUnpublishedChannelBuild\s*\)/);
+    expect(autoUpdaterSrc).toMatch(
+      /if\s*\(\s*isDev\s*\|\|\s*isUnpublishedChannelBuild\s*\|\|\s*isMicrosoftStoreApp\s*\)/,
+    );
+  });
 });
 
 describe("menu.js — 「アップデートを確認」導線", () => {

--- a/electron/auto-updater.js
+++ b/electron/auto-updater.js
@@ -4,7 +4,12 @@ const { app, dialog } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const log = require("electron-log");
 const { isDev, isMicrosoftStoreApp } = require("./app-constants");
-const { resolveUpdaterFlags } = require("./lib/update-policy");
+const { resolveUpdaterFlags, isUnpublishedChannelVersion } = require("./lib/update-policy");
+
+// dev/alpha ブランチのビルドは GitHub Release を持たない CI 専用成果物のため、
+// auto-updater を走らせると安定版/beta への誤ダウングレードを招く。バージョン文字列で
+// 検出して更新を無効化する（isDev は環境変数依存で packaged dev 版を検出できない）。
+const isUnpublishedChannelBuild = isUnpublishedChannelVersion(app.getVersion());
 
 // auto-updater のログ設定
 autoUpdater.logger = log;
@@ -50,6 +55,12 @@ function setupAutoUpdater() {
   // 開発モードではアップデート確認をしない
   if (isDev) {
     log.info("開発モードのため auto-updater は無効です");
+    return;
+  }
+
+  // dev/alpha チャンネルのビルドは公開 Release が無く、更新先が存在しない
+  if (isUnpublishedChannelBuild) {
+    log.info(`dev/alpha チャンネルビルド (${app.getVersion()}) のため auto-updater は無効です`);
     return;
   }
 
@@ -181,6 +192,24 @@ async function checkForUpdates(manual = false) {
     return;
   }
 
+  if (isUnpublishedChannelBuild) {
+    if (manual) {
+      const { getMainWindow } = require("./window-manager");
+      const mainWindow = getMainWindow();
+      if (mainWindow) {
+        dialog.showMessageBox(mainWindow, {
+          type: "info",
+          title: "アップデート",
+          message: "開発版",
+          detail:
+            "この開発版 (dev/alpha) はアップデート機能の対象外です。安定版または beta 版をご利用ください。",
+          buttons: ["OK"],
+        });
+      }
+    }
+    return;
+  }
+
   if (isMicrosoftStoreApp) {
     if (manual) {
       const { getMainWindow } = require("./window-manager");
@@ -211,7 +240,7 @@ async function checkForUpdates(manual = false) {
  * ダイアログ表示のみ。OFF にした場合も latest へ戻す）。
  */
 async function reevaluateUpdateChannel() {
-  if (isDev || isMicrosoftStoreApp) return;
+  if (isDev || isUnpublishedChannelBuild || isMicrosoftStoreApp) return;
   await checkForUpdates(false);
 }
 

--- a/electron/lib/__tests__/update-policy.test.ts
+++ b/electron/lib/__tests__/update-policy.test.ts
@@ -8,8 +8,9 @@ import { describe, expect, it } from "vitest";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
-const { resolveUpdaterFlags } = require("../update-policy") as {
+const { resolveUpdaterFlags, isUnpublishedChannelVersion } = require("../update-policy") as {
   resolveUpdaterFlags: (v: unknown) => { allowPrerelease: boolean; allowDowngrade: boolean };
+  isUnpublishedChannelVersion: (v: unknown) => boolean;
 };
 
 describe("resolveUpdaterFlags", () => {
@@ -42,5 +43,34 @@ describe("resolveUpdaterFlags", () => {
       const { allowPrerelease, allowDowngrade } = resolveUpdaterFlags(v);
       expect(allowPrerelease).toBe(!allowDowngrade);
     }
+  });
+});
+
+describe("isUnpublishedChannelVersion", () => {
+  it.each(["1.2.20-dev", "0.1.0-dev", "10.20.30-alpha", "1.2.20-alpha"])(
+    "dev/alpha チャンネルのビルド (%s) は true（公開 Release が無く更新先が無い）",
+    (version) => {
+      expect(isUnpublishedChannelVersion(version)).toBe(true);
+    },
+  );
+
+  it.each([
+    "1.2.20", // 安定版
+    "1.2.20-beta.20260620.162756", // beta は公開フィードを持つので対象外
+    "1.2.20-beta.20260619.45436",
+  ])("安定版/beta (%s) は false（更新を継続する）", (version) => {
+    expect(isUnpublishedChannelVersion(version)).toBe(false);
+  });
+
+  it.each([undefined, null, 0, {}, [], 1.22])(
+    "文字列以外 (%s) は安全側 = false（更新を止めない）",
+    (value) => {
+      expect(isUnpublishedChannelVersion(value)).toBe(false);
+    },
+  );
+
+  it("'develop' のような部分一致では誤検出しない（ハイフン区切りのチャンネル接尾辞のみ）", () => {
+    expect(isUnpublishedChannelVersion("1.2.20-developer")).toBe(false);
+    expect(isUnpublishedChannelVersion("1.2.20-alphabet")).toBe(false);
   });
 });

--- a/electron/lib/update-policy.js
+++ b/electron/lib/update-policy.js
@@ -26,4 +26,28 @@ function resolveUpdaterFlags(allowBetaUpdates) {
   };
 }
 
-module.exports = { resolveUpdaterFlags };
+/**
+ * 実行中バージョンが「公開フィードを持たないチャンネル」のビルドかを判定する。
+ *
+ * build.yml の `release` ジョブは dev/alpha ブランチでは実行されない
+ * （`github.ref != 'refs/heads/dev'`、alpha も同様に Release を作らない）。
+ * そのため `X.Y.Z-dev` / `X.Y.Z-alpha` の packaged ビルドは CI 専用成果物であり、
+ * 追従すべき GitHub Release が存在しない。にもかかわらず auto-updater を走らせると、
+ * 「自分より古い最新安定版/beta」を down-/cross-grade として誤って提案・ダウンロード
+ * してしまう（`isDev` は NODE_ENV/ELECTRON_DEV 環境変数依存で、packaged dev 版では
+ * false になりガードできない）。
+ *
+ * beta（`X.Y.Z-beta.YYYYMMDD.N`）は公開フィードを持つ正規チャンネルなので **対象外**
+ * （更新を継続する）。安定版（接尾辞なし）も対象外。
+ *
+ * @param {unknown} version - app.getVersion() の戻り値（文字列以外は false 扱い）
+ * @returns {boolean} dev/alpha チャンネルのビルドなら true
+ */
+function isUnpublishedChannelVersion(version) {
+  if (typeof version !== "string") return false;
+  // build.yml は dev/alpha で bare な接尾辞 `-dev` / `-alpha` のみを付与する。
+  // 末尾、または将来 `.` 区切りの識別子が続く場合の両方を許容する。
+  return /-(?:dev|alpha)(?:\.|$)/.test(version);
+}
+
+module.exports = { resolveUpdaterFlags, isUnpublishedChannelVersion };


### PR DESCRIPTION
## 問題

beta 版のダウンロード周りで、**dev（開発版）でも更新チェック→ダウンロードが走ってしまう**。

## 根本原因

`build.yml` の `release` ジョブは `github.ref != 'refs/heads/dev'` で gate されており、**dev/alpha ブランチは GitHub Release を作らない**（CI ビルド成果物のみ）。つまり `X.Y.Z-dev` / `X.Y.Z-alpha` の packaged ビルドには追従すべき公開フィードが存在しない。

ところが auto-updater の無効化判定 `isDev` は `NODE_ENV === "development" || ELECTRON_DEV === "1"` という **環境変数依存**で、packaged な `-dev` ビルドではこれらが立たず `isDev === false`。結果、auto-updater が起動して：

- beta opt-in OFF: `allowDowngrade=true` のため、自分より古い**最新安定版へダウングレード**を提案・ダウンロード
- 自分のバージョンが最新 beta より新しい（semver で `dev` > `beta`）ため、本来追従すべきでない Release を掴む

## 修正

`app.getVersion()` を pure 関数 `isUnpublishedChannelVersion()` で判定し、`-dev` / `-alpha` 接尾辞のビルドでは auto-updater を全経路（`setupAutoUpdater` / `checkForUpdates` / `reevaluateUpdateChannel`）で無効化する。

- beta (`-beta.YYYYMMDD.N`) は公開フィードを持つ正規チャンネルなので **対象外**（更新継続）
- 安定版（接尾辞なし）も対象外
- 部分一致誤検出を避けるため `-(?:dev|alpha)(?:\.|$)` でハイフン区切りのチャンネル接尾辞のみマッチ

## テスト

- `update-policy.test.ts`: `isUnpublishedChannelVersion` の単体（dev/alpha=true、安定版/beta=false、非文字列=false、`developer`/`alphabet` 誤検出なし）
- `auto-updater.test.ts`: 3 経路で `isUnpublishedChannelBuild` ガードが結線されていることの drift guard
- `npm run type-check` クリーン / 既存 44 tests green

## 関連 issue
関連 issue なし