### PR TITLE
fix(text-codec): 非UTF-8原稿を読込時に拒否し原本破壊を防ぐ (#1888)

### DIFF
--- a/electron/ipc/__tests__/file-ipc-size-validation.test.ts
+++ b/electron/ipc/__tests__/file-ipc-size-validation.test.ts
@@ -103,7 +103,8 @@ describe("content size validation — Buffer.byteLength vs .length", () => {
 //
 // fs.readFile(path, "utf-8") does NOT strip a leading UTF-8 BOM (U+FEFF).
 // The .txt read path (readTextWithEncoding in text-codec.ts) strips it.
-// file-ipc.js must do the same for .mdi reads via its local stripBom() helper.
+// file-ipc.js gets the same behaviour via readFileStrictUtf8() (#1888), which
+// BOM-strips after a strict decode. The pure unit below pins the BOM semantics.
 //
 // file-ipc.js is a CommonJS Electron main-process module and cannot be
 // imported directly in vitest, so:
@@ -168,20 +169,23 @@ describe("file-ipc.js source regression guard", () => {
     expect(source).not.toMatch(/\.length\s*>\s*MAX_CONTENT_BYTES/);
   });
 
-  // BOM stripping regression guard (#1842)
-  it("defines a stripBom helper", () => {
-    expect(source).toContain("function stripBom(");
+  // Strict UTF-8 read regression guard (#1888, supersedes the #1842 stripBom guard)
+  //
+  // Content reads now go through readFileStrictUtf8() (electron/lib/text-decode.js),
+  // which BOM-strips AND rejects non-UTF-8 bytes instead of decoding them lossily
+  // into U+FFFD that a later save would write back over the original file.
+  it("imports the strict UTF-8 read helper", () => {
+    expect(source).toContain('require("../lib/text-decode")');
+    expect(source).toContain("readFileStrictUtf8");
   });
 
-  it("applies stripBom at every fs.readFile call site that returns content", () => {
-    // Each fs.readFile in the file is wrapped in stripBom(...)
-    const readFileCalls = source.match(/fs\.readFile\([^)]+\)/g) ?? [];
-    expect(readFileCalls.length).toBeGreaterThanOrEqual(3);
-    for (const call of readFileCalls) {
-      // The call itself appears inside stripBom(...) — check surrounding context
-      const idx = source.indexOf(call);
-      const before = source.slice(Math.max(0, idx - 20), idx);
-      expect(before).toContain("stripBom(");
-    }
+  it("reads document content via readFileStrictUtf8, never lossy fs.readFile(..., utf-8)", () => {
+    // The lossy string read is the bug (#1888): it must not return content.
+    expect(source).not.toMatch(/fs\.readFile\([^)]*["']utf-8["']\)/);
+
+    // Every manuscript-open site uses the strict helper. There are three:
+    // system open, dialog open, and pending-file drain.
+    const strictReads = source.match(/readFileStrictUtf8\(/g) ?? [];
+    expect(strictReads.length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -8,6 +8,7 @@ const { createApprovedPathRegistry } = require("../lib/approved-paths");
 const { normalizeSeparators } = require("../lib/path-utils");
 const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
 const { FILE_CHANNELS, EXPORT_CHANNELS } = require("../lib/ipc-channels");
+const { readFileStrictUtf8 } = require("../lib/text-decode");
 
 // --- save-file path security validation ---
 // Tracks file paths that have been approved via native dialog or system file association,
@@ -51,21 +52,6 @@ function isSavePathDenied(normalizedPath) {
 }
 
 const VALID_SAVE_FILE_TYPES = [".mdi", ".md", ".txt"];
-
-/**
- * Strip a leading UTF-8 BOM (U+FEFF) from a string if present.
- *
- * A utf-8 file read does not strip the BOM, so a .mdi file saved by
- * an editor that writes a BOM would have U+FEFF at position 0.  The .txt read
- * path (readTextWithEncoding in shared/lib/text-codec.ts) already strips it;
- * this helper gives .mdi reads the same behaviour (fix for issue #1842).
- *
- * @param {string} s - String that may have a leading BOM
- * @returns {string} String with leading BOM removed
- */
-function stripBom(s) {
-  return s.charCodeAt(0) === 0xfeff ? s.slice(1) : s;
-}
 
 /**
  * Validate a file path provided by the renderer for the save-file IPC handler.
@@ -195,8 +181,10 @@ async function handleMdiFileOpen(filePath) {
       log.info("Opening as standalone file:", filePath);
       // Approve system-opened file path for future saves, scoped to the target window
       approveDialogPath(targetWindow.webContents.id, path.resolve(filePath));
-      // Strip UTF-8 BOM if present — fs.readFile does not strip it (#1842)
-      const content = stripBom(await fs.readFile(filePath, "utf-8"));
+      // Read as strict UTF-8: non-UTF-8 manuscripts throw instead of opening
+      // with lossy U+FFFD that would later be saved back over the original (#1888).
+      // BOM is stripped inside readFileStrictUtf8 (#1842).
+      const content = await readFileStrictUtf8(filePath);
       targetWindow.webContents.send(FILE_CHANNELS.event.openFileFromSystem, {
         path: filePath,
         content,
@@ -238,8 +226,11 @@ function registerFileHandlers() {
     // Approve opened file path so it can be saved back without a new dialog.
     // Scoped to the requesting window to prevent cross-window reuse.
     approveDialogPath(event.sender.id, path.resolve(filePath));
-    // Strip UTF-8 BOM if present — fs.readFile does not strip it (#1842)
-    const content = stripBom(await fs.readFile(filePath, "utf-8"));
+    // Read as strict UTF-8: non-UTF-8 files throw (surfaced to the renderer as
+    // a "UTF-8 へ変換してから開いてください" notice) instead of opening with
+    // lossy U+FFFD that a later save would write back over the original (#1888).
+    // BOM is stripped inside readFileStrictUtf8 (#1842).
+    const content = await readFileStrictUtf8(filePath);
     return { path: filePath, content };
   });
 
@@ -361,8 +352,11 @@ function registerFileHandlers() {
         } else {
           // Standalone file: approve path for future saves, scoped to the requesting window
           approveDialogPath(event.sender.id, path.resolve(filePath));
-          // Strip UTF-8 BOM if present — fs.readFile does not strip it (#1842)
-          const content = stripBom(await fs.readFile(filePath, "utf-8"));
+          // Read as strict UTF-8: non-UTF-8 files throw (caught per-file below,
+          // so no lossy tab is created) instead of opening with U+FFFD that a
+          // later save would write back over the original (#1888).
+          // BOM is stripped inside readFileStrictUtf8 (#1842).
+          const content = await readFileStrictUtf8(filePath);
           results.push({
             type: "standalone",
             path: filePath,

--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -16,23 +16,11 @@ const {
 } = require("../lib/path-utils");
 const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
 const { VFS_CHANNELS } = require("../lib/ipc-channels");
+const { readFileStrictUtf8 } = require("../lib/text-decode");
 // #1476: rehydration — begin
 const { loadApprovals, saveApprovals } = require("../lib/vfs-approvals");
 const { createIndexLockManager } = require("../lib/index-lock");
 // #1476: rehydration — end
-
-/**
- * Strip a leading UTF-8 BOM (U+FEFF) from a decoded string.
- * Node's `fs.readFile(path, "utf-8")` preserves the BOM as the first character
- * when present in the raw bytes (EF BB BF). Stripping it here ensures
- * the VFS .mdi read path is symmetric with the .txt path (text-codec.ts).
- *
- * @param {string} content - String decoded from a UTF-8 file
- * @returns {string} Content with the leading BOM removed if present
- */
-function stripBom(content) {
-  return content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
-}
 
 function registerVFSHandlers() {
   // Track the opened root directory per window for path validation.
@@ -192,7 +180,15 @@ function registerVFSHandlers() {
       if (stats.size > MAX_READ_BYTES) {
         throw new Error("ファイルサイズが上限を超えています");
       }
-      return stripBom(await fs.readFile(resolved, "utf-8"));
+      // Read as strict UTF-8 and BOM-strip. Non-UTF-8 byte sequences throw
+      // (code "NON_UTF8") instead of being silently replaced with U+FFFD, which
+      // previously let a non-UTF-8 manuscript open lossy and be saved back over
+      // the original (#1888). App-written metadata/JSON (project.json,
+      // workspace.json, etc.) is always valid UTF-8 and decodes unchanged;
+      // genuinely non-UTF-8 files are refused. Callers that read arbitrary
+      // project files (e.g. search indexing) already handle read errors
+      // per-file and simply skip the offending file.
+      return await readFileStrictUtf8(resolved);
     } catch (error) {
       // ENOENT is expected for optional config files — skip noisy logging
       if (error.code !== "ENOENT") {

--- a/electron/lib/__tests__/text-decode.test.ts
+++ b/electron/lib/__tests__/text-decode.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the main-process strict UTF-8 decode helper (#1888).
+ *
+ * `decodeUtf8Strict` / `readFileStrictUtf8` replace the lossy
+ * `fs.readFile(path, "utf-8")` reads in file-ipc.js and vfs-ipc.js so that a
+ * non-UTF-8 manuscript is REFUSED on open instead of being silently decoded
+ * into U+FFFD and later saved back over the original (data loss).
+ *
+ * The byte-level test below asserts the source file on disk is byte-for-byte
+ * unchanged after a failed open — i.e. nothing is ever written back.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import os from "os";
+import path from "path";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const fs = require("fs") as typeof import("fs");
+
+const { decodeUtf8Strict, readFileStrictUtf8, stripBom } =
+  require("../../../electron/lib/text-decode") as {
+    decodeUtf8Strict: (buf: Uint8Array | Buffer) => string;
+    readFileStrictUtf8: (filePath: string) => Promise<string>;
+    stripBom: (s: string) => string;
+  };
+
+// ---------------------------------------------------------------------------
+// decodeUtf8Strict — TABLE: rejected encodings vs accepted UTF-8
+// ---------------------------------------------------------------------------
+
+describe("decodeUtf8Strict (#1888)", () => {
+  const REJECTED: Array<{ name: string; bytes: number[] }> = [
+    { name: "Shift_JIS bytes", bytes: [0x93, 0xfa, 0x96, 0x7b, 0x8c, 0xea] },
+    { name: "EUC-JP bytes", bytes: [0xc6, 0xfc, 0xcb, 0xdc] },
+    { name: "UTF-16 LE (lone low bytes)", bytes: [0x48, 0x00, 0x69, 0x00, 0x80] },
+    { name: "lone continuation byte", bytes: [0x41, 0x80, 0x42] },
+    { name: "truncated multi-byte", bytes: [0xe3, 0x81] },
+    { name: "random invalid bytes", bytes: [0xff, 0xfe, 0xfd, 0xc0, 0x80] },
+  ];
+
+  it.each(REJECTED)("throws NON_UTF8 on $name", ({ bytes }) => {
+    const buf = Buffer.from(bytes);
+    let thrown: unknown;
+    try {
+      decodeUtf8Strict(buf);
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as { code?: string }).code).toBe("NON_UTF8");
+    expect((thrown as Error).message).toBe("UTF-8 以外のファイルは現在サポートされていません");
+  });
+
+  it("decodes valid UTF-8 and strips a leading BOM", () => {
+    const bom = Buffer.from([0xef, 0xbb, 0xbf]);
+    const buf = Buffer.concat([bom, Buffer.from("本文テキスト", "utf-8")]);
+    expect(decodeUtf8Strict(buf)).toBe("本文テキスト");
+  });
+
+  it("accepts valid UTF-8 containing a legitimate U+FFFD (not a naive check)", () => {
+    const buf = Buffer.from("a�b", "utf-8");
+    expect(decodeUtf8Strict(buf)).toBe("a�b");
+  });
+
+  it("stripBom only removes a leading U+FEFF", () => {
+    expect(stripBom("﻿hi")).toBe("hi");
+    expect(stripBom("hi")).toBe("hi");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readFileStrictUtf8 — byte-level: original file unchanged after failed open
+// ---------------------------------------------------------------------------
+
+describe("readFileStrictUtf8 — original bytes preserved on failure (#1888)", () => {
+  const tmpFiles: string[] = [];
+
+  afterEach(() => {
+    for (const f of tmpFiles.splice(0)) {
+      try {
+        fs.unlinkSync(f);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  function writeTmp(name: string, bytes: Buffer): string {
+    const p = path.join(os.tmpdir(), `illusions-1888-${Date.now()}-${name}`);
+    fs.writeFileSync(p, bytes);
+    tmpFiles.push(p);
+    return p;
+  }
+
+  it("throws on a non-UTF-8 file and leaves the file bytes byte-for-byte identical", async () => {
+    // Shift_JIS-encoded manuscript bytes.
+    const original = Buffer.from([0x93, 0xfa, 0x96, 0x7b, 0x8c, 0xea, 0x0a]);
+    const filePath = writeTmp("sjis.txt", original);
+
+    await expect(readFileStrictUtf8(filePath)).rejects.toThrow(
+      "UTF-8 以外のファイルは現在サポートされていません",
+    );
+
+    // The failed open performed no write-back: disk content is unchanged.
+    const after = fs.readFileSync(filePath);
+    expect(Array.from(after)).toEqual(Array.from(original));
+  });
+
+  it("reads a valid UTF-8 file successfully", async () => {
+    const original = Buffer.from("有効なUTF-8\n", "utf-8");
+    const filePath = writeTmp("utf8.txt", original);
+    await expect(readFileStrictUtf8(filePath)).resolves.toBe("有効なUTF-8\n");
+  });
+});

--- a/electron/lib/text-decode.js
+++ b/electron/lib/text-decode.js
@@ -1,0 +1,66 @@
+// Shared fatal UTF-8 decode for main-process user-document reads (#1888).
+//
+// Node's `fs.readFile(path, "utf-8")` decodes with a *non-fatal* TextDecoder:
+// invalid byte sequences (Shift_JIS, EUC-JP, BOM-less UTF-16, arbitrary binary)
+// are silently replaced with U+FFFD. Opening such a manuscript and saving then
+// writes the lossy U+FFFD content back over the original file, destroying it.
+//
+// This helper decodes the same bytes with a *fatal* TextDecoder so genuinely
+// non-UTF-8 input throws instead of being silently corrupted. The thrown error
+// carries `code: "NON_UTF8"` and a Japanese message so the renderer can refuse
+// to open the file (no editable tab) instead of round-tripping garbage.
+//
+// Mirrors the discriminator in shared/lib/text-codec.ts: it is NOT a naive
+// "contains U+FFFD" check — valid UTF-8 documents may legitimately contain
+// U+FFFD and must still open and save. Only invalid byte sequences throw.
+
+const fsPromises = require("fs/promises");
+
+/**
+ * Strip a leading UTF-8 BOM (U+FEFF) from a decoded string.
+ * @param {string} content - String decoded from a UTF-8 file
+ * @returns {string} Content with the leading BOM removed if present
+ */
+function stripBom(content) {
+  return content.charCodeAt(0) === 0xfeff ? content.slice(1) : content;
+}
+
+/**
+ * Decode a raw byte buffer as strict UTF-8, throwing on invalid sequences.
+ *
+ * @param {Buffer | Uint8Array} buf - Raw file bytes
+ * @returns {string} The decoded, BOM-stripped UTF-8 text
+ * @throws {Error} with `code: "NON_UTF8"` when the bytes are not valid UTF-8
+ */
+function decodeUtf8Strict(buf) {
+  let text;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(buf);
+  } catch (error) {
+    if (error instanceof TypeError) {
+      const err = new Error("UTF-8 以外のファイルは現在サポートされていません");
+      err.code = "NON_UTF8";
+      throw err;
+    }
+    throw error;
+  }
+  return stripBom(text);
+}
+
+/**
+ * Read a user-document file as strict UTF-8 text.
+ *
+ * Replaces lossy `fs.readFile(path, "utf-8")` for manuscript reads: reads raw
+ * bytes and validates them through {@link decodeUtf8Strict}, throwing on any
+ * non-UTF-8 input so the caller never writes corrupted content back (#1888).
+ *
+ * @param {string} filePath - Absolute path to the file
+ * @returns {Promise<string>} The decoded, BOM-stripped UTF-8 text
+ * @throws {Error} with `code: "NON_UTF8"` when the file is not valid UTF-8
+ */
+async function readFileStrictUtf8(filePath) {
+  const buf = await fsPromises.readFile(filePath);
+  return decodeUtf8Strict(buf);
+}
+
+module.exports = { stripBom, decodeUtf8Strict, readFileStrictUtf8 };

--- a/lib/editor-page/project-file-utils.ts
+++ b/lib/editor-page/project-file-utils.ts
@@ -11,7 +11,16 @@ export type AnyDirectoryHandle = VFSDirectoryHandle | FileSystemDirectoryHandle;
 /** Supported main-file extensions, in detection-priority order. */
 const SUPPORTED_MAIN_EXTENSIONS: readonly SupportedFileExtension[] = [".mdi", ".md", ".txt"];
 
-/** Read text from a file handle (VFS or Web) */
+/**
+ * Read text from a file handle (VFS or Web).
+ *
+ * #1888 scoping: this reads `.illusions` JSON metadata (project.json /
+ * workspace.json / index.json), which is always app-written valid UTF-8. The
+ * `getFile().text()` fallback is intentionally kept tolerant so a metadata read
+ * never hard-fails on a stray byte. The strict/fatal UTF-8 decode that refuses
+ * non-UTF-8 manuscripts is applied to the document content path instead — the
+ * Web `WebVFSFileHandle.read()` used by ProjectService.readProjectContent.
+ */
 export async function readFileHandle(handle: {
   read?: () => Promise<string>;
   getFile?: () => Promise<File>;

--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -112,6 +112,15 @@ export function useFileOpening({
       if (error instanceof DOMException && error.name === "AbortError") return;
       if (error instanceof Error && error.message.includes("キャンセル")) return;
       console.error("Failed to open file:", error);
+      // #1888: non-UTF-8 manuscript — refuse to open (no editable tab) and tell
+      // the user to convert it first, instead of silently loading lossy U+FFFD
+      // content that a later save would write back over the original file.
+      if (error instanceof Error && error.message.includes("UTF-8 以外")) {
+        notificationManager.error(
+          "UTF-8 以外の文字コードのため開けませんでした。UTF-8 へ変換してから開いてください。",
+        );
+        return;
+      }
       notificationManager.error("ファイルを開けませんでした。");
     }
   }, [setStandaloneMode, tabLoadSystemFile, incrementEditorKey]);

--- a/platform/browser/vfs.ts
+++ b/platform/browser/vfs.ts
@@ -343,8 +343,16 @@ export class WebVFS implements VirtualFileSystem {
     try {
       const fileHandle = await resolveFileHandle(root, path);
       const file = await fileHandle.getFile();
-      return file.text();
+      // #1888: decode with a fatal TextDecoder instead of File.text(), which
+      // silently replaces invalid bytes with U+FFFD. A non-UTF-8 manuscript
+      // would otherwise open lossy and be saved back over the original.
+      const buf = await file.arrayBuffer();
+      return new TextDecoder("utf-8", { fatal: true }).decode(buf);
     } catch (error) {
+      if (error instanceof TypeError) {
+        // Invalid UTF-8 byte sequence — refuse rather than corrupt on save.
+        throw new Error("UTF-8 以外のファイルは現在サポートされていません");
+      }
       throw new Error(
         `Failed to read file "${path}": ${error instanceof Error ? error.message : String(error)}`,
       );

--- a/platform/browser/vfs.ts
+++ b/platform/browser/vfs.ts
@@ -14,6 +14,7 @@ import type {
   VirtualFileSystem,
 } from "@/lib/vfs/types";
 import { joinPath } from "@/lib/vfs/path-utils";
+import { readTextWithEncoding } from "@/shared/lib/text-codec";
 
 // -----------------------------------------------------------------------
 // Helpers
@@ -123,7 +124,14 @@ export class WebVFSFileHandle implements VFSFileHandle {
 
   async read(): Promise<string> {
     const file = await this.handle.getFile();
-    return file.text();
+    // #1888: decode through the shared strict codec (BOM strip + fatal UTF-8)
+    // instead of File.text(), which silently replaces invalid bytes with
+    // U+FFFD. This handle's read() backs ProjectService.readProjectContent —
+    // the project main-file content path — so a non-UTF-8 (Shift_JIS/EUC-JP/
+    // UTF-16) manuscript must be refused here rather than opened lossy and then
+    // saved back over the original file.
+    const buf = await file.arrayBuffer();
+    return readTextWithEncoding(new Uint8Array(buf)).text;
   }
 
   async write(content: string): Promise<void> {
@@ -343,15 +351,21 @@ export class WebVFS implements VirtualFileSystem {
     try {
       const fileHandle = await resolveFileHandle(root, path);
       const file = await fileHandle.getFile();
-      // #1888: decode with a fatal TextDecoder instead of File.text(), which
-      // silently replaces invalid bytes with U+FFFD. A non-UTF-8 manuscript
-      // would otherwise open lossy and be saved back over the original.
+      // #1888: decode through the shared strict codec instead of File.text(),
+      // which silently replaces invalid bytes with U+FFFD. The shared codec
+      // strips a UTF-8 BOM, normalizes EOL, rejects non-UTF-8 BOMs, and
+      // fatally rejects invalid byte sequences — so a non-UTF-8 manuscript is
+      // refused here rather than opened lossy and saved back over the original.
       const buf = await file.arrayBuffer();
-      return new TextDecoder("utf-8", { fatal: true }).decode(buf);
+      return readTextWithEncoding(new Uint8Array(buf)).text;
     } catch (error) {
-      if (error instanceof TypeError) {
-        // Invalid UTF-8 byte sequence — refuse rather than corrupt on save.
-        throw new Error("UTF-8 以外のファイルは現在サポートされていません");
+      // readTextWithEncoding throws the Japanese non-UTF-8 message directly for
+      // both non-UTF-8 BOMs and invalid byte sequences; re-throw it unchanged.
+      if (
+        error instanceof Error &&
+        error.message === "UTF-8 以外のファイルは現在サポートされていません"
+      ) {
+        throw error;
       }
       throw new Error(
         `Failed to read file "${path}": ${error instanceof Error ? error.message : String(error)}`,

--- a/shared/lib/__tests__/text-codec.test.ts
+++ b/shared/lib/__tests__/text-codec.test.ts
@@ -78,6 +78,121 @@ describe("readTextWithEncoding", () => {
 });
 
 // ---------------------------------------------------------------------------
+// #1888: fatal (strict) UTF-8 decoding
+//
+// Non-UTF-8 manuscripts (Shift_JIS, EUC-JP, BOM-less UTF-16, arbitrary binary)
+// must be REJECTED on read instead of silently decoded into U+FFFD, which would
+// be saved back over the original file. The discriminator is fatal decoding —
+// NOT a naive "contains U+FFFD" check — so valid UTF-8 that legitimately
+// contains U+FFFD still decodes successfully.
+// ---------------------------------------------------------------------------
+
+describe("readTextWithEncoding — strict UTF-8 (#1888)", () => {
+  // 「こんにちは」in various encodings + other non-UTF-8 byte patterns.
+  const REJECTED: Array<{ name: string; bytes: number[] }> = [
+    {
+      // Shift_JIS for "日本語" (82 in lead-byte range, invalid as UTF-8)
+      name: "Shift_JIS bytes",
+      bytes: [0x93, 0xfa, 0x96, 0x7b, 0x8c, 0xea],
+    },
+    {
+      // EUC-JP for "日本" (high bytes form an invalid UTF-8 sequence)
+      name: "EUC-JP bytes",
+      bytes: [0xc6, 0xfc, 0xcb, 0xdc],
+    },
+    {
+      // UTF-16 LE BOM + content (rejected by BOM check before decode)
+      name: "UTF-16 LE with BOM",
+      bytes: [0xff, 0xfe, 0x48, 0x00, 0x69, 0x00],
+    },
+    {
+      // UTF-16 BE BOM + content
+      name: "UTF-16 BE with BOM",
+      bytes: [0xfe, 0xff, 0x00, 0x48, 0x00, 0x69],
+    },
+    {
+      // Lone continuation byte — never valid UTF-8
+      name: "lone continuation byte 0x80",
+      bytes: [0x41, 0x80, 0x42],
+    },
+    {
+      // Truncated multi-byte sequence (lead byte without continuation)
+      name: "truncated multi-byte sequence",
+      bytes: [0xe3, 0x81],
+    },
+    {
+      // Random invalid bytes
+      name: "random invalid bytes",
+      bytes: [0xff, 0xfe, 0xfd, 0xfc, 0x00, 0x80, 0xc0],
+    },
+  ];
+
+  it.each(REJECTED)("rejects $name", ({ bytes }) => {
+    const buf = new Uint8Array(bytes);
+    expect(() => readTextWithEncoding(buf)).toThrow(
+      "UTF-8 以外のファイルは現在サポートされていません",
+    );
+  });
+
+  const ACCEPTED: Array<{ name: string; build: () => Uint8Array; expected: string }> = [
+    {
+      name: "valid UTF-8 (no BOM)",
+      build: () => new TextEncoder().encode("こんにちは、世界\n"),
+      expected: "こんにちは、世界\n",
+    },
+    {
+      name: "valid UTF-8 with BOM",
+      build: () => {
+        const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+        const content = new TextEncoder().encode("先頭BOM");
+        return new Uint8Array([...bom, ...content]);
+      },
+      expected: "先頭BOM",
+    },
+    {
+      name: "valid UTF-8 containing a legitimate U+FFFD",
+      // U+FFFD is itself a valid Unicode scalar; its UTF-8 encoding (EF BF BD)
+      // is valid UTF-8 and MUST NOT be rejected.
+      build: () => new TextEncoder().encode("text�more"),
+      expected: "text�more",
+    },
+    {
+      name: "ASCII only",
+      build: () => new TextEncoder().encode("plain ascii"),
+      expected: "plain ascii",
+    },
+  ];
+
+  it.each(ACCEPTED)("accepts $name", ({ build, expected }) => {
+    const result = readTextWithEncoding(build());
+    expect(result.text).toBe(expected);
+  });
+
+  it("does NOT use a naive U+FFFD string check: a document made only of U+FFFD decodes", () => {
+    // Three legitimately-encoded U+FFFD characters (valid UTF-8).
+    const buf = new TextEncoder().encode("���");
+    const result = readTextWithEncoding(buf);
+    expect(result.text).toBe("���");
+  });
+
+  it("leaves the original file bytes UNCHANGED after a failed (rejected) open", () => {
+    // Simulate the open→(no write) flow: when decode throws, nothing is written
+    // back, so the source bytes are byte-for-byte identical to disk.
+    const originalBytes = new Uint8Array([0x93, 0xfa, 0x96, 0x7b, 0x8c, 0xea]); // Shift_JIS
+    const snapshot = Uint8Array.from(originalBytes);
+
+    expect(() => readTextWithEncoding(originalBytes)).toThrow(
+      "UTF-8 以外のファイルは現在サポートされていません",
+    );
+
+    // The buffer the caller would write back is untouched; no lossy round-trip.
+    expect(Array.from(originalBytes)).toEqual(Array.from(snapshot));
+    // And re-encoding the (never produced) decode output cannot have replaced
+    // any byte, because no decode output exists to write.
+  });
+});
+
+// ---------------------------------------------------------------------------
 // writeTextPreservingEol
 // ---------------------------------------------------------------------------
 

--- a/shared/lib/text-codec.ts
+++ b/shared/lib/text-codec.ts
@@ -55,7 +55,26 @@ export function readTextWithEncoding(buf: Uint8Array): DecodedText {
     start = 3;
   }
 
-  const text = new TextDecoder("utf-8", { fatal: false }).decode(buf.slice(start));
+  // Fatal decode: invalid byte sequences (Shift_JIS, EUC-JP, BOM-less UTF-16,
+  // arbitrary binary, etc.) throw a TypeError instead of being silently
+  // replaced with U+FFFD. Silent replacement previously corrupted non-UTF-8
+  // manuscripts on save (#1888). We map the TypeError to the same Japanese
+  // error used for non-UTF-8 BOM rejection so callers can refuse to open the
+  // file rather than create an editable tab full of replacement characters.
+  //
+  // NOTE: this is intentionally NOT a "contains U+FFFD" string check — valid
+  // UTF-8 content may legitimately include U+FFFD, and such documents must
+  // still open and save. Fatal decoding only throws on genuinely invalid byte
+  // sequences, which is the correct discriminator.
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(buf.slice(start));
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error("UTF-8 以外のファイルは現在サポートされていません");
+    }
+    throw error;
+  }
 
   // Detect EOL style before normalization
   const eol: "lf" | "crlf" = /\r\n/.test(text) ? "crlf" : "lf";


### PR DESCRIPTION
Closes #1888

## 根本原因 (Root cause)

メインプロセスのテキスト読み込みは Node の非 fatal な UTF-8 デコードを使っており、不正バイトを silently に U+FFFD へ置換していた。

- `shared/lib/text-codec.ts` の `TextDecoder` が `{ fatal: false }`
- `electron/ipc/vfs-ipc.js` と `electron/ipc/file-ipc.js` が `fs.readFile(..., "utf-8")` で読み込み

その結果、Shift_JIS / EUC-JP / UTF-16 等の非 UTF-8 原稿は U+FFFD だらけで開き、保存するとその欠損内容を**原本へ上書き**してしまう (S1 データ損失)。

## 修正 (Fix)

- **shared/lib/text-codec.ts**: fatal な `TextDecoder` に切り替え、`TypeError` を既存の日本語エラー (`UTF-8 以外のファイルは現在サポートされていません`) にマップ。判別は fatal デコードの throw で行い、**「U+FFFD を含むか」の素朴な文字列チェックは使わない**ため、正当な UTF-8 が U+FFFD を含む場合は従来どおり開いて保存できる。
- **electron/lib/text-decode.js (新規)**: メインプロセスのユーザー文書読み込み用の strict UTF-8 読み込み (BOM ストリップ + fatal デコード, `code: "NON_UTF8"`)。
- **electron/ipc/file-ipc.js**: システムオープン / ダイアログオープン / pending-file の各読み込みを `readFileStrictUtf8` に変更。
- **electron/ipc/vfs-ipc.js**: `readFile` を strict デコードに変更。アプリが書き出す JSON/メタデータ (project.json, workspace.json 等) は常に正当な UTF-8 なので影響なし。検索インデックスは元々ファイル単位の読み込みエラーを握って skip する。
- **lib/editor-page/use-file-opening.ts**: 失敗時に日本語通知 (`UTF-8 へ変換してから開いてください`) を表示し、編集タブを作らない。
- **platform/browser/vfs.ts**: Web の `readFile` も `File.text()` ではなく fatal デコードに変更 (Electron が本 issue の優先対象だが Web も同根のため対応)。

## テスト (Test plan)

- `shared/lib/__tests__/text-codec.test.ts` / `electron/lib/__tests__/text-decode.test.ts` に TABLE テストを追加:
  - 拒否: Shift_JIS / EUC-JP / UTF-16 BOM / ランダム不正バイト → throw
  - 受理: 正当な UTF-8 / UTF-8 BOM / **正当な U+FFFD を含む UTF-8** → デコード成功 (拒否されない)
  - **バイトレベルテスト**: 読み込み失敗後、原本ファイルのバイトが byte-for-byte 不変であることを検証
- `npx tsc --noEmit` クリーン
- 対象テストファイル green (72 tests)

## 未検証 (pending)

実機の開くダイアログ経由 (UI) での挙動確認は未実施。ユニットテストで判別ロジックとバイト不変性は確証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)