### PR TITLE
fix(mdi): recover serializer-escaped bracket macros on .md save (#1916)

### DIFF
--- a/lib/tab-manager/__tests__/types-sanitize-blank.test.ts
+++ b/lib/tab-manager/__tests__/types-sanitize-blank.test.ts
@@ -41,7 +41,7 @@ describe("sanitizeMdiContent — blank paragraph conversion (.mdi only)", () => 
   });
 });
 
-describe("sanitizeMdiContent — bracket macro escape recovery (.mdi only)", () => {
+describe("sanitizeMdiContent — bracket macro escape recovery (.mdi / .md)", () => {
   it("(.mdi) serializer-escaped \\[\\[blank]] → [[blank]]", () => {
     expect(sanitizeMdiContent("\\[\\[blank]]", MDI)).toBe("[[blank]]");
   });
@@ -64,7 +64,26 @@ describe("sanitizeMdiContent — bracket macro escape recovery (.mdi only)", () 
   it("(.mdi) fully-escaped brackets \\[\\[blank\\]\\] → [[blank]]", () => {
     expect(sanitizeMdiContent("\\[\\[blank\\]\\]", MDI)).toBe("[[blank]]");
   });
-  it("(.md) escape recovery is skipped (Step 0 is .mdi only)", () => {
-    expect(sanitizeMdiContent("\\[\\[blank]]", MD)).toBe("\\[\\[blank]]");
+  it("(.md) escape recovery now runs so authored bytes round-trip (#1916)", () => {
+    expect(sanitizeMdiContent("\\[\\[blank]]", MD)).toBe("[[blank]]");
+  });
+  it("(.md) escaped \\[\\[br]] → [[br]] (#1916)", () => {
+    expect(sanitizeMdiContent("行1\\[\\[br]]行2", MD)).toBe("行1[[br]]行2");
+  });
+  it("(.md) escaped no-break macro → unescaped (#1916)", () => {
+    expect(sanitizeMdiContent("\\[\\[no-break:東京]]", MD)).toBe("[[no-break:東京]]");
+  });
+  it("(.md) escaped kern macro → unescaped (#1916)", () => {
+    expect(sanitizeMdiContent("\\[\\[kern:0.5em:漢字]]", MD)).toBe("[[kern:0.5em:漢字]]");
+  });
+  it("(.md) escaped macro in context (#1916)", () => {
+    const input = "A段落\n\n\\[\\[blank]]\n\nB段落";
+    expect(sanitizeMdiContent(input, MD)).toBe("A段落\n\n[[blank]]\n\nB段落");
+  });
+  it("(.md) non-macro \\[ literal escape is preserved (#1916)", () => {
+    // Only macro-shaped sequences are recovered; unrelated link/literal escapes
+    // must survive untouched on .md save.
+    expect(sanitizeMdiContent("\\[link]\\(url)", MD)).toBe("\\[link]\\(url)");
+    expect(sanitizeMdiContent("\\[\\[note]]", MD)).toBe("\\[\\[note]]");
   });
 });

--- a/packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts
@@ -71,10 +71,34 @@ describe("MdiDocument.fromEditorOutput — editor serializer normalization", () 
     expect(MdiDocument.fromEditorOutput("\\[\\[blank]]", MDI).toRawText()).toBe("[[blank]]");
   });
 
-  it("(.md) skips marker recovery and blank conversion", () => {
+  it("(.md) recovers serializer-escaped bracket macros but skips blank conversion", () => {
+    // Step 1a (<br /> → [[blank]]) is .mdi-only: .md keeps standalone <br /> as a
+    // plain newline via Step 1b.
     expect(MdiDocument.fromEditorOutput("<br />", { fileType: ".md" }).toRawText()).toBe("\n");
+    // Step 0 now runs for .md so authored macro bytes round-trip (#1916).
     expect(MdiDocument.fromEditorOutput("\\[\\[blank]]", { fileType: ".md" }).toRawText()).toBe(
-      "\\[\\[blank]]",
+      "[[blank]]",
+    );
+  });
+
+  it("(.md) round-trips all serializer-escaped bracket macros (#1916)", () => {
+    const MD = { fileType: ".md" };
+    expect(MdiDocument.fromEditorOutput("\\[\\[blank]]", MD).toRawText()).toBe("[[blank]]");
+    expect(MdiDocument.fromEditorOutput("\\[\\[br]]", MD).toRawText()).toBe("[[br]]");
+    expect(MdiDocument.fromEditorOutput("\\[\\[no-break:固有名詞]]", MD).toRawText()).toBe(
+      "[[no-break:固有名詞]]",
+    );
+    expect(MdiDocument.fromEditorOutput("\\[\\[kern:2]]", MD).toRawText()).toBe("[[kern:2]]");
+  });
+
+  it("(.md) preserves a non-macro \\[ literal escape (#1916)", () => {
+    // A backslash-escaped bracket that is NOT a known MDI macro must be left
+    // untouched: only macro-shaped sequences are recovered.
+    expect(MdiDocument.fromEditorOutput("\\[link]\\(url)", { fileType: ".md" }).toRawText()).toBe(
+      "\\[link]\\(url)",
+    );
+    expect(MdiDocument.fromEditorOutput("\\[\\[note]]", { fileType: ".md" }).toRawText()).toBe(
+      "\\[\\[note]]",
     );
   });
 

--- a/packages/milkdown-plugin-japanese-novel/mdi-document.ts
+++ b/packages/milkdown-plugin-japanese-novel/mdi-document.ts
@@ -521,8 +521,9 @@ const VOID_TAG_PATTERN = new RegExp(`<(${VOID_HTML_TAGS.join("|")})(\\s[^>]*)?\\
 export interface MdiEditorOutputOptions {
   /**
    * File extension the content will be persisted as (".mdi" | ".md" | ".txt").
-   * Marker recovery (Step 0) and blank-paragraph conversion (Step 1a) only
-   * apply to ".mdi"; other types (or omitted) skip those steps.
+   * Bracket-macro escape recovery (Step 0) applies to ".mdi" and ".md" so
+   * authored input bytes round-trip (#1916). Blank-paragraph conversion
+   * (Step 1a) is ".mdi" only; other types (or omitted) skip those steps.
    */
   fileType?: string;
 }
@@ -537,16 +538,21 @@ export interface MdiEditorOutputOptions {
  */
 function normalizeEditorOutput(content: string, options?: MdiEditorOutputOptions): string {
   let result = content;
-  // Step 0 (MDI only): the Milkdown markdown serializer escapes the leading `[`
-  // of MDI bracket macros (`[[blank]]`, `[[br]]`, `[[no-break:…]]`, `[[kern:…]]`)
-  // to `\[`, because CommonMark treats `[` as a link/reference opener. The result
-  // is `\[\[blank]]` on disk instead of `[[blank]]`. Strip those backslashes so
-  // the macros round-trip as authored. Backslashes before `]` are optional too,
-  // in case a serializer config also escapes the closing brackets. Idempotent:
-  // already-clean markers pass through unchanged.
+  // Step 0 (".mdi" / ".md"): the Milkdown markdown serializer escapes the leading
+  // `[` of MDI bracket macros (`[[blank]]`, `[[br]]`, `[[no-break:…]]`,
+  // `[[kern:…]]`) to `\[`, because CommonMark treats `[` as a link/reference
+  // opener. The result is `\[\[blank]]` on disk instead of `[[blank]]`. Strip
+  // those backslashes so the macros round-trip as authored. The macro-shaped
+  // regex only touches sequences matching the known macro names, so unrelated
+  // `\[` link/literal escapes are left alone. Backslashes before `]` are optional
+  // too, in case a serializer config also escapes the closing brackets.
+  // Idempotent: already-clean markers pass through unchanged.
+  // `.md` is included so authored input bytes are preserved for markdown files
+  // that happen to contain MDI-shaped literals (#1916); `.txt` never goes through
+  // the markdown serializer, so it is unaffected.
   // Known limitation (documented behavior, see module JSDoc): this also means a
   // user cannot escape `[[blank]]` to keep it as literal text on its own line.
-  if (options?.fileType === ".mdi") {
+  if (options?.fileType === ".mdi" || options?.fileType === ".md") {
     result = result.replace(
       /\\?\[\\?\[(blank|br|no-break:[^\]\n]*|kern:[^\]\n]*)\\?\]\\?\]/g,
       "[[$1]]",


### PR DESCRIPTION
Closes #1916

## Root cause
`normalizeEditorOutput()` Step 0 (`packages/milkdown-plugin-japanese-novel/mdi-document.ts`) un-escapes Milkdown/CommonMark-escaped MDI bracket macros (`\[\[blank]]`, `\[\[br]]`, `\[\[no-break:…]]`, `\[\[kern:…]]` → `[[…]]`), but was gated on `options?.fileType === ".mdi"`. The `.md` save path calls `MdiDocument.fromEditorOutput(tab.content, { fileType: ".md" })` (`save-executor.ts:216`), so Step 0 was skipped and serializer-injected backslashes persisted to disk, mutating the author's input bytes. `.txt` never passes through the markdown serializer and was unaffected.

## Fix
Extend the Step 0 macro-shaped escape recovery to run for `.md` as well as `.mdi`. The same macro-shaped regex is kept, so only known macro names are recovered and unrelated `\[` link/literal escapes are left untouched. Step 1a (`<br />` → `[[blank]]`) remains `.mdi`-only and is NOT applied to `.md`. This aligns `.md` with the documented `.mdi` escape limitation; byte-fidelity of authored input is the priority (acceptable per issue).

## Test plan
- Updated the two tests that pinned the buggy `.md` skip behavior:
  - `packages/milkdown-plugin-japanese-novel/__tests__/mdi-document.test.ts`
  - `lib/tab-manager/__tests__/types-sanitize-blank.test.ts`
- Added positive `.md` round-trip cases for blank / br / no-break / kern.
- Added a guard case proving a non-macro `\[` literal (`\[link]\(url)`, `\[\[note]]`) is preserved on `.md`.
- `npx tsc --noEmit` clean.
- `npx vitest run` on both files: 45 passed.

Unit-testable; no UI verification needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)