### PR TITLE
fix(standalone): use filePath for dictionary key and window title in Electron

### DIFF
--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -89,7 +89,10 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
         const entries = await dictService.loadEntries();
         setUserEntries(entries);
       } else if (editorMode && isStandaloneMode(editorMode)) {
-        const entries = await dictService.loadEntriesStandalone(editorMode.fileName);
+        // Use full path (Electron) to avoid basename collisions between same-named files in
+        // different directories. Fall back to fileName on Web where filePath is not available.
+        const stableKey = editorMode.filePath ?? editorMode.fileName;
+        const entries = await dictService.loadEntriesStandalone(stableKey);
         setUserEntries(entries);
       }
     } catch {
@@ -103,7 +106,10 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
         if (editorMode && isProjectMode(editorMode)) {
           await dictService.saveEntries(entries);
         } else if (editorMode && isStandaloneMode(editorMode)) {
-          await dictService.saveEntriesStandalone(editorMode.fileName, entries);
+          // Use full path (Electron) to avoid basename collisions between same-named files in
+          // different directories. Fall back to fileName on Web where filePath is not available.
+          const stableKey = editorMode.filePath ?? editorMode.fileName;
+          await dictService.saveEntriesStandalone(stableKey, entries);
         }
       } catch {
         // Silently fail

--- a/components/TitleUpdater.tsx
+++ b/components/TitleUpdater.tsx
@@ -13,7 +13,10 @@ export default function TitleUpdater({ editorMode, isDirty }: TitleUpdaterProps)
     let name: string;
     if (isProjectMode(editorMode)) {
       name = editorMode.name;
-    } else if (isStandaloneMode(editorMode) && editorMode.fileHandle) {
+    } else if (isStandaloneMode(editorMode) && (editorMode.fileHandle ?? editorMode.filePath)) {
+      // Show the file name when a file is open — either via Web File System Access API
+      // (fileHandle) or via Electron native path (filePath). Both are non-null only when an
+      // existing file has been opened; a new unsaved tab has both as null/undefined.
       name = isDirty ? `${editorMode.fileName} *` : editorMode.fileName;
     } else {
       name = isDirty ? "新規ファイル *" : "新規ファイル";

--- a/components/__tests__/TitleUpdater.test.ts
+++ b/components/__tests__/TitleUpdater.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the title-selection logic mirrored from TitleUpdater.tsx.
+ *
+ * TitleUpdater is a React effects-only component; without @testing-library/react
+ * we extract and unit-test the pure title-computation function instead.
+ *
+ * Covers (#1922):
+ * - Electron standalone: fileHandle is null, filePath is set → should show fileName
+ * - Web standalone: fileHandle is set, filePath is undefined → should show fileName
+ * - Unsaved new tab: both fileHandle and filePath are null/undefined → "新規ファイル"
+ * - Project mode: shows project name
+ * - Dirty flag: appends " *" to name
+ */
+
+import { describe, it, expect } from "vitest";
+import type { EditorMode, StandaloneMode, ProjectMode } from "@/lib/project/project-types";
+import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
+
+// ---------------------------------------------------------------------------
+// Extracted title logic (mirrors TitleUpdater.tsx — must stay in sync)
+// ---------------------------------------------------------------------------
+
+/**
+ * Pure function that replicates the title-name computation from TitleUpdater.tsx.
+ * When the component logic changes, this function must be updated to match.
+ */
+function computeTitle(editorMode: EditorMode, isDirty: boolean): string {
+  let name: string;
+  if (isProjectMode(editorMode)) {
+    name = editorMode.name;
+  } else if (isStandaloneMode(editorMode) && (editorMode.fileHandle ?? editorMode.filePath)) {
+    name = isDirty ? `${editorMode.fileName} *` : editorMode.fileName;
+  } else {
+    name = isDirty ? "新規ファイル *" : "新規ファイル";
+  }
+  return `${name} - illusions`;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStandalone(overrides: Partial<StandaloneMode>): StandaloneMode {
+  return {
+    type: "standalone",
+    fileHandle: null,
+    fileName: "novel.mdi",
+    fileExtension: ".mdi",
+    editorSettings: {
+      fontScale: 1,
+      lineHeight: 1.8,
+      paragraphSpacing: 1,
+      textIndent: 1,
+      fontFamily: "serif",
+      charsPerLine: 40,
+      showParagraphNumbers: false,
+      mdiExtensionsEnabled: true,
+      posHighlightEnabled: false,
+      posHighlightColors: {},
+    },
+    ...overrides,
+  };
+}
+
+function makeProject(): ProjectMode {
+  return {
+    type: "project",
+    projectId: "proj-1",
+    name: "春の小説",
+    rootHandle: {} as FileSystemDirectoryHandle,
+    mainFileHandle: {} as FileSystemFileHandle,
+    metadata: {} as ProjectMode["metadata"],
+    workspaceState: {} as ProjectMode["workspaceState"],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TitleUpdater — title computation logic", () => {
+  // --- #1922 regression: Electron standalone ---
+  describe("Electron standalone (fileHandle=null, filePath set)", () => {
+    it("shows fileName when filePath is present", () => {
+      const mode = makeStandalone({
+        fileHandle: null,
+        filePath: "/Users/x/standalone-a/same.mdi",
+        fileName: "same.mdi",
+      });
+      expect(computeTitle(mode, false)).toBe("same.mdi - illusions");
+    });
+
+    it("appends dirty marker when isDirty=true", () => {
+      const mode = makeStandalone({
+        fileHandle: null,
+        filePath: "/Users/x/draft/novel.mdi",
+        fileName: "novel.mdi",
+      });
+      expect(computeTitle(mode, true)).toBe("novel.mdi * - illusions");
+    });
+
+    it("does NOT show '新規ファイル' for an existing Electron file", () => {
+      const mode = makeStandalone({
+        fileHandle: null,
+        filePath: "/Users/x/my-story.mdi",
+        fileName: "my-story.mdi",
+      });
+      const title = computeTitle(mode, false);
+      expect(title).not.toContain("新規ファイル");
+      expect(title).toContain("my-story.mdi");
+    });
+  });
+
+  // --- Web standalone (fileHandle present) ---
+  describe("Web standalone (fileHandle set, filePath undefined)", () => {
+    it("shows fileName when fileHandle is present", () => {
+      const mode = makeStandalone({
+        fileHandle: {} as FileSystemFileHandle,
+        filePath: undefined,
+        fileName: "web-novel.mdi",
+      });
+      expect(computeTitle(mode, false)).toBe("web-novel.mdi - illusions");
+    });
+  });
+
+  // --- Unsaved new tab ---
+  describe("unsaved new tab (fileHandle=null, filePath=undefined)", () => {
+    it("shows '新規ファイル' when no file is associated", () => {
+      const mode = makeStandalone({
+        fileHandle: null,
+        filePath: undefined,
+        fileName: "新規ファイル",
+      });
+      expect(computeTitle(mode, false)).toBe("新規ファイル - illusions");
+    });
+
+    it("appends dirty marker for unsaved new file", () => {
+      const mode = makeStandalone({
+        fileHandle: null,
+        filePath: undefined,
+        fileName: "新規ファイル",
+      });
+      expect(computeTitle(mode, true)).toBe("新規ファイル * - illusions");
+    });
+  });
+
+  // --- Project mode ---
+  describe("project mode", () => {
+    it("shows project name", () => {
+      const mode = makeProject();
+      expect(computeTitle(mode, false)).toBe("春の小説 - illusions");
+    });
+
+    it("project name is not affected by isDirty (no dirty marker in project mode)", () => {
+      const mode = makeProject();
+      expect(computeTitle(mode, true)).toBe("春の小説 - illusions");
+    });
+  });
+
+  // --- null mode ---
+  describe("null mode (no file open)", () => {
+    it("shows '新規ファイル' when mode is null", () => {
+      expect(computeTitle(null, false)).toBe("新規ファイル - illusions");
+    });
+  });
+});

--- a/lib/services/__tests__/user-dictionary-service.test.ts
+++ b/lib/services/__tests__/user-dictionary-service.test.ts
@@ -303,4 +303,39 @@ describe("UserDictionaryService — standalone mode (StorageService)", () => {
       expect.any(String),
     );
   });
+
+  // Regression test for #1921: same-named files in different directories must
+  // not share dictionary data when the full path is used as the storage key.
+  it("files with identical basename in different directories use separate storage keys", async () => {
+    const entryA = makeEntry({ id: "a-only", word: "A専用語" });
+    const entryB = makeEntry({ id: "b-only", word: "B専用語" });
+
+    const pathA = "/Users/x/standalone-a/same.mdi";
+    const pathB = "/Users/x/standalone-b/same.mdi";
+
+    // Save dictionary for file A
+    await svc.saveEntriesStandalone(pathA, [entryA]);
+
+    // Save dictionary for file B
+    await svc.saveEntriesStandalone(pathB, [entryB]);
+
+    // Each path should have been written with a distinct key
+    const calls = mockStorage.setItem.mock.calls;
+    const keyA = calls.find((c) => (c[0] as string).includes("standalone-a"))?.[0] as string;
+    const keyB = calls.find((c) => (c[0] as string).includes("standalone-b"))?.[0] as string;
+
+    expect(keyA).toBeDefined();
+    expect(keyB).toBeDefined();
+    expect(keyA).not.toBe(keyB);
+
+    // Loading from path A must NOT return B's entries
+    const loadedA = await svc.loadEntriesStandalone(pathA);
+    expect(loadedA.map((e) => e.id)).toContain("a-only");
+    expect(loadedA.map((e) => e.id)).not.toContain("b-only");
+
+    // Loading from path B must NOT return A's entries
+    const loadedB = await svc.loadEntriesStandalone(pathB);
+    expect(loadedB.map((e) => e.id)).toContain("b-only");
+    expect(loadedB.map((e) => e.id)).not.toContain("a-only");
+  });
 });


### PR DESCRIPTION
## Summary

- **#1921**: `components/Dictionary.tsx` was passing `editorMode.fileName` (basename only) to `loadEntriesStandalone` / `saveEntriesStandalone`. Changed to use `editorMode.filePath ?? editorMode.fileName` so same-named files in different directories get separate storage keys on Electron.
- **#1922**: `components/TitleUpdater.tsx` required `editorMode.fileHandle` to show the file name in the window title. On Electron, standalone mode sets `filePath` instead of `fileHandle`, so the condition always fell through to "新規ファイル". Fixed by checking `editorMode.fileHandle ?? editorMode.filePath` — either non-null value means a real file is open.

Closes #1921
Closes #1922

## Changed files

- `components/Dictionary.tsx` — use `filePath ?? fileName` as storage key in both `loadEntries` and `persistEntries` callbacks
- `components/TitleUpdater.tsx` — accept either `fileHandle` or `filePath` as proof that a file is open
- `lib/services/__tests__/user-dictionary-service.test.ts` — new regression test: same-basename files in different directories must not share storage keys
- `components/__tests__/TitleUpdater.test.ts` — new tests covering Electron standalone (filePath-only), Web standalone (fileHandle-only), unsaved new tab, and project mode

## Test plan

- [ ] `npx tsc --noEmit` — passes (0 errors)
- [ ] `npx vitest run components/__tests__/TitleUpdater.test.ts lib/services/__tests__/user-dictionary-service.test.ts` — 26 tests pass
- [ ] UI: open two files named `same.mdi` from different folders in Electron; confirm their user dictionaries are independent
- [ ] UI: open an existing `.mdi` file via Welcome → "ファイルを開く" in Electron; confirm window title shows `same.mdi - illusions` (not `新規ファイル - illusions`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)