### PR TITLE
feat(dict): 辞書照合に正規化層を追加し候補キー抽出を API 化 (#1935)

### DIFF
--- a/electron/__tests__/dict-manager-access.test.ts
+++ b/electron/__tests__/dict-manager-access.test.ts
@@ -26,10 +26,12 @@ vi.mock("electron", () => ({
 
 type DbMode = "healthy" | "no-table" | "malformed";
 
+type FakeRow = { entry: string; reading_primary: string; raw_json: string };
+
 class FakeStatement {
   constructor(
     private readonly sql: string,
-    private readonly rows: Array<{ entry: string; raw_json: string }>,
+    private readonly rows: FakeRow[],
     private readonly mode: DbMode,
   ) {}
   get(): unknown {
@@ -44,7 +46,15 @@ class FakeStatement {
   all(...args: unknown[]): unknown[] {
     if (this.sql.includes("WHERE entry IN")) {
       const wanted = new Set(args as string[]);
-      return this.rows.filter((r) => wanted.has(r.entry)).map((r) => ({ ...r }));
+      return this.rows
+        .filter((r) => wanted.has(r.entry))
+        .map((r) => ({ entry: r.entry, raw_json: r.raw_json }));
+    }
+    if (this.sql.includes("WHERE reading_primary IN")) {
+      const wanted = new Set(args as string[]);
+      return this.rows
+        .filter((r) => wanted.has(r.reading_primary))
+        .map((r) => ({ reading_primary: r.reading_primary, raw_json: r.raw_json }));
     }
     return [];
   }
@@ -53,7 +63,7 @@ class FakeStatement {
 
 class FakeDatabase {
   constructor(
-    private readonly rows: Array<{ entry: string; raw_json: string }>,
+    private readonly rows: FakeRow[],
     private readonly mode: DbMode,
   ) {
     if (mode === "malformed") throw new Error("file is not a database");
@@ -92,7 +102,10 @@ interface TestableManager {
   _getDictDir: () => string;
   _createDatabase: (dbPath: string, opts?: unknown) => unknown;
   verify: () => { ok: boolean; reason?: string };
-  lookupBatch: (terms: string[]) => Array<{
+  lookupBatch: (
+    terms: string[],
+    normalize?: boolean,
+  ) => Array<{
     entry: string;
     found: boolean;
     reading?: string;
@@ -110,7 +123,11 @@ interface ManagerOptions {
 
 async function freshManager(dictDir: string, opts: ManagerOptions = {}): Promise<TestableManager> {
   const { rows = [], mode = "healthy" } = opts;
-  const fakeRows = rows.map((r) => ({ entry: r.entry, raw_json: rawJson(r) }));
+  const fakeRows = rows.map((r) => ({
+    entry: r.entry,
+    reading_primary: r.reading,
+    raw_json: rawJson(r),
+  }));
   const { getDictManager } = await import("../dict-manager.js");
   const mgr = getDictManager() as unknown as TestableManager;
   mgr._getDictDir = () => dictDir;
@@ -204,6 +221,48 @@ describe("DictManager analysis access (#1624)", () => {
       const mgr = await freshManager(dictDir, { rows: LOOKUP_ROWS });
       expect(mgr.lookupBatch([])).toEqual([]);
       expect(mgr.lookupBatch(["", "  "].map((s) => s.trim()))).toEqual([]);
+    });
+  });
+
+  describe("lookupBatch() kana reading normalization (#1935)", () => {
+    // Dictionary stores verbs under their kanji headword with a kana reading.
+    const NORMALIZE_ROWS: RawJsonInput[] = [
+      { entry: "有る", reading: "ある", pos: ["動詞"] },
+      { entry: "分かる", reading: "わかる", pos: ["動詞"] },
+      { entry: "読む", reading: "よむ", pos: ["動詞"] },
+      { entry: "雪", reading: "ゆき", pos: ["名詞"] },
+    ];
+
+    it("resolves an all-kana term to its kanji headword via the reading index", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: NORMALIZE_ROWS });
+      // 「ある」 (kana) misses the headword index but its reading matches 有る.
+      const hit = mgr.lookupBatch(["ある"]);
+      expect(hit).toEqual([{ entry: "ある", found: true, reading: "ある", pos: "動詞" }]);
+    });
+
+    it("does NOT flag kana content words 「ある」「わかる」 as out-of-dictionary", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: NORMALIZE_ROWS });
+      const found = new Set(mgr.lookupBatch(["ある", "わかる"]).map((r) => r.entry));
+      expect(found.has("ある")).toBe(true);
+      expect(found.has("わかる")).toBe(true);
+    });
+
+    it("STILL flags genuinely out-of-dictionary terms with kanji (圕 / 讀む)", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: NORMALIZE_ROWS });
+      // 讀む shares reading よむ with 読む, but the kana gate skips it (讀 is kanji),
+      // so it must NOT be over-suppressed. 圕 is absent and not kana.
+      const found = new Set(mgr.lookupBatch(["圕", "讀む"]).map((r) => r.entry));
+      expect(found.has("圕")).toBe(false);
+      expect(found.has("讀む")).toBe(false);
+    });
+
+    it("normalize:false disables the reading fallback (strict headword match)", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: NORMALIZE_ROWS });
+      expect(mgr.lookupBatch(["ある"], false)).toEqual([]);
     });
   });
 });

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -24,6 +24,55 @@ const DB_FILENAME = "genji.db";
 const DB_TEMP_FILENAME = "genji.db.tmp";
 const VERSION_FILENAME = "genji_version.txt";
 
+// ---------------------------------------------------------------------------
+// Kana normalization for reading-index fallback (#1935)
+//
+// The dictionary indexes headwords by their written form only (`entry`), so a
+// kana spelling of a word the dict stores under a kanji headword — e.g. the verb
+// 「ある」 (dict headword 「有る」) — misses an exact lookup and the 辞書外語 rule
+// wrongly flags it. When an all-kana term misses, we re-query the reading index
+// (`reading_primary`) so the kana resolves to its canonical headword.
+//
+// The all-kana GATE is the safety boundary: only fully-kana terms get the
+// reading fallback. A term containing kanji (圕, 讀む) keeps exact-match
+// semantics and stays flagged when genuinely absent — this avoids turning the
+// lookup into a homophone engine (讀む would otherwise match 読む by reading).
+// ---------------------------------------------------------------------------
+
+/** Every char is hiragana / katakana / 長音符 (no kanji, ASCII, or symbols). */
+function isAllKana(s) {
+  return typeof s === "string" && s.length > 0 && /^[ぁ-ゖァ-ヺーー]+$/.test(s);
+}
+
+/** Hiragana → Katakana (code-point shift); other chars pass through. */
+function toKatakana(s) {
+  let out = "";
+  for (const ch of s) {
+    const c = ch.codePointAt(0);
+    out += c >= 0x3041 && c <= 0x3096 ? String.fromCodePoint(c + 0x60) : ch;
+  }
+  return out;
+}
+
+/** Katakana → Hiragana (code-point shift); other chars pass through. */
+function toHiragana(s) {
+  let out = "";
+  for (const ch of s) {
+    const c = ch.codePointAt(0);
+    out += c >= 0x30a1 && c <= 0x30f6 ? String.fromCodePoint(c - 0x60) : ch;
+  }
+  return out;
+}
+
+/**
+ * Candidate reading_primary keys for an all-kana term. We probe BOTH scripts so
+ * the fallback is robust to whichever convention the dictionary stores readings
+ * in (hiragana or katakana).
+ */
+function readingForms(term) {
+  return [...new Set([term, toKatakana(term), toHiragana(term)])];
+}
+
 // Security: dictionary assets may only be downloaded over https from these hosts
 const ALLOWED_DOWNLOAD_HOSTS = new Set([
   "github.com",
@@ -219,6 +268,16 @@ class DictManager {
         rwDb.exec("CREATE INDEX IF NOT EXISTS idx_dict_entry_text ON entries(entry);");
         console.log("[DictManager] Indexes created");
       }
+      // Reading index: powers homophone lookup (queryByReading) and the all-kana
+      // reading fallback in lookupBatch (#1935). Best-effort — guarded so an
+      // older DB lacking the reading_primary column doesn't fail the open.
+      try {
+        rwDb.exec(
+          "CREATE INDEX IF NOT EXISTS idx_dict_reading_primary ON entries(reading_primary);",
+        );
+      } catch (readingIdxErr) {
+        console.warn("[DictManager] reading index create skipped:", readingIdxErr.message);
+      }
     } catch (err) {
       // Index creation is best-effort; don't fail the whole open
       console.warn("[DictManager] Index check/create failed:", err);
@@ -303,10 +362,16 @@ class DictManager {
    * never the full DictEntry — so hundreds of words cost one query + one small
    * IPC payload. Terms with no match are simply absent from the result.
    *
+   * When `normalize` is true (default), all-kana terms that miss the headword
+   * index are re-resolved against the reading index so 表記ゆれ (e.g. kana
+   * 「ある」 → headword 「有る」) does not read as out-of-dictionary. Results are
+   * keyed by the REQUESTED term, so callers/caches stay keyed by what they asked.
+   *
    * @param {string[]} terms
+   * @param {boolean} [normalize=true] Enable the all-kana reading fallback.
    * @returns {Array<{ entry: string } & import("../lib/dict/dict-types").DictLookup>}
    */
-  lookupBatch(terms) {
+  lookupBatch(terms, normalize = true) {
     if (this._downloadMutex.locked) return [];
     if (!Array.isArray(terms)) return [];
     const unique = [...new Set(terms.filter((t) => typeof t === "string" && t.length > 0))];
@@ -315,23 +380,74 @@ class DictManager {
     const db = this._openDb();
     if (!db) return [];
 
+    const byEntry = new Map();
     try {
       const placeholders = unique.map(() => "?").join(",");
       const rows = db
         .prepare(`SELECT entry, raw_json FROM entries WHERE entry IN (${placeholders})`)
         .all(...unique);
 
-      const byEntry = new Map();
       for (const row of rows) {
         if (byEntry.has(row.entry)) continue; // first row wins for a given headword
         const proj = this._rawJsonToLookup(row.raw_json);
         if (proj) byEntry.set(row.entry, { entry: row.entry, ...proj });
       }
-      return [...byEntry.values()];
     } catch (err) {
       console.error("[DictManager] lookupBatch error:", err);
       if (this._isCorruptionError(err)) this._corrupt = true;
       return [];
+    }
+
+    if (normalize) {
+      this._resolveKanaByReading(db, unique, byEntry);
+    }
+    return [...byEntry.values()];
+  }
+
+  /**
+   * Reading-index fallback for all-kana terms that missed the headword index.
+   * Mutates `byEntry`, keying each resolved hit by the original requested term.
+   * Isolated try/catch: a missing `reading_primary` column (older DB) or any
+   * reading-query failure degrades silently to exact-match-only — never flips a
+   * word to absent and never marks the DB corrupt.
+   * @private
+   */
+  _resolveKanaByReading(db, unique, byEntry) {
+    const kanaMisses = unique.filter((t) => !byEntry.has(t) && isAllKana(t));
+    if (kanaMisses.length === 0) return;
+
+    // reading_primary candidate → requested terms that map to it
+    const readingToTerms = new Map();
+    for (const t of kanaMisses) {
+      for (const r of readingForms(t)) {
+        const list = readingToTerms.get(r);
+        if (list) list.push(t);
+        else readingToTerms.set(r, [t]);
+      }
+    }
+    const readings = [...readingToTerms.keys()];
+    if (readings.length === 0) return;
+
+    try {
+      const placeholders = readings.map(() => "?").join(",");
+      const rows = db
+        .prepare(
+          `SELECT reading_primary, raw_json FROM entries WHERE reading_primary IN (${placeholders})`,
+        )
+        .all(...readings);
+
+      for (const row of rows) {
+        const targets = readingToTerms.get(row.reading_primary);
+        if (!targets) continue;
+        const proj = this._rawJsonToLookup(row.raw_json);
+        if (!proj) continue;
+        for (const t of targets) {
+          if (!byEntry.has(t)) byEntry.set(t, { entry: t, ...proj });
+        }
+      }
+    } catch (err) {
+      // Reading fallback is best-effort. Do NOT mark corrupt or clear results.
+      console.warn("[DictManager] reading fallback failed:", err);
     }
   }
 
@@ -801,4 +917,4 @@ function getDictManager() {
   return _manager;
 }
 
-module.exports = { getDictManager };
+module.exports = { getDictManager, isAllKana, toKatakana, toHiragana, readingForms };

--- a/electron/ipc/dict-ipc.js
+++ b/electron/ipc/dict-ipc.js
@@ -43,13 +43,14 @@ function registerDictHandlers() {
   const MAX_BATCH_TERMS = 1000;
 
   // Exact-match batch lookup (lightweight projection) for analysis features
-  ipcMain.handle(DICT_CHANNELS.invoke.lookupBatch, async (_event, { terms } = {}) => {
+  ipcMain.handle(DICT_CHANNELS.invoke.lookupBatch, async (_event, { terms, normalize } = {}) => {
     try {
       if (!Array.isArray(terms)) return [];
       const safe = terms
         .filter((t) => typeof t === "string" && t.length > 0)
         .slice(0, MAX_BATCH_TERMS);
-      return mgr.lookupBatch(safe);
+      // Default true (kana reading fallback); only an explicit `false` disables it.
+      return mgr.lookupBatch(safe, normalize !== false);
     } catch (err) {
       console.error("[Dict IPC] dict:lookup-batch failed:", err);
       return [];

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -201,7 +201,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
       reading,
       limit,
     })),
-    lookupBatch: invokeChannel(DICT_CHANNELS.invoke.lookupBatch, (terms) => ({ terms })),
+    lookupBatch: invokeChannel(DICT_CHANNELS.invoke.lookupBatch, (terms, normalize) => ({
+      terms,
+      normalize,
+    })),
     verify: invokeChannel(DICT_CHANNELS.invoke.verify, { arity: 0 }),
     getStatus: invokeChannel(DICT_CHANNELS.invoke.getStatus, { arity: 0 }),
     checkUpdate: invokeChannel(DICT_CHANNELS.invoke.checkUpdate, { arity: 0 }),

--- a/lib/dict/__tests__/dict-access.test.ts
+++ b/lib/dict/__tests__/dict-access.test.ts
@@ -136,7 +136,8 @@ describe("DictAccess (#1624)", () => {
       const access = await importFresh();
 
       await access.lookupBatch(["雪", "雪", ""]);
-      expect(lookupBatch).toHaveBeenCalledWith(["雪"]);
+      // normalize defaults true → forwarded to the Electron lookup (#1935).
+      expect(lookupBatch).toHaveBeenCalledWith(["雪"], true);
     });
 
     it("does NOT record an I/O error as a miss (leaves terms unresolved, re-queries next time)", async () => {

--- a/lib/dict/__tests__/kana.test.ts
+++ b/lib/dict/__tests__/kana.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+
+import { isAllKana, toKatakana, toHiragana, readingForms } from "@/lib/dict/kana";
+
+describe("kana helpers (#1935 reading normalization)", () => {
+  describe("isAllKana — the safety gate for reading fallback", () => {
+    it("accepts fully-kana content words", () => {
+      expect(isAllKana("ある")).toBe(true);
+      expect(isAllKana("わかる")).toBe(true);
+      expect(isAllKana("アル")).toBe(true);
+      expect(isAllKana("コーヒー")).toBe(true); // includes 長音符
+    });
+
+    it("rejects terms containing kanji so they keep exact-match semantics", () => {
+      expect(isAllKana("讀む")).toBe(false); // 讀 is kanji → must stay flaggable
+      expect(isAllKana("圕")).toBe(false);
+      expect(isAllKana("有る")).toBe(false);
+    });
+
+    it("rejects ascii / empty / symbols", () => {
+      expect(isAllKana("")).toBe(false);
+      expect(isAllKana("abc")).toBe(false);
+      expect(isAllKana("123")).toBe(false);
+    });
+  });
+
+  describe("script conversion", () => {
+    it("hiragana → katakana", () => {
+      expect(toKatakana("ある")).toBe("アル");
+      expect(toKatakana("わかる")).toBe("ワカル");
+    });
+    it("katakana → hiragana", () => {
+      expect(toHiragana("アル")).toBe("ある");
+    });
+    it("passes through long vowel and non-kana", () => {
+      expect(toKatakana("ー")).toBe("ー");
+    });
+  });
+
+  describe("readingForms — probes both scripts", () => {
+    it("returns the term plus its katakana/hiragana variants, deduped", () => {
+      expect(readingForms("ある").sort()).toEqual(["ある", "アル"].sort());
+      expect(readingForms("アル").sort()).toEqual(["ある", "アル"].sort());
+    });
+  });
+});

--- a/lib/dict/dict-access.ts
+++ b/lib/dict/dict-access.ts
@@ -36,9 +36,22 @@ export interface GenjiHealth {
 }
 
 interface ElectronDictApi {
-  lookupBatch: (terms: string[]) => Promise<Array<{ entry: string } & DictLookup>>;
+  lookupBatch: (
+    terms: string[],
+    normalize?: boolean,
+  ) => Promise<Array<{ entry: string } & DictLookup>>;
   verify: () => Promise<{ ok: boolean; reason?: string }>;
   getStatus: () => Promise<{ status: string; installedVersion?: string }>;
+}
+
+/** Options for {@link DictAccess.lookupBatch}. */
+export interface DictLookupOptions {
+  /**
+   * Resolve all-kana terms that miss the headword index via the reading index
+   * (e.g. kana 「ある」 → headword 「有る」, #1935). Default true. Pass false for a
+   * strict headword-only lookup.
+   */
+  normalize?: boolean;
 }
 
 function getElectronDict(): ElectronDictApi | null {
@@ -133,7 +146,11 @@ class DictAccess {
    * Batch exact-match lookup. Returns a map keyed by every requested (deduped,
    * non-empty) term; misses map to `{ found: false }`. Cached per-term.
    */
-  async lookupBatch(terms: string[]): Promise<Map<string, DictLookup>> {
+  async lookupBatch(
+    terms: string[],
+    opts: DictLookupOptions = {},
+  ): Promise<Map<string, DictLookup>> {
+    const normalize = opts.normalize ?? true;
     const out = new Map<string, DictLookup>();
     const misses: string[] = [];
     const seen = new Set<string>();
@@ -152,9 +169,9 @@ class DictAccess {
 
     const dict = getElectronDict();
     if (dict) {
-      await this.lookupLocal(dict, misses, out);
+      await this.lookupLocal(dict, misses, out, normalize);
     } else {
-      await this.lookupRemote(misses, out);
+      await this.lookupRemote(misses, out, normalize);
     }
     return out;
   }
@@ -163,12 +180,13 @@ class DictAccess {
     dict: ElectronDictApi,
     misses: string[],
     out: Map<string, DictLookup>,
+    normalize: boolean,
   ): Promise<void> {
     for (let i = 0; i < misses.length; i += LOCAL_BATCH_CHUNK) {
       const chunk = misses.slice(i, i + LOCAL_BATCH_CHUNK);
       let rows: Array<{ entry: string } & DictLookup>;
       try {
-        rows = await dict.lookupBatch(chunk);
+        rows = await dict.lookupBatch(chunk, normalize);
       } catch (err) {
         // A transient IPC error must NOT be recorded as "these words are absent":
         // leave the chunk unresolved (callers see no entry → treat as unknown,
@@ -198,7 +216,11 @@ class DictAccess {
     }
   }
 
-  private async lookupRemote(misses: string[], out: Map<string, DictLookup>): Promise<void> {
+  private async lookupRemote(
+    misses: string[],
+    out: Map<string, DictLookup>,
+    normalize: boolean,
+  ): Promise<void> {
     const capped = misses.slice(0, REMOTE_MAX_TERMS);
     if (capped.length < misses.length) {
       console.warn(
@@ -208,7 +230,7 @@ class DictAccess {
 
     let map: Map<string, DictLookup>;
     try {
-      map = await GenjiApiBackend.lookupBatchRemote(capped);
+      map = await GenjiApiBackend.lookupBatchRemote(capped, normalize);
     } catch (err) {
       // Same fail-safe as the local path: a network error must not be cached as
       // "absent". Leave the terms unresolved so a later request can retry and so

--- a/lib/dict/kana.ts
+++ b/lib/dict/kana.ts
@@ -1,0 +1,47 @@
+/**
+ * Kana helpers for the reading-index normalization fallback (#1935).
+ *
+ * The dictionary indexes headwords by written form only, so a kana spelling of a
+ * word stored under a kanji headword (e.g. verb 「ある」 → 「有る」) misses an exact
+ * lookup. When an ALL-KANA term misses we re-resolve it through the reading
+ * index. The all-kana gate is the safety boundary: terms containing kanji (圕,
+ * 讀む) keep exact-match semantics so genuinely out-of-dictionary words stay
+ * flagged and the lookup never becomes a homophone engine.
+ *
+ * NOTE: `electron/dict-manager.js` (main process, CommonJS) intentionally keeps
+ * a copy of this logic — the two run in different runtimes and cannot share a
+ * module. Keep them behaviorally in sync.
+ */
+
+/** Every char is hiragana / katakana / 長音符 (no kanji, ASCII, or symbols). */
+export function isAllKana(s: string): boolean {
+  return typeof s === "string" && s.length > 0 && /^[ぁ-ゖァ-ヺーー]+$/.test(s);
+}
+
+/** Hiragana → Katakana (code-point shift); other chars pass through. */
+export function toKatakana(s: string): string {
+  let out = "";
+  for (const ch of s) {
+    const c = ch.codePointAt(0) ?? 0;
+    out += c >= 0x3041 && c <= 0x3096 ? String.fromCodePoint(c + 0x60) : ch;
+  }
+  return out;
+}
+
+/** Katakana → Hiragana (code-point shift); other chars pass through. */
+export function toHiragana(s: string): string {
+  let out = "";
+  for (const ch of s) {
+    const c = ch.codePointAt(0) ?? 0;
+    out += c >= 0x30a1 && c <= 0x30f6 ? String.fromCodePoint(c - 0x60) : ch;
+  }
+  return out;
+}
+
+/**
+ * Candidate reading_primary keys for an all-kana term. Probes BOTH scripts so the
+ * fallback is robust to whichever convention the dictionary stores readings in.
+ */
+export function readingForms(term: string): string[] {
+  return [...new Set([term, toKatakana(term), toHiragana(term)])];
+}

--- a/lib/dict/providers/__tests__/genji-api-backend.test.ts
+++ b/lib/dict/providers/__tests__/genji-api-backend.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mapRawJsonToDictEntry, queryByEntry, queryByReading } from "../genji-api-backend";
+import {
+  mapRawJsonToDictEntry,
+  queryByEntry,
+  queryByReading,
+  lookupBatchRemote,
+} from "../genji-api-backend";
 
 // ---------------------------------------------------------------------------
 // Sample raw_json fixture
@@ -215,5 +220,60 @@ describe("queryByReading", () => {
 
     expect(results).toHaveLength(1);
     expect(results[0].reading.primary).toBe("ゆき");
+  });
+});
+
+describe("lookupBatchRemote kana reading normalization (#1935)", () => {
+  const originalFetch = globalThis.fetch;
+
+  // Verb 有る stored under its kanji headword with kana reading ある.
+  const ARU_RAW = {
+    uuid: "u-aru",
+    entry: "有る",
+    reading: { primary: "ある", alternatives: [] },
+    grammar: { pos: ["動詞"], ctype: null, inflections: null },
+    definitions: [{ index: 1, gloss: "to exist" }],
+    relations: { homophones: [], synonyms: [], antonyms: [], related: [] },
+  };
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  /** Mock that branches on the SQL: entry-IN misses, reading-IN finds 有る. */
+  function mockBranchingFetch() {
+    return vi.fn((input: RequestInfo | URL) => {
+      const sql = new URL(String(input)).searchParams.get("sql") ?? "";
+      const rows = sql.includes("reading_primary IN")
+        ? [{ raw_json: JSON.stringify(ARU_RAW) }]
+        : [];
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ rows }),
+      }) as Promise<Response>;
+    });
+  }
+
+  it("resolves all-kana 「ある」 to 有る via the reading index", async () => {
+    globalThis.fetch = mockBranchingFetch();
+    const map = await lookupBatchRemote(["ある"]);
+    expect(map.get("ある")).toMatchObject({ found: true, reading: "ある", pos: "動詞" });
+  });
+
+  it("does NOT issue a reading query when normalize is false", async () => {
+    const fetchMock = mockBranchingFetch();
+    globalThis.fetch = fetchMock;
+    const map = await lookupBatchRemote(["ある"], false);
+    expect(map.get("ある")).toEqual({ found: false });
+    const calledReading = fetchMock.mock.calls.some((c) =>
+      String(c[0]).includes("reading_primary"),
+    );
+    expect(calledReading).toBe(false);
+  });
+
+  it("does NOT reading-resolve kanji terms (圕 stays out-of-dictionary)", async () => {
+    globalThis.fetch = mockBranchingFetch();
+    const map = await lookupBatchRemote(["圕"]);
+    expect(map.get("圕")).toEqual({ found: false });
   });
 });

--- a/lib/dict/providers/genji-api-backend.ts
+++ b/lib/dict/providers/genji-api-backend.ts
@@ -13,6 +13,7 @@ import type {
   DictReading,
   DictLookup,
 } from "../dict-types";
+import { isAllKana, readingForms } from "../kana";
 
 const GENJI_API_BASE = "https://api.dict.illusions.app";
 const FETCH_TIMEOUT_MS = 5000;
@@ -204,13 +205,20 @@ function rawJsonToLookup(raw: RawJson): DictLookup {
 const REMOTE_BATCH_CHUNK = 50;
 
 /**
- * Exact-match batch lookup over the remote Genji API (web fallback). Issues one
+ * Batch lookup over the remote Genji API (web fallback). Issues one
  * parameterized `entry IN (...)` query per chunk. Returns a map keyed by the
  * requested term; misses map to `{ found: false }`. Slower than the local
  * Electron path, so callers doing bulk analysis should gate on dictionary
  * health and prefer the local DB.
+ *
+ * When `normalize` is true (default), all-kana terms that miss the headword
+ * index are re-resolved via the reading index (kana 「ある」 → headword 「有る」,
+ * #1935), keyed by the requested term — mirroring the local DictManager path.
  */
-export async function lookupBatchRemote(terms: string[]): Promise<Map<string, DictLookup>> {
+export async function lookupBatchRemote(
+  terms: string[],
+  normalize = true,
+): Promise<Map<string, DictLookup>> {
   const result = new Map<string, DictLookup>();
   const unique = [...new Set(terms.filter((t) => typeof t === "string" && t.length > 0))];
 
@@ -228,10 +236,57 @@ export async function lookupBatchRemote(terms: string[]): Promise<Map<string, Di
     }
   }
 
+  if (normalize) {
+    await resolveKanaByReadingRemote(unique, result);
+  }
+
   for (const t of unique) {
     if (!result.has(t)) result.set(t, { found: false });
   }
   return result;
+}
+
+/**
+ * Reading-index fallback for all-kana misses (web). Queries `reading_primary IN
+ * (...)` and maps each hit back to the requested kana term via its reading forms.
+ * Mutates `result`; never overwrites an existing (exact) hit.
+ */
+async function resolveKanaByReadingRemote(
+  unique: string[],
+  result: Map<string, DictLookup>,
+): Promise<void> {
+  const kanaMisses = unique.filter((t) => !result.has(t) && isAllKana(t));
+  if (kanaMisses.length === 0) return;
+
+  // reading_primary candidate → requested terms that map to it
+  const readingToTerms = new Map<string, string[]>();
+  for (const t of kanaMisses) {
+    for (const r of readingForms(t)) {
+      const list = readingToTerms.get(r);
+      if (list) list.push(t);
+      else readingToTerms.set(r, [t]);
+    }
+  }
+  const readings = [...readingToTerms.keys()];
+
+  for (let i = 0; i < readings.length; i += REMOTE_BATCH_CHUNK) {
+    const chunk = readings.slice(i, i + REMOTE_BATCH_CHUNK);
+    const params: Record<string, string> = {};
+    const names = chunk.map((r, j) => {
+      params[`p${j}`] = r;
+      return `:p${j}`;
+    });
+    const sql = `SELECT raw_json FROM entries WHERE reading_primary IN (${names.join(",")})`;
+    const raws = await executeSql(sql, params);
+    for (const raw of raws) {
+      const targets = readingToTerms.get(raw.reading?.primary);
+      if (!targets) continue;
+      const lookup = rawJsonToLookup(raw);
+      for (const t of targets) {
+        if (!result.has(t)) result.set(t, lookup);
+      }
+    }
+  }
 }
 
 /**

--- a/lib/linting/sdk/index.ts
+++ b/lib/linting/sdk/index.ts
@@ -34,6 +34,7 @@ export type {
   UnitDetectorOptions,
   UnitSpec,
   WordListMatch,
+  DictCandidateOptions,
 } from "./ruleset-context";
 
 // Core lint types ruleset code interacts with

--- a/lib/linting/sdk/ruleset-context.ts
+++ b/lib/linting/sdk/ruleset-context.ts
@@ -13,6 +13,9 @@
 import type { Token } from "@/lib/nlp-client/types";
 import type { DictLookup } from "@/lib/dict/dict-types";
 import type { GenjiHealthState } from "@/lib/dict/dict-access";
+import type { DictCandidateOptions } from "@/lib/linting/dict-candidate-terms";
+
+export type { DictCandidateOptions };
 
 import type {
   AbstractDocumentLintRule,
@@ -109,6 +112,22 @@ export interface DictToolkit {
   hasCached(term: string): boolean;
   /** Synchronous projection lookup against the current prewarmed snapshot. */
   lookupCached(term: string): DictLookup | undefined;
+  /**
+   * The dictionary headword a token should be looked up under, or `null` if the
+   * token is not a checkable content word (名詞 → surface, 動詞/形容詞 → basic
+   * form, falling back to surface).
+   *
+   * Host-owned so rulesets need NOT vendor a private copy of this selection.
+   * The host prewarms snapshot membership with the exact same logic, so the key
+   * a rule queries always matches a key that was prewarmed — eliminating the
+   * "ruleset mirror drifts out of sync → snapshot miss" failure mode.
+   */
+  candidateTerm(token: Token, opts?: DictCandidateOptions): string | null;
+  /**
+   * Deduplicated list of dictionary headwords to query for a token set — the
+   * same selection {@link candidateTerm} applies, used by the host at prewarm.
+   */
+  candidateTerms(tokens: ReadonlyArray<Token>, opts?: DictCandidateOptions): string[];
 }
 
 /** Shared detector library. Centralizes logic so rules stay declarative-ish. */

--- a/lib/linting/toolkit/__tests__/dict-toolkit.test.ts
+++ b/lib/linting/toolkit/__tests__/dict-toolkit.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect, vi } from "vitest";
 
 import { createDictToolkit, createSnapshotDictToolkit } from "../dict-toolkit";
 import type { GenjiHealth } from "@/lib/dict/dict-access";
+import type { Token } from "@/lib/nlp-client/types";
+
+function tok(partial: Partial<Token> & { surface: string; pos: string }): Token {
+  return {
+    pos_detail_1: undefined,
+    pos_detail_2: undefined,
+    pos_detail_3: undefined,
+    basic_form: partial.surface,
+    reading: undefined,
+    start: 0,
+    end: partial.surface.length,
+    ...partial,
+  } as Token;
+}
 
 function spyDict() {
   return {
@@ -39,6 +53,32 @@ describe("createDictToolkit", () => {
     const tk = createDictToolkit({ state: "ready" } as GenjiHealth, spyDict());
     expect(tk.hasCached("猫")).toBe(false);
     expect(tk.lookupCached("猫")).toBeUndefined();
+  });
+});
+
+describe("candidateTerm / candidateTerms (Tier 0, #1935)", () => {
+  // Host-owned headword selection so rulesets need not vendor a private copy.
+  it.each([
+    createDictToolkit({ state: "ready" } as GenjiHealth, spyDict()),
+    createSnapshotDictToolkit(),
+  ])("exposes the host headword selection on every toolkit variant", (tk) => {
+    // 名詞 → surface; 動詞 → basic_form; auxiliary/ascii → null.
+    expect(tk.candidateTerm(tok({ surface: "辞書", pos: "名詞", pos_detail_1: "一般" }))).toBe(
+      "辞書",
+    );
+    expect(
+      tk.candidateTerm(
+        tok({ surface: "走っ", pos: "動詞", pos_detail_1: "自立", basic_form: "走る" }),
+      ),
+    ).toBe("走る");
+    expect(tk.candidateTerm(tok({ surface: "を", pos: "助詞" }))).toBeNull();
+
+    const terms = tk.candidateTerms([
+      tok({ surface: "猫", pos: "名詞", pos_detail_1: "一般" }),
+      tok({ surface: "が", pos: "助詞" }),
+      tok({ surface: "走っ", pos: "動詞", pos_detail_1: "自立", basic_form: "走る" }),
+    ]);
+    expect(terms.sort()).toEqual(["猫", "走る"].sort());
   });
 });
 

--- a/lib/linting/toolkit/dict-toolkit.ts
+++ b/lib/linting/toolkit/dict-toolkit.ts
@@ -10,6 +10,12 @@
 import type { DictLookup } from "@/lib/dict/dict-types";
 import type { GenjiHealth, GenjiHealthState } from "@/lib/dict/dict-access";
 import type { DictToolkit } from "../sdk/ruleset-context";
+import type { Token } from "@/lib/nlp-client/types";
+import {
+  collectDictCandidateTerms,
+  dictCandidateTerm,
+  type DictCandidateOptions,
+} from "../dict-candidate-terms";
 
 /** Minimal dictionary surface needed by the toolkit (injectable for tests). */
 export interface DictLike {
@@ -70,6 +76,12 @@ export function createDictToolkit(health: GenjiHealth, dict: DictLike): DictTool
     lookupCached(): DictLookup | undefined {
       return undefined;
     },
+    candidateTerm(token: Token, opts?: DictCandidateOptions): string | null {
+      return dictCandidateTerm(token, opts);
+    },
+    candidateTerms(tokens: ReadonlyArray<Token>, opts?: DictCandidateOptions): string[] {
+      return collectDictCandidateTerms(tokens, opts);
+    },
   };
 }
 
@@ -108,6 +120,12 @@ export function createSnapshotDictToolkit(): DictToolkitInternal {
     lookupCached(term: string): DictLookup | undefined {
       if (!ready) return undefined;
       return snapshot.get(term);
+    },
+    candidateTerm(token: Token, opts?: DictCandidateOptions): string | null {
+      return dictCandidateTerm(token, opts);
+    },
+    candidateTerms(tokens: ReadonlyArray<Token>, opts?: DictCandidateOptions): string[] {
+      return collectDictCandidateTerms(tokens, opts);
     },
     setSnapshot(entries: ReadonlyArray<DictSnapshotEntry>, isReady: boolean): void {
       snapshot = new Map(entries);

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -311,10 +311,16 @@ declare global {
       /** Query entries by kana reading (homophone lookup) */
       queryByReading: (reading: string, limit?: number) => Promise<DictEntry[]>;
       /**
-       * Exact-match batch lookup (lightweight projection) for analysis features.
-       * Terms with no match are omitted from the result array.
+       * Batch lookup (lightweight projection) for analysis features and lint
+       * prewarm. Headword exact-match by default; when `normalize` is true
+       * (default), all-kana terms that miss are resolved via the reading index
+       * (e.g. kana 「ある」 → headword 「有る」, #1935) and returned keyed by the
+       * requested term. Terms with no match are omitted from the result array.
        */
-      lookupBatch: (terms: string[]) => Promise<Array<{ entry: string } & DictLookup>>;
+      lookupBatch: (
+        terms: string[],
+        normalize?: boolean,
+      ) => Promise<Array<{ entry: string } & DictLookup>>;
       /** Fast integrity check; `ok: false` means the DB should be re-downloaded. */
       verify: () => Promise<{
         ok: boolean;


### PR DESCRIPTION
## 概要

`dict:genji` 系ルール（幻辞 未知語検出 等）で、かな表記の自立語（例:「ある」）が誤って「辞書外」と判定される誤検出を修正します。設計方針 #1935 の **Tier 0 + Tier 1-lite** を illusions 本体に実装したものです。

Closes #1935

## 根本原因

1. **一方向索引** — 辞書は見出し文字列の完全一致でしか引けず、正規化概念が無い。幻辞は動詞を漢字見出し（有る/在る）で収録するため、かな「ある」(basic_form=ある) が外れる。`reading_primary` 索引は存在するのに照合キーに使われていなかった。
2. **ミラーコピー** — prewarm の候補キー抽出ロジックを各ルールセットが信頼境界越しに byte-for-byte 複製しており、ドリフトの温床になっていた（SDK は型しか runtime export できず、ルールが import できなかったため）。

## 変更内容

### Tier 0 — 候補キー生成を API 化（方式 a）
- `DictToolkit` に `candidateTerm` / `candidateTerms` を追加（`createDictToolkit` / `createSnapshotDictToolkit` 両実装）
- ルールセットは `ctx.toolkit.dict.candidateTerm()` を呼べばよく、プライベートなミラーコピーが不要に（掃除は **genji-vocab#6** で追従）
- prewarm と同一ロジックを共有 → prewarm キー集合とルール照合キーの一致を**構造的に保証**（undefined スキップ問題を解消）
- `DictCandidateOptions` を SDK から export

### Tier 1-lite — reading 正規化フォールバック（**既定 ON・kana 限定**）
- `lookupBatch` の miss のうち「**全 kana**」の語だけ `reading_primary` 索引へ寄せ、**requested term をキーに**結果を返す（local `DictManager` / web `genji-api-backend` 両対応）
- **kana 限定ゲートが過剰抑制を防ぐ**:「ある」「わかる」は救済、漢字を含む「圕」「讀む」は exact 維持で検出継続（讀む は 読む と同読みだが kana でないため寄せない）
- `normalize` はオプション引数（既定 `true`、後方互換）。IPC 署名へ optional 引数を追加するのみ
- `reading_primary` に best-effort 索引を追加（queryByReading も高速化）

### fail-safe（不変）
未 prewarm→`undefined` スキップ / I/O エラー→MISS 非キャッシュ / dict 未 ready→無検出 をすべて維持。reading 索引欠落 DB は exact のみへ静かに縮退（corrupt 判定しない）。

## 設計判断（#1935 への回答）
- **方式 (a)** を採用：ルールは runtime 値を SDK から import できないため、toolkit メソッドとしてホストが注入する形が唯一の経路
- **normalize は既定 ON**：データ層（dict-access/manager/remote）で正規化するため、prewarm 経由で snapshot が正規化済みになり、**genji-vocab を含む全ルールセットが無改修**で表記ゆれから解放される
- ルールセット側は **ミラー廃止の掃除のみ**で済む（genji-vocab#6）

## テスト
- 「ある」「わかる」非検出 /「圕」「讀む」検出継続（local manager + web remote 両方）
- kana ゲート単体（isAllKana / readingForms）
- `candidateTerm` 全 toolkit variant
- `normalize:false` で厳格 headword 一致

✅ `tsc --noEmit` / `eslint` / `vitest run`（2168 tests）/ `check:boundaries` / `bundle:electron` すべて green

## やらないこと（Tier 2 — 範囲外）
フル読み照合エンジン・網羅的異表記テーブル・同音異義ポリシーをホストに抱え込まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)