### PR TITLE
fix(tab-manager): 既開ファイルの再オープンでdirty内容を破棄しない (#1873)

### DIFF
--- a/lib/tab-manager/__tests__/reopen-dirty-tab-no-clobber.test.tsx
+++ b/lib/tab-manager/__tests__/reopen-dirty-tab-no-clobber.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * Regression tests for #1873 (P0 DATA LOSS):
+ * 未保存ファイルを再度開くとdirty内容を無警告でディスク値へ置換する.
+ *
+ * When a path with unsaved (dirty) edits is opened again — via the "ファイルを開く"
+ * dialog (openFile) or a Finder / OS open-file event (loadSystemFile) — the
+ * existing tab must be ACTIVATED with its in-memory buffer left untouched. The
+ * old code unconditionally overwrote content / lastSavedContent and reset
+ * isDirty=false, silently destroying the user's unsaved work.
+ *
+ * These tests drive the REAL useFileIO hook via createRoot + act (repo pattern,
+ * no @testing-library/react) so they cover the actual dedup branches, not a
+ * re-implementation.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useEffect, useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { useFileIO } from "../use-file-io";
+import { decideReopenExistingTab } from "../reopen-existing-tab";
+import type { EditorTabState, TabState, TabId } from "../tab-types";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { openMdiFileMock } = vi.hoisted(() => ({
+  openMdiFileMock: vi.fn(),
+}));
+
+vi.mock("../../project/mdi-file", () => ({
+  openMdiFile: openMdiFileMock,
+}));
+
+vi.mock("../../services/notification-manager", () => ({
+  notificationManager: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), showMessage: vi.fn() },
+}));
+
+vi.mock("../../storage/storage-service", () => ({
+  getStorageService: () => ({
+    initialize: vi.fn(async () => undefined),
+    saveEditorBuffer: vi.fn(async () => undefined),
+    setItem: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("../../storage/app-state-manager", () => ({
+  persistAppState: vi.fn(async () => undefined),
+}));
+
+vi.mock("../../services/history-service", () => ({
+  getHistoryService: () => ({
+    shouldCreateSnapshot: vi.fn(async () => false),
+    createSnapshot: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("../../services/project-file-service", () => ({
+  getProjectFileService: () => ({ isRootOpen: () => false, readFile: vi.fn(async () => "") }),
+}));
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const DIRTY_CONTENT = "ユーザーが書いた未保存の本文";
+const DISK_CONTENT = "ディスク上の古い内容";
+const FILE_PATH = "/Users/x/novel.mdi";
+
+function makeDirtyTab(): EditorTabState {
+  return {
+    tabKind: "editor",
+    id: "tab-dirty",
+    file: { path: FILE_PATH, handle: null, name: "novel.mdi" },
+    content: DIRTY_CONTENT,
+    lastSavedContent: DISK_CONTENT,
+    isDirty: true,
+    lastSavedTime: 1_000,
+    lastSaveWasAuto: false,
+    isSaving: false,
+    isPreview: false,
+    fileType: ".mdi",
+    fileSyncStatus: "dirty",
+    conflictDiskContent: null,
+  };
+}
+
+interface Captured {
+  openFile: () => Promise<void>;
+  loadSystemFile: (path: string, content: string) => void;
+  updateTab: ReturnType<typeof vi.fn>;
+  setActiveTabId: ReturnType<typeof vi.fn>;
+  setTabs: ReturnType<typeof vi.fn>;
+}
+
+// Stable module-level sink the Harness writes into via an effect (avoids
+// mutating React props and avoids reassigning during render).
+const captured: Partial<Captured> = {};
+
+function resetCaptured(): void {
+  captured.openFile = undefined;
+  captured.loadSystemFile = undefined;
+  captured.updateTab = undefined;
+  captured.setActiveTabId = undefined;
+  captured.setTabs = undefined;
+}
+
+function Harness({ tabs }: { tabs: TabState[] }): null {
+  const tabsRef = useRef<TabState[]>(tabs);
+  tabsRef.current = tabs;
+  const activeTabIdRef = useRef<TabId>("tab-other"); // some other tab is active
+  const isProjectRef = useRef(false);
+
+  const setTabs = useRef(vi.fn()).current;
+  const setActiveTabId = useRef(vi.fn()).current;
+  const updateTab = useRef(vi.fn()).current;
+  const findTabByPath = useRef((p: string) =>
+    tabsRef.current.find((t): t is EditorTabState => t.tabKind === "editor" && t.file?.path === p),
+  ).current;
+
+  const io = useFileIO({
+    tabs,
+    setTabs,
+    activeTabId: "tab-other",
+    setActiveTabId,
+    tabsRef,
+    activeTabIdRef,
+    isProjectRef,
+    isElectron: true,
+    updateTab,
+    findTabByPath,
+  });
+
+  useEffect(() => {
+    captured.openFile = io.openFile;
+    captured.loadSystemFile = io.loadSystemFile;
+    captured.updateTab = updateTab;
+    captured.setActiveTabId = setActiveTabId;
+    captured.setTabs = setTabs;
+  });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetCaptured();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+// ---------------------------------------------------------------------------
+// Pure decision helper
+// ---------------------------------------------------------------------------
+
+describe("#1873 decideReopenExistingTab", () => {
+  it("returns null when no existing tab (caller creates a new tab)", () => {
+    expect(decideReopenExistingTab(undefined)).toBeNull();
+  });
+
+  it("activates the existing tab and never reloads from disk (dirty tab)", () => {
+    const decision = decideReopenExistingTab(makeDirtyTab());
+    expect(decision).toEqual({ activateTabId: "tab-dirty", reloadFromDisk: false });
+  });
+
+  it("activates the existing tab and never reloads from disk (clean tab)", () => {
+    const clean: EditorTabState = { ...makeDirtyTab(), isDirty: false, fileSyncStatus: "clean" };
+    const decision = decideReopenExistingTab(clean);
+    expect(decision?.reloadFromDisk).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openFile (file dialog) — repro A
+// ---------------------------------------------------------------------------
+
+describe("#1873 openFile reopening a dirty tab", () => {
+  it("activates the existing dirty tab WITHOUT overwriting its content/isDirty", async () => {
+    openMdiFileMock.mockResolvedValue({
+      descriptor: { path: FILE_PATH, handle: null, name: "novel.mdi" },
+      content: DISK_CONTENT,
+    });
+
+    await act(async () => {
+      root.render(<Harness tabs={[makeDirtyTab()]} />);
+    });
+
+    await act(async () => {
+      await captured.openFile!();
+    });
+
+    // Existing tab is activated…
+    expect(captured.setActiveTabId).toHaveBeenCalledWith("tab-dirty");
+    // …and its buffer was NOT touched (no updateTab clobber on the dirty tab).
+    const clobbered = captured.updateTab!.mock.calls.some((call: unknown[]) => {
+      const id = call[0] as TabId;
+      const updates = call[1] as Partial<EditorTabState>;
+      return (
+        id === "tab-dirty" &&
+        ("content" in updates || "lastSavedContent" in updates || "isDirty" in updates)
+      );
+    });
+    expect(clobbered).toBe(false);
+    // No new tab created.
+    expect(captured.setTabs).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadSystemFile (Finder / OS open-file event) — repro B
+// ---------------------------------------------------------------------------
+
+describe("#1873 loadSystemFile reopening a dirty tab", () => {
+  it("activates the existing dirty tab WITHOUT overwriting content/isDirty", async () => {
+    await act(async () => {
+      root.render(<Harness tabs={[makeDirtyTab()]} />);
+    });
+
+    await act(async () => {
+      captured.loadSystemFile!(FILE_PATH, DISK_CONTENT);
+    });
+
+    expect(captured.setActiveTabId).toHaveBeenCalledWith("tab-dirty");
+    const clobbered = captured.updateTab!.mock.calls.some(
+      (call: unknown[]) => (call[0] as TabId) === "tab-dirty",
+    );
+    expect(clobbered).toBe(false);
+    expect(captured.setTabs).not.toHaveBeenCalled();
+  });
+
+  it("activates a clean tab without implicitly reloading disk content", async () => {
+    const clean: EditorTabState = {
+      ...makeDirtyTab(),
+      content: DISK_CONTENT,
+      isDirty: false,
+      fileSyncStatus: "clean",
+    };
+    await act(async () => {
+      root.render(<Harness tabs={[clean]} />);
+    });
+
+    await act(async () => {
+      captured.loadSystemFile!(FILE_PATH, "別の新しいディスク内容");
+    });
+
+    expect(captured.setActiveTabId).toHaveBeenCalledWith("tab-dirty");
+    // Clean tab must not be implicitly reloaded either (reload = explicit action).
+    expect(captured.updateTab!.mock.calls.length).toBe(0);
+  });
+});

--- a/lib/tab-manager/reopen-existing-tab.ts
+++ b/lib/tab-manager/reopen-existing-tab.ts
@@ -1,0 +1,50 @@
+/**
+ * Decision logic for re-opening a path that is already open in a tab (#1873).
+ *
+ * Data-loss bug: previously, both `openFile` (system dialog) and
+ * `loadSystemFile` (Finder / OS open-file event) unconditionally overwrote the
+ * existing tab's `content` / `lastSavedContent` with the freshly-read disk
+ * value and reset `isDirty` to `false`. If the tab had unsaved edits, those
+ * edits were silently destroyed with no warning, snapshot, or undo recovery.
+ *
+ * Correct behaviour (per #1873 期待する結果):
+ *   - If the same path is already open, ALWAYS just activate that tab.
+ *   - Never implicitly overwrite in-memory content from disk — neither for
+ *     dirty tabs (would lose edits) nor for clean tabs (reload-from-disk must
+ *     be an explicit user action, not a side effect of "open").
+ *
+ * An explicit "reload from disk" flow that discards unsaved edits with
+ * confirmation + pre-reload snapshot lives elsewhere (file-watch integration);
+ * the plain "open the same file again" path must preserve user data.
+ */
+
+import type { EditorTabState } from "./tab-types";
+
+/** Outcome of the reopen-existing-tab decision. */
+export interface ReopenDecision {
+  /** Activate this existing tab (always set when a duplicate is found). */
+  activateTabId: string;
+  /**
+   * Whether the in-memory content may be safely refreshed from disk.
+   *
+   * Always `false`: re-opening a path never clobbers the buffer. A true
+   * disk reload is a separate, explicit, confirmation-gated action.
+   */
+  reloadFromDisk: false;
+}
+
+/**
+ * Decide what to do when the user opens a path that is already open.
+ *
+ * @returns a decision that only ever activates the existing tab. Returns
+ *          `null` when there is no existing tab (caller proceeds to create one).
+ */
+export function decideReopenExistingTab(
+  existing: EditorTabState | undefined,
+): ReopenDecision | null {
+  if (!existing) return null;
+  return {
+    activateTabId: existing.id,
+    reloadFromDisk: false,
+  };
+}

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -14,6 +14,7 @@ import type { SnapshotType } from "../services/history-policy";
 import { getProjectFileService } from "../services/project-file-service";
 import { executeTabSave } from "./save-executor";
 import type { SaveOutcome } from "./save-executor";
+import { decideReopenExistingTab } from "./reopen-existing-tab";
 import type { TabId, EditorTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
 import { generateTabId, inferFileType, getErrorMessage } from "./types";
@@ -233,18 +234,15 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
     const { descriptor, content: fileContent } = result;
 
-    // Deduplicate: if the same path is already open, reload from disk and activate
+    // Deduplicate: if the same path is already open, just activate that tab.
+    // #1873: NEVER overwrite the in-memory buffer from disk here. Doing so
+    // silently destroyed unsaved edits (dirty tab) and forced an implicit
+    // reload on clean tabs. A real disk reload is a separate, explicit,
+    // confirmation-gated action handled by the file-watch integration.
     if (descriptor.path) {
-      const existing = findTabByPath(descriptor.path);
-      if (existing) {
-        // Force-refresh tab content so stale in-memory state is replaced with the
-        // latest content that was just read from disk by openMdiFile().
-        updateTab(existing.id, {
-          content: fileContent,
-          lastSavedContent: fileContent,
-          isDirty: false,
-        });
-        setActiveTabId(existing.id);
+      const decision = decideReopenExistingTab(findTabByPath(descriptor.path));
+      if (decision) {
+        setActiveTabId(decision.activateTabId);
         return;
       }
     }
@@ -502,16 +500,12 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
   /** Load a file by path + content into a new tab (or reuse/deduplicate) */
   const loadSystemFile = useCallback(
     (path: string, fileContent: string) => {
-      // Deduplication
-      const existing = findTabByPath(path);
-      if (existing) {
-        updateTab(existing.id, {
-          content: fileContent,
-          lastSavedContent: fileContent,
-          isDirty: false,
-          lastSavedTime: Date.now(),
-        });
-        setActiveTabId(existing.id);
+      // Deduplication (#1873): if the same path is already open (e.g. Finder
+      // re-open / OS open-file event), just activate the tab. Never overwrite
+      // the in-memory buffer from disk — that silently destroyed unsaved edits.
+      const decision = decideReopenExistingTab(findTabByPath(path));
+      if (decision) {
+        setActiveTabId(decision.activateTabId);
         return;
       }
 


### PR DESCRIPTION
## 概要

Closes #1873

未保存編集 (dirty) のあるファイルを再度開くと、既存タブの buffer が
ディスク内容で無条件に置換され、未保存編集が警告なしに失われる
P0 データ損失バグを修正する。

## 根本原因

`lib/tab-manager/use-file-io.ts` の dedup 分岐 2 箇所が、同じ path の
既存タブに対して `content` / `lastSavedContent` を上書きし
`isDirty=false` にリセットしていた。`isDirty` / `fileSyncStatus` の
確認が一切なかった。

- `openFile()`（メニュー「ファイルを開く」）
- `loadSystemFile()`（Finder / OS open-file event、`onOpenFileFromSystem` 経由）

なお `openProjectFile()` の dedup は元から activate のみで安全。

## 修正

- dedup 時は **既存タブを activate するだけ** とし、メモリ上の内容を
  一切変更しない（dirty/clean いずれも暗黙 reload しない）。
- ディスクからの明示的な再読込はユーザーの明示操作（file-watch 統合の
  「ディスクの内容を採用」確認 + pre-external-reload snapshot）に委ねる。
- 判断ロジックを pure な `decideReopenExistingTab()` (`reopen-existing-tab.ts`)
  に切り出し、openFile / loadSystemFile で共有。

## テスト

`reopen-dirty-tab-no-clobber.test.tsx`（実 `useFileIO` フックを
createRoot + act で駆動）:

- dirty タブの再 Open で content/isDirty が変わらず activate のみ（再現手順 A）
- Finder open-file event でも dirty content が保持される（再現手順 B）
- clean タブは activate のみで暗黙 reload しない
- `decideReopenExistingTab` の pure ユニット

```
tab-manager 全体: 27 test files / 253 tests pass
npx tsc --noEmit: clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)