### PR TITLE
fix(print): reflect page numbers and fullwidth indent in Electron actual print (#1884)

### DIFF
--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -434,12 +434,21 @@ function registerFileHandlers() {
       const { BrowserWindow } = require("electron");
       const { mdiToHtml } = require("../../lib/export/mdi-to-html");
       const { calculateTypesetting } = require("../../lib/export/pdf-export-settings");
+      const { fullwidthIndentCount } = require("../../lib/export/fullwidth-indent");
 
       const opts = options || {};
       const pageSize = opts.pageSize ?? "A5";
       const margins = opts.margins ?? { top: 20, bottom: 20, left: 15, right: 15 };
       const verticalWriting = opts.verticalWriting ?? false;
       const landscape = opts.landscape ?? false;
+
+      // Full-width-space 字下げ: literal U+3000 characters replace CSS text-indent.
+      // When the toggle is on, suppress textIndentEm to avoid double indentation
+      // (same logic as pdf-exporter.ts).
+      const fullwidthSpaceCount = opts.fullwidthSpaceIndent
+        ? fullwidthIndentCount(opts.textIndent ?? 0)
+        : 0;
+      const effectiveTextIndentEm = opts.fullwidthSpaceIndent ? 0 : opts.textIndent;
 
       // Build typesetting when chars/lines specified
       let typesetting;
@@ -456,7 +465,7 @@ function registerFileHandlers() {
           fontFamily: opts.fontFamily,
           fontSizeMm,
           lineHeightRatio,
-          textIndentEm: opts.textIndent,
+          textIndentEm: effectiveTextIndentEm,
           margins,
           pageSize,
           landscape,
@@ -471,6 +480,17 @@ function registerFileHandlers() {
         typesetting,
         googleFontFamily: opts.googleFontFamily,
         fileType: opts.fileType,
+        fullwidthSpaceIndentCount: fullwidthSpaceCount,
+        // Embed page numbers via CSS @page margin boxes so they appear in the
+        // actual print output (webContents.print does not support
+        // headerTemplate/footerTemplate unlike printToPDF).
+        pageNumbers: opts.showPageNumbers
+          ? {
+              show: true,
+              format: opts.pageNumberFormat,
+              position: opts.pageNumberPosition,
+            }
+          : undefined,
       });
 
       const partition = `print-${Date.now()}`;

--- a/lib/export/__tests__/print-settings-parity.test.ts
+++ b/lib/export/__tests__/print-settings-parity.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Regression tests for issue #1884:
+ * 印刷プレビューのページ番号・全角字下げが実際の印刷に反映されない
+ *
+ * Root causes fixed:
+ * 1. `mdiToHtml` now accepts a `pageNumbers` option that embeds page numbers
+ *    via CSS @page margin boxes — works for both printToPDF and webContents.print().
+ * 2. The `file-ipc.js` printDocument handler now passes `fullwidthSpaceIndentCount`
+ *    and `pageNumbers` to `mdiToHtml` (verified here via source-text assertions
+ *    following the established pattern in file-ipc-print-window-leak.test.ts).
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+import { mdiToHtml, getMdiStylesheet } from "../mdi-to-html";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fileIpcSource = readFileSync(
+  path.resolve(here, "../../../electron/ipc/file-ipc.js"),
+  "utf-8",
+);
+
+// Narrow to the printDocument handler to avoid false positives from other handlers.
+const printHandlerMatch = fileIpcSource.match(
+  /ipcMain\.handle\(EXPORT_CHANNELS\.invoke\.printDocument[\s\S]*?(?=\n\s*ipcMain\.handle\()/,
+);
+const printHandler = printHandlerMatch ? printHandlerMatch[0] : "";
+
+// ---------------------------------------------------------------------------
+// CSS @page margin-box page numbers (getMdiStylesheet)
+// ---------------------------------------------------------------------------
+
+describe("getMdiStylesheet — CSS @page margin-box page numbers (#1884)", () => {
+  it("emits no page number CSS when showPageNumbers is absent", () => {
+    const css = getMdiStylesheet({ pageSize: "A5", landscape: false });
+    expect(css).not.toContain("counter(page)");
+    expect(css).not.toContain("@bottom");
+    expect(css).not.toContain("@top");
+  });
+
+  it("emits simple counter for bottom-center (default position)", () => {
+    const css = getMdiStylesheet({ showPageNumbers: true });
+    expect(css).toContain("@bottom-center");
+    expect(css).toContain("counter(page)");
+  });
+
+  it("emits dash format", () => {
+    const css = getMdiStylesheet({
+      showPageNumbers: true,
+      pageNumberFormat: "dash",
+      pageNumberPosition: "bottom-center",
+    });
+    expect(css).toContain('"- " counter(page) " -"');
+  });
+
+  it("emits fraction format with pages counter", () => {
+    const css = getMdiStylesheet({
+      showPageNumbers: true,
+      pageNumberFormat: "fraction",
+      pageNumberPosition: "bottom-right",
+    });
+    expect(css).toContain("@bottom-right");
+    expect(css).toContain('counter(page) " / " counter(pages)');
+  });
+
+  it("maps all six positions to the correct CSS margin box", () => {
+    const positions = [
+      ["bottom-left", "@bottom-left"],
+      ["bottom-center", "@bottom-center"],
+      ["bottom-right", "@bottom-right"],
+      ["top-left", "@top-left"],
+      ["top-center", "@top-center"],
+      ["top-right", "@top-right"],
+    ] as const;
+
+    for (const [position, expected] of positions) {
+      const css = getMdiStylesheet({
+        showPageNumbers: true,
+        pageNumberPosition: position,
+      });
+      expect(css).toContain(expected);
+    }
+  });
+
+  it("applies page size and margin alongside page numbers", () => {
+    const css = getMdiStylesheet({
+      pageSize: "A5",
+      landscape: false,
+      margins: { top: 20, bottom: 20, left: 15, right: 15 },
+      showPageNumbers: true,
+      pageNumberFormat: "simple",
+      pageNumberPosition: "bottom-center",
+    });
+    // Both @page margin declaration and counter must be present
+    expect(css).toContain("@page");
+    expect(css).toContain("counter(page)");
+    // Page size must still be set
+    expect(css).toContain("size:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mdiToHtml — pageNumbers option forwarded to stylesheet (#1884)
+// ---------------------------------------------------------------------------
+
+describe("mdiToHtml — pageNumbers option embeds CSS counters (#1884)", () => {
+  it("embeds @page margin-box counter when pageNumbers.show is true", () => {
+    const html = mdiToHtml("本文", {
+      pageNumbers: { show: true, format: "simple", position: "bottom-center" },
+    });
+    expect(html).toContain("counter(page)");
+    expect(html).toContain("@bottom-center");
+  });
+
+  it("does not embed counter when pageNumbers is absent", () => {
+    const html = mdiToHtml("本文");
+    expect(html).not.toContain("counter(page)");
+  });
+
+  it("does not embed counter when pageNumbers.show is false", () => {
+    const html = mdiToHtml("本文", {
+      pageNumbers: { show: false },
+    });
+    expect(html).not.toContain("counter(page)");
+  });
+
+  it("embeds counter in complete HTML document (not bodyOnly)", () => {
+    const html = mdiToHtml("本文", {
+      pageNumbers: { show: true, format: "dash", position: "top-right" },
+    });
+    // Should be a complete HTML doc with the counter in the <style> block
+    expect(html).toContain("<!DOCTYPE html>");
+    expect(html).toContain("@top-right");
+    expect(html).toContain('"- " counter(page) " -"');
+  });
+
+  it("bodyOnly mode ignores pageNumbers (no stylesheet emitted)", () => {
+    // bodyOnly skips the <style> block entirely, so page numbers cannot be embedded
+    const html = mdiToHtml("本文", {
+      bodyOnly: true,
+      pageNumbers: { show: true },
+    });
+    expect(html).not.toContain("counter(page)");
+  });
+
+  it("combines fullwidthSpaceIndentCount and pageNumbers correctly", () => {
+    const html = mdiToHtml("本文\n\n二行目", {
+      fullwidthSpaceIndentCount: 1,
+      pageNumbers: { show: true, format: "simple", position: "bottom-center" },
+    });
+    // Full-width indent must be injected
+    expect(html).toContain("<p>　本文</p>");
+    // Page numbers must also be present
+    expect(html).toContain("counter(page)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// file-ipc.js printDocument handler — source-text assertions (#1884)
+// ---------------------------------------------------------------------------
+
+describe("file-ipc.js printDocument handler — settings parity (#1884)", () => {
+  it("printHandler section was found in source", () => {
+    expect(printHandler.length).toBeGreaterThan(100);
+  });
+
+  it("imports fullwidthIndentCount from fullwidth-indent module", () => {
+    expect(printHandler).toMatch(/require\(["'].*fullwidth-indent["']\)/);
+    expect(printHandler).toMatch(/fullwidthIndentCount/);
+  });
+
+  it("computes fullwidthSpaceCount from opts.fullwidthSpaceIndent and opts.textIndent", () => {
+    expect(printHandler).toMatch(/fullwidthSpaceCount/);
+    expect(printHandler).toMatch(/opts\.fullwidthSpaceIndent/);
+    expect(printHandler).toMatch(/opts\.textIndent/);
+  });
+
+  it("suppresses effectiveTextIndentEm when fullwidthSpaceIndent is on", () => {
+    // When toggle is on, CSS text-indent must be 0 to avoid double indentation
+    expect(printHandler).toMatch(/effectiveTextIndentEm/);
+    // textIndentEm in typesetting must use the effective value (not raw textIndent)
+    expect(printHandler).toMatch(/textIndentEm:\s*effectiveTextIndentEm/);
+  });
+
+  it("passes fullwidthSpaceIndentCount to mdiToHtml", () => {
+    expect(printHandler).toMatch(/fullwidthSpaceIndentCount:\s*fullwidthSpaceCount/);
+  });
+
+  it("passes showPageNumbers to mdiToHtml as pageNumbers.show", () => {
+    expect(printHandler).toMatch(/opts\.showPageNumbers/);
+    expect(printHandler).toMatch(/pageNumbers:/);
+    // The show field must reference opts.showPageNumbers
+    expect(printHandler).toMatch(/show:\s*true/);
+  });
+
+  it("passes pageNumberFormat to mdiToHtml pageNumbers", () => {
+    expect(printHandler).toMatch(/opts\.pageNumberFormat/);
+    expect(printHandler).toMatch(/format:\s*opts\.pageNumberFormat/);
+  });
+
+  it("passes pageNumberPosition to mdiToHtml pageNumbers", () => {
+    expect(printHandler).toMatch(/opts\.pageNumberPosition/);
+    expect(printHandler).toMatch(/position:\s*opts\.pageNumberPosition/);
+  });
+
+  it("conditionally enables pageNumbers only when opts.showPageNumbers is truthy", () => {
+    // pageNumbers must be undefined (not emitted) when showPageNumbers is off
+    expect(printHandler).toMatch(/opts\.showPageNumbers\s*\?[\s\S]*?:\s*undefined/);
+  });
+});

--- a/lib/export/mdi-to-html.ts
+++ b/lib/export/mdi-to-html.ts
@@ -169,6 +169,25 @@ export interface MdiStylesheetOptions {
   pageSize?: ExportPageSize;
   /** Landscape orientation for @page CSS rule */
   landscape?: boolean;
+  /**
+   * Embed page numbers via CSS @page margin boxes.
+   * When true, a CSS counter-based page number is added to the @page rule.
+   * This works for both printToPDF and webContents.print().
+   */
+  showPageNumbers?: boolean;
+  /** Page number display format: plain number, dashes, or fraction */
+  pageNumberFormat?: "simple" | "dash" | "fraction";
+  /**
+   * Position of the page number in the page margin.
+   * Maps to the CSS @page named margin box (e.g. @bottom-center).
+   */
+  pageNumberPosition?:
+    | "bottom-left"
+    | "bottom-center"
+    | "bottom-right"
+    | "top-left"
+    | "top-center"
+    | "top-right";
 }
 
 /**
@@ -231,6 +250,43 @@ export function getMdiStylesheet(options?: MdiStylesheetOptions): string {
     rules.push(`@page { ${pageDecls.join("; ")}; }`);
   }
 
+  // CSS @page margin-box page numbers.
+  // This embeds page numbers directly in the HTML so that both printToPDF and
+  // webContents.print() render the same output (the Electron header/footer
+  // template API is only available for printToPDF, not webContents.print).
+  if (options?.showPageNumbers) {
+    const format = options.pageNumberFormat ?? "simple";
+    const position = options.pageNumberPosition ?? "bottom-center";
+
+    // Map position string → CSS @page named margin box
+    // See https://www.w3.org/TR/css-page-3/#margin-boxes
+    const marginBoxMap: Record<string, string> = {
+      "bottom-left": "@bottom-left",
+      "bottom-center": "@bottom-center",
+      "bottom-right": "@bottom-right",
+      "top-left": "@top-left",
+      "top-center": "@top-center",
+      "top-right": "@top-right",
+    };
+    const marginBox = marginBoxMap[position] ?? "@bottom-center";
+
+    // Build the CSS `content` value for the chosen format
+    let contentValue: string;
+    switch (format) {
+      case "dash":
+        contentValue = '"- " counter(page) " -"';
+        break;
+      case "fraction":
+        contentValue = 'counter(page) " / " counter(pages)';
+        break;
+      default:
+        contentValue = "counter(page)";
+        break;
+    }
+
+    rules.push(`@page { ${marginBox} { content: ${contentValue}; font-size: 8pt; color: #666; } }`);
+  }
+
   return rules.join("\n");
 }
 
@@ -242,6 +298,7 @@ export function getMdiStylesheet(options?: MdiStylesheetOptions): string {
  * @param options.verticalWriting - Enable vertical writing mode
  * @param options.bodyOnly - If true, return only the inner HTML content without document wrapper
  * @param options.typesetting - PDF typesetting options forwarded to getMdiStylesheet()
+ * @param options.pageNumbers - Page number CSS embedding options forwarded to getMdiStylesheet()
  * @returns Complete HTML document string, or body content if bodyOnly is true
  */
 export function mdiToHtml(
@@ -267,6 +324,22 @@ export function mdiToHtml(
      * double indentation. Blank ([[blank]]) paragraphs are left untouched.
      */
     fullwidthSpaceIndentCount?: number;
+    /**
+     * Embed page numbers via CSS @page margin boxes.
+     * Works for both printToPDF and webContents.print() (unlike Electron's
+     * headerTemplate/footerTemplate which is only available for printToPDF).
+     */
+    pageNumbers?: {
+      show: boolean;
+      format?: "simple" | "dash" | "fraction";
+      position?:
+        | "bottom-left"
+        | "bottom-center"
+        | "bottom-right"
+        | "top-left"
+        | "top-center"
+        | "top-right";
+    };
   },
 ): string {
   const fileType = options?.fileType ?? ".mdi";
@@ -322,6 +395,15 @@ export function mdiToHtml(
   const stylesheet = getMdiStylesheet({
     verticalWriting: options?.verticalWriting,
     ...options?.typesetting,
+    // Page number options are injected as CSS @page margin boxes so both
+    // printToPDF and webContents.print() render the same page number output.
+    ...(options?.pageNumbers?.show
+      ? {
+          showPageNumbers: true,
+          pageNumberFormat: options.pageNumbers.format,
+          pageNumberPosition: options.pageNumbers.position,
+        }
+      : undefined),
   });
 
   // Build <meta> tags for optional metadata

--- a/lib/export/web-print-preview.ts
+++ b/lib/export/web-print-preview.ts
@@ -60,6 +60,15 @@ export async function openWebPrintPreview(
       },
       fileType,
       fullwidthSpaceIndentCount: fullwidthSpaceCount,
+      // Embed page numbers via CSS @page margin boxes so browser print also
+      // renders page numbers consistently with Electron print.
+      pageNumbers: settings.showPageNumbers
+        ? {
+            show: true,
+            format: settings.pageNumberFormat,
+            position: settings.pageNumberPosition,
+          }
+        : undefined,
     });
 
     printWindow.document.open();


### PR DESCRIPTION
## Summary

- **Root cause**: The `printDocument` IPC handler (`electron/ipc/file-ipc.js`) called `mdiToHtml` without `fullwidthSpaceIndentCount`, and used `webContents.print()` which does **not** support Electron's `headerTemplate`/`footerTemplate` (that API is only available for `printToPDF`). As a result, both page numbers and 全角字下げ were silently dropped from real print output.

- **Fix for page numbers**: Added `showPageNumbers`, `pageNumberFormat`, `pageNumberPosition` to `MdiStylesheetOptions` and emit CSS `@page` named margin-box counters (e.g. `@bottom-center { content: counter(page) }`) directly in the HTML stylesheet. This CSS mechanism works for both `printToPDF` and `webContents.print()`, making preview and real print use the same source.

- **Fix for 全角字下げ**: Updated the `printDocument` IPC handler to import `fullwidthIndentCount`, compute `fullwidthSpaceIndentCount`, suppress `textIndentEm` when the toggle is on (same pattern as `pdf-exporter.ts`), and pass both to `mdiToHtml`.

- Also updated `web-print-preview.ts` to pass `pageNumbers` for consistency with the Electron print path.

## Changed files

| File | Change |
|------|--------|
| `lib/export/mdi-to-html.ts` | Add page number fields to `MdiStylesheetOptions`; emit CSS `@page` margin-box counters in `getMdiStylesheet`; add `pageNumbers` option to `mdiToHtml` |
| `electron/ipc/file-ipc.js` | Pass `fullwidthSpaceIndentCount` and `pageNumbers` to `mdiToHtml` in `printDocument` handler |
| `lib/export/web-print-preview.ts` | Pass `pageNumbers` to `mdiToHtml` |
| `lib/export/__tests__/print-settings-parity.test.ts` | 21 regression tests (new file) |

## Test plan

- [x] `npx tsc --noEmit` — exit 0
- [x] `npx vitest run lib/export/__tests__/print-settings-parity.test.ts` — 21 tests green
- [x] Full test suite (`npx vitest run lib/export/__tests__/ electron/ipc/__tests__/`) — 254 tests green
- [ ] Real-device verification (Electron app + print to PDF): tracked in #1937

## Notes

- PDF export (`pdf-exporter.ts`) still uses Electron's `headerTemplate`/`footerTemplate` for `printToPDF` — that path is unaffected and continues to work. The CSS `@page` counter is only injected when explicitly requested via the new `pageNumbers` option, so there is no risk of double page numbers in PDF export.
- `webContents.print()` sends the HTML through Chromium's print engine, which supports CSS `@page` margin boxes. Printer driver support may vary — real-device confirmation is in #1937.

Closes #1884
Real-device verification: #1937