### PR TITLE
fix(tab-manager): 開いているファイルの rename/移動/削除をタブと同期 (#1868)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -379,6 +379,9 @@ export default function EditorPage() {
     handleCloseTabCancel,
     flushTabState,
     restoreProjectTabs,
+    notifyFileRenamed,
+    findTabsAffectedByDelete,
+    notifyFileDeleted,
   } = tabManager;
 
   // Keep a live tabs ref for dockview panel renderers captured by stale closures.
@@ -1407,6 +1410,9 @@ export default function EditorPage() {
     onProjectBufferChange: handleProjectSearchBufferChange,
     newFileTrigger,
     openProjectFile,
+    onFileRenamed: notifyFileRenamed,
+    onFileDeleted: notifyFileDeleted,
+    findTabsAffectedByDelete,
     incrementEditorKey,
     onWordSearch: (word: string) => {
       // 共有検索語へ反映し、フローティング検索窓を開く。

--- a/components/SidebarPanel.tsx
+++ b/components/SidebarPanel.tsx
@@ -12,6 +12,7 @@ import { isProjectMode } from "@/lib/project/project-types";
 import type { ActivityBarView } from "@/components/ActivityBar";
 import type { EditorMode } from "@/lib/project/project-types";
 import type { SearchMatch, SearchTarget } from "@/lib/editor-page/find-search-matches";
+import type { AffectedTab } from "@/lib/tab-manager/tab-path-sync";
 import type { EditorView } from "@milkdown/prose/view";
 
 interface SidebarPanelProps {
@@ -62,6 +63,12 @@ interface SidebarPanelProps {
   newFileTrigger: number;
   /** Opens a project file by VFS path. */
   openProjectFile: (vfsPath: string, options: { preview: boolean }) => Promise<void>;
+  /** Notify the tab manager that a project file/folder was renamed/moved (#1868). */
+  onFileRenamed: (oldPath: string, newPath: string) => void;
+  /** Notify the tab manager that a project file/folder was deleted (#1868). */
+  onFileDeleted: (deletedPath: string) => void;
+  /** List open tabs affected by deleting a path, for dirty-confirmation (#1868). */
+  findTabsAffectedByDelete: (deletedPath: string) => AffectedTab[];
   /** Increments the editor key, forcing the editor to remount. */
   incrementEditorKey: () => void;
   /** Called when a word in the word-frequency panel should be searched. */
@@ -109,6 +116,9 @@ export default function SidebarPanel({
   onProjectBufferChange,
   newFileTrigger,
   openProjectFile,
+  onFileRenamed,
+  onFileDeleted,
+  findTabsAffectedByDelete,
   onWordSearch,
 }: SidebarPanelProps): React.ReactElement | null {
   switch (view) {
@@ -128,6 +138,9 @@ export default function SidebarPanel({
                 void openProjectFile(vfsPath, { preview: false });
               }}
               newFileTrigger={newFileTrigger}
+              onFileRenamed={onFileRenamed}
+              onFileDeleted={onFileDeleted}
+              findTabsAffectedByDelete={findTabsAffectedByDelete}
             />
           </div>
         </aside>

--- a/components/explorer/FilesPanel.tsx
+++ b/components/explorer/FilesPanel.tsx
@@ -20,6 +20,7 @@ import {
 } from "./tree-navigation";
 import type { FileTreeEntry, EditingEntry } from "./types";
 import type { VirtualFileSystem } from "@/lib/vfs/types";
+import type { AffectedTab } from "@/lib/tab-manager/tab-path-sync";
 
 /**
  * Check whether a file/directory name already exists inside a VFS parent directory.
@@ -55,6 +56,15 @@ interface FilesPanelProps {
   onFileMiddleClick?: (vfsPath: string) => void;
   /** Increment to trigger a new file creation at root with default name. */
   newFileTrigger?: number;
+  /**
+   * Notify the tab manager that a file/folder was renamed/moved (#1868).
+   * Paths are VFS-relative (no leading slash), matching `tab.file.path`.
+   */
+  onFileRenamed?: (oldVfsPath: string, newVfsPath: string) => void;
+  /** Notify the tab manager that a file/folder was deleted (#1868). */
+  onFileDeleted?: (deletedVfsPath: string) => void;
+  /** List open tabs affected by deleting a path, for dirty-confirmation (#1868). */
+  findTabsAffectedByDelete?: (deletedVfsPath: string) => AffectedTab[];
 }
 
 /** File tree panel for browsing and managing project files */
@@ -64,6 +74,9 @@ export function FilesPanel({
   onFileDoubleClick,
   onFileMiddleClick,
   newFileTrigger,
+  onFileRenamed,
+  onFileDeleted,
+  findTabsAffectedByDelete,
 }: FilesPanelProps) {
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set(["/"]));
   const [tree, setTree] = useState<FileTreeEntry[] | null>(null);
@@ -74,6 +87,8 @@ export function FilesPanel({
     path: string;
     kind: "file" | "directory";
     name: string;
+    /** Open tabs (#1868) affected by this delete; dirty ones need a warning. */
+    affectedTabs: AffectedTab[];
   } | null>(null);
   /** Pending overwrite confirmation: holds the operation to execute after user confirms */
   const [overwriteConfirm, setOverwriteConfirm] = useState<{
@@ -254,10 +269,16 @@ export function FilesPanel({
   /** Convert tree path (e.g. "/subdir/file.txt") to VFS-relative path (e.g. "subdir/file.txt") */
   const toVFSPath = (treePath: string): string => treePath.replace(/^\//, "");
 
-  const handleDelete = useCallback((fullPath: string, kind: "file" | "directory") => {
-    const name = fullPath.split("/").pop() || fullPath;
-    setDeleteConfirm({ path: fullPath, kind, name });
-  }, []);
+  const handleDelete = useCallback(
+    (fullPath: string, kind: "file" | "directory") => {
+      const name = fullPath.split("/").pop() || fullPath;
+      // #1868: detect open tabs (incl. nested files for a folder delete) so the
+      // confirmation can warn about unsaved edits before destroying them.
+      const affectedTabs = findTabsAffectedByDelete?.(toVFSPath(fullPath)) ?? [];
+      setDeleteConfirm({ path: fullPath, kind, name, affectedTabs });
+    },
+    [findTabsAffectedByDelete],
+  );
 
   const executeDelete = useCallback(
     async (fullPath: string, kind: "file" | "directory") => {
@@ -279,12 +300,15 @@ export function FilesPanel({
         } else {
           await vfs.deleteFile(toVFSPath(fullPath));
         }
+        // #1868: detach any open tabs at/under the deleted path so the next
+        // save cannot recreate the now-deleted file at its old location.
+        onFileDeleted?.(toVFSPath(fullPath));
         refresh();
       } catch (error) {
         console.error("Failed to delete:", error);
       }
     },
-    [refresh],
+    [refresh, onFileDeleted],
   );
 
   const handleRename = useCallback(
@@ -311,6 +335,8 @@ export function FilesPanel({
             name: newName,
             execute: async () => {
               await vfs.rename(toVFSPath(fullPath), toVFSPath(newFullPath));
+              // #1868: keep open tabs in sync with the new path before refresh.
+              onFileRenamed?.(toVFSPath(fullPath), toVFSPath(newFullPath));
               refresh();
             },
           });
@@ -318,13 +344,15 @@ export function FilesPanel({
         }
 
         await vfs.rename(toVFSPath(fullPath), toVFSPath(newFullPath));
+        // #1868: keep open tabs in sync with the new path before refresh.
+        onFileRenamed?.(toVFSPath(fullPath), toVFSPath(newFullPath));
         setEditing(null);
         refresh();
       } catch (error) {
         console.error("Failed to rename:", error);
       }
     },
-    [refresh],
+    [refresh, onFileRenamed],
   );
 
   const handleDuplicate = useCallback(
@@ -523,6 +551,8 @@ export function FilesPanel({
             name,
             execute: async () => {
               await vfs.rename(toVFSPath(srcPath), toVFSPath(newPath));
+              // #1868: keep open tabs in sync with the moved path.
+              onFileRenamed?.(toVFSPath(srcPath), toVFSPath(newPath));
               refresh();
             },
           });
@@ -530,12 +560,14 @@ export function FilesPanel({
         }
 
         await vfs.rename(toVFSPath(srcPath), toVFSPath(newPath));
+        // #1868: keep open tabs in sync with the moved path.
+        onFileRenamed?.(toVFSPath(srcPath), toVFSPath(newPath));
         refresh();
       } catch (error) {
         console.error("Failed to move:", error);
       }
     },
-    [refresh],
+    [refresh, onFileRenamed],
   );
 
   /** Import external files dropped from the OS into destDir */
@@ -1314,11 +1346,23 @@ export function FilesPanel({
       <ConfirmDialog
         isOpen={deleteConfirm !== null}
         title="削除の確認"
-        message={
-          deleteConfirm?.kind === "directory"
-            ? `フォルダ「${deleteConfirm.name}」を削除しますか？中のファイルもすべて削除されます。`
-            : `ファイル「${deleteConfirm?.name ?? ""}」を削除しますか？`
-        }
+        message={(() => {
+          if (!deleteConfirm) return "";
+          const base =
+            deleteConfirm.kind === "directory"
+              ? `フォルダ「${deleteConfirm.name}」を削除しますか？中のファイルもすべて削除されます。`
+              : `ファイル「${deleteConfirm.name}」を削除しますか？`;
+          // #1868: warn when open tabs — especially dirty ones — are affected.
+          const dirtyTabs = deleteConfirm.affectedTabs.filter((t) => t.isDirty);
+          if (dirtyTabs.length > 0) {
+            const names = dirtyTabs.map((t) => `「${t.name}」`).join("、");
+            return `${base}\n\n未保存の変更があるファイル（${names}）が開かれています。削除すると未保存の変更は失われます。`;
+          }
+          if (deleteConfirm.affectedTabs.length > 0) {
+            return `${base}\n\n開いているタブはファイル未関連付けの状態になります。`;
+          }
+          return base;
+        })()}
         confirmLabel="削除する"
         cancelLabel="キャンセル"
         dangerous={true}

--- a/lib/project/project-types.ts
+++ b/lib/project/project-types.ts
@@ -51,6 +51,18 @@ export interface WorkspaceTab {
   fileName: string;
   isPreview?: boolean;
   fileType?: SupportedFileExtension;
+  /**
+   * Editor buffer of an unsaved tab, persisted so its content survives an app
+   * restart. Only written for tabs that have NO file-backing (`relativePath`
+   * is null) AND are dirty — e.g. a freshly typed untitled buffer, or a tab
+   * detached after its file was deleted from the explorer (#1868). For
+   * file-backed tabs the content is re-read from disk on restore, so it is
+   * intentionally omitted here to avoid bloating workspace.json.
+   *
+   * 未保存タブのエディタバッファ。アプリ再起動後も内容を失わないよう保存する。
+   * file 紐付けが無く (relativePath が null) かつ dirty なタブにのみ書き込む。
+   */
+  unsavedContent?: string;
 }
 
 /** Simplified, ID-independent dockview layout for workspace.json persistence. */

--- a/lib/tab-manager/__tests__/detached-tab-persistence-roundtrip.test.tsx
+++ b/lib/tab-manager/__tests__/detached-tab-persistence-roundtrip.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Regression test for #1868 — detached dirty tab survives an app restart.
+ *
+ * When an OPEN file is deleted from the explorer, applyTabDelete detaches the
+ * tab (file → null) and marks it dirty so the next save can no longer resurrect
+ * the deleted path. Earlier the project-mode persistence layer stored only
+ * relativePath + fileName, so a detached tab (relativePath === null) was
+ * restored as a BLANK new tab — silently losing the unsaved buffer across a
+ * quit/reopen cycle.
+ *
+ * These tests exercise the REAL persistence round-trip (persistTabStateNow →
+ * workspace.json shape → restoreProjectTabs) and prove the detached dirty tab's
+ * content is recovered, not dropped. They drive the real hook via
+ * createRoot + act (repo pattern, no @testing-library/react).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import { useTabPersistence, type UseTabPersistenceReturn } from "../use-tab-persistence";
+import { generateTabId } from "../types";
+import { applyTabDelete } from "../tab-path-sync";
+import { isEditorTab } from "../tab-types";
+import type { EditorTabState, TabState, TabId } from "../tab-types";
+import type { WorkspaceTab } from "../../project/project-types";
+
+// Capture the openTabs payload written to workspace.json so we can feed it back
+// into restoreProjectTabs and verify the full round-trip.
+const { persistWorkspaceJsonMock } = vi.hoisted(() => ({
+  persistWorkspaceJsonMock: vi.fn(async (_state: unknown) => undefined),
+}));
+
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({
+    initialize: vi.fn(async () => undefined),
+    loadAppState: vi.fn(async () => null),
+    getItem: vi.fn(async () => null),
+    loadEditorBuffer: vi.fn(async () => null),
+    clearEditorBuffer: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("@/lib/storage/app-state-manager", () => ({
+  fetchWindowState: vi.fn(async () => null),
+  persistWindowState: vi.fn(async () => undefined),
+  persistAppState: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/project/workspace-persistence", () => ({
+  persistWorkspaceJson: persistWorkspaceJsonMock,
+  toRelativePath: (p: string) => p,
+  toAbsolutePath: (p: string) => p,
+}));
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => ({ readFile: vi.fn(async () => "disk content") }),
+}));
+
+// ---------------------------------------------------------------------------
+// Harness — exposes the hook's API + tab state to the test
+// ---------------------------------------------------------------------------
+
+interface HarnessHandle {
+  api: UseTabPersistenceReturn;
+  tabs: TabState[];
+  setTabs: (next: TabState[]) => void;
+}
+
+function Harness({ onReady }: { onReady: (h: HarnessHandle) => void }): null {
+  const [tabs, setTabsState] = React.useState<TabState[]>([]);
+  const [activeTabId, setActiveTabId] = React.useState<TabId>("");
+
+  const tabsRef = useRef<TabState[]>(tabs);
+  tabsRef.current = tabs;
+  const activeTabIdRef = useRef<TabId>(activeTabId);
+  activeTabIdRef.current = activeTabId;
+  const isProjectRef = useRef(true); // project mode → workspace.json path
+
+  const api = useTabPersistence({
+    tabs,
+    setTabs: setTabsState as never,
+    activeTabId,
+    setActiveTabId: setActiveTabId as never,
+    tabsRef,
+    activeTabIdRef,
+    isProjectRef,
+    isElectron: true,
+    skipAutoRestore: true,
+    windowKey: "/proj",
+  });
+
+  onReady({ api, tabs, setTabs: (next) => setTabsState(next) });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  persistWorkspaceJsonMock.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+function makeFileTab(path: string, name: string, content: string): EditorTabState {
+  return {
+    tabKind: "editor",
+    id: generateTabId(),
+    file: { path, handle: null, name },
+    content,
+    lastSavedContent: content,
+    isDirty: false,
+    lastSavedTime: Date.now(),
+    lastSaveWasAuto: false,
+    isSaving: false,
+    isPreview: false,
+    fileType: ".mdi",
+    fileSyncStatus: "clean",
+    conflictDiskContent: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("#1868 — detached dirty tab persistence round-trip", () => {
+  it("recovers the unsaved buffer of a tab detached after its file was deleted", async () => {
+    let handle!: HarnessHandle;
+    await act(async () => {
+      root.render(<Harness onReady={(h) => (handle = h)} />);
+    });
+
+    // 1. Open a file-backed tab, then the user edits it (dirty).
+    const opened = makeFileTab("chapter1.mdi", "chapter1.mdi", "下書きの本文");
+    const dirty: EditorTabState = {
+      ...opened,
+      content: "編集した未保存の本文",
+      isDirty: true,
+      fileSyncStatus: "dirty",
+    };
+
+    // 2. The file is deleted from the explorer → tab is detached (file → null).
+    const { tabs: detachedTabs } = applyTabDelete([dirty], "chapter1.mdi");
+    const detached = detachedTabs.find(isEditorTab)!;
+    expect(detached.file).toBeNull();
+    expect(detached.isDirty).toBe(true);
+
+    await act(async () => {
+      handle.setTabs(detachedTabs);
+    });
+
+    // 3. Persist (quit) — capture the workspace.json openTabs payload.
+    await act(async () => {
+      await handle.api.flushTabState();
+    });
+
+    expect(persistWorkspaceJsonMock).toHaveBeenCalled();
+    const lastCall = persistWorkspaceJsonMock.mock.calls.at(-1)![0] as {
+      openTabs: { tabs: WorkspaceTab[]; activeIndex: number };
+    };
+    const savedTabs = lastCall.openTabs.tabs;
+    expect(savedTabs).toHaveLength(1);
+    // GAP guard: the detached tab has no path, but its content IS persisted.
+    expect(savedTabs[0].relativePath).toBeNull();
+    expect(savedTabs[0].unsavedContent).toBe("編集した未保存の本文");
+
+    // 4. Reopen (restore) — the buffer must come back, dirty, not blank.
+    let recovered = false;
+    await act(async () => {
+      recovered = await handle.api.restoreProjectTabs({ tabs: savedTabs, activeIndex: 0 }, "/proj");
+    });
+    expect(recovered).toBe(true);
+
+    const restored = handle.tabs.filter(isEditorTab);
+    expect(restored).toHaveLength(1);
+    expect(restored[0].content).toBe("編集した未保存の本文");
+    expect(restored[0].isDirty).toBe(true);
+    expect(restored[0].fileSyncStatus).toBe("dirty");
+  });
+
+  it("does not persist content for clean file-backed tabs (re-read from disk)", async () => {
+    let handle!: HarnessHandle;
+    await act(async () => {
+      root.render(<Harness onReady={(h) => (handle = h)} />);
+    });
+
+    const clean = makeFileTab("chapter2.mdi", "chapter2.mdi", "保存済み本文");
+    await act(async () => {
+      handle.setTabs([clean]);
+    });
+    await act(async () => {
+      await handle.api.flushTabState();
+    });
+
+    const payload = persistWorkspaceJsonMock.mock.calls.at(-1)![0] as {
+      openTabs: { tabs: WorkspaceTab[] };
+    };
+    expect(payload.openTabs.tabs[0].relativePath).toBe("chapter2.mdi");
+    expect(payload.openTabs.tabs[0].unsavedContent).toBeUndefined();
+  });
+
+  it("restores an empty untitled tab as a clean blank tab", async () => {
+    let handle!: HarnessHandle;
+    await act(async () => {
+      root.render(<Harness onReady={(h) => (handle = h)} />);
+    });
+
+    await act(async () => {
+      await handle.api.restoreProjectTabs(
+        {
+          tabs: [{ relativePath: null, fileName: "新規ファイル", fileType: ".mdi" }],
+          activeIndex: 0,
+        },
+        "/proj",
+      );
+    });
+
+    const restored = handle.tabs.filter(isEditorTab);
+    expect(restored).toHaveLength(1);
+    expect(restored[0].content).toBe("");
+    expect(restored[0].isDirty).toBe(false);
+  });
+});

--- a/lib/tab-manager/__tests__/tab-path-sync.test.ts
+++ b/lib/tab-manager/__tests__/tab-path-sync.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Unit tests for the explorer ↔ tab path-sync helpers (#1868).
+ *
+ * Covers the three distinct explorer mutations that previously left open tabs
+ * pointing at a stale `tab.file.path`, resurrecting the old path on the next
+ * save:
+ *   - rename / move of an open file
+ *   - rename / move of a folder containing open files (fan-out)
+ *   - delete of an open file or folder (descriptor detach, no resurrection)
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  applyTabDelete,
+  applyTabRename,
+  findTabsUnderPath,
+  isPathAtOrUnder,
+  rewritePath,
+} from "@/lib/tab-manager/tab-path-sync";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
+import type { EditorTabState, TabState } from "@/lib/tab-manager/tab-types";
+import { generateTabId } from "@/lib/tab-manager/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEditorTab(
+  path: string | null,
+  name: string,
+  overrides?: Partial<EditorTabState>,
+): EditorTabState {
+  return {
+    tabKind: "editor",
+    id: generateTabId(),
+    file: path === null ? null : { path, handle: null, name },
+    content: "本文",
+    lastSavedContent: "本文",
+    isDirty: false,
+    lastSavedTime: null,
+    lastSaveWasAuto: false,
+    isSaving: false,
+    isPreview: false,
+    fileType: ".mdi",
+    fileSyncStatus: "clean",
+    conflictDiskContent: null,
+    ...overrides,
+  };
+}
+
+function editorTabById(tabs: TabState[], id: string): EditorTabState {
+  const tab = tabs.find((t) => t.id === id);
+  if (!tab || !isEditorTab(tab)) throw new Error("expected editor tab");
+  return tab;
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+describe("isPathAtOrUnder", () => {
+  it("matches the exact path", () => {
+    expect(isPathAtOrUnder("a/b.mdi", "a/b.mdi")).toBe(true);
+  });
+
+  it("matches descendants of a directory", () => {
+    expect(isPathAtOrUnder("dir/sub/file.mdi", "dir")).toBe(true);
+    expect(isPathAtOrUnder("dir/file.mdi", "dir")).toBe(true);
+  });
+
+  it("does not match sibling prefixes (no false positive on name overlap)", () => {
+    // "dir2" must NOT be considered under "dir".
+    expect(isPathAtOrUnder("dir2/file.mdi", "dir")).toBe(false);
+    expect(isPathAtOrUnder("formatting-2.mdi", "formatting.mdi")).toBe(false);
+  });
+});
+
+describe("rewritePath", () => {
+  it("rewrites an exact file rename", () => {
+    expect(rewritePath("a.mdi", "a.mdi", "b.mdi")).toBe("b.mdi");
+  });
+
+  it("rewrites nested paths under a renamed directory", () => {
+    expect(rewritePath("old/c1/file.mdi", "old", "new")).toBe("new/c1/file.mdi");
+  });
+
+  it("returns null for unaffected paths", () => {
+    expect(rewritePath("other.mdi", "a.mdi", "b.mdi")).toBeNull();
+    expect(rewritePath("dir2/x.mdi", "dir", "renamed")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rename / move
+// ---------------------------------------------------------------------------
+
+describe("applyTabRename", () => {
+  it("updates the path and name of a renamed open file", () => {
+    const tab = makeEditorTab("formatting.mdi", "formatting.mdi", { isDirty: true });
+    const { tabs, changed } = applyTabRename([tab], "formatting.mdi", "formatting-renamed.mdi");
+
+    expect(changed).toBe(true);
+    const updated = editorTabById(tabs, tab.id);
+    expect(updated.file?.path).toBe("formatting-renamed.mdi");
+    expect(updated.file?.name).toBe("formatting-renamed.mdi");
+    // Content / dirty state preserved (byte-preserving).
+    expect(updated.content).toBe("本文");
+    expect(updated.isDirty).toBe(true);
+  });
+
+  it("recomputes fileType when the extension changes", () => {
+    const tab = makeEditorTab("note.mdi", "note.mdi");
+    const { tabs } = applyTabRename([tab], "note.mdi", "note.md");
+    expect(editorTabById(tabs, tab.id).fileType).toBe(".md");
+  });
+
+  it("fans out to every tab under a renamed/moved folder", () => {
+    const a = makeEditorTab("chapter/a.mdi", "a.mdi");
+    const b = makeEditorTab("chapter/sub/b.mdi", "b.mdi");
+    const unrelated = makeEditorTab("other.mdi", "other.mdi");
+
+    const { tabs, changed } = applyTabRename([a, b, unrelated], "chapter", "part1");
+
+    expect(changed).toBe(true);
+    expect(editorTabById(tabs, a.id).file?.path).toBe("part1/a.mdi");
+    expect(editorTabById(tabs, b.id).file?.path).toBe("part1/sub/b.mdi");
+    // Unrelated tab is untouched (same reference).
+    expect(tabs.find((t) => t.id === unrelated.id)).toBe(unrelated);
+  });
+
+  it("does not touch sibling files that merely share a name prefix", () => {
+    const tab = makeEditorTab("formatting-2.mdi", "formatting-2.mdi");
+    const { tabs, changed } = applyTabRename([tab], "formatting.mdi", "renamed.mdi");
+    expect(changed).toBe(false);
+    expect(tabs).toBe(tabs); // same array (no change)
+    expect(editorTabById(tabs, tab.id).file?.path).toBe("formatting-2.mdi");
+  });
+
+  it("is a no-op when old === new", () => {
+    const tab = makeEditorTab("a.mdi", "a.mdi");
+    const result = applyTabRename([tab], "a.mdi", "a.mdi");
+    expect(result.changed).toBe(false);
+    expect(result.tabs).toBe(result.tabs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+describe("findTabsUnderPath", () => {
+  it("lists the affected file tab with dirty flag", () => {
+    const tab = makeEditorTab("a.mdi", "a.mdi", { isDirty: true });
+    const affected = findTabsUnderPath([tab], "a.mdi");
+    expect(affected).toEqual([{ id: tab.id, path: "a.mdi", name: "a.mdi", isDirty: true }]);
+  });
+
+  it("lists every tab under a deleted folder", () => {
+    const a = makeEditorTab("dir/a.mdi", "a.mdi", { isDirty: true });
+    const b = makeEditorTab("dir/sub/b.mdi", "b.mdi");
+    const outside = makeEditorTab("dir2/c.mdi", "c.mdi");
+
+    const affected = findTabsUnderPath([a, b, outside], "dir");
+    expect(affected.map((t) => t.id).sort()).toEqual([a.id, b.id].sort());
+  });
+});
+
+describe("applyTabDelete", () => {
+  it("detaches the descriptor of a deleted file so it cannot be resurrected", () => {
+    const tab = makeEditorTab("a.mdi", "a.mdi");
+    const { tabs, changed } = applyTabDelete([tab], "a.mdi");
+
+    expect(changed).toBe(true);
+    const updated = editorTabById(tabs, tab.id);
+    // No path/handle → save executor's project-VFS branch is skipped and
+    // background auto-save's `!tab.file` guard skips the tab.
+    expect(updated.file).toBeNull();
+    // Content survives; tab is flagged unsaved.
+    expect(updated.content).toBe("本文");
+    expect(updated.isDirty).toBe(true);
+    expect(updated.fileSyncStatus).toBe("dirty");
+  });
+
+  it("detaches every tab under a deleted folder, leaving siblings intact", () => {
+    const a = makeEditorTab("dir/a.mdi", "a.mdi");
+    const b = makeEditorTab("dir/sub/b.mdi", "b.mdi");
+    const outside = makeEditorTab("dir2/c.mdi", "c.mdi");
+
+    const { tabs } = applyTabDelete([a, b, outside], "dir");
+
+    expect(editorTabById(tabs, a.id).file).toBeNull();
+    expect(editorTabById(tabs, b.id).file).toBeNull();
+    // The sibling folder's tab keeps its descriptor.
+    expect(editorTabById(tabs, outside.id).file?.path).toBe("dir2/c.mdi");
+  });
+
+  it("is a no-op when no open tab matches", () => {
+    const tab = makeEditorTab("a.mdi", "a.mdi");
+    const result = applyTabDelete([tab], "b.mdi");
+    expect(result.changed).toBe(false);
+    expect(editorTabById(result.tabs, tab.id).file?.path).toBe("a.mdi");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resurrection-prevention contract (the core of #1868)
+// ---------------------------------------------------------------------------
+
+describe("stale-path resurrection prevention (#1868)", () => {
+  it("after rename, the tab targets ONLY the new path (no old-path write)", () => {
+    const tab = makeEditorTab("formatting.mdi", "formatting.mdi", { isDirty: true });
+    const { tabs } = applyTabRename([tab], "formatting.mdi", "formatting-renamed.mdi");
+    const updated = editorTabById(tabs, tab.id);
+    // The save executor writes to `tab.file.path` — it must now be the new path.
+    expect(updated.file?.path).toBe("formatting-renamed.mdi");
+    expect(updated.file?.path).not.toBe("formatting.mdi");
+  });
+
+  it("after delete, the tab has no path for any save flow to write back to", () => {
+    const tab = makeEditorTab("formatting.mdi", "formatting.mdi", { isDirty: true });
+    const { tabs } = applyTabDelete([tab], "formatting.mdi");
+    expect(editorTabById(tabs, tab.id).file?.path ?? null).toBeNull();
+  });
+});

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useRef, type MutableRefObject } from "react";
 import type { UseTabManagerReturn } from "./types";
+import { applyTabDelete, applyTabRename, findTabsUnderPath } from "./tab-path-sync";
+import type { AffectedTab } from "./tab-path-sync";
 import { useTabState } from "./use-tab-state";
 import { useFileIO } from "./use-file-io";
 import { useAutoSave } from "./use-auto-save";
@@ -173,6 +175,48 @@ export function useTabManager(options?: {
   // Update the ref so useElectronMenuBindings can access flushTabState
   flushTabStateRef.current = _flushTabState;
 
+  // --- Explorer file-system mutation sync (#1868) -------------------------
+  // Keep open tabs in sync when a project file/folder is renamed, moved, or
+  // deleted from the explorer (or inspector, #1870). Without this the tab keeps
+  // a stale `file.path`, and the next save resurrects the old path.
+
+  const { setTabs, tabsRef } = tabState;
+
+  /**
+   * Notify the tab manager that a file/folder was renamed or moved from
+   * `oldPath` to `newPath` (both VFS-relative). Atomically rewrites the
+   * path/name (and fileType) of the affected tab and every tab nested under a
+   * renamed directory. The file watcher self-corrects to the new path on the
+   * next render (watcherPaths mismatch).
+   */
+  const notifyFileRenamed = useCallback(
+    (oldPath: string, newPath: string): void => {
+      setTabs((prev) => applyTabRename(prev, oldPath, newPath).tabs);
+    },
+    [setTabs],
+  );
+
+  /**
+   * List the open editor tabs at or under `deletedPath` (VFS-relative). The
+   * explorer uses this to confirm dirty tabs before deleting.
+   */
+  const findTabsAffectedByDelete = useCallback(
+    (deletedPath: string): AffectedTab[] => findTabsUnderPath(tabsRef.current, deletedPath),
+    [tabsRef],
+  );
+
+  /**
+   * Notify the tab manager that a file/folder at `deletedPath` (VFS-relative)
+   * was deleted. Detaches the descriptor of every affected tab so no save flow
+   * can recreate the old path; the tab survives as an untitled dirty buffer.
+   */
+  const notifyFileDeleted = useCallback(
+    (deletedPath: string): void => {
+      setTabs((prev) => applyTabDelete(prev, deletedPath).tabs);
+    },
+    [setTabs],
+  );
+
   // --- Backward compat alias: newFile === newTab --------------------------
   const newFile = tabState.newTab;
 
@@ -235,5 +279,10 @@ export function useTabManager(options?: {
 
     // Project tab restore
     restoreProjectTabs,
+
+    // Explorer file-system mutation sync (#1868)
+    notifyFileRenamed,
+    findTabsAffectedByDelete,
+    notifyFileDeleted,
   };
 }

--- a/lib/tab-manager/tab-path-sync.ts
+++ b/lib/tab-manager/tab-path-sync.ts
@@ -1,0 +1,183 @@
+"use client";
+
+/**
+ * Reusable, pure tab path-sync helpers (#1868, shared with #1870).
+ *
+ * When a project file is renamed / moved / deleted from the explorer (or
+ * inspector), any open editor tab that references the old path keeps a stale
+ * `tab.file.path`. The next save (manual or auto) then writes to the old path
+ * via the save executor, resurrecting the renamed/deleted file at its previous
+ * location and splitting the document in two.
+ *
+ * These helpers compute the corrected tabs array for each mutation:
+ *   - applyTabRename : rewrite the path/name of the renamed file and every tab
+ *     under a renamed directory (atomic, byte-preserving — content untouched).
+ *   - applyTabDelete : detach the file descriptor (file → null) of every tab
+ *     under a deleted path so the save executor / auto-save can no longer
+ *     resurrect the old path. Detached tabs become "untitled" dirty tabs whose
+ *     content the user can still save elsewhere.
+ *
+ * All paths here are VFS-relative (e.g. "subdir/file.mdi"), matching both the
+ * explorer's `toVFSPath()` output and the project-mode `tab.file.path` value.
+ * They are pure functions over a tabs array so they can be unit-tested without
+ * React and reused by any caller (explorer mutations, inspector rename, …).
+ */
+
+import { isEditorTab } from "./tab-types";
+import { inferFileType } from "./types";
+import type { EditorTabState, TabState } from "./tab-types";
+
+// ---------------------------------------------------------------------------
+// Path matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether `candidate` is exactly `base` or a descendant path of the `base`
+ * directory. Used so a folder rename/delete also catches files nested inside.
+ *
+ * Both arguments must be VFS-relative paths with no leading slash.
+ */
+export function isPathAtOrUnder(candidate: string, base: string): boolean {
+  if (candidate === base) return true;
+  return candidate.startsWith(`${base}/`);
+}
+
+/**
+ * Rewrite a path that lives at or under `oldBase` so it lives at or under
+ * `newBase` instead. Returns the rewritten path, or null if `path` is not
+ * affected by the rename.
+ */
+export function rewritePath(path: string, oldBase: string, newBase: string): string | null {
+  if (path === oldBase) return newBase;
+  if (path.startsWith(`${oldBase}/`)) {
+    return `${newBase}${path.slice(oldBase.length)}`;
+  }
+  return null;
+}
+
+/** Extract the base name (last path segment) from a VFS-relative path. */
+function baseName(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}
+
+// ---------------------------------------------------------------------------
+// Rename / move
+// ---------------------------------------------------------------------------
+
+export interface ApplyTabRenameResult {
+  /** The new tabs array (referentially new only if something changed). */
+  tabs: TabState[];
+  /** Whether any tab descriptor was updated. */
+  changed: boolean;
+}
+
+/**
+ * Update every editor tab whose file path is at or under `oldPath` so it now
+ * references `newPath`, preserving content/dirty state. Handles both single
+ * file renames and directory renames/moves (which fan out to nested files).
+ *
+ * The tab's `fileType` is recomputed from the new name so an extension change
+ * (e.g. ".mdi" → ".md") is reflected. Content is never touched.
+ */
+export function applyTabRename(
+  tabs: TabState[],
+  oldPath: string,
+  newPath: string,
+): ApplyTabRenameResult {
+  if (oldPath === newPath) return { tabs, changed: false };
+
+  let changed = false;
+  const next = tabs.map((tab): TabState => {
+    if (!isEditorTab(tab) || !tab.file?.path) return tab;
+    const rewritten = rewritePath(tab.file.path, oldPath, newPath);
+    if (rewritten === null) return tab;
+    changed = true;
+    const newName = baseName(rewritten);
+    const updated: EditorTabState = {
+      ...tab,
+      file: { ...tab.file, path: rewritten, name: newName },
+      fileType: inferFileType(newName),
+    };
+    return updated;
+  });
+
+  return changed ? { tabs: next, changed } : { tabs, changed: false };
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+/** Information about an open tab affected by a delete, for confirmation UIs. */
+export interface AffectedTab {
+  id: string;
+  /** VFS-relative path of the affected tab. */
+  path: string;
+  /** Display name. */
+  name: string;
+  /** Whether the tab has unsaved edits (needs explicit confirmation). */
+  isDirty: boolean;
+}
+
+/**
+ * List the open editor tabs whose file path is at or under `deletedPath`.
+ * Callers use this to drive a save/discard/cancel confirmation before the
+ * actual VFS deletion, and to know which tabs to detach afterwards.
+ */
+export function findTabsUnderPath(tabs: TabState[], deletedPath: string): AffectedTab[] {
+  const result: AffectedTab[] = [];
+  for (const tab of tabs) {
+    if (!isEditorTab(tab) || !tab.file?.path) continue;
+    if (!isPathAtOrUnder(tab.file.path, deletedPath)) continue;
+    result.push({
+      id: tab.id,
+      path: tab.file.path,
+      name: tab.file.name,
+      isDirty: tab.isDirty,
+    });
+  }
+  return result;
+}
+
+export interface ApplyTabDeleteResult {
+  tabs: TabState[];
+  changed: boolean;
+}
+
+/**
+ * Detach the file descriptor of every editor tab at or under `deletedPath`.
+ *
+ * After detachment `tab.file` is null, so:
+ *   - the save executor's project-VFS branch (`isProject && tab.file?.path`)
+ *     is skipped — no implicit recreation of the deleted path;
+ *   - background auto-save skips the tab (`!tab.file` guard);
+ *   - the file watcher for the tab is torn down (path gone).
+ *
+ * The tab itself stays open as an untitled buffer so the user does not lose
+ * unsaved content; it is marked dirty so the content is recognized as unsaved.
+ * The associated watcher is removed by the watch-integration effect because the
+ * path no longer exists on the tab.
+ */
+export function applyTabDelete(tabs: TabState[], deletedPath: string): ApplyTabDeleteResult {
+  let changed = false;
+  const next = tabs.map((tab): TabState => {
+    if (!isEditorTab(tab) || !tab.file?.path) return tab;
+    if (!isPathAtOrUnder(tab.file.path, deletedPath)) return tab;
+    changed = true;
+    const detached: EditorTabState = {
+      ...tab,
+      // Drop path/handle so no save flow can write back to the deleted
+      // location. The user must choose a new save target via Save As.
+      file: null,
+      // The on-disk file is gone; remaining buffer content is now unsaved.
+      isDirty: true,
+      fileSyncStatus: "dirty",
+      conflictDiskContent: null,
+      pendingExternalContent: null,
+    };
+    return detached;
+  });
+
+  return changed ? { tabs: next, changed } : { tabs, changed: false };
+}

--- a/lib/tab-manager/tab-path-sync.ts
+++ b/lib/tab-manager/tab-path-sync.ts
@@ -14,8 +14,9 @@
  *     under a renamed directory (atomic, byte-preserving — content untouched).
  *   - applyTabDelete : detach the file descriptor (file → null) of every tab
  *     under a deleted path so the save executor / auto-save can no longer
- *     resurrect the old path. Detached tabs become "untitled" dirty tabs whose
- *     content the user can still save elsewhere.
+ *     resurrect the old path. Detached tabs become "untitled" dirty tabs; their
+ *     editor buffer is persisted by use-tab-persistence (project mode) so the
+ *     content survives an app restart and can be saved to a new location.
  *
  * All paths here are VFS-relative (e.g. "subdir/file.mdi"), matching both the
  * explorer's `toVFSPath()` output and the project-mode `tab.file.path` value.
@@ -156,6 +157,9 @@ export interface ApplyTabDeleteResult {
  *
  * The tab itself stays open as an untitled buffer so the user does not lose
  * unsaved content; it is marked dirty so the content is recognized as unsaved.
+ * In project mode the detached buffer is also persisted to workspace.json
+ * (WorkspaceTab.unsavedContent) by use-tab-persistence, so the content is
+ * recovered on the next app launch instead of being silently dropped (#1868).
  * The associated watcher is removed by the watch-integration effect because the
  * path no longer exists on the tab.
  */

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -6,6 +6,7 @@ import type { MdiFileDescriptor } from "../project/mdi-file";
 import type { SupportedFileExtension, WorkspaceTab } from "../project/project-types";
 import type { TabId, TabState, EditorTabState, TerminalTabState } from "./tab-types";
 import type { SaveOutcome } from "./save-executor";
+import type { AffectedTab } from "./tab-path-sync";
 
 // ---------------------------------------------------------------------------
 // Save-all aggregate result (#1859)
@@ -123,6 +124,26 @@ export interface UseTabManagerReturn {
     savedTabs: { tabs: WorkspaceTab[]; activeIndex: number } | undefined,
     rootPath: string | null,
   ) => Promise<boolean>;
+
+  // Explorer file-system mutation sync (#1868, shared with #1870)
+  /**
+   * Notify the tab manager that a project file/folder was renamed or moved
+   * (paths VFS-relative). Atomically rewrites the path/name/fileType of the
+   * affected tab and every tab nested under a renamed directory so the next
+   * save targets the new path instead of resurrecting the old one.
+   */
+  notifyFileRenamed: (oldPath: string, newPath: string) => void;
+  /**
+   * List the open editor tabs at or under the given VFS-relative path. The
+   * explorer uses this to confirm dirty tabs before a delete.
+   */
+  findTabsAffectedByDelete: (deletedPath: string) => AffectedTab[];
+  /**
+   * Notify the tab manager that a project file/folder was deleted (VFS-relative
+   * path). Detaches the descriptor of every affected tab so no save flow can
+   * recreate the deleted path; the tab survives as an untitled dirty buffer.
+   */
+  notifyFileDeleted: (deletedPath: string) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/tab-manager/use-file-watch-integration.ts
+++ b/lib/tab-manager/use-file-watch-integration.ts
@@ -404,9 +404,16 @@ export function useFileWatchIntegration(params: UseFileWatchIntegrationParams): 
 
     const watcherPaths = watcherPathsRef.current;
 
-    // Stop and remove watchers for tabs that no longer exist
+    // Tabs that still have a watchable file path this render.
+    const pathfulTabIds = new Set(
+      tabs.filter((t) => isEditorTab(t) && t.file?.path).map((t) => t.id),
+    );
+
+    // Stop and remove watchers for tabs that no longer exist OR that lost their
+    // file path (#1868: a deleted open file is detached to an untitled tab —
+    // its watcher must stop so it cannot keep observing the now-deleted path).
     for (const [tabId, watcher] of watchers) {
-      if (!currentTabIds.has(tabId)) {
+      if (!currentTabIds.has(tabId) || !pathfulTabIds.has(tabId)) {
         watcher.stop();
         watchers.delete(tabId);
         watcherPaths.delete(tabId);

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -132,12 +132,21 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     // --- Project mode: write to workspace.json ---
     if (isProjectRef.current) {
       const rootPath = windowKeyRef.current; // rootPath for Electron, null for Web
-      const workspaceTabs: WorkspaceTab[] = editorTabs.map((t) => ({
-        relativePath: t.file?.path ? toRelativePath(t.file.path, rootPath) : null,
-        fileName: t.file?.name ?? "新規ファイル",
-        isPreview: t.isPreview || undefined,
-        fileType: t.fileType,
-      }));
+      const workspaceTabs: WorkspaceTab[] = editorTabs.map((t) => {
+        const relativePath = t.file?.path ? toRelativePath(t.file.path, rootPath) : null;
+        return {
+          relativePath,
+          fileName: t.file?.name ?? "新規ファイル",
+          isPreview: t.isPreview || undefined,
+          fileType: t.fileType,
+          // #1868: persist the editor buffer of unsaved, non-file-backed tabs so
+          // their content survives an app restart. This covers a tab detached
+          // after its file was deleted from the explorer (file → null), as well
+          // as freshly typed untitled buffers. File-backed tabs are re-read from
+          // disk on restore, so their content is intentionally not duplicated.
+          unsavedContent: !relativePath && t.isDirty ? t.content : undefined,
+        };
+      });
       await persistWorkspaceJson({
         openTabs: {
           tabs: workspaceTabs,
@@ -219,8 +228,15 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
       const restoredTabs: EditorTabState[] = [];
       for (const saved of savedTabs.tabs) {
         if (!saved.relativePath) {
-          // Unsaved tab — restore as blank
-          restoredTabs.push(createNewTab(undefined, saved.fileType ?? ".mdi"));
+          // Unsaved tab (untitled, or detached after its file was deleted).
+          // Recover its persisted buffer so unsaved content is not lost across
+          // restart (#1868). A tab carrying content is restored dirty so the
+          // user is still prompted to save it; an empty one stays clean.
+          const unsaved = saved.unsavedContent ?? "";
+          const tab = createNewTab(unsaved, saved.fileType ?? ".mdi");
+          restoredTabs.push(
+            unsaved.length > 0 ? { ...tab, isDirty: true, fileSyncStatus: "dirty" } : tab,
+          );
           continue;
         }
         try {


### PR DESCRIPTION
## 概要

開いているファイル（または開いているファイルを含むフォルダ）をエクスプローラーで名前変更・ドラッグ移動・削除しても、タブの `file.path` が更新されず旧パスを保持し続ける問題を修正します。これにより次回保存（手動 / 5 秒自動保存）で旧パスへ書き込まれ、名前変更/削除したファイルが旧位置に復活していました（セッション復元でも旧パスが残存）。

## 原因

- `FilesPanel` の rename / drag-move / delete は VFS 操作とツリー `refresh()` のみを実行し、タブ管理へ通知する経路がなかった。
- タブは旧 `tab.file.path` を保持し、`save-executor` がその旧パスへ `vfs.writeFile()` していた。
- 削除時は開いたタブが残り、次の保存で旧パスを再作成。dirty タブを含むフォルダも警告なしに削除できた。

## 修正

再利用可能な純粋ヘルパー `lib/tab-manager/tab-path-sync.ts` を新設（インスペクター rename #1870 と共有）:

- **rename / move**: `applyTabRename` が対象タブと、rename されたフォルダ配下の全タブの path / name / fileType を原子的に更新（本文は不変）。
- **delete**: `applyTabDelete` が対象 path 配下の全タブの descriptor を detach（`file → null`）。これにより
  - save-executor の project-VFS 分岐（`isProject && tab.file?.path`）がスキップ → 旧パス再作成なし
  - 背景自動保存の `!tab.file` ガードでスキップ
  - 当該タブの file watcher を停止（旧パス監視を止める）
  - タブは untitled の dirty バッファとして残る
- `findTabsUnderPath` で削除前に影響タブを列挙し、未保存タブがある場合は削除確認ダイアログで警告。

## ハードニング（レビュー指摘の追加修正）

当初の実装では detach 後のタブは「内容は失われない」と説明していましたが、これは **誤り** でした。プロジェクトモードの永続化（`use-tab-persistence.ts` → `workspace.json`）は `relativePath` + `fileName` のみを保存しており、detach されたタブ（`relativePath === null`）は次回起動時に **空の新規タブ** として復元され、未保存内容がサイレントに失われていました（メモリ上は `isDirty=true` でも、quit→reopen で消失）。既存ユニットテストはメモリ上の `isDirty` のみ検証し、永続化ラウンドトリップを検証していなかったため見逃していました。

修正:

- `WorkspaceTab` に任意フィールド `unsavedContent` を追加し、**file 紐付けが無く（`relativePath === null`）かつ dirty なタブ** のエディタバッファを `workspace.json` に保存。
- `restoreProjectTabs` でこれを dirty な untitled タブとして復元。これにより削除されたファイルの detach タブ／新規 untitled バッファの内容が再起動後も **確実に回復** され、サイレントなデータ損失が無くなる。
- file 紐付けタブは従来どおりディスクから再読込するため内容は重複保存しない。
- `tab-path-sync.ts` の「内容は失われない」というコメントを、実際の永続化保証を説明する記述に修正。

## テスト

`lib/tab-manager/__tests__/tab-path-sync.test.ts` に 18 ユニットテスト（既存・維持）:
- rename（ファイル / フォルダ fan-out / 拡張子変更 / 名前プレフィックス誤検知なし / no-op）
- delete（detach / フォルダ fan-out / 兄弟保持 / no-op）
- 旧パス復活防止コントラクト（rename 後は新パスのみ、delete 後は path なし）

`lib/tab-manager/__tests__/detached-tab-persistence-roundtrip.test.tsx` に 3 件追加（ハードニング検証）:
- 削除で detach された dirty タブの **persist → restore ラウンドトリップ** で内容が dirty のまま回復することを検証
- clean な file 紐付けタブは `unsavedContent` を保存しない（ディスク再読込）
- 空の untitled タブは clean な空白タブとして復元

`npx tsc --noEmit` green、`npx vitest run lib/tab-manager/` 28 ファイル / 268 件 green。

Closes #1868

🤖 Generated with [Claude Code](https://claude.com/claude-code)
