### PR TITLE
fix(print): destroy hidden BrowserWindow in finally to prevent leak (#1919)

### DIFF
--- a/electron/ipc/__tests__/file-ipc-print-window-leak.test.ts
+++ b/electron/ipc/__tests__/file-ipc-print-window-leak.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Regression tests for the print BrowserWindow resource-leak fix (#1919).
+ *
+ * Root cause: the `printWin` variable was declared INSIDE the try block so the
+ * catch path (print failure) had no reference to the hidden BrowserWindow, leaving
+ * it alive. Repeated print failures accumulated invisible windows with their own
+ * sessions and webContents.
+ *
+ * Fix: `printWin` is now declared as `let printWin = null` BEFORE the try block,
+ * and a `finally` block calls `printWin.destroy()` when the window exists and has
+ * not already been destroyed, covering the success, cancel, AND failure paths.
+ *
+ * file-ipc.js is a CommonJS Electron main-process module and cannot be imported
+ * directly in vitest. These tests use source-text assertions to guard the invariant,
+ * following the established pattern in file-ipc-size-validation.test.ts.
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.resolve(here, "../file-ipc.js"), "utf-8");
+
+// Narrow to the printDocument handler to avoid false positives from other handlers.
+// The handler starts at `ipcMain.handle(EXPORT_CHANNELS.invoke.printDocument` and
+// ends before the next `ipcMain.handle(` call.
+const printHandlerMatch = source.match(
+  /ipcMain\.handle\(EXPORT_CHANNELS\.invoke\.printDocument[\s\S]*?(?=\n\s*ipcMain\.handle\()/,
+);
+const printHandler = printHandlerMatch ? printHandlerMatch[0] : "";
+
+describe("file-ipc.js printDocument handler — BrowserWindow leak fix (#1919)", () => {
+  it("printHandler section was found in source", () => {
+    expect(printHandler.length).toBeGreaterThan(100);
+  });
+
+  it("printWin is declared with let before the try block (not const inside try)", () => {
+    // The fix moves the declaration outside try: `let printWin = null;`
+    expect(printHandler).toMatch(/let printWin\s*=\s*null/);
+  });
+
+  it("printWin is NOT declared with const inside the try block", () => {
+    // Pre-fix: `const printWin = new BrowserWindow(...)` inside try
+    expect(printHandler).not.toMatch(/const printWin\s*=/);
+  });
+
+  it("printWin is assigned via assignment (not declaration) inside try", () => {
+    // Post-fix: `printWin = new BrowserWindow(...)` — no leading const/let
+    expect(printHandler).toMatch(/^\s*printWin\s*=\s*new BrowserWindow\(/m);
+  });
+
+  it("has a finally block that guards destruction with isDestroyed()", () => {
+    // The finally block must check isDestroyed() to avoid double-destroy
+    expect(printHandler).toMatch(/finally\s*\{/);
+    expect(printHandler).toMatch(/printWin\.isDestroyed\(\)/);
+    expect(printHandler).toMatch(/printWin\.destroy\(\)/);
+  });
+
+  it("finally block guards against null printWin (pre-BrowserWindow-construction throw)", () => {
+    // Guard: `if (printWin && !printWin.isDestroyed())` — printWin could still be null
+    // if an exception was thrown before the BrowserWindow was constructed
+    expect(printHandler).toMatch(/if\s*\(\s*printWin\s*&&\s*!printWin\.isDestroyed\(\)\s*\)/);
+  });
+
+  it("success path does NOT call printWin.destroy() (finally handles it)", () => {
+    // The redundant success-path destroy was removed; finally covers all paths.
+    // Extract only the try block body (before catch/finally) to check.
+    const tryBodyMatch = printHandler.match(/\btry\s*\{([\s\S]*?)\}\s*catch\s*\(/);
+    const tryBody = tryBodyMatch ? tryBodyMatch[1] : "";
+    expect(tryBody).not.toMatch(/printWin\.destroy\(\)/);
+  });
+
+  it("catch block does NOT call printWin.destroy() (finally handles it)", () => {
+    const catchBodyMatch = printHandler.match(
+      /\bcatch\s*\([^)]+\)\s*\{([\s\S]*?)\}\s*finally\s*\{/,
+    );
+    const catchBody = catchBodyMatch ? catchBodyMatch[1] : "";
+    expect(catchBody).not.toMatch(/printWin\.destroy\(\)/);
+  });
+});

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -427,6 +427,9 @@ function registerFileHandlers() {
     if (typeof content !== "string") {
       return { success: false, error: "Invalid content" };
     }
+    // Declared outside try so the finally block can always destroy it,
+    // preventing hidden BrowserWindow accumulation on print failures (#1919).
+    let printWin = null;
     try {
       const { BrowserWindow } = require("electron");
       const { mdiToHtml } = require("../../lib/export/mdi-to-html");
@@ -471,7 +474,7 @@ function registerFileHandlers() {
       });
 
       const partition = `print-${Date.now()}`;
-      const printWin = new BrowserWindow({
+      printWin = new BrowserWindow({
         show: false,
         width: 800,
         height: 600,
@@ -528,11 +531,16 @@ function registerFileHandlers() {
         });
       });
 
-      printWin.destroy();
       return { success: true };
     } catch (error) {
       log.error("Print failed:", error);
       return { success: false, error: error.message || "Print failed" };
+    } finally {
+      // Always destroy the hidden print window to prevent resource leaks,
+      // regardless of whether the print succeeded, was cancelled, or failed.
+      if (printWin && !printWin.isDestroyed()) {
+        printWin.destroy();
+      }
     }
   });
 


### PR DESCRIPTION
## 概要

印刷ハンドラで `printWin` が try ブロック内に `const` 宣言されており、印刷失敗時（`catch` パス）にウィンドウを参照できず破棄されなかった問題を修正します。

- `let printWin = null` を try の**外**に移動
- `finally` ブロックで `printWin && !printWin.isDestroyed()` をガードしてから `destroy()` を呼ぶ
- 成功パスの冗長な `printWin.destroy()` を除去（finally がすべてのパスをカバー）

これにより成功・キャンセル・失敗のすべてのパスで必ず非表示ウィンドウが破棄されます。

Closes #1919

## 変更ファイル

- `electron/ipc/file-ipc.js` — fix: let + finally パターン (2 files total)
- `electron/ipc/__tests__/file-ipc-print-window-leak.test.ts` — 新規リグレッションテスト

## テスト計画

- [x] `npx vitest run electron/ipc/__tests__/` → 74 tests passed (5 suites)
- [x] `npm run type-check` → clean
- [x] `npx eslint electron/ipc/file-ipc.js` → clean
- [x] `npm run generate:credits` → clean

### リグレッションテスト内容

ソーステキストアサーションで以下を検証:
1. `let printWin = null` が try の前に宣言されている
2. `const printWin =` が try 内に存在しない
3. `printWin = new BrowserWindow(...)` が代入形式になっている
4. `finally` ブロックが `isDestroyed()` ガード付きで存在する
5. 成功パス・catch パスに `printWin.destroy()` が残っていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)