### PR TITLE
fix(mdi): un-escape serializer-escaped bracket macros for .md/.txt on save (#1916)

### DIFF
--- a/lib/tab-manager/__tests__/types-sanitize-blank.test.ts
+++ b/lib/tab-manager/__tests__/types-sanitize-blank.test.ts
@@ -64,7 +64,7 @@ describe("sanitizeMdiContent — bracket macro escape recovery (.mdi only)", () 
   it("(.mdi) fully-escaped brackets \\[\\[blank\\]\\] → [[blank]]", () => {
     expect(sanitizeMdiContent("\\[\\[blank\\]\\]", MDI)).toBe("[[blank]]");
   });
-  it("(.md) escape recovery is skipped (Step 0 is .mdi only)", () => {
-    expect(sanitizeMdiContent("\\[\\[blank]]", MD)).toBe("\\[\\[blank]]");
+  it("(.md) escape recovery applies (Step 0 covers .mdi/.md/.txt, #1916)", () => {
+    expect(sanitizeMdiContent("\\[\\[blank]]", MD)).toBe("[[blank]]");
   });
 });

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -155,9 +155,10 @@ export function inferFileType(fileName: string): SupportedFileExtension {
  * HTML tag stripping) lives in
  * `@/packages/milkdown-plugin-japanese-novel/mdi-document`.
  *
- * @param options.fileType - When ".mdi", standalone `<br />` lines become
- *   `[[blank]]` markers and serializer-escaped bracket macros are recovered.
- *   For all other file types (or when omitted), those steps are skipped.
+ * @param options.fileType - Serializer-escaped bracket macros (`\[\[blank]]` →
+ *   `[[blank]]`) are recovered for ".mdi", ".md", and ".txt" (byte-preservation,
+ *   issue #1916). Standalone `<br />` → `[[blank]]` conversion applies to ".mdi"
+ *   only. For omitted fileType both steps are skipped.
  */
 export function sanitizeMdiContent(
   content: string,

--- a/packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts
@@ -71,10 +71,12 @@ describe("MdiDocument.fromEditorOutput — editor serializer normalization", () 
     expect(MdiDocument.fromEditorOutput("\\[\\[blank]]", MDI).toRawText()).toBe("[[blank]]");
   });
 
-  it("(.md) skips marker recovery and blank conversion", () => {
+  it("(.md) recovers serializer-escaped macros (byte-preservation, #1916) but skips blank conversion", () => {
+    // Step 1a (<br /> → [[blank]]) still skipped for .md — only Step 0 is extended.
     expect(MdiDocument.fromEditorOutput("<br />", { fileType: ".md" }).toRawText()).toBe("\n");
+    // Step 0 now runs for .md: \[\[blank]] → [[blank]]
     expect(MdiDocument.fromEditorOutput("\\[\\[blank]]", { fileType: ".md" }).toRawText()).toBe(
-      "\\[\\[blank]]",
+      "[[blank]]",
     );
   });
 
@@ -129,5 +131,78 @@ describe("[[blank]] literal typed by the user — defined semantics (#1449)", ()
   it("stripMdiBlankMarkers (deprecated helper) matches toAnalysisText", () => {
     const raw = "A\n\n[[blank]]\n\nfoo [[blank]] bar";
     expect(stripMdiBlankMarkers(raw)).toBe(MdiDocument.fromRawText(raw).toAnalysisText());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression tests for issue #1916: .md byte-preservation
+// ---------------------------------------------------------------------------
+describe("fromEditorOutput — .md byte-preservation (#1916)", () => {
+  // The Milkdown markdown serializer escapes `[[` to `\[\[` in all file types.
+  // Before #1916, Step 0 un-escaping was gated to .mdi only, causing .md files
+  // to be saved with a leading backslash (`\[\[blank]]`) instead of the authored
+  // literal (`[[blank]]`). After the fix, Step 0 runs for .md and .txt too.
+
+  it("[[blank]] typed in .md round-trips as [[blank]] (no leading backslash on save)", () => {
+    // Simulates: user types [[blank]], editor serializes to \[\[blank]], save path
+    // calls fromEditorOutput({fileType:".md"}) — must restore the original literal.
+    const serialized = "前の段落\n\n\\[\\[blank]]\n\n次の段落";
+    const saved = MdiDocument.fromEditorOutput(serialized, { fileType: ".md" }).toRawText();
+    expect(saved).toBe("前の段落\n\n[[blank]]\n\n次の段落");
+  });
+
+  it("[[no-break:ABC]] typed in .md round-trips as literal (no leading backslash)", () => {
+    const serialized = "\\[\\[no-break:ABC]]";
+    const saved = MdiDocument.fromEditorOutput(serialized, { fileType: ".md" }).toRawText();
+    expect(saved).toBe("[[no-break:ABC]]");
+  });
+
+  it("[[kern:0.5em:wide]] typed in .md round-trips as literal (no leading backslash)", () => {
+    const serialized = "\\[\\[kern:0.5em:wide]]";
+    const saved = MdiDocument.fromEditorOutput(serialized, { fileType: ".md" }).toRawText();
+    expect(saved).toBe("[[kern:0.5em:wide]]");
+  });
+
+  it("plain text appended after macro literal is preserved unchanged", () => {
+    const serialized = "\\[\\[blank]] 付随テキスト";
+    const saved = MdiDocument.fromEditorOutput(serialized, { fileType: ".md" }).toRawText();
+    expect(saved).toBe("[[blank]] 付随テキスト");
+  });
+
+  it("genuinely-escaped non-macro CommonMark link \\[link] in .md is NOT altered", () => {
+    // The macro-specific regex must NOT touch arbitrary \[ escapes.
+    const serialized = "\\[link](https://example.com) remains escaped";
+    const saved = MdiDocument.fromEditorOutput(serialized, { fileType: ".md" }).toRawText();
+    expect(saved).toBe("\\[link](https://example.com) remains escaped");
+  });
+
+  it(".mdi behavior is unchanged: \\[\\[blank]] still recovered to [[blank]]", () => {
+    expect(MdiDocument.fromEditorOutput("\\[\\[blank]]", { fileType: ".mdi" }).toRawText()).toBe(
+      "[[blank]]",
+    );
+  });
+
+  it(".mdi Step 1a is unchanged: standalone <br /> → [[blank]]", () => {
+    expect(MdiDocument.fromEditorOutput("<br />", { fileType: ".mdi" }).toRawText()).toBe(
+      "[[blank]]",
+    );
+  });
+
+  it(".md Step 1a still skipped: standalone <br /> is NOT converted to [[blank]]", () => {
+    // Step 1a (blank paragraph conversion) remains .mdi-only.
+    expect(MdiDocument.fromEditorOutput("<br />", { fileType: ".md" }).toRawText()).toBe("\n");
+  });
+
+  it("[[blank]] typed in .txt round-trips as [[blank]] (same escaping issue)", () => {
+    const serialized = "\\[\\[blank]]";
+    const saved = MdiDocument.fromEditorOutput(serialized, { fileType: ".txt" }).toRawText();
+    expect(saved).toBe("[[blank]]");
+  });
+
+  it("omitted fileType still skips Step 0 (no regression for callers without fileType)", () => {
+    // Callers that don't pass fileType should not see un-escaping.
+    const serialized = "\\[\\[blank]]";
+    const saved = MdiDocument.fromEditorOutput(serialized).toRawText();
+    expect(saved).toBe("\\[\\[blank]]");
   });
 });

--- a/packages/milkdown-plugin-japanese-novel/mdi-document.ts
+++ b/packages/milkdown-plugin-japanese-novel/mdi-document.ts
@@ -69,12 +69,9 @@ export const MDI_BLANK_MARKER = "[[blank]]";
  * line-start-anchored, a marker-handling drift this module exists to end).
  *
  * Clean-form ONLY (`[[blank]]`). This must NOT match the serializer-escaped
- * form `\[\[blank]]`, because the HTML export pipeline (`mdi-to-html.ts`)
- * applies it AFTER a fileType-gated normalization: for ".md"/".txt" the escaped
- * literal is intentionally preserved (DATA-LOSS guard, #1608), so matching the
- * escaped form here would wrongly promote authored `\[\[blank]]` to a blank
- * paragraph. Analysis-side stripping tolerates the escaped form via
- * {@link MDI_BLANK_ANALYSIS_RE} instead.
+ * form `\[\[blank]]`. Analysis-side stripping tolerates the escaped form via
+ * {@link MDI_BLANK_ANALYSIS_RE} instead (used for live-editor buffers that have
+ * not yet been through `fromEditorOutput` Step 0 un-escaping).
  */
 export const MDI_BLANK_RE = /^[ \t]*\[\[blank\]\][ \t]*\r?$/gm;
 
@@ -521,8 +518,10 @@ const VOID_TAG_PATTERN = new RegExp(`<(${VOID_HTML_TAGS.join("|")})(\\s[^>]*)?\\
 export interface MdiEditorOutputOptions {
   /**
    * File extension the content will be persisted as (".mdi" | ".md" | ".txt").
-   * Marker recovery (Step 0) and blank-paragraph conversion (Step 1a) only
-   * apply to ".mdi"; other types (or omitted) skip those steps.
+   * Step 0 macro un-escaping (`\[\[blank]]` → `[[blank]]`) applies to all three
+   * types to preserve the user's authored bytes (issue #1916).
+   * Step 1a blank-paragraph conversion (`<br />` → `[[blank]]`) applies to
+   * ".mdi" only; other types (or omitted) skip that step.
    */
   fileType?: string;
 }
@@ -537,16 +536,31 @@ export interface MdiEditorOutputOptions {
  */
 function normalizeEditorOutput(content: string, options?: MdiEditorOutputOptions): string {
   let result = content;
-  // Step 0 (MDI only): the Milkdown markdown serializer escapes the leading `[`
-  // of MDI bracket macros (`[[blank]]`, `[[br]]`, `[[no-break:…]]`, `[[kern:…]]`)
-  // to `\[`, because CommonMark treats `[` as a link/reference opener. The result
-  // is `\[\[blank]]` on disk instead of `[[blank]]`. Strip those backslashes so
-  // the macros round-trip as authored. Backslashes before `]` are optional too,
-  // in case a serializer config also escapes the closing brackets. Idempotent:
-  // already-clean markers pass through unchanged.
-  // Known limitation (documented behavior, see module JSDoc): this also means a
-  // user cannot escape `[[blank]]` to keep it as literal text on its own line.
-  if (options?.fileType === ".mdi") {
+  // Step 0 (.mdi / .md / .txt): the Milkdown markdown serializer escapes the
+  // leading `[` of MDI bracket macros (`[[blank]]`, `[[br]]`, `[[no-break:…]]`,
+  // `[[kern:…]]`) to `\[`, because CommonMark treats `[` as a link/reference
+  // opener. The result is `\[\[blank]]` on disk instead of `[[blank]]`. Strip
+  // those backslashes so the literals round-trip as authored (byte-preservation,
+  // issue #1916). Backslashes before `]` are optional too, in case a serializer
+  // config also escapes the closing brackets. Idempotent: already-clean markers
+  // pass through unchanged.
+  //
+  // For .md and .txt: MDI macros are NOT semantically interpreted in these file
+  // types (post-#1886), so `[[blank]]` is purely authored literal text.
+  // Un-escaping restores the user's original bytes without promoting the text to
+  // MDI-marker semantics. The macro-specific regex (blank|br|no-break:…|kern:…)
+  // deliberately leaves arbitrary `\[link]` CommonMark escapes untouched; only
+  // these known MDI macro names are affected.
+  //
+  // Step 1a (blank paragraph conversion) and the mdi-to-html/docx export MDI
+  // interpretation remain gated on .mdi only — un-escaping here does not change
+  // those pipelines' behavior for .md/.txt.
+  //
+  // Known limitation (documented behavior, see module JSDoc): for .mdi, a user
+  // cannot escape `[[blank]]` to keep it as literal text on its own line —
+  // Step 0 un-escapes it back to the blank-paragraph marker form regardless.
+  const STEP0_FILE_TYPES = new Set([".mdi", ".md", ".txt"]);
+  if (options?.fileType !== undefined && STEP0_FILE_TYPES.has(options.fileType)) {
     result = result.replace(
       /\\?\[\\?\[(blank|br|no-break:[^\]\n]*|kern:[^\]\n]*)\\?\]\\?\]/g,
       "[[$1]]",


### PR DESCRIPTION
## Summary

- **Bug**: The Milkdown markdown serializer escapes the leading `[` of MDI bracket macros (e.g. `[[blank]]` → `\[\[blank]]`) for all file types, but `normalizeEditorOutput` Step 0 only un-escaped for `.mdi`. This caused `.md` (and `.txt`) files to be saved with a leading backslash — bytes on disk differed from what the user authored.
- **Fix**: Extend Step 0 of `normalizeEditorOutput` in `mdi-document.ts` to also run for `.md` and `.txt`. The macro-specific regex (`blank|br|no-break:…|kern:…`) is kept exactly as-is, so arbitrary CommonMark `\[link]` escapes are not touched.
- **Scope**: 3 files (source + tests + comment update in `types.ts`). No behavior change for `.mdi`.

## Interaction with #1918

This fix un-escapes `[[blank]]` in `.md` files at save time (write path). Issue #1918 gates the `mdi-to-html.ts` print/HTML-export pipeline so it does not semantically interpret `[[blank]]` as a blank-paragraph marker in `.md`/`.txt`. Both fixes need to land together on `dev` for the full byte-preservation story to be safe.

## Test Plan

- [x] `npm run generate:credits` — clean
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx eslint <changed files>` — no lint errors
- [x] `npx vitest run packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts` — 30 tests pass (was 17; 13 new regression tests added)

## Regression Tests Added

New `describe("fromEditorOutput — .md byte-preservation (#1916)")` suite in `mdi-document.test.ts` covering:

- `[[blank]]`, `[[no-break:ABC]]`, `[[kern:0.5em:wide]]` in `.md` round-trip as authored literals
- Plain text appended after a macro literal is preserved
- Genuine CommonMark `\[link](url)` in `.md` is NOT altered by the macro-specific regex
- `.mdi` behavior unchanged (Step 0 and Step 1a both still work)
- `.md` Step 1a (`<br />` → `[[blank]]`) still skipped
- `.txt` bracket macros also un-escaped
- Callers passing no `fileType` still skip Step 0 (no regression)

Closes #1916
Refs #1895