### PR TITLE
fix(explorer): make file tree keyboard-accessible (WAI-ARIA tree) (#1854)

### DIFF
--- a/components/explorer/FilesPanel.tsx
+++ b/components/explorer/FilesPanel.tsx
@@ -9,6 +9,15 @@ import ConfirmDialog from "@/shared/ui/ConfirmDialog";
 import { isElectronRenderer, detectOSPlatform } from "@/lib/utils/runtime-env";
 import { isTextDroppable } from "@/lib/utils/file-type-guard";
 import { notificationManager } from "@/lib/services/notification-manager";
+import {
+  flattenVisibleRows,
+  nextRowPath,
+  prevRowPath,
+  firstRowPath,
+  lastRowPath,
+  arrowRight,
+  arrowLeft,
+} from "./tree-navigation";
 import type { FileTreeEntry, EditingEntry } from "./types";
 import type { VirtualFileSystem } from "@/lib/vfs/types";
 
@@ -83,6 +92,26 @@ export function FilesPanel({
   const [dropTargetPath, setDropTargetPath] = useState<string | null>(null);
   const dragExpandTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // ---- Keyboard navigation (WAI-ARIA tree, roving tabindex) ----
+  /** Tree path of the row that currently holds the roving tabIndex={0}. */
+  const [activeRowPath, setActiveRowPath] = useState<string>("/");
+  /** Map of tree path -> row DOM element for programmatic .focus(). */
+  const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  const registerRowRef = useCallback((path: string, el: HTMLDivElement | null) => {
+    if (el) rowRefs.current.set(path, el);
+    else rowRefs.current.delete(path);
+  }, []);
+
+  /** Move the roving focus to a row and physically focus its DOM element. */
+  const focusRow = useCallback((path: string) => {
+    setActiveRowPath(path);
+    // Focus after the current render so the target element exists with tabIndex=0.
+    requestAnimationFrame(() => {
+      rowRefs.current.get(path)?.focus();
+    });
+  }, []);
+
   const refresh = useCallback(() => setRefreshToken((v) => v + 1), []);
 
   const loadDirectory = useCallback(
@@ -147,6 +176,16 @@ export function FilesPanel({
     };
   }, [loadDirectory, refreshToken]);
 
+  // Keep the roving-tabindex target valid: if the active row is no longer
+  // visible (folder collapsed, file deleted/renamed), fall back to the root row.
+  useEffect(() => {
+    const rows = flattenVisibleRows(tree, expandedDirs);
+    if (rows.length === 0) return;
+    if (!rows.some((r) => r.path === activeRowPath)) {
+      setActiveRowPath(rows[0].path);
+    }
+  }, [tree, expandedDirs, activeRowPath]);
+
   // Auto-focus the inline edit input when editing starts
   useEffect(() => {
     if (editing && editInputRef.current) {
@@ -185,6 +224,26 @@ export function FilesPanel({
       } else {
         next.add(path);
       }
+      return next;
+    });
+    setRefreshToken((v) => v + 1);
+  }, []);
+
+  const expandDir = useCallback((path: string) => {
+    setExpandedDirs((prev) => {
+      if (prev.has(path)) return prev;
+      const next = new Set(prev);
+      next.add(path);
+      return next;
+    });
+    setRefreshToken((v) => v + 1);
+  }, []);
+
+  const collapseDir = useCallback((path: string) => {
+    setExpandedDirs((prev) => {
+      if (!prev.has(path)) return prev;
+      const next = new Set(prev);
+      next.delete(path);
       return next;
     });
     setRefreshToken((v) => v + 1);
@@ -824,6 +883,117 @@ export function FilesPanel({
     [showContextMenu, handleContextAction],
   );
 
+  /**
+   * Build a synthetic React.MouseEvent-like object anchored at the focused row,
+   * so existing context-menu handlers (which read clientX/clientY) can be invoked
+   * from the keyboard (ContextMenu key / Shift+F10).
+   */
+  const synthContextMenuEvent = useCallback((path: string): React.MouseEvent => {
+    const el = rowRefs.current.get(path);
+    const rect = el?.getBoundingClientRect();
+    const x = rect ? rect.left + 16 : 0;
+    const y = rect ? rect.bottom : 0;
+    return {
+      clientX: x,
+      clientY: y,
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      target: el,
+      currentTarget: el,
+    } as unknown as React.MouseEvent;
+  }, []);
+
+  /**
+   * Keyboard handler for tree rows (WAI-ARIA Tree View pattern).
+   * Operates on the flattened list of currently visible rows.
+   */
+  const handleRowKeyDown = useCallback(
+    (e: React.KeyboardEvent, path: string, kind: "file" | "directory") => {
+      // Never hijack typing inside the inline rename/new input.
+      if (e.target instanceof HTMLInputElement) return;
+
+      const rows = flattenVisibleRows(tree, expandedDirs);
+
+      switch (e.key) {
+        case "ArrowDown": {
+          e.preventDefault();
+          const target = nextRowPath(rows, path);
+          if (target) focusRow(target);
+          break;
+        }
+        case "ArrowUp": {
+          e.preventDefault();
+          const target = prevRowPath(rows, path);
+          if (target) focusRow(target);
+          break;
+        }
+        case "Home": {
+          e.preventDefault();
+          const target = firstRowPath(rows);
+          if (target) focusRow(target);
+          break;
+        }
+        case "End": {
+          e.preventDefault();
+          const target = lastRowPath(rows);
+          if (target) focusRow(target);
+          break;
+        }
+        case "ArrowRight": {
+          e.preventDefault();
+          const result = arrowRight(rows, path);
+          if (result.expand) expandDir(result.expand);
+          else if (result.focus) focusRow(result.focus);
+          break;
+        }
+        case "ArrowLeft": {
+          e.preventDefault();
+          const result = arrowLeft(rows, path);
+          if (result.collapse) collapseDir(result.collapse);
+          else if (result.focus) focusRow(result.focus);
+          break;
+        }
+        case "Enter":
+        case " ": {
+          e.preventDefault();
+          if (kind === "directory") {
+            toggleDir(path);
+          } else if (onFileClick) {
+            onFileClick(toVFSPath(path));
+          }
+          break;
+        }
+        case "ContextMenu": {
+          e.preventDefault();
+          const ev = synthContextMenuEvent(path);
+          if (kind === "directory") void onFolderContextMenu(ev, path);
+          else void onFileContextMenu(ev, path);
+          break;
+        }
+        case "F10": {
+          if (!e.shiftKey) break;
+          e.preventDefault();
+          const ev = synthContextMenuEvent(path);
+          if (kind === "directory") void onFolderContextMenu(ev, path);
+          else void onFileContextMenu(ev, path);
+          break;
+        }
+      }
+    },
+    [
+      tree,
+      expandedDirs,
+      focusRow,
+      expandDir,
+      collapseDir,
+      toggleDir,
+      onFileClick,
+      synthContextMenuEvent,
+      onFolderContextMenu,
+      onFileContextMenu,
+    ],
+  );
+
   // ---- Render tree entries ----
   const renderEntries = (entries: FileTreeEntry[], parentPath: string, level: number) => {
     const rows: React.ReactNode[] = [];
@@ -842,6 +1012,13 @@ export function FilesPanel({
         rows.push(
           <div
             key={fullPath}
+            ref={(el) => registerRowRef(fullPath, el)}
+            role="treeitem"
+            aria-level={level}
+            aria-selected={activeRowPath === fullPath}
+            tabIndex={activeRowPath === fullPath ? 0 : -1}
+            onKeyDown={(e) => handleRowKeyDown(e, fullPath, "file")}
+            onFocus={() => setActiveRowPath(fullPath)}
             draggable={!isRenaming}
             onDragStart={(e) => handleDragStart(e, fullPath, "file")}
             onDragEnd={handleDragEnd}
@@ -851,7 +1028,7 @@ export function FilesPanel({
               void handleTreeDrop(e, fullPath, "file");
             }}
             className={clsx(
-              "flex items-center gap-1.5 px-2 py-1 text-sm text-foreground-secondary hover:bg-hover rounded cursor-pointer",
+              "flex items-center gap-1.5 px-2 py-1 text-sm text-foreground-secondary hover:bg-hover rounded cursor-pointer outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent -outline-offset-1",
               dragSourcePath === fullPath && "opacity-40",
             )}
             style={{ paddingLeft: `${level * 16 + 8}px` }}
@@ -904,6 +1081,14 @@ export function FilesPanel({
             }}
           >
             <div
+              ref={(el) => registerRowRef(fullPath, el)}
+              role="treeitem"
+              aria-level={level}
+              aria-selected={activeRowPath === fullPath}
+              aria-expanded={isExpanded}
+              tabIndex={activeRowPath === fullPath ? 0 : -1}
+              onKeyDown={(e) => handleRowKeyDown(e, fullPath, "directory")}
+              onFocus={() => setActiveRowPath(fullPath)}
               draggable={!isRenaming}
               onDragStart={(e) => handleDragStart(e, fullPath, "directory")}
               onDragEnd={handleDragEnd}
@@ -912,7 +1097,7 @@ export function FilesPanel({
                 void onFolderContextMenu(e, fullPath);
               }}
               className={clsx(
-                "group flex items-center gap-1.5 px-2 py-1 text-sm text-foreground hover:bg-hover rounded cursor-pointer",
+                "group flex items-center gap-1.5 px-2 py-1 text-sm text-foreground hover:bg-hover rounded cursor-pointer outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent -outline-offset-1",
                 dragSourcePath === fullPath && "opacity-40",
                 isFolderDropTarget &&
                   "bg-accent/15 outline outline-1 outline-accent/50 -outline-offset-1",
@@ -931,12 +1116,15 @@ export function FilesPanel({
               ) : (
                 <span className="truncate font-medium flex-1">{entry.name}</span>
               )}
-              {/* Inline hover buttons (VS Code style) */}
+              {/* Inline hover buttons (VS Code style). Hidden from Tab order while
+                  invisible; revealed (and tabbable) on hover or keyboard focus. */}
               {!isRenaming && (
-                <span className="ml-auto flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                <span className="ml-auto flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
                   <button
-                    className="p-0.5 hover:bg-hover rounded"
+                    className="p-0.5 hover:bg-hover rounded outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
                     title="新規ファイル"
+                    aria-label={`${entry.name} に新規ファイルを作成`}
+                    tabIndex={activeRowPath === fullPath ? 0 : -1}
                     onClick={(e) => {
                       e.stopPropagation();
                       startNewFile(fullPath, ".mdi");
@@ -945,8 +1133,10 @@ export function FilesPanel({
                     <FilePlus className="w-3.5 h-3.5" />
                   </button>
                   <button
-                    className="p-0.5 hover:bg-hover rounded"
+                    className="p-0.5 hover:bg-hover rounded outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
                     title="新規フォルダ"
+                    aria-label={`${entry.name} に新規フォルダを作成`}
+                    tabIndex={activeRowPath === fullPath ? 0 : -1}
                     onClick={(e) => {
                       e.stopPropagation();
                       startNewFolder(fullPath);
@@ -958,7 +1148,7 @@ export function FilesPanel({
               )}
             </div>
             {isExpanded && entry.children && (
-              <div>{renderEntries(entry.children, fullPath, level + 1)}</div>
+              <div role="group">{renderEntries(entry.children, fullPath, level + 1)}</div>
             )}
             {/* New file/folder input row inside this directory */}
             {isExpanded &&
@@ -1005,6 +1195,7 @@ export function FilesPanel({
         <button
           className="p-1 text-foreground-tertiary hover:text-foreground hover:bg-hover rounded transition-colors"
           title="更新"
+          aria-label="ファイル一覧を更新"
           onClick={refresh}
         >
           <RefreshCw className={clsx("w-4 h-4", loading && "animate-spin")} />
@@ -1016,9 +1207,17 @@ export function FilesPanel({
       )}
 
       {tree !== null && (
-        <div>
+        <div role="tree" aria-label="プロジェクトファイル">
           {/* Root directory header */}
           <div
+            ref={(el) => registerRowRef("/", el)}
+            role="treeitem"
+            aria-level={1}
+            aria-selected={activeRowPath === "/"}
+            aria-expanded={expandedDirs.has("/")}
+            tabIndex={activeRowPath === "/" ? 0 : -1}
+            onKeyDown={(e) => handleRowKeyDown(e, "/", "directory")}
+            onFocus={() => setActiveRowPath("/")}
             onClick={() => toggleDir("/")}
             onContextMenu={(e) => {
               void onFolderContextMenu(e, "/");
@@ -1029,7 +1228,7 @@ export function FilesPanel({
               void handleTreeDrop(e, "/", "directory");
             }}
             className={clsx(
-              "group flex items-center gap-1.5 px-2 py-1 text-sm text-foreground hover:bg-hover rounded cursor-pointer",
+              "group flex items-center gap-1.5 px-2 py-1 text-sm text-foreground hover:bg-hover rounded cursor-pointer outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent -outline-offset-1",
               dropTargetPath === "/" &&
                 dragSourcePath !== "/" &&
                 "bg-accent/15 outline outline-1 outline-accent/50 -outline-offset-1",
@@ -1043,11 +1242,14 @@ export function FilesPanel({
             />
             <Folder className="w-4 h-4 shrink-0 text-accent" />
             <span className="truncate font-medium flex-1">{projectName || "プロジェクト"}</span>
-            {/* Root inline buttons */}
-            <span className="ml-auto flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+            {/* Root inline buttons. Hidden from Tab order while invisible;
+                revealed (and tabbable) on hover or keyboard focus. */}
+            <span className="ml-auto flex items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
               <button
-                className="p-0.5 hover:bg-hover rounded"
+                className="p-0.5 hover:bg-hover rounded outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
                 title="新規ファイル"
+                aria-label="プロジェクト直下に新規ファイルを作成"
+                tabIndex={activeRowPath === "/" ? 0 : -1}
                 onClick={(e) => {
                   e.stopPropagation();
                   startNewFile("/", ".mdi");
@@ -1056,8 +1258,10 @@ export function FilesPanel({
                 <FilePlus className="w-3.5 h-3.5" />
               </button>
               <button
-                className="p-0.5 hover:bg-hover rounded"
+                className="p-0.5 hover:bg-hover rounded outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-accent"
                 title="新規フォルダ"
+                aria-label="プロジェクト直下に新規フォルダを作成"
+                tabIndex={activeRowPath === "/" ? 0 : -1}
                 onClick={(e) => {
                   e.stopPropagation();
                   startNewFolder("/");

--- a/components/explorer/__tests__/FilesPanel.keyboard-nav.test.tsx
+++ b/components/explorer/__tests__/FilesPanel.keyboard-nav.test.tsx
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import {
+  flattenVisibleRows,
+  nextRowPath,
+  prevRowPath,
+  firstRowPath,
+  lastRowPath,
+  arrowRight,
+  arrowLeft,
+  parentTreePath,
+  joinTreePath,
+  indexOfRow,
+} from "../tree-navigation";
+import type { FileTreeEntry } from "../types";
+
+/**
+ * Pure-logic tests for FilesPanel keyboard navigation (#1854).
+ * These exercise the flatten + roving-tabindex navigation computation without a
+ * DOM render library, so no new devDependency is required.
+ */
+
+// A small tree:
+//   /                       (root)
+//   ├── docs/               (expanded)
+//   │   ├── deep/           (collapsed) -> children hidden
+//   │   │   └── inner.txt   (hidden)
+//   │   └── a.txt
+//   └── b.txt
+const tree: FileTreeEntry[] = [
+  {
+    name: "docs",
+    kind: "directory",
+    children: [
+      {
+        name: "deep",
+        kind: "directory",
+        children: [{ name: "inner.txt", kind: "file" }],
+      },
+      { name: "a.txt", kind: "file" },
+    ],
+  },
+  { name: "b.txt", kind: "file" },
+];
+
+const expandedAll = new Set<string>(["/", "/docs", "/docs/deep"]);
+const expandedDeepCollapsed = new Set<string>(["/", "/docs"]);
+
+describe("path helpers", () => {
+  it("joinTreePath handles root vs nested", () => {
+    expect(joinTreePath("/", "x.txt")).toBe("/x.txt");
+    expect(joinTreePath("/docs", "x.txt")).toBe("/docs/x.txt");
+  });
+
+  it("parentTreePath ascends and stops at root", () => {
+    expect(parentTreePath("/")).toBeNull();
+    expect(parentTreePath("/b.txt")).toBe("/");
+    expect(parentTreePath("/docs/a.txt")).toBe("/docs");
+    expect(parentTreePath("/docs/deep/inner.txt")).toBe("/docs/deep");
+  });
+});
+
+describe("flattenVisibleRows", () => {
+  it("returns empty list for null tree", () => {
+    expect(flattenVisibleRows(null, new Set(["/"]))).toEqual([]);
+  });
+
+  it("collapsed root shows only the root row", () => {
+    const rows = flattenVisibleRows(tree, new Set());
+    expect(rows.map((r) => r.path)).toEqual(["/"]);
+    expect(rows[0].expanded).toBe(false);
+  });
+
+  it("hides descendants of collapsed folders", () => {
+    const rows = flattenVisibleRows(tree, expandedDeepCollapsed);
+    expect(rows.map((r) => r.path)).toEqual(["/", "/docs", "/docs/deep", "/docs/a.txt", "/b.txt"]);
+    // inner.txt is hidden because /docs/deep is collapsed
+    expect(rows.find((r) => r.path === "/docs/deep")?.expanded).toBe(false);
+  });
+
+  it("shows full depth when everything is expanded with correct aria levels", () => {
+    const rows = flattenVisibleRows(tree, expandedAll);
+    expect(rows.map((r) => r.path)).toEqual([
+      "/",
+      "/docs",
+      "/docs/deep",
+      "/docs/deep/inner.txt",
+      "/docs/a.txt",
+      "/b.txt",
+    ]);
+    expect(rows.find((r) => r.path === "/")?.level).toBe(1);
+    expect(rows.find((r) => r.path === "/docs")?.level).toBe(2);
+    expect(rows.find((r) => r.path === "/docs/deep")?.level).toBe(3);
+    expect(rows.find((r) => r.path === "/docs/deep/inner.txt")?.level).toBe(4);
+  });
+
+  it("empty project (empty tree array) yields just the root row", () => {
+    const rows = flattenVisibleRows([], new Set(["/"]));
+    expect(rows.map((r) => r.path)).toEqual(["/"]);
+  });
+});
+
+describe("ArrowDown / ArrowUp (stop at ends, no wrap)", () => {
+  const rows = flattenVisibleRows(tree, expandedAll);
+
+  it("ArrowDown moves to the next visible row", () => {
+    expect(nextRowPath(rows, "/")).toBe("/docs");
+    expect(nextRowPath(rows, "/docs")).toBe("/docs/deep");
+    expect(nextRowPath(rows, "/docs/deep")).toBe("/docs/deep/inner.txt");
+  });
+
+  it("ArrowDown stops at the last row (returns null)", () => {
+    expect(nextRowPath(rows, "/b.txt")).toBeNull();
+  });
+
+  it("ArrowUp moves to the previous visible row", () => {
+    expect(prevRowPath(rows, "/b.txt")).toBe("/docs/a.txt");
+    expect(prevRowPath(rows, "/docs")).toBe("/");
+  });
+
+  it("ArrowUp stops at the first row (returns null)", () => {
+    expect(prevRowPath(rows, "/")).toBeNull();
+  });
+
+  it("defaults to first row when current path is unknown/null", () => {
+    expect(nextRowPath(rows, null)).toBe("/");
+    expect(prevRowPath(rows, "/nonexistent")).toBe("/");
+  });
+
+  it("single-row tree: ArrowDown/Up have no movement", () => {
+    const single = flattenVisibleRows(tree, new Set()); // only "/"
+    expect(single).toHaveLength(1);
+    expect(nextRowPath(single, "/")).toBeNull();
+    expect(prevRowPath(single, "/")).toBeNull();
+  });
+
+  it("empty tree: navigation returns null", () => {
+    expect(nextRowPath([], "/")).toBeNull();
+    expect(prevRowPath([], null)).toBeNull();
+  });
+});
+
+describe("Home / End", () => {
+  const rows = flattenVisibleRows(tree, expandedAll);
+
+  it("Home -> first, End -> last", () => {
+    expect(firstRowPath(rows)).toBe("/");
+    expect(lastRowPath(rows)).toBe("/b.txt");
+  });
+
+  it("empty tree -> null", () => {
+    expect(firstRowPath([])).toBeNull();
+    expect(lastRowPath([])).toBeNull();
+  });
+});
+
+describe("ArrowRight (expand / descend)", () => {
+  it("collapsed folder expands", () => {
+    const rows = flattenVisibleRows(tree, new Set(["/"]));
+    // root is expanded; /docs is collapsed in this set
+    expect(arrowRight(rows, "/docs")).toEqual({ expand: "/docs" });
+  });
+
+  it("expanded folder focuses first child", () => {
+    const rows = flattenVisibleRows(tree, expandedAll);
+    expect(arrowRight(rows, "/docs")).toEqual({ focus: "/docs/deep" });
+    expect(arrowRight(rows, "/")).toEqual({ focus: "/docs" });
+  });
+
+  it("expanded but empty folder is a no-op", () => {
+    const emptyDir: FileTreeEntry[] = [{ name: "empty", kind: "directory", children: [] }];
+    const rows = flattenVisibleRows(emptyDir, new Set(["/", "/empty"]));
+    expect(arrowRight(rows, "/empty")).toEqual({});
+  });
+
+  it("file is a no-op", () => {
+    const rows = flattenVisibleRows(tree, expandedAll);
+    expect(arrowRight(rows, "/b.txt")).toEqual({});
+  });
+
+  it("unknown path is a no-op", () => {
+    const rows = flattenVisibleRows(tree, expandedAll);
+    expect(arrowRight(rows, "/nope")).toEqual({});
+  });
+});
+
+describe("ArrowLeft (collapse / ascend to parent)", () => {
+  it("expanded folder collapses", () => {
+    const rows = flattenVisibleRows(tree, expandedAll);
+    expect(arrowLeft(rows, "/docs")).toEqual({ collapse: "/docs" });
+    expect(arrowLeft(rows, "/")).toEqual({ collapse: "/" });
+  });
+
+  it("collapsed folder ascends to parent", () => {
+    const rows = flattenVisibleRows(tree, expandedDeepCollapsed);
+    expect(arrowLeft(rows, "/docs/deep")).toEqual({ focus: "/docs" });
+  });
+
+  it("file ascends to parent", () => {
+    const rows = flattenVisibleRows(tree, expandedAll);
+    expect(arrowLeft(rows, "/docs/a.txt")).toEqual({ focus: "/docs" });
+    expect(arrowLeft(rows, "/b.txt")).toEqual({ focus: "/" });
+  });
+
+  it("top-level item with no visible parent (root collapsed scenario) is bounded", () => {
+    // When focused on root itself and collapsed, no parent exists -> no-op.
+    const rows = flattenVisibleRows(tree, new Set());
+    expect(arrowLeft(rows, "/")).toEqual({});
+  });
+
+  it("unknown path is a no-op", () => {
+    const rows = flattenVisibleRows(tree, expandedAll);
+    expect(arrowLeft(rows, "/nope")).toEqual({});
+  });
+});
+
+describe("roving tabindex selection (indexOfRow)", () => {
+  const rows = flattenVisibleRows(tree, expandedAll);
+
+  it("locates the active row for tabIndex=0 assignment", () => {
+    expect(indexOfRow(rows, "/docs/a.txt")).toBe(4);
+  });
+
+  it("returns -1 for paths not currently visible", () => {
+    expect(indexOfRow(rows, "/docs/deep/inner.txt")).toBe(3);
+    expect(
+      indexOfRow(flattenVisibleRows(tree, expandedDeepCollapsed), "/docs/deep/inner.txt"),
+    ).toBe(-1);
+  });
+
+  it("returns -1 for null", () => {
+    expect(indexOfRow(rows, null)).toBe(-1);
+  });
+});

--- a/components/explorer/tree-navigation.ts
+++ b/components/explorer/tree-navigation.ts
@@ -1,0 +1,151 @@
+import type { FileTreeEntry } from "./types";
+
+/**
+ * A single keyboard-navigable row in the flattened file tree.
+ * Pure data structure — no DOM, no React — so navigation logic is unit-testable.
+ */
+export interface VisibleRow {
+  /** Full tree path, e.g. "/" (root) or "/sub/file.txt" */
+  path: string;
+  kind: "file" | "directory";
+  /** Nesting depth: root = 1, its children = 2, ... (matches aria-level) */
+  level: number;
+  /** For directories only: whether the folder is currently expanded */
+  expanded?: boolean;
+}
+
+/** Build the full tree path for a child entry under the given parent path. */
+export function joinTreePath(parentPath: string, name: string): string {
+  return parentPath === "/" ? `/${name}` : `${parentPath}/${name}`;
+}
+
+/** Return the parent path of a tree path. Root ("/") has no parent (returns null). */
+export function parentTreePath(path: string): string | null {
+  if (path === "/") return null;
+  const lastSlash = path.lastIndexOf("/");
+  if (lastSlash <= 0) return "/";
+  return path.substring(0, lastSlash);
+}
+
+/**
+ * Flatten the visible portion of the tree into an ordered list of rows,
+ * mirroring the DOM rendering order (root header first, then expanded children
+ * depth-first). Collapsed folders contribute their own row but not descendants.
+ *
+ * @param tree         Root-level entries (null when no project is open)
+ * @param expandedDirs Set of expanded directory tree paths (includes "/")
+ * @param projectName  Used only for the conceptual root; path is always "/"
+ */
+export function flattenVisibleRows(
+  tree: FileTreeEntry[] | null,
+  expandedDirs: Set<string>,
+): VisibleRow[] {
+  if (tree === null) return [];
+
+  const rows: VisibleRow[] = [];
+  const rootExpanded = expandedDirs.has("/");
+  rows.push({ path: "/", kind: "directory", level: 1, expanded: rootExpanded });
+
+  if (!rootExpanded) return rows;
+
+  const walk = (entries: FileTreeEntry[], parentPath: string, level: number): void => {
+    for (const entry of entries) {
+      const fullPath = joinTreePath(parentPath, entry.name);
+      if (entry.kind === "directory") {
+        const expanded = expandedDirs.has(fullPath);
+        rows.push({ path: fullPath, kind: "directory", level, expanded });
+        if (expanded && entry.children) {
+          walk(entry.children, fullPath, level + 1);
+        }
+      } else {
+        rows.push({ path: fullPath, kind: "file", level });
+      }
+    }
+  };
+
+  walk(tree, "/", 2);
+  return rows;
+}
+
+/** Index of the row matching the given path, or -1 if not present/visible. */
+export function indexOfRow(rows: VisibleRow[], path: string | null): number {
+  if (path === null) return -1;
+  return rows.findIndex((r) => r.path === path);
+}
+
+/**
+ * Compute the path to move focus to for ArrowDown.
+ * Stops (does not wrap) at the last row. Returns null when no movement is possible.
+ */
+export function nextRowPath(rows: VisibleRow[], currentPath: string | null): string | null {
+  if (rows.length === 0) return null;
+  const idx = indexOfRow(rows, currentPath);
+  if (idx === -1) return rows[0].path;
+  if (idx >= rows.length - 1) return null;
+  return rows[idx + 1].path;
+}
+
+/**
+ * Compute the path to move focus to for ArrowUp.
+ * Stops (does not wrap) at the first row. Returns null when no movement is possible.
+ */
+export function prevRowPath(rows: VisibleRow[], currentPath: string | null): string | null {
+  if (rows.length === 0) return null;
+  const idx = indexOfRow(rows, currentPath);
+  if (idx === -1) return rows[0].path;
+  if (idx <= 0) return null;
+  return rows[idx - 1].path;
+}
+
+/** First visible row path (Home), or null when the tree is empty. */
+export function firstRowPath(rows: VisibleRow[]): string | null {
+  return rows.length > 0 ? rows[0].path : null;
+}
+
+/** Last visible row path (End), or null when the tree is empty. */
+export function lastRowPath(rows: VisibleRow[]): string | null {
+  return rows.length > 0 ? rows[rows.length - 1].path : null;
+}
+
+/** Result of an ArrowRight/ArrowLeft navigation computation. */
+export interface HorizontalNavResult {
+  /** A directory path that should be expanded, if any. */
+  expand?: string;
+  /** A directory path that should be collapsed, if any. */
+  collapse?: string;
+  /** A path that focus should move to, if any. */
+  focus?: string;
+}
+
+/**
+ * ArrowRight behavior (WAI-ARIA tree):
+ *  - On a collapsed folder: expand it.
+ *  - On an expanded folder: move focus to its first child (if any).
+ *  - On a file: no-op.
+ */
+export function arrowRight(rows: VisibleRow[], currentPath: string | null): HorizontalNavResult {
+  const idx = indexOfRow(rows, currentPath);
+  if (idx === -1) return {};
+  const row = rows[idx];
+  if (row.kind !== "directory") return {};
+  if (!row.expanded) return { expand: row.path };
+  // Expanded: focus first child if the next row is deeper.
+  const child = rows[idx + 1];
+  if (child && child.level > row.level) return { focus: child.path };
+  return {};
+}
+
+/**
+ * ArrowLeft behavior (WAI-ARIA tree):
+ *  - On an expanded folder: collapse it.
+ *  - On a collapsed folder or file: move focus to its parent row (if visible).
+ */
+export function arrowLeft(rows: VisibleRow[], currentPath: string | null): HorizontalNavResult {
+  const idx = indexOfRow(rows, currentPath);
+  if (idx === -1) return {};
+  const row = rows[idx];
+  if (row.kind === "directory" && row.expanded) return { collapse: row.path };
+  const parent = parentTreePath(row.path);
+  if (parent !== null && indexOfRow(rows, parent) !== -1) return { focus: parent };
+  return {};
+}


### PR DESCRIPTION
Closes #1854

## 背景 / Root cause
`components/explorer/FilesPanel.tsx` のファイルツリーには WAI-ARIA tree のセマンティクスも roving tabindex もキーボードハンドラも無く、行へキーボードで到達・操作できなかった。hover でしか出ないアクションボタンもキーボードから到達不能だった (P1 アクセシビリティ)。

## 修正 / Fix
WAI-ARIA Tree View パターンを実装:

- `role="tree"` + `aria-label`、サブツリーに `role="group"`、各行に `role="treeitem"`（`aria-level` / `aria-selected` / `aria-expanded`）
- roving tabindex: アクティブ行のみ `tabIndex={0}`、他は `-1`（`activeRowPath` state で管理）。可視でなくなった場合はルートへフォールバック
- `onKeyDown`:
  - Enter / Space: ファイルを開く or フォルダ開閉（`onFileClick` 連携）
  - ArrowDown / ArrowUp: 可視行を上下移動（端で停止・ラップしない）
  - ArrowRight: 折り畳みフォルダを展開 / 展開済みなら最初の子へ
  - ArrowLeft: 展開フォルダを折り畳み / それ以外は親へ上昇
  - Home / End: 先頭 / 末尾
  - ContextMenu / Shift+F10: フォーカス行を基点にした合成 anchor で既存 `onFile/onFolderContextMenu` を呼び出し
- hover アクションボタン: `group-focus-within:opacity-100` を追加し、不可視時は `tabIndex={-1}` で Tab 順から除外。アイコンのみボタンに `aria-label` を付与
- ナビゲーション計算を純粋関数モジュール `components/explorer/tree-navigation.ts` に抽出してユニットテスト化（新規 devDependency なし）

既存のマウス / ドラッグ&ドロップ / ダブルクリック / ミドルクリック / IME 対応インラインリネームは全て維持。

## テスト / Test plan
- `npx tsc --noEmit` clean
- `npx vitest run components/explorer/__tests__/` → 41 passed（新規 29 件 + 既存 collision-guard）
- 新規テスト: ArrowDown/Up の端停止・無ラップ、ArrowRight/Left の展開/折り畳み/親辿り、Home/End、roving tabindex の選択（indexOfRow）、エッジ: 空ツリー / 単一行 / 深いネスト
- eslint clean

## UI 検証 / Note
実際のキーボード操作（フォーカス移動・コンテキストメニュー起動・スクリーンリーダー読み上げ）は実機 UI 検証が必要。本 PR ではナビゲーション計算ロジックをユニットで確証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)