### PR TITLE
fix(explorer): reject binary file drops before UTF-8 read to prevent corruption (#1880)

### DIFF
--- a/components/explorer/FilesPanel.tsx
+++ b/components/explorer/FilesPanel.tsx
@@ -7,6 +7,8 @@ import { useContextMenu } from "@/lib/hooks/use-context-menu";
 import ContextMenu from "@/shared/ui/ContextMenu";
 import ConfirmDialog from "@/shared/ui/ConfirmDialog";
 import { isElectronRenderer, detectOSPlatform } from "@/lib/utils/runtime-env";
+import { isTextDroppable } from "@/lib/utils/file-type-guard";
+import { notificationManager } from "@/lib/services/notification-manager";
 import type { FileTreeEntry, EditingEntry } from "./types";
 import type { VirtualFileSystem } from "@/lib/vfs/types";
 
@@ -487,6 +489,16 @@ export function FilesPanel({
 
         for (let i = 0; i < files.length; i++) {
           const file = files[i];
+          // Reject non-text files before touching their bytes.
+          // file.text() silently replaces invalid UTF-8 bytes with U+FFFD,
+          // which would corrupt any binary (PDF, DOCX, image, …) dropped here.
+          if (!isTextDroppable(file)) {
+            notificationManager.error(
+              `「${file.name}」はサポートされていない形式です。` +
+                "テキストファイル（.mdi / .md / .txt）のみインポートできます。",
+            );
+            continue;
+          }
           try {
             const content = await file.text();
             const filePath = destDir === "/" ? `/${file.name}` : `${destDir}/${file.name}`;

--- a/lib/utils/__tests__/file-type-guard.test.ts
+++ b/lib/utils/__tests__/file-type-guard.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for file-type-guard.ts (issue #1880).
+ *
+ * Verifies that:
+ * - Binary formats (PDF, DOCX, PNG, JPEG, ZIP, …) are correctly rejected
+ *   before they reach file.text() / writeFile, preventing UTF-8 corruption.
+ * - Supported text formats (.mdi, .md, .txt) and bare filenames are allowed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isTextDroppable, extractFileExtension, TEXT_EXTENSIONS } from "../file-type-guard";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a minimal File-like object for testing.
+ * The browser File constructor is not always available in Node/vitest, so we
+ * use a plain object cast to File.
+ */
+function makeFile(name: string, type: string): File {
+  return { name, type } as File;
+}
+
+// ---------------------------------------------------------------------------
+// extractFileExtension
+// ---------------------------------------------------------------------------
+
+describe("extractFileExtension", () => {
+  it("returns '' for filenames without a dot", () => {
+    expect(extractFileExtension("README")).toBe("");
+    expect(extractFileExtension("Makefile")).toBe("");
+  });
+
+  it("returns lowercased dotted extension", () => {
+    expect(extractFileExtension("novel.mdi")).toBe(".mdi");
+    expect(extractFileExtension("report.PDF")).toBe(".pdf");
+    expect(extractFileExtension("image.PNG")).toBe(".png");
+  });
+
+  it("handles multiple dots — returns last segment", () => {
+    expect(extractFileExtension("archive.tar.gz")).toBe(".gz");
+    expect(extractFileExtension("file.backup.txt")).toBe(".txt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TEXT_EXTENSIONS constant
+// ---------------------------------------------------------------------------
+
+describe("TEXT_EXTENSIONS", () => {
+  it("includes .mdi, .md, .txt", () => {
+    expect(TEXT_EXTENSIONS).toContain(".mdi");
+    expect(TEXT_EXTENSIONS).toContain(".md");
+    expect(TEXT_EXTENSIONS).toContain(".txt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isTextDroppable — text files allowed
+// ---------------------------------------------------------------------------
+
+describe("isTextDroppable — text files", () => {
+  it("allows .mdi files", () => {
+    expect(isTextDroppable(makeFile("chapter1.mdi", "text/plain"))).toBe(true);
+    expect(isTextDroppable(makeFile("chapter1.mdi", ""))).toBe(true);
+  });
+
+  it("allows .md files", () => {
+    expect(isTextDroppable(makeFile("README.md", "text/markdown"))).toBe(true);
+    expect(isTextDroppable(makeFile("README.md", ""))).toBe(true);
+  });
+
+  it("allows .txt files", () => {
+    expect(isTextDroppable(makeFile("notes.txt", "text/plain"))).toBe(true);
+    expect(isTextDroppable(makeFile("notes.txt", ""))).toBe(true);
+  });
+
+  it("allows bare filenames with no extension", () => {
+    expect(isTextDroppable(makeFile("README", ""))).toBe(true);
+    expect(isTextDroppable(makeFile("Makefile", "text/plain"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isTextDroppable — binary files rejected (extension check)
+// ---------------------------------------------------------------------------
+
+describe("isTextDroppable — binary formats rejected by extension", () => {
+  it("rejects .pdf files", () => {
+    expect(isTextDroppable(makeFile("document.pdf", "application/pdf"))).toBe(false);
+    // Even when browser reports empty MIME type
+    expect(isTextDroppable(makeFile("document.pdf", ""))).toBe(false);
+  });
+
+  it("rejects .docx files", () => {
+    expect(
+      isTextDroppable(
+        makeFile(
+          "report.docx",
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ),
+      ),
+    ).toBe(false);
+    expect(isTextDroppable(makeFile("report.docx", ""))).toBe(false);
+  });
+
+  it("rejects .doc files", () => {
+    expect(isTextDroppable(makeFile("old.doc", "application/vnd.ms-word"))).toBe(false);
+    expect(isTextDroppable(makeFile("old.doc", ""))).toBe(false);
+  });
+
+  it("rejects .xlsx files", () => {
+    expect(
+      isTextDroppable(
+        makeFile("data.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+      ),
+    ).toBe(false);
+    expect(isTextDroppable(makeFile("data.xlsx", ""))).toBe(false);
+  });
+
+  it("rejects .png files", () => {
+    expect(isTextDroppable(makeFile("cover.png", "image/png"))).toBe(false);
+    expect(isTextDroppable(makeFile("cover.png", ""))).toBe(false);
+  });
+
+  it("rejects .jpg / .jpeg files", () => {
+    expect(isTextDroppable(makeFile("photo.jpg", "image/jpeg"))).toBe(false);
+    expect(isTextDroppable(makeFile("photo.jpeg", "image/jpeg"))).toBe(false);
+    expect(isTextDroppable(makeFile("photo.jpg", ""))).toBe(false);
+  });
+
+  it("rejects .gif files", () => {
+    expect(isTextDroppable(makeFile("anim.gif", "image/gif"))).toBe(false);
+    expect(isTextDroppable(makeFile("anim.gif", ""))).toBe(false);
+  });
+
+  it("rejects .webp files", () => {
+    expect(isTextDroppable(makeFile("image.webp", "image/webp"))).toBe(false);
+    expect(isTextDroppable(makeFile("image.webp", ""))).toBe(false);
+  });
+
+  it("rejects .svg files", () => {
+    // SVG has unknown extension from the allowlist perspective
+    expect(isTextDroppable(makeFile("logo.svg", "image/svg+xml"))).toBe(false);
+    // When browser returns empty MIME for .svg, extension is not in allowlist
+    expect(isTextDroppable(makeFile("logo.svg", ""))).toBe(false);
+  });
+
+  it("rejects .mp3 / .mp4 files", () => {
+    expect(isTextDroppable(makeFile("music.mp3", "audio/mpeg"))).toBe(false);
+    expect(isTextDroppable(makeFile("video.mp4", "video/mp4"))).toBe(false);
+  });
+
+  it("rejects .zip files", () => {
+    expect(isTextDroppable(makeFile("archive.zip", "application/zip"))).toBe(false);
+    expect(isTextDroppable(makeFile("archive.zip", ""))).toBe(false);
+  });
+
+  it("rejects .exe files", () => {
+    expect(isTextDroppable(makeFile("setup.exe", "application/octet-stream"))).toBe(false);
+    expect(isTextDroppable(makeFile("setup.exe", ""))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isTextDroppable — binary MIME wins even for unknown extension
+// ---------------------------------------------------------------------------
+
+describe("isTextDroppable — binary MIME rejects unknown extensions", () => {
+  it("rejects a file with no extension but binary MIME", () => {
+    // Bare filename + image MIME → reject
+    expect(isTextDroppable(makeFile("data", "image/png"))).toBe(false);
+    expect(isTextDroppable(makeFile("blob", "application/octet-stream"))).toBe(false);
+  });
+
+  it("rejects a text-looking extension if MIME is clearly binary", () => {
+    // .txt extension but MIME says PDF — MIME wins
+    expect(isTextDroppable(makeFile("trick.txt", "application/pdf"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Minimum-viable reproduction from the issue
+// ---------------------------------------------------------------------------
+
+describe("issue #1880 minimal reproduction", () => {
+  it("rejects the binary formats listed in the bug report", () => {
+    const binaryFiles: Array<[string, string]> = [
+      ["normal.pdf", "application/pdf"],
+      ["document.docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
+      ["image.png", "image/png"],
+    ];
+    for (const [name, type] of binaryFiles) {
+      expect(isTextDroppable(makeFile(name, type))).toBe(false);
+    }
+  });
+
+  it("allows supported text extensions through", () => {
+    const textFiles: Array<[string, string]> = [
+      ["novel.mdi", "text/plain"],
+      ["notes.md", "text/markdown"],
+      ["draft.txt", "text/plain"],
+    ];
+    for (const [name, type] of textFiles) {
+      expect(isTextDroppable(makeFile(name, type))).toBe(true);
+    }
+  });
+});

--- a/lib/utils/file-type-guard.ts
+++ b/lib/utils/file-type-guard.ts
@@ -1,0 +1,79 @@
+/**
+ * File-type guard for external file drop operations.
+ *
+ * Determines whether a File (from a DataTransfer / FileList) can safely be
+ * imported into the project as a UTF-8 text document. Binary formats such as
+ * PDF, DOCX, PNG, JPEG, etc. must NOT be passed through `File.text()` because
+ * the UTF-8 decode step silently replaces invalid bytes with U+FFFD, producing
+ * a corrupted copy that looks intact in the UI.
+ *
+ * Guard logic (both checks must pass):
+ * 1. Extension allowlist  — file name ends with a known text extension, or
+ *    has no extension at all (bare filenames are assumed to be plain text).
+ * 2. MIME denylist        — file.type does NOT start with a known binary
+ *    MIME prefix, unless the browser reports an empty string (common when
+ *    dragging from Finder for unknown extensions).
+ *
+ * These checks are conservative: when in doubt we deny rather than corrupt.
+ * See issue #1880 for the original bug report.
+ */
+
+/** Extensions that the editor can open as UTF-8 text. */
+export const TEXT_EXTENSIONS = [".mdi", ".md", ".txt"] as const;
+
+/**
+ * MIME type prefixes that are definitively binary. Anything matching these
+ * is rejected regardless of file extension.
+ */
+const BINARY_MIME_PREFIXES = [
+  "image/",
+  "audio/",
+  "video/",
+  "application/pdf",
+  "application/zip",
+  "application/x-zip",
+  "application/vnd.openxmlformats", // .docx / .xlsx / .pptx
+  "application/vnd.ms-", // .doc / .xls / .ppt
+  "application/vnd.oasis", // LibreOffice ODF formats
+  "application/octet-stream",
+  "application/x-bzip",
+  "application/x-rar",
+  "application/x-tar",
+  "application/x-7z",
+  "font/",
+] as const;
+
+/**
+ * Return the lowercased dotted extension (".txt") from a filename, or ""
+ * when the name has no dot.
+ */
+export function extractFileExtension(name: string): string {
+  if (!name.includes(".")) return "";
+  return "." + (name.split(".").pop() ?? "").toLowerCase();
+}
+
+/**
+ * Return true if this File should be imported as UTF-8 text, false if it is
+ * a known binary format and must be rejected.
+ *
+ * @param file - Browser File object from a DataTransfer
+ */
+export function isTextDroppable(file: File): boolean {
+  const ext = extractFileExtension(file.name);
+  const mime = file.type.toLowerCase();
+
+  // Extension check: if there is an extension it must be in the allowlist.
+  // No extension (bare filenames like "README") → allowed.
+  if (ext !== "" && !(TEXT_EXTENSIONS as readonly string[]).includes(ext)) {
+    return false;
+  }
+
+  // MIME check: reject any known-binary MIME prefix.
+  // Empty MIME ("") means the browser doesn't know — we fall through to the
+  // extension decision already made above.
+  if (mime !== "" && BINARY_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix))) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
## 概要

Finder（または OS）からプロジェクトツリーへ PDF・DOCX・PNG などのバイナリファイルをドロップすると、`File.text()` で UTF-8 デコードされ、不正バイトが `U+FFFD` に置換されたまま VFS に書き込まれていた (#1880)。

- 新モジュール `lib/utils/file-type-guard.ts` を追加し、`isTextDroppable(file)` を公開
  - **拡張子許可リスト**（`.mdi` / `.md` / `.txt` / 拡張子なし）
  - **MIME 拒否リスト**（`image/`・`audio/`・`video/`・`application/pdf`・`application/vnd.openxmlformats*`・`application/octet-stream` 等）
- `FilesPanel.handleExternalFileDrop` で `isTextDroppable()` を先に評価し、バイナリと判定されたファイルは `file.text()` を呼ばずにスキップ
- 拒否された場合は `notificationManager.error()` で日本語エラートースト表示

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `lib/utils/file-type-guard.ts` | 新規：`isTextDroppable` / `extractFileExtension` / `TEXT_EXTENSIONS` |
| `lib/utils/__tests__/file-type-guard.test.ts` | 新規：24 ケース（PDF / DOCX / PNG / JPEG / ZIP / .exe 等の拒否 + .mdi/.md/.txt の通過） |
| `components/explorer/FilesPanel.tsx` | `handleExternalFileDrop` にガード追加 + import 追加 |

## テスト

```
npx vitest run lib/utils/__tests__/file-type-guard.test.ts
→ 24 passed
```

```
npx tsc --noEmit
→ exit 0（エラーなし）
```

## 残リスク・UI テスト

- 実際の Electron で Finder からドロップする手動検証は別 issue で追跡
- バイナリコピー API（`File.arrayBuffer()` + バイナリ VFS write）を将来追加すれば、PDF 等のバイト列保全インポートも実現可能（本 PR のスコープ外）

Closes #1880