### PR TITLE
fix(tab-manager): エディタ分割の同一ファイル独立buffer相互上書きを解消 (#1874)

### DIFF
--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -605,9 +605,12 @@ export function useDockviewAdapter({
       // Split is only supported for editor tabs
       if (!isEditorTab(activeTab)) return;
 
-      // Clone the active tab's content and file association into a new tab.
-      // The new panel will be positioned in the split direction
-      // by the sync effect above (via pendingSplitRef).
+      // Duplicate the active tab's content into a new INDEPENDENT draft tab
+      // (#1874). The clone is detached from the source file so the two panes
+      // cannot silently overwrite each other on save. The new panel will be
+      // positioned in the split direction by the sync effect above (via
+      // pendingSplitRef). NOTE: this is "duplicate as draft", not a second view
+      // of the same document; full single-buffer multi-view is a follow-up.
       cloneTab(activeTab);
 
       pendingSplitRef.current = {

--- a/lib/tab-manager/__tests__/clone-tab-draft.test.ts
+++ b/lib/tab-manager/__tests__/clone-tab-draft.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Regression test for #1874 (P0 data loss): editor split created independent
+ * buffers for the SAME file that silently overwrote each other on save.
+ *
+ * Root cause: cloneTab copied `source.file` so the clone shared the original
+ * file path while holding an independent buffer; createNewTab also forced
+ * isDirty=false, so a clone of a dirty buffer was reported clean.
+ *
+ * Fix: cloneTabState() detaches the file descriptor (file=null) and marks the
+ * clone dirty, turning split into "duplicate as draft" that cannot save to the
+ * original path. These tests exercise the production helper directly.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import type { EditorTabState } from "@/lib/tab-manager/tab-types";
+import { cloneTabState, createNewTab } from "@/lib/tab-manager/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a saved, file-backed editor tab (simulates an opened document). */
+function makeSavedFileTab(path: string, content: string): EditorTabState {
+  const tab = createNewTab(content);
+  tab.file = { path, handle: null, name: "doc.mdi" };
+  tab.lastSavedContent = content;
+  tab.isDirty = false;
+  return tab;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cloneTabState — independent draft clone (#1874)", () => {
+  it("(a) cloning a dirty buffer yields a clone with file=null and isDirty=true", () => {
+    const source = makeSavedFileTab("/Users/x/novel.mdi", "saved text");
+    // Source becomes dirty (unsaved edits in pane A)
+    source.content = "saved text + unsaved edits";
+    source.isDirty = true;
+
+    const clone = cloneTabState(source);
+
+    expect(clone.file).toBeNull();
+    expect(clone.isDirty).toBe(true);
+    // Content is carried over so the user keeps their work as a draft
+    expect(clone.content).toBe("saved text + unsaved edits");
+  });
+
+  it("(b) clone shares NO path with source — cannot save to the original file", () => {
+    const source = makeSavedFileTab("/Users/x/novel.mdi", "body");
+
+    const clone = cloneTabState(source);
+
+    // No path means the save pipeline must prompt for a destination (Save As),
+    // so it can never silently overwrite the source path.
+    expect(clone.file?.path ?? null).toBeNull();
+    expect(clone.file?.path).not.toBe(source.file?.path);
+  });
+
+  it("(c) editing the clone does not mutate the source tab", () => {
+    const source = makeSavedFileTab("/Users/x/novel.mdi", "original");
+
+    const clone = cloneTabState(source);
+    clone.content = "clone edited";
+    clone.isDirty = true;
+
+    // Source is untouched
+    expect(source.content).toBe("original");
+    expect(source.isDirty).toBe(false);
+    expect(source.file?.path).toBe("/Users/x/novel.mdi");
+    // Distinct tab ids guarantee setContent/setTabContent target only one tab
+    expect(clone.id).not.toBe(source.id);
+  });
+
+  it("clone of a CLEAN file-backed tab is still detached and dirty (no hidden-clean clone)", () => {
+    const source = makeSavedFileTab("/Users/x/novel.mdi", "clean body");
+    expect(source.isDirty).toBe(false);
+
+    const clone = cloneTabState(source);
+
+    expect(clone.file).toBeNull();
+    // Born dirty: the unsaved draft is never silently discarded on close
+    expect(clone.isDirty).toBe(true);
+  });
+
+  it("regression guard: the OLD clone logic shared the path and reported clean", () => {
+    const source = makeSavedFileTab("/Users/x/novel.mdi", "body");
+    source.content = "dirty body";
+    source.isDirty = true;
+
+    // Reproduce the pre-fix behaviour: copy file descriptor, keep createNewTab's
+    // forced isDirty=false.
+    const broken = createNewTab(source.content, source.fileType);
+    broken.file = source.file;
+
+    // The bug: same path + reported clean despite a dirty source buffer.
+    expect(broken.file?.path).toBe(source.file?.path);
+    expect(broken.isDirty).toBe(false);
+
+    // The fix avoids both.
+    const fixed = cloneTabState(source);
+    expect(fixed.file).toBeNull();
+    expect(fixed.isDirty).toBe(true);
+  });
+});

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -32,7 +32,11 @@ export interface UseTabManagerReturn {
   tabs: TabState[];
   activeTabId: TabId;
   newTab: (fileType?: SupportedFileExtension) => void;
-  /** Create a new editor tab pre-populated with content and file association from a source tab. */
+  /**
+   * Duplicate a source tab's content into a new INDEPENDENT draft tab (#1874).
+   * The clone is detached from the source file (untitled) and born dirty so it
+   * cannot silently overwrite the original path. See cloneTabState().
+   */
   cloneTab: (source: EditorTabState) => void;
   closeTab: (tabId: TabId) => void;
   switchTab: (tabId: TabId) => void;
@@ -205,4 +209,32 @@ export function createNewTab(
     fileSyncStatus: "clean",
     conflictDiskContent: null,
   };
+}
+
+/**
+ * Produce a TRUE independent draft clone of an editor tab (issue #1874).
+ *
+ * Historically cloneTab copied `source.file` so the new tab shared the same
+ * file path. That made editor split create two tabs pointing at the SAME file
+ * but holding independent buffers, so each pane could silently overwrite the
+ * other's edits on save (P0 data loss). It also reported the clone as clean
+ * even when the source buffer was dirty.
+ *
+ * The interim fix detaches the file descriptor (`file = null`) so the clone is
+ * an untitled draft that CANNOT save to the original path, and marks it dirty
+ * so the unsaved draft is never silently lost. This trades the "second view of
+ * the same document" UX for a "duplicate as draft" UX, eliminating the
+ * data-loss path. A full single-buffer multi-view refactor is a follow-up.
+ *
+ * `lastSavedContent` is set to the empty string (the descriptor-less baseline)
+ * so the clone is correctly reported dirty as long as it holds any content.
+ */
+export function cloneTabState(source: EditorTabState): EditorTabState {
+  const draft = createNewTab(source.content, source.fileType);
+  // Detach from the source document: an untitled draft with no save target.
+  draft.file = null;
+  // Born dirty so the unsaved draft is never silently discarded.
+  draft.isDirty = true;
+  draft.lastSavedContent = "";
+  return draft;
 }

--- a/lib/tab-manager/use-tab-state.ts
+++ b/lib/tab-manager/use-tab-state.ts
@@ -5,7 +5,7 @@ import type { MdiFileDescriptor } from "../project/mdi-file";
 import type { SupportedFileExtension } from "../project/project-types";
 import type { TabId, TabState, EditorTabState, TerminalTabState, DiffTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
-import { createNewTab, generateTabId } from "./types";
+import { cloneTabState, createNewTab, generateTabId } from "./types";
 import type { TabManagerCore } from "./types";
 import { nextTerminalLabel } from "./terminal-label";
 import { useEditorMode } from "@/contexts/EditorModeContext";
@@ -46,7 +46,11 @@ export interface UseTabStateReturn extends TabManagerCore {
   // Tab CRUD operations
   /** Create a new empty editor tab. */
   newTab: (fileType?: SupportedFileExtension) => void;
-  /** Create a new editor tab pre-populated with content and file association from a source tab. */
+  /**
+   * Duplicate a source tab's content into a new INDEPENDENT draft tab (#1874).
+   * The clone is detached from the source file (untitled) and born dirty so it
+   * cannot silently overwrite the original path. See cloneTabState().
+   */
   cloneTab: (source: EditorTabState) => void;
   /** Open a new terminal tab with placeholder values. Optionally pass a pendingId for spawn correlation. */
   newTerminalTab: (pendingId?: string) => void;
@@ -177,9 +181,10 @@ export function useTabState(): UseTabStateReturn {
   }, []);
 
   const cloneTab = useCallback((source: EditorTabState) => {
-    const tab = createNewTab(source.content, source.fileType);
-    // Copy the file descriptor so the cloned tab is associated with the same document.
-    tab.file = source.file;
+    // Produce a TRUE independent draft (#1874): detached from the source file so
+    // it cannot silently overwrite the original path, and born dirty so the
+    // unsaved draft is never lost. See cloneTabState() for the rationale.
+    const tab = cloneTabState(source);
     setTabs((prev) => [...prev, tab]);
     setActiveTabId(tab.id);
   }, []);


### PR DESCRIPTION
Closes #1874

## Root cause (P0 data loss)
`splitEditor` (lib/dockview/use-dockview-adapter.ts) implemented split right/down by calling `cloneTab(activeTab)`. `cloneTab` did `createNewTab(source.content, source.fileType)` then `tab.file = source.file`, producing a fully independent tab that shared only the file descriptor (path).

- `createNewTab` copies content into both `content` and `lastSavedContent` and forces `isDirty=false`, so a clone of a dirty buffer was born unsaved but reported clean.
- Edits never propagate (`setContent`/`setTabContent` only update the matching tab id).
- Because both tabs carried the same `file.path`, each pane could save to the same file and the stale pane silently overwrote the other's edits.

## Fix (minimal interim, sanctioned by the issue)
New `cloneTabState()` helper (lib/tab-manager/types.ts) produces a TRUE independent draft:
- `file = null` → the clone is an untitled draft that **cannot save to the original path** (save pipeline must prompt for a destination), eliminating the silent overwrite.
- `isDirty = true` → the unsaved draft is never silently discarded; no hidden-clean clone.
- `lastSavedContent = ""` baseline so the draft stays dirty as long as it holds content.

`cloneTab` (use-tab-state.ts) now delegates to `cloneTabState`. The legitimate "reuse untitled clean tab" branches are untouched (cloneTab is only used by split).

## UX change
Split becomes "duplicate as draft" rather than a second view of the same document. This is acceptable — it removes the data-loss path. The full single-buffer multi-view refactor is a **follow-up**.

## Test plan
New `lib/tab-manager/__tests__/clone-tab-draft.test.ts` (exercises the production helper directly):
- (a) cloning a dirty buffer → clone has `file=null` and `isDirty=true`
- (b) clone shares NO path with source → cannot save to the original file
- (c) editing the clone does not mutate the source tab
- plus clean-source clone is still detached+dirty, and a regression guard reproducing the old shared-path/clean-clone bug

Verified:
- `npx vitest run lib/tab-manager/__tests__/clone-tab-draft.test.ts` → 5 passed
- `npx tsc --noEmit` → clean

## UI verification
⏳ Pending — split-pane behavior in the running app (Electron/Web) not yet manually verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)