### PR TITLE
fix(tab-manager): プロジェクト切替の保存で未保存タブ/キャンセルを尊重 (#1859)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -350,6 +350,7 @@ export default function EditorPage() {
     lastSaveWasAuto,
     openFile: tabOpenFile,
     saveFile,
+    saveAllDirtyTabs,
     saveAsFile,
     newFile: tabNewFile,
     updateFileName,
@@ -646,8 +647,11 @@ export default function EditorPage() {
   } = projectLifecycle;
 
   // Unsaved warning hook (project mode transitions only; tabs handle per-tab dirty checks)
+  // #1859: save ALL dirty tabs (not just the active one) and block the pending
+  // action when any save is cancelled/failed, so background dirty tabs and
+  // cancelled saves no longer lose unsaved content.
   const anyDirty = tabs.some((t) => isEditorTab(t) && t.isDirty);
-  const unsavedWarning = useUnsavedWarning(anyDirty, saveFile, currentFile?.name || null);
+  const unsavedWarning = useUnsavedWarning(anyDirty, saveAllDirtyTabs, currentFile?.name || null);
 
   // Auto-recovered editor remount
   useEffect(() => {

--- a/lib/hooks/__tests__/use-unsaved-warning.test.tsx
+++ b/lib/hooks/__tests__/use-unsaved-warning.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for the unsaved-warning save gate (#1859).
+ *
+ * Root cause: handleSave ran the pending action (project switch) after the
+ * save resolved, regardless of whether the save actually succeeded — so a
+ * cancelled/failed save still proceeded and lost unsaved content.
+ *
+ * The fix: the save callback now returns an aggregate { allSaved } and
+ * handleSave only runs the pending action (and closes the dialog) when
+ * allSaved !== false.
+ *
+ * Drives the REAL hook (createRoot + act, repo pattern).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { useUnsavedWarning } from "../use-unsaved-warning";
+import type { UseUnsavedWarningReturn, UnsavedSaveResult } from "../use-unsaved-warning";
+
+let api: UseUnsavedWarningReturn | null = null;
+
+function HookHost({
+  isDirty,
+  saveFile,
+}: {
+  isDirty: boolean;
+  saveFile: () => Promise<UnsavedSaveResult | void>;
+}): null {
+  const value = useUnsavedWarning(isDirty, saveFile, "test.mdi");
+  useEffect(() => {
+    api = value;
+  });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  api = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+async function mount(
+  isDirty: boolean,
+  saveFile: () => Promise<UnsavedSaveResult | void>,
+): Promise<void> {
+  await act(async () => {
+    root.render(<HookHost isDirty={isDirty} saveFile={saveFile} />);
+  });
+}
+
+describe("#1859 useUnsavedWarning save gate", () => {
+  it("runs the pending action and closes the dialog when allSaved=true", async () => {
+    const saveFile = vi.fn(async () => ({ allSaved: true }));
+    const pending = vi.fn();
+    await mount(true, saveFile);
+
+    await act(async () => {
+      await api!.confirmBeforeAction(pending);
+    });
+    expect(api!.showWarning).toBe(true);
+
+    await act(async () => {
+      await api!.handleSave();
+    });
+
+    expect(saveFile).toHaveBeenCalledTimes(1);
+    expect(pending).toHaveBeenCalledTimes(1);
+    expect(api!.showWarning).toBe(false);
+  });
+
+  it("BLOCKS the pending action and keeps the dialog open when allSaved=false", async () => {
+    const saveFile = vi.fn(async () => ({ allSaved: false }));
+    const pending = vi.fn();
+    await mount(true, saveFile);
+
+    await act(async () => {
+      await api!.confirmBeforeAction(pending);
+    });
+
+    await act(async () => {
+      await api!.handleSave();
+    });
+
+    expect(saveFile).toHaveBeenCalledTimes(1);
+    // Data-loss guard: project switch must NOT run on a cancelled/failed save.
+    expect(pending).not.toHaveBeenCalled();
+    // Dialog stays open so the user can retry or cancel.
+    expect(api!.showWarning).toBe(true);
+  });
+
+  it("treats a void result as success (backward compatibility)", async () => {
+    const saveFile = vi.fn(async () => undefined);
+    const pending = vi.fn();
+    await mount(true, saveFile);
+
+    await act(async () => {
+      await api!.confirmBeforeAction(pending);
+    });
+    await act(async () => {
+      await api!.handleSave();
+    });
+
+    expect(pending).toHaveBeenCalledTimes(1);
+    expect(api!.showWarning).toBe(false);
+  });
+});

--- a/lib/hooks/use-unsaved-warning.ts
+++ b/lib/hooks/use-unsaved-warning.ts
@@ -2,6 +2,18 @@
 
 import { useState, useCallback, useRef } from "react";
 
+/**
+ * Result of the save callback passed to useUnsavedWarning (#1859).
+ *
+ * `allSaved` must be true only when every dirty buffer was actually written.
+ * When false (a save was cancelled / failed / conflicted), the pending action
+ * is NOT executed and the warning stays open — preventing silent data loss on
+ * project switch.
+ */
+export interface UnsavedSaveResult {
+  allSaved: boolean;
+}
+
 export interface UseUnsavedWarningReturn {
   showWarning: boolean;
   confirmBeforeAction: (action: () => void | Promise<void>) => Promise<void>;
@@ -20,7 +32,13 @@ export interface UseUnsavedWarningReturn {
  */
 export function useUnsavedWarning(
   isDirty: boolean,
-  saveFile: () => Promise<void>,
+  /**
+   * Save callback. Must save ALL dirty buffers (not just the active tab) and
+   * report whether every one succeeded (#1859). A `void`-returning callback is
+   * still accepted for backward compatibility; the absence of a result is
+   * treated as success.
+   */
+  saveFile: () => Promise<UnsavedSaveResult | void>,
   _currentFileName: string | null,
 ): UseUnsavedWarningReturn {
   const [showWarning, setShowWarning] = useState(false);
@@ -51,10 +69,16 @@ export function useUnsavedWarning(
    */
   const handleSave = useCallback(async () => {
     try {
-      // まずファイルを保存
-      await saveFile();
+      // まず全ての未保存バッファを保存 (#1859)
+      const result = await saveFile();
 
-      // 保存成功後、待機中の操作を実行
+      // 保存がキャンセル/失敗した場合は操作を実行せず、ダイアログも閉じない。
+      // (result が void の場合は後方互換のため成功扱い)
+      if (result && result.allSaved === false) {
+        return;
+      }
+
+      // 全保存成功後、待機中の操作を実行
       if (pendingActionRef.current) {
         await pendingActionRef.current();
         pendingActionRef.current = null;

--- a/lib/tab-manager/__tests__/save-all-dirty-tabs.test.tsx
+++ b/lib/tab-manager/__tests__/save-all-dirty-tabs.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Regression tests for the project-switch data-loss fix (#1859).
+ *
+ * Root cause: the unsaved-warning flow saved only the ACTIVE tab and ran the
+ * pending action (project switch) even when a save was cancelled/failed,
+ * silently dropping unsaved content in background tabs.
+ *
+ * The fix adds useFileIO.saveAllDirtyTabs(): it loops EVERY dirty editor tab
+ * through the shared executor and reports an aggregate result.
+ *
+ * These tests drive the REAL useFileIO hook (createRoot + act, repo pattern)
+ * with the executor's VFS dependencies mocked, and verify:
+ *   (a) a background dirty tab is actually written, and
+ *   (b) when one tab's save is cancelled, the aggregate reports allSaved=false
+ *       (so the caller blocks the project switch) and a later tab is NOT saved.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Mocks (must precede importing the modules under test)
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: {
+    warning: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    showMessage: vi.fn(),
+  },
+}));
+
+vi.mock("../../project/mdi-file", () => ({
+  saveMdiFile: vi.fn(),
+  openMdiFile: vi.fn(),
+}));
+vi.mock("../../services/project-file-service", () => ({
+  getProjectFileService: vi.fn(),
+}));
+vi.mock("../../services/file-watcher", () => ({
+  suppressFileWatch: vi.fn(),
+}));
+vi.mock("../../storage/storage-service", () => ({
+  getStorageService: vi.fn(),
+}));
+vi.mock("../../storage/app-state-manager", () => ({
+  persistAppState: vi.fn(async () => undefined),
+}));
+vi.mock("../../services/history-service", () => ({
+  getHistoryService: vi.fn(() => ({
+    shouldCreateSnapshot: vi.fn(async () => false),
+    createSnapshot: vi.fn(async () => undefined),
+  })),
+}));
+
+import { getProjectFileService } from "../../services/project-file-service";
+import { useFileIO } from "../use-file-io";
+import { clearSaveLocks } from "../save-lock";
+import { isEditorTab } from "../tab-types";
+import type { UseFileIOParams, UseFileIOReturn } from "../use-file-io";
+import type { Dispatch, SetStateAction } from "react";
+import type { EditorTabState, TabId, TabState } from "../tab-types";
+
+const getProjectFileServiceMock = vi.mocked(getProjectFileService);
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+function makeTab(overrides: Partial<EditorTabState> = {}): EditorTabState {
+  return {
+    tabKind: "editor",
+    id: "tab-1",
+    file: { path: "/p/a.mdi", handle: null, name: "a.mdi" },
+    content: "edited",
+    lastSavedContent: "old",
+    isDirty: true,
+    lastSavedTime: null,
+    lastSaveWasAuto: false,
+    isSaving: false,
+    isPreview: false,
+    fileType: ".mdi",
+    fileSyncStatus: "dirty",
+    conflictDiskContent: null,
+    ...overrides,
+  };
+}
+
+interface Harness {
+  params: UseFileIOParams;
+  tabsRef: { current: TabState[] };
+  getTab: (id: TabId) => EditorTabState;
+}
+
+function makeHarness(initialTabs: TabState[], activeTabId: TabId): Harness {
+  const tabsRef = { current: initialTabs };
+  const setTabs: Dispatch<SetStateAction<TabState[]>> = (updater) => {
+    tabsRef.current =
+      typeof updater === "function"
+        ? (updater as (prev: TabState[]) => TabState[])(tabsRef.current)
+        : updater;
+  };
+  return {
+    tabsRef,
+    getTab: (id: TabId): EditorTabState => {
+      const found = tabsRef.current.find((t) => t.id === id);
+      if (!found || !isEditorTab(found)) throw new Error(`editor tab not found: ${id}`);
+      return found;
+    },
+    params: {
+      tabs: tabsRef.current,
+      setTabs,
+      activeTabId,
+      setActiveTabId: vi.fn(),
+      tabsRef,
+      activeTabIdRef: { current: activeTabId },
+      isProjectRef: { current: true },
+      isElectron: true,
+      updateTab: vi.fn(),
+      findTabByPath: vi.fn(),
+    },
+  };
+}
+
+let api: UseFileIOReturn | null = null;
+
+function HookHost({ params }: { params: UseFileIOParams }): null {
+  const value = useFileIO(params);
+  useEffect(() => {
+    api = value;
+  });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+let vfsWriteFile: ReturnType<typeof vi.fn>;
+let vfsReadFile: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearSaveLocks();
+  api = null;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  vfsWriteFile = vi.fn().mockResolvedValue(undefined);
+  vfsReadFile = vi.fn().mockResolvedValue("{}");
+  getProjectFileServiceMock.mockReturnValue({
+    writeFile: vfsWriteFile,
+    readFile: vfsReadFile,
+    isRootOpen: () => false,
+    getRootPath: () => "/p",
+  } as unknown as ReturnType<typeof getProjectFileService>);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+async function mountHook(params: UseFileIOParams): Promise<void> {
+  await act(async () => {
+    root.render(<HookHost params={params} />);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("#1859 saveAllDirtyTabs", () => {
+  it("saves a BACKGROUND dirty tab (not just the active tab)", async () => {
+    const active = makeTab({
+      id: "active",
+      file: { path: "/p/active.mdi", handle: null, name: "active.mdi" },
+    });
+    const background = makeTab({
+      id: "bg",
+      file: { path: "/p/bg.mdi", handle: null, name: "bg.mdi" },
+      content: "bg edited",
+    });
+    const h = makeHarness([active, background], "active");
+    await mountHook(h.params);
+
+    let result: { allSaved: boolean } | undefined;
+    await act(async () => {
+      result = await api!.saveAllDirtyTabs();
+    });
+
+    expect(result?.allSaved).toBe(true);
+    // Both project-mode VFS writes happened — background tab is NOT dropped.
+    const writtenPaths = vfsWriteFile.mock.calls.map((c) => c[0] as string);
+    expect(writtenPaths).toContain("/p/active.mdi");
+    expect(writtenPaths).toContain("/p/bg.mdi");
+    expect(h.getTab("active").isDirty).toBe(false);
+    expect(h.getTab("bg").isDirty).toBe(false);
+  });
+
+  it("returns allSaved=false and stops when a tab's save is cancelled", async () => {
+    // Untitled tab (no path) → standalone branch → saveMdiFile dialog → cancel.
+    const { saveMdiFile } = await import("../../project/mdi-file");
+    const saveMdiFileMock = vi.mocked(saveMdiFile);
+    saveMdiFileMock.mockResolvedValue(null); // user cancels dialog
+
+    const untitled = makeTab({
+      id: "untitled",
+      file: null,
+      content: "never saved",
+    });
+    const second = makeTab({
+      id: "second",
+      file: { path: "/p/second.mdi", handle: null, name: "second.mdi" },
+      content: "second edited",
+    });
+    // Untitled is first in the dirty list → its cancel must block the rest.
+    const h = makeHarness([untitled, second], "untitled");
+    // active is untitled so flush is irrelevant; force standalone (not project)
+    h.params.isProjectRef.current = false;
+    await mountHook(h.params);
+
+    let result: { allSaved: boolean } | undefined;
+    await act(async () => {
+      result = await api!.saveAllDirtyTabs();
+    });
+
+    // Cancelled save → caller must block the project switch.
+    expect(result?.allSaved).toBe(false);
+    // Short-circuit: the second tab was never written to disk.
+    expect(vfsWriteFile).not.toHaveBeenCalled();
+    expect(saveMdiFileMock).toHaveBeenCalledTimes(1);
+    // The second tab remains dirty (its content is preserved, not lost).
+    expect(h.getTab("second").isDirty).toBe(true);
+  });
+
+  it("returns allSaved=true with no dirty tabs", async () => {
+    const clean = makeTab({ id: "clean", isDirty: false, fileSyncStatus: "clean" });
+    const h = makeHarness([clean], "clean");
+    await mountHook(h.params);
+
+    let result: { allSaved: boolean } | undefined;
+    await act(async () => {
+      result = await api!.saveAllDirtyTabs();
+    });
+
+    expect(result?.allSaved).toBe(true);
+    expect(vfsWriteFile).not.toHaveBeenCalled();
+  });
+});

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -196,6 +196,7 @@ export function useTabManager(options?: {
     lastSaveWasAuto: tabState.lastSaveWasAuto,
     openFile: fileIO.openFile,
     saveFile: fileIO.saveFile,
+    saveAllDirtyTabs: fileIO.saveAllDirtyTabs,
     saveAsFile: fileIO.saveAsFile,
     newFile,
     updateFileName: tabState.updateFileName,

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -5,6 +5,24 @@ import { MdiDocument } from "@/packages/milkdown-plugin-japanese-novel/mdi-docum
 import type { MdiFileDescriptor } from "../project/mdi-file";
 import type { SupportedFileExtension, WorkspaceTab } from "../project/project-types";
 import type { TabId, TabState, EditorTabState, TerminalTabState } from "./tab-types";
+import type { SaveOutcome } from "./save-executor";
+
+// ---------------------------------------------------------------------------
+// Save-all aggregate result (#1859)
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate result of saving every dirty editor tab (#1859).
+ *
+ * `allSaved` is true only when EVERY dirty tab returned status "saved". Any
+ * non-saved outcome (cancelled / failed / conflicted / locked / skipped) makes
+ * it false so the project-switch unsaved warning can block the pending action
+ * and keep the dialog open — preventing silent data loss.
+ */
+export interface SaveAllDirtyResult {
+  allSaved: boolean;
+  outcomes: SaveOutcome[];
+}
 
 // ---------------------------------------------------------------------------
 // Public return type (must stay identical to the original useTabManager)
@@ -21,6 +39,12 @@ export interface UseTabManagerReturn {
   lastSaveWasAuto: boolean;
   openFile: () => Promise<void>;
   saveFile: (isAutoSave?: boolean) => Promise<void>;
+  /**
+   * Save every dirty editor tab and report an aggregate result (#1859).
+   * `allSaved` is false unless every dirty tab was written, so callers (the
+   * project-switch unsaved warning) can block the pending action on cancel/fail.
+   */
+  saveAllDirtyTabs: () => Promise<SaveAllDirtyResult>;
   saveAsFile: () => Promise<void>;
   newFile: (fileType?: SupportedFileExtension) => void;
   updateFileName: (newName: string) => void;

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -13,11 +13,12 @@ import { getHistoryService } from "../services/history-service";
 import type { SnapshotType } from "../services/history-policy";
 import { getProjectFileService } from "../services/project-file-service";
 import { executeTabSave } from "./save-executor";
+import type { SaveOutcome } from "./save-executor";
 import type { TabId, EditorTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
 import { generateTabId, inferFileType, getErrorMessage } from "./types";
 import { isEditableExtension, resolveNativePath } from "./open-with-default-app";
-import type { TabManagerCore } from "./types";
+import type { TabManagerCore, SaveAllDirtyResult } from "./types";
 
 // ---------------------------------------------------------------------------
 // Params
@@ -43,6 +44,13 @@ export interface UseFileIOReturn {
   openFile: () => Promise<void>;
   /** Save the active tab. */
   saveFile: (isAutoSave?: boolean) => Promise<void>;
+  /**
+   * Save every dirty editor tab (#1859). Used by the unsaved-warning flow
+   * (project switch) so that background dirty tabs are not silently dropped.
+   * Returns an aggregate result; the pending action must only proceed when
+   * `allSaved` is true.
+   */
+  saveAllDirtyTabs: () => Promise<SaveAllDirtyResult>;
   /** Save As (always shows dialog). */
   saveAsFile: () => Promise<void>;
   /** Load a system file by path + content into a tab. */
@@ -343,6 +351,96 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
     ],
   );
 
+  /**
+   * Save every dirty editor tab (#1859).
+   *
+   * Root cause this fixes: the project-switch unsaved warning raised for ALL
+   * dirty editor tabs but only ever saved the active tab, and because the
+   * single-tab saveFile swallows non-saved SaveOutcome statuses, the pending
+   * action ran even when a save was cancelled/failed — losing unsaved content.
+   *
+   * This loops every dirty editor tab through executeTabSave (reusing the
+   * shared per-path save lock for serialization), flushing the active tab's
+   * live content first. Save As / untitled tabs may pop a native dialog; if
+   * the user cancels one, we short-circuit the remaining saves cleanly.
+   * Notifications are surfaced here so the caller only needs the aggregate.
+   */
+  const saveAllDirtyTabs = useCallback(async (): Promise<SaveAllDirtyResult> => {
+    if (isSavingRef.current) {
+      // A save is already in flight; report locked so the caller blocks.
+      return { allSaved: false, outcomes: [{ status: "locked" }] };
+    }
+
+    const dirtyTabs = tabsRef.current.filter(
+      (t): t is EditorTabState => isEditorTab(t) && t.isDirty,
+    );
+    if (dirtyTabs.length === 0) {
+      return { allSaved: true, outcomes: [] };
+    }
+
+    isSavingRef.current = true;
+    const outcomes: SaveOutcome[] = [];
+    try {
+      for (const tab of dirtyTabs) {
+        // Block conflicted tabs up front (mirrors saveFile's guard).
+        if (tab.fileSyncStatus === "conflicted") {
+          notificationManager.warning(
+            "ファイルが外部で変更されています。保存する前にコンフリクトを解決してください。",
+          );
+          outcomes.push({ status: "conflicted" });
+          break;
+        }
+
+        // #1840: flush live editor content for the active tab before saving.
+        const tabToSave = flushActiveTabContent(tab);
+        const outcome = await executeTabSave({
+          tab: tabToSave,
+          isProject: isProjectRef.current,
+          tabsRef,
+          setTabs,
+          tryCreateSnapshot,
+          snapshotType: "manual",
+          updateProjectMetadata: true,
+          persistFileReference,
+        });
+        outcomes.push(outcome);
+
+        if (outcome.status === "saved") {
+          if (outcome.persistFailed) {
+            notificationManager.warning(PERSIST_FAILURE_WARNING);
+          }
+          continue;
+        }
+
+        // Non-saved: surface the right notification and stop saving the rest.
+        if (outcome.status === "conflicted") {
+          notificationManager.warning(
+            "ファイルが外部で変更されています。保存する前にコンフリクトを解決してください。",
+          );
+        } else if (outcome.status === "failed") {
+          console.error("保存に失敗しました:", outcome.error);
+          notificationManager.error(`保存に失敗しました: ${getErrorMessage(outcome.error)}`);
+        }
+        // "cancelled" (user dismissed Save As) / "locked" / "skipped":
+        // no notification, but still blocks the pending action.
+        break;
+      }
+    } finally {
+      isSavingRef.current = false;
+    }
+
+    const allSaved =
+      outcomes.length === dirtyTabs.length && outcomes.every((o) => o.status === "saved");
+    return { allSaved, outcomes };
+  }, [
+    persistFileReference,
+    tryCreateSnapshot,
+    setTabs,
+    tabsRef,
+    isProjectRef,
+    flushActiveTabContent,
+  ]);
+
   /** Save As (always shows dialog) */
   const saveAsFile = useCallback(async () => {
     if (isSavingRef.current) return;
@@ -603,6 +701,7 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
   return {
     openFile,
     saveFile,
+    saveAllDirtyTabs,
     saveAsFile,
     loadSystemFile,
     openProjectFile,


### PR DESCRIPTION
Closes #1859

## 問題 (P0 データ損失)

プロジェクト切替の「保存」が、アクティブタブ以外の未保存タブや保存キャンセルを無視して、未保存データを失っていた。

## Root cause（2つの結合した欠陥）

1. `app/page.tsx` は **全ての** dirty なエディタタブに対して未保存警告を出していたが、`useUnsavedWarning` には**アクティブタブ専用の** `saveFile` を渡していた。そのためバックグラウンドの dirty タブは一度も書き込まれなかった。
2. `saveFile` は `executeTabSave` の `SaveOutcome` を握り潰し、cancelled/failed でも reject しなかった（`save-executor` は "Never throws"）。そのため `useUnsavedWarning.handleSave` は保存がキャンセル/失敗しても常に pending action（プロジェクト切替）を実行してしまい、未保存内容を失っていた。

## 修正

- `useFileIO.saveAllDirtyTabs()` を追加。全 dirty タブを共有 executor でループ保存（アクティブタブはライブ内容を flush）、共有 per-path save lock で直列化、キャンセル時は残りを short-circuit、通知を表示し、集約結果 `{ allSaved, outcomes }` を返す。
- `useUnsavedWarning` の保存コールバックは `{ allSaved }` を返すようになり、`handleSave` は `allSaved !== false` の時のみ pending action を実行。それ以外はダイアログを開いたまま保持。`void` 戻り値は後方互換で成功扱い。
- `app/page.tsx` を `saveAllDirtyTabs` に配線。Cmd+S / メニュー / 自動保存用の単一タブ `saveFile` は変更なし。

## テスト

修正なしで FAIL・修正ありで PASS する回帰テストを追加:

- `lib/tab-manager/__tests__/save-all-dirty-tabs.test.tsx`
  - (a) バックグラウンド dirty タブがプロジェクト切替で保存される
  - (b) あるタブの保存がキャンセルされると `allSaved=false` を返し、後続タブは保存されず dirty のまま残る
  - (c) dirty タブなし → `allSaved=true`
- `lib/hooks/__tests__/use-unsaved-warning.test.tsx`
  - `allSaved=true` → pending action 実行・ダイアログ閉じる
  - `allSaved=false` → pending action **ブロック**・ダイアログ維持
  - `void` 戻り値 → 後方互換で成功扱い

検証:
- `npx tsc --noEmit` clean
- `npx vitest run`（新規 + 関連既存）47 tests green

UI 検証不要（ユニットテストで確証可能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)