### PR TITLE
fix(print): .txt/.md印刷・プレビューでMDIマクロを解釈しないよう修正 (#1918)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1537,6 +1537,7 @@ export default function EditorPage() {
             onPrint: handlePrintConfirm,
             content: printDialogState?.content ?? "",
             metadata: printDialogState?.metadata ?? { title: "" },
+            fileType: printDialogState?.fileType,
           },
         }}
         recovery={{

--- a/lib/export/__tests__/mdi-to-html.test.ts
+++ b/lib/export/__tests__/mdi-to-html.test.ts
@@ -54,6 +54,53 @@ describe("mdiToHtml", () => {
     }
   });
 
+  describe(".txt/.md fileType MDI macro pass-through (#1918)", () => {
+    // For non-.mdi files, bracket macros are authored literal text and must NOT
+    // be interpreted as MDI syntax in print/PDF/preview output.
+
+    it(".txt: [[blank]] is preserved as literal text, not removed", () => {
+      for (const fileType of [".txt", ".md"]) {
+        const html = mdiToHtml("[[blank]]", { bodyOnly: true, fileType });
+        expect(html).toContain("[[blank]]");
+      }
+    });
+
+    it(".txt: [[no-break:…]] passes through unchanged, no mdi-nobr span", () => {
+      for (const fileType of [".txt", ".md"]) {
+        const html = mdiToHtml("ABC[[no-break:DEF]]GHI", { bodyOnly: true, fileType });
+        expect(html).toContain("[[no-break:DEF]]");
+        expect(html).not.toContain('class="mdi-nobr"');
+      }
+    });
+
+    it(".txt: [[kern:…]] passes through unchanged, no mdi-kern span", () => {
+      for (const fileType of [".txt", ".md"]) {
+        const html = mdiToHtml("[[kern:0.5em:テスト]]", { bodyOnly: true, fileType });
+        expect(html).toContain("[[kern:0.5em:テスト]]");
+        expect(html).not.toContain('class="mdi-kern"');
+      }
+    });
+
+    it(".mdi: [[blank]] is still removed (sentinel path preserved)", () => {
+      const html = mdiToHtml("[[blank]]", { bodyOnly: true, fileType: ".mdi" });
+      expect(html).not.toContain("[[blank]]");
+      // blank paragraph becomes empty <p></p>
+      expect(html).toContain("<p></p>");
+    });
+
+    it(".mdi: [[no-break:…]] still converts to mdi-nobr span", () => {
+      const html = mdiToHtml("[[no-break:ABC]]", { bodyOnly: true, fileType: ".mdi" });
+      expect(html).toContain('<span class="mdi-nobr">ABC</span>');
+      expect(html).not.toContain("[[no-break:ABC]]");
+    });
+
+    it(".mdi: [[kern:…]] still converts to mdi-kern span", () => {
+      const html = mdiToHtml("[[kern:0.5em:wide]]", { bodyOnly: true, fileType: ".mdi" });
+      expect(html).toContain('<span class="mdi-kern" style="--mdi-kern:0.5em;">wide</span>');
+      expect(html).not.toContain("[[kern:0.5em:wide]]");
+    });
+  });
+
   it(".mdi: recovers serializer-escaped bracket macros so they render (PDF/EPUB parity)", () => {
     // The Milkdown serializer escapes the leading `[` of MDI bracket macros to
     // `\[`. For ".mdi" the HTML pipeline un-escapes them (Step 0) — matching the

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -135,14 +135,20 @@ function installMdiInlinePlugin(md: MarkdownIt): void {
  * html is disabled to prevent user-authored HTML (e.g. <script>, <img onerror>)
  * from being passed through. Safe MDI-generated HTML (ruby, span, br) is emitted
  * only from the custom MDI inline tokenizer.
+ *
+ * @param mdiInlineRules - When true (default), install the MDI inline rules
+ *   (ruby, tcy, no-break, kern, break). Set to false for non-.mdi files so
+ *   literal `[[no-break:…]]` / `[[kern:…]]` are not converted to spans (#1918).
  */
-function createMarkdownIt(): MarkdownIt {
+function createMarkdownIt(mdiInlineRules: boolean = true): MarkdownIt {
   const md = new MarkdownIt({
     html: false,
     breaks: true,
   });
 
-  installMdiInlinePlugin(md);
+  if (mdiInlineRules) {
+    installMdiInlinePlugin(md);
+  }
 
   return md;
 }
@@ -263,27 +269,33 @@ export function mdiToHtml(
     fullwidthSpaceIndentCount?: number;
   },
 ): string {
-  const md = createMarkdownIt();
+  const fileType = options?.fileType ?? ".mdi";
+  const isMdi = fileType === ".mdi";
+  // For non-.mdi files, skip MDI inline rules so literal [[no-break:…]] / [[kern:…]]
+  // etc. are not converted to spans — they are authored text, not macros (#1918).
+  const md = createMarkdownIt(isMdi);
   // Normalize editor-serialized output into canonical MDI text before rendering.
   // The Milkdown serializer escapes the leading `[` of MDI macros to `\[`; without
   // this, MDI_BLANK_RE (and the inline macro rules) never match and `[[blank]]`
   // leaks as literal text into PDF/EPUB/print output. TXT/DOCX already normalize
   // this way via MdiDocument — this brings the HTML pipeline to parity.
-  const fileType = options?.fileType ?? ".mdi";
-  const rawNormalized =
-    fileType === ".mdi"
-      ? MdiDocument.fromEditorOutput(markdown, { fileType: ".mdi" }).toRawText()
-      : MdiDocument.fromRawText(markdown).toRawText();
+  const rawNormalized = isMdi
+    ? MdiDocument.fromEditorOutput(markdown, { fileType: ".mdi" }).toRawText()
+    : MdiDocument.fromRawText(markdown).toRawText();
   // Promote author-intentional blank lines (Enter-key empty paragraphs, no
   // [[blank]] macro) into explicit [[blank]] markers so markdown-it does not
   // collapse them — TXT already preserves these, this brings HTML/PDF/EPUB to
   // parity (#1826). Scoped to ".mdi": .md/.txt keep CommonMark collapse and the
   // DATA-LOSS guard (#1608). Markers feed the existing sentinel path below.
-  const normalized = fileType === ".mdi" ? promoteBlankRunsToMarkers(rawNormalized) : rawNormalized;
+  const normalized = isMdi ? promoteBlankRunsToMarkers(rawNormalized) : rawNormalized;
   // Pre-process: replace [[blank]] paragraph markers with a U+E000 PUA sentinel.
+  // For non-.mdi files, skip this — [[blank]] is authored literal text and must
+  // not be silently removed (#1918).
   // markdown-it will wrap the sentinel in <p>…</p>; we swap it for an empty <p></p> after rendering.
   const BLANK_SENTINEL = "";
-  const preprocessed = normalized.replace(new RegExp(MDI_BLANK_RE.source, "gm"), BLANK_SENTINEL);
+  const preprocessed = isMdi
+    ? normalized.replace(new RegExp(MDI_BLANK_RE.source, "gm"), BLANK_SENTINEL)
+    : normalized;
   const rawHtml = md.render(preprocessed);
   // Replace the sentinel paragraph with a true empty paragraph. Then final-sweep any
   // remaining sentinel that escaped the <p>…</p> wrap (e.g. inside fenced code blocks


### PR DESCRIPTION
## 概要

`.txt` / `.md` ファイルの印刷・プレビューで `[[blank]]` / `[[no-break:…]]` / `[[kern:…]]` が MDI マクロとして解釈され、本文が変形・消去されていた問題を修正する。

**根本原因 2 点**:

1. `mdiToHtml()` で `createMarkdownIt()` が fileType に関わらず MDI インラインルール（no-break / kern / ruby / tcy / br）を常にインストールしていた → `.txt` 内の `[[no-break:ABC]]` が `<span class="mdi-nobr">` に変換される
2. `[[blank]]` → sentinel 置換が非 `.mdi` でも実行されていた → `.txt` 内のリテラル `[[blank]]` が空段落に化けて消える
3. `app/page.tsx` の `printDialog` オブジェクトに `fileType` を渡していなかった → 印刷プレビュー経路が常に `.mdi` フォールバックになる

## 変更内容

| ファイル | 変更 |
|---|---|
| `lib/export/mdi-to-html.ts` | `createMarkdownIt(mdiInlineRules)` にフラグ追加。非 `.mdi` では MDI インラインプラグインをスキップ。`[[blank]]` sentinel 置換を `isMdi` 条件でガード |
| `app/page.tsx` | `printDialog` に `fileType: printDialogState?.fileType` を追加 |
| `lib/export/__tests__/mdi-to-html.test.ts` | 回帰テスト 6 件追加（`.txt`/`.md` でのマクロ保持 × 3、`.mdi` での変換継続 × 3） |

`.mdi` の PDF / EPUB / 印刷出力は変更なし。

Closes #1918
Refs #1900
Refs #1895
Refs #1916

## テスト計画

- [x] `npx vitest run lib/export/__tests__/mdi-to-html.test.ts` → 11 件全 pass
- [x] `npm run type-check` → エラーなし
- [x] `npx eslint` 変更ファイル → エラーなし
- [ ] UI 手動確認: `.txt` に `[[blank]]` / `[[no-break:ABC]]` を含むファイルを印刷プレビューして本文が消えない・変形しないこと
- [ ] UI 手動確認: `.mdi` ファイルの印刷が従来通り機能すること (#1900)

## 回帰リスク

- `.mdi` の動作パスは変更なし（`isMdi === true` のコードパスは既存と同一）
- 非 `.mdi` での MDI インラインルール無効化は #1916（`.md` でのリテラル `[[blank]]` 保持）と連携して機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)