### PR TITLE
fix(layout): 狭いウィンドウで本文先頭・ツールバーがクリップされる (#1856)

### DIFF
--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -52,6 +52,8 @@ import type { DocxExportSettings } from "@/lib/export/docx-export-settings";
 import type { EpubExportOptions } from "@/lib/export/epub-shared";
 import type { ExportMetadata } from "@/lib/export/types";
 import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
+import { decideResponsivePanels } from "@/lib/editor-page/responsive-layout";
+import { useWindowWidth } from "@/lib/editor-page/use-window-width";
 import { DockviewReact } from "dockview-react";
 type SidebarPanelSharedProps = Omit<React.ComponentProps<typeof SidebarPanel>, "view">;
 
@@ -226,6 +228,18 @@ export default function EditorLayout({
   mainArea,
   inspector,
 }: EditorLayoutProps): React.JSX.Element {
+  // #1856: 狭いウィンドウでは本文先頭がクリップされないよう、サイドパネルを
+  // 表示上だけ自動折りたたみする。永続化されたパネル状態
+  // （inspector.isRightPanelCollapsed 等）は変更しない。
+  const windowWidth = useWindowWidth();
+  const { collapseLeft: autoCollapseLeft, collapseRight: autoCollapseRight } =
+    decideResponsivePanels({
+      // windowWidth が 0（SSR 初期 / マウント前）の場合は折りたたまない。
+      windowWidth: windowWidth || Number.POSITIVE_INFINITY,
+      compactMode: chrome.compactMode,
+      rightAlreadyCollapsed: inspector.isRightPanelCollapsed,
+    });
+
   return (
     <DiffTabContext.Provider value={providers.diffTabContextValue}>
       <TerminalTabContext.Provider value={providers.terminalTabContextValue}>
@@ -381,38 +395,39 @@ export default function EditorLayout({
                   }}
                 />
 
-                {(activityBar.topView !== "none" || activityBar.bottomView !== "none") && (
-                  <ResizablePanel
-                    side="left"
-                    defaultWidth={chrome.compactMode ? 200 : 256}
-                    minWidth={chrome.compactMode ? 160 : 200}
-                    maxWidth={chrome.compactMode ? 320 : 400}
-                    className=""
-                  >
-                    {(() => {
-                      const topPanel =
-                        activityBar.topView !== "none" ? (
-                          <SidebarPanel
-                            view={activityBar.topView}
-                            {...mainArea.sidebarPanelProps}
-                          />
-                        ) : null;
-                      const bottomPanel =
-                        activityBar.bottomView !== "none" ? (
-                          <SidebarPanel
-                            view={activityBar.bottomView}
-                            {...mainArea.sidebarPanelProps}
-                          />
-                        ) : null;
+                {!autoCollapseLeft &&
+                  (activityBar.topView !== "none" || activityBar.bottomView !== "none") && (
+                    <ResizablePanel
+                      side="left"
+                      defaultWidth={chrome.compactMode ? 200 : 256}
+                      minWidth={chrome.compactMode ? 160 : 200}
+                      maxWidth={chrome.compactMode ? 320 : 400}
+                      className=""
+                    >
+                      {(() => {
+                        const topPanel =
+                          activityBar.topView !== "none" ? (
+                            <SidebarPanel
+                              view={activityBar.topView}
+                              {...mainArea.sidebarPanelProps}
+                            />
+                          ) : null;
+                        const bottomPanel =
+                          activityBar.bottomView !== "none" ? (
+                            <SidebarPanel
+                              view={activityBar.bottomView}
+                              {...mainArea.sidebarPanelProps}
+                            />
+                          ) : null;
 
-                      if (topPanel && bottomPanel) {
-                        return <SidebarSplitter top={topPanel} bottom={bottomPanel} />;
-                      }
+                        if (topPanel && bottomPanel) {
+                          return <SidebarSplitter top={topPanel} bottom={bottomPanel} />;
+                        }
 
-                      return topPanel || bottomPanel;
-                    })()}
-                  </ResizablePanel>
-                )}
+                        return topPanel || bottomPanel;
+                      })()}
+                    </ResizablePanel>
+                  )}
 
                 <main className="flex-1 flex flex-col overflow-hidden min-h-0 relative bg-background">
                   {mainArea.tabs.length === 0 && (
@@ -612,7 +627,11 @@ export default function EditorLayout({
                   minWidth={chrome.compactMode ? 160 : 200}
                   maxWidth={chrome.compactMode ? 320 : 400}
                   collapsible={true}
-                  isCollapsed={inspector.isRightPanelCollapsed || mainArea.tabs.length === 0}
+                  isCollapsed={
+                    inspector.isRightPanelCollapsed ||
+                    autoCollapseRight ||
+                    mainArea.tabs.length === 0
+                  }
                   onToggleCollapse={inspector.handleToggleRightPanel}
                 >
                   <ErrorBoundary sectionName="インスペクタ">

--- a/components/editor/EditorToolbar.tsx
+++ b/components/editor/EditorToolbar.tsx
@@ -39,21 +39,24 @@ export default function EditorToolbar({
   const paragraphSpacingOptions = Array.from({ length: 31 }, (_, i) => +(i * 0.1).toFixed(1)); // 0–3.0
 
   return (
-    <div className="h-12 border-y border-border bg-background-secondary flex items-center justify-between px-4">
-      <div className="flex items-center gap-4">
+    // #1856: 狭いウィンドウで検索／読み上げボタンが画面外に押し出されないよう、
+    // gap-x を縮め、設定グループ(min-w-0)が縮小・はみ出しを許容するようにする。
+    // 縦書き／読み上げ／検索の主要操作は shrink-0 で常に可視のまま残す。
+    <div className="min-h-12 border-y border-border bg-background-secondary flex items-center justify-between gap-2 px-4 py-1">
+      <div className="flex min-w-0 items-center gap-2 overflow-hidden sm:gap-4">
         {/* 縦書き/横書き */}
         <button
           onClick={onToggleVertical}
-          className="flex items-center gap-2 px-3 py-1.5 rounded font-medium bg-accent text-accent-foreground hover:bg-accent-hover transition-colors whitespace-nowrap"
+          className="flex shrink-0 items-center gap-2 px-3 py-1.5 rounded font-medium bg-accent text-accent-foreground hover:bg-accent-hover transition-colors whitespace-nowrap"
           style={{ fontSize: "clamp(0.75rem, 1.5vw, 0.875rem)" }}
         >
           <Type className="w-4 h-4 shrink-0" />
           <span className="overflow-hidden text-ellipsis">{isVertical ? "縦書き" : "横書き"}</span>
         </button>
 
-        {/* 現在の設定 */}
-        <div className="flex items-center gap-2 text-xs text-foreground-secondary">
-          <AlignLeft className="w-4 h-4 text-foreground-tertiary" />
+        {/* 現在の設定 — 狭幅では本グループが先に縮む／横スクロールする */}
+        <div className="flex min-w-0 items-center gap-2 overflow-x-auto text-xs text-foreground-secondary">
+          <AlignLeft className="w-4 h-4 shrink-0 text-foreground-tertiary" />
           <ValuePicker
             value={fontScale}
             label={`${fontScale}%`}
@@ -79,7 +82,7 @@ export default function EditorToolbar({
         </div>
       </div>
 
-      <div className="flex items-center gap-4">
+      <div className="flex shrink-0 items-center gap-2 sm:gap-4">
         {/* 読み上げ */}
         {speechState.isSupported && (
           <button

--- a/electron/window-manager.js
+++ b/electron/window-manager.js
@@ -57,6 +57,12 @@ async function createWindow({ showWelcome = false, hasPendingFile = false } = {}
   const newWindow = new BrowserWindow({
     width: 1400,
     height: 900,
+    // #1856: 狭いウィンドウで本文先頭やツールバーがクリップされるのを防ぐため
+    // 最小サイズの床を設ける。ActivityBar(48) + サイドパネル最小(200) +
+    // 読みやすい本文幅(>=360) が収まる値（lib/editor-page/responsive-layout.ts の
+    // MIN_WINDOW_WIDTH / MIN_WINDOW_HEIGHT と一致）。
+    minWidth: 640,
+    minHeight: 480,
     show: false,
     backgroundColor: "#0f172a",
     webPreferences: {

--- a/lib/editor-page/__tests__/responsive-layout.test.ts
+++ b/lib/editor-page/__tests__/responsive-layout.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  decideResponsivePanels,
+  MIN_WINDOW_WIDTH,
+  MIN_WINDOW_HEIGHT,
+  MAIN_MIN_READABLE_WIDTH,
+} from "../responsive-layout";
+
+describe("decideResponsivePanels", () => {
+  it("wide window keeps both panels open", () => {
+    const d = decideResponsivePanels({
+      windowWidth: 1400,
+      compactMode: false,
+      rightAlreadyCollapsed: false,
+    });
+    expect(d.collapseLeft).toBe(false);
+    expect(d.collapseRight).toBe(false);
+  });
+
+  it("collapses right panel first when main gets cramped", () => {
+    // 48 + 200*2 = 448 オーバーヘッド。本文確保に MAIN_MIN_READABLE_WIDTH 必要。
+    // 800 - 448 = 352 < 360 → 右を畳む。800 - 48 - 200 = 552 >= 360 → 左は維持。
+    const d = decideResponsivePanels({
+      windowWidth: 800,
+      compactMode: false,
+      rightAlreadyCollapsed: false,
+    });
+    expect(d.collapseRight).toBe(true);
+    expect(d.collapseLeft).toBe(false);
+  });
+
+  it("collapses both panels at the minimum window width", () => {
+    // 640 - 48 - 200 = 392 >= 360 → 左は維持されるが右は畳まれる。
+    const d = decideResponsivePanels({
+      windowWidth: MIN_WINDOW_WIDTH,
+      compactMode: false,
+      rightAlreadyCollapsed: false,
+    });
+    expect(d.collapseRight).toBe(true);
+    expect(d.collapseLeft).toBe(false);
+  });
+
+  it("collapses left panel too when even one panel leaves main too narrow", () => {
+    // 560 - 48 - 200 = 312 < 360 → 左も畳む。
+    const d = decideResponsivePanels({
+      windowWidth: 560,
+      compactMode: false,
+      rightAlreadyCollapsed: false,
+    });
+    expect(d.collapseRight).toBe(true);
+    expect(d.collapseLeft).toBe(true);
+  });
+
+  it("does not auto-collapse the right panel when user already collapsed it", () => {
+    const d = decideResponsivePanels({
+      windowWidth: 800,
+      compactMode: false,
+      rightAlreadyCollapsed: true,
+    });
+    expect(d.collapseRight).toBe(false);
+  });
+
+  it("uses compact panel widths in compact mode", () => {
+    // compact: 40 + 160*2 = 360 オーバーヘッド。760 - 360 = 400 >= 360 → 維持。
+    const d = decideResponsivePanels({
+      windowWidth: 760,
+      compactMode: true,
+      rightAlreadyCollapsed: false,
+    });
+    expect(d.collapseRight).toBe(false);
+    expect(d.collapseLeft).toBe(false);
+  });
+
+  it("exposes sane window-size floors", () => {
+    expect(MIN_WINDOW_WIDTH).toBeGreaterThanOrEqual(MAIN_MIN_READABLE_WIDTH);
+    expect(MIN_WINDOW_HEIGHT).toBeGreaterThan(0);
+  });
+});

--- a/lib/editor-page/responsive-layout.ts
+++ b/lib/editor-page/responsive-layout.ts
@@ -1,0 +1,67 @@
+// 狭いウィンドウでのレイアウト判定（純粋関数）。#1856
+//
+// 狭いウィンドウで本文先頭やツールバーがクリップされるのを防ぐため、
+// ウィンドウ幅に応じてサイドパネルを自動折りたたみするかどうかを決める。
+// ここで決定するのは「表示上の上書き」だけで、ユーザーが保存したパネル状態
+// （isRightPanelCollapsed など）は変更しない（永続レイアウトを壊さない）。
+
+/** Electron BrowserWindow / Web ビューポートの最小幅・高さの床（px）。 */
+export const MIN_WINDOW_WIDTH = 640;
+export const MIN_WINDOW_HEIGHT = 480;
+
+/** ActivityBar の幅（px）。Tailwind `w-12`(=48) / compact `w-10`(=40)。 */
+const ACTIVITY_BAR_WIDTH = 48;
+const ACTIVITY_BAR_WIDTH_COMPACT = 40;
+
+/** サイドパネル（左右）の最小幅（px）。EditorLayout の minWidth と一致させる。 */
+const SIDE_PANEL_MIN_WIDTH = 200;
+const SIDE_PANEL_MIN_WIDTH_COMPACT = 160;
+
+/** 本文（main）が読みやすさを保つために確保したい最小幅（px）。 */
+export const MAIN_MIN_READABLE_WIDTH = 360;
+
+export interface ResponsivePanelDecision {
+  /** 左サイドパネル（ファイルツリー等）を表示上折りたたむか。 */
+  collapseLeft: boolean;
+  /** 右サイドパネル（インスペクタ）を表示上折りたたむか。 */
+  collapseRight: boolean;
+}
+
+interface DecideParams {
+  /** 現在のウィンドウ（ビューポート）幅（px）。 */
+  windowWidth: number;
+  /** コンパクトモードか（ActivityBar / パネル幅が縮む）。 */
+  compactMode: boolean;
+  /** ユーザー設定で右パネルが既に折りたたまれているか。 */
+  rightAlreadyCollapsed: boolean;
+}
+
+/**
+ * ウィンドウ幅から、サイドパネルを表示上自動折りたたみすべきかを決める。
+ *
+ * 優先順位:
+ *   1. まず右パネル（インスペクタ）を畳んで本文幅を確保する。
+ *   2. それでも本文が最小幅に満たなければ左パネルも畳む。
+ *
+ * これにより、狭いウィンドウでも本文（先頭文字を含む）が必ず可視のまま残る。
+ */
+export function decideResponsivePanels({
+  windowWidth,
+  compactMode,
+  rightAlreadyCollapsed,
+}: DecideParams): ResponsivePanelDecision {
+  const activityBar = compactMode ? ACTIVITY_BAR_WIDTH_COMPACT : ACTIVITY_BAR_WIDTH;
+  const panelMin = compactMode ? SIDE_PANEL_MIN_WIDTH_COMPACT : SIDE_PANEL_MIN_WIDTH;
+
+  // 左パネルが開いている前提で、両パネル + ActivityBar を引いた本文幅を試算する。
+  const mainWithBoth = windowWidth - activityBar - panelMin * 2;
+  const mainWithRightCollapsed = windowWidth - activityBar - panelMin;
+
+  // 右が既にユーザー設定で畳まれているなら、右の自動畳みは不要（状態を尊重）。
+  const collapseRight = !rightAlreadyCollapsed && mainWithBoth < MAIN_MIN_READABLE_WIDTH;
+
+  // 右を畳んでもなお本文が狭ければ左も畳む。
+  const collapseLeft = mainWithRightCollapsed < MAIN_MIN_READABLE_WIDTH;
+
+  return { collapseLeft, collapseRight };
+}

--- a/lib/editor-page/use-window-width.ts
+++ b/lib/editor-page/use-window-width.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * 現在のウィンドウ幅（px）を返すフック。#1856
+ *
+ * リサイズに追従して再レンダリングを促す。SSR 安全（初期値は 0、
+ * マウント後に実値へ更新）。狭いウィンドウでのレスポンシブ判定に使う。
+ */
+export function useWindowWidth(): number {
+  const [width, setWidth] = useState<number>(() =>
+    typeof window === "undefined" ? 0 : window.innerWidth,
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleResize = (): void => setWidth(window.innerWidth);
+    // マウント直後に実値へ同期（SSR 初期値 0 のケースを補正）。
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return width;
+}


### PR DESCRIPTION
Closes #1856

## 根本原因
狭いウィンドウ向けの最小幅の床／レスポンシブなフォールバックが無かった。

- `electron/window-manager.js` の BrowserWindow に `minWidth`/`minHeight` が未設定。
- `EditorLayout.tsx` の左右サイドパネルは minWidth 200 を保持し、ActivityBar が中央を圧迫。`main` は `flex-1 overflow-hidden` のため横スクロールなしで本文先頭がクリップされる。
- `EditorToolbar.tsx` は単一 flex 行で wrap/overflow が無く、検索・読み上げボタンが画面外へ押し出される。

## 変更点
1. **electron/window-manager.js**: BrowserWindow に `minWidth: 640` / `minHeight: 480` を追加。ActivityBar(48) + サイドパネル最小(200) + 読みやすい本文幅(>=360) が収まる床。
2. **lib/editor-page/responsive-layout.ts (新規・純粋関数)**: ウィンドウ幅から「右→左」の順でサイドパネルを表示上折りたたむかを決定。本文が最小可読幅(360px)を下回らないよう保証。**ユニットテスト同梱**。
3. **lib/editor-page/use-window-width.ts (新規)**: SSR 安全なウィンドウ幅追従フック。
4. **EditorLayout.tsx**: 上記判定で狭幅時にサイドパネルを表示上だけ自動折りたたみ。**永続化されたパネル状態 (`isRightPanelCollapsed` 等) は変更しない** ためレイアウト破壊なし。ユーザーが既に右を畳んでいる場合は自動畳みをスキップ。
5. **EditorToolbar.tsx**: 設定グループ(フォント/行間/段落)を `min-w-0` + 横スクロール/縮小可能にし、縦書き・読み上げ・検索の主要操作を `shrink-0` で常時可視化。`searchButtonRef` のアンカーは DOM から外れないため維持される。

## テスト
- `npx tsc --noEmit` clean
- `npx vitest run lib/editor-page/__tests__/responsive-layout.test.ts` → 7 passed

## ⚠️ UI 検証が必要 (UI test pending)
本修正は実レンダリングのジオメトリに依存するため、**狭いウィンドウ幅での視覚／UI 検証が必須**です（自動ユニットテストでは純粋関数のみ確証）。実機 Electron + 各幅でのツールバー操作可達性・本文先頭の可視性・パネル自動折りたたみ挙動を手動確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)