### PR TITLE
fix(dockview): dirtyタブ閉じるキャンセル時にeditor panelを復元 (#1875)

### DIFF
--- a/lib/dockview/__tests__/panel-heal.test.ts
+++ b/lib/dockview/__tests__/panel-heal.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the panel-heal decision logic (#1875).
+ *
+ * computeMissingEditorPanels() is the pure core of the fix: it decides which
+ * editor tabs need their dockview panel recreated to restore the tab ⇆ panel
+ * invariant after dockview removes a panel out from under a still-pending tab.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeMissingEditorPanels } from "../panel-heal";
+import { createNewTab } from "@/lib/tab-manager/types";
+import type { TabState, TerminalTabState, DiffTabState } from "@/lib/tab-manager/tab-types";
+
+function makeTerminalTab(id: string): TerminalTabState {
+  return {
+    tabKind: "terminal",
+    id,
+    sessionId: id,
+    pendingId: null,
+    label: "term",
+    cwd: "",
+    shell: "",
+    status: "running",
+    exitCode: null,
+    createdAt: 0,
+    source: "user",
+  };
+}
+
+function makeDiffTab(id: string): DiffTabState {
+  return {
+    tabKind: "diff",
+    id,
+    sourceTabId: "src",
+    sourceFileName: "a.mdi",
+    localContent: "",
+    remoteContent: "",
+    remoteTimestamp: 0,
+  };
+}
+
+describe("#1875 computeMissingEditorPanels", () => {
+  it("returns the editor tab whose panel is missing (dirty-close cancelled)", () => {
+    const a = createNewTab("a");
+    const b = createNewTab("b");
+    const tabs: TabState[] = [a, b];
+    // b's panel was removed by dockview but b is still in the tab list.
+    const existing = new Set([a.id]);
+
+    const missing = computeMissingEditorPanels(tabs, existing);
+
+    expect(missing.map((t) => t.id)).toEqual([b.id]);
+  });
+
+  it("returns an empty list when every editor tab still has a panel", () => {
+    const a = createNewTab("a");
+    const b = createNewTab("b");
+    const existing = new Set([a.id, b.id]);
+
+    expect(computeMissingEditorPanels([a, b], existing)).toEqual([]);
+  });
+
+  it("ignores missing non-editor tabs (terminal / diff are removed eagerly)", () => {
+    const editor = createNewTab("a");
+    const term = makeTerminalTab("term-1");
+    const diff = makeDiffTab("diff-1");
+    // None of the panels exist, but only the editor tab should be healed.
+    const existing = new Set<string>();
+
+    const missing = computeMissingEditorPanels([editor, term, diff], existing);
+
+    expect(missing.map((t) => t.id)).toEqual([editor.id]);
+  });
+
+  it("preserves tab order across multiple missing editor panels", () => {
+    const a = createNewTab("a");
+    const b = createNewTab("b");
+    const c = createNewTab("c");
+    const existing = new Set([b.id]); // a and c lost their panels
+
+    const missing = computeMissingEditorPanels([a, b, c], existing);
+
+    expect(missing.map((t) => t.id)).toEqual([a.id, c.id]);
+  });
+
+  it("returns nothing when there are no tabs", () => {
+    expect(computeMissingEditorPanels([], new Set())).toEqual([]);
+  });
+});

--- a/lib/dockview/__tests__/use-dockview-adapter-panel-heal.test.tsx
+++ b/lib/dockview/__tests__/use-dockview-adapter-panel-heal.test.tsx
@@ -1,0 +1,328 @@
+/**
+ * Regression tests for #1875 — dirty-tab close-cancel must not lose the editor panel.
+ *
+ * Root cause: dockview has no panel close-veto. The tab close button calls
+ * panel.api.close() → dockview removes the panel → onDidRemovePanel fires →
+ * closeTab(id). For a DIRTY editor tab, closeTab keeps the tab (it only opens
+ * the unsaved dialog), so the tab survives but its panel is already gone.
+ * Cancelling the dialog never recreated the panel → invisible orphaned tab.
+ *
+ * Fix: record each panel's placement before removal and run a heal pass
+ * (driven by a healTick bumped in onDidRemovePanel) that recreates a panel for
+ * any editor tab still present in the tab list but missing its panel.
+ *
+ * Tests drive the REAL hook via createRoot + act (repo pattern) with a fake
+ * DockviewApi that models groups, panel placement and onDidRemovePanel.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { createNewTab } from "@/lib/tab-manager/types";
+import { useDockviewAdapter } from "../use-dockview-adapter";
+import type { DockviewApi } from "dockview-react";
+import type { UseTabManagerReturn } from "@/lib/tab-manager/types";
+import type { TabState } from "@/lib/tab-manager/tab-types";
+import type { UseDockviewAdapterReturn } from "../use-dockview-adapter";
+
+vi.mock("../use-dockview-persistence", () => ({
+  loadDockviewLayout: vi.fn().mockResolvedValue(null),
+}));
+
+// ---------------------------------------------------------------------------
+// Fake DockviewApi with group + placement modelling
+// ---------------------------------------------------------------------------
+
+interface FakeGroup {
+  id: string;
+  panels: FakePanel[];
+}
+
+interface FakePanel {
+  id: string;
+  title: string;
+  group: FakeGroup;
+  api: {
+    isActive: boolean;
+    setActive: ReturnType<typeof vi.fn>;
+    setTitle: ReturnType<typeof vi.fn>;
+    updateParameters: ReturnType<typeof vi.fn>;
+    moveTo: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  };
+}
+
+interface AddPanelOpts {
+  id: string;
+  title?: string;
+  position?: { referenceGroup?: string; index?: number; direction?: string };
+}
+
+interface FakeApiBundle {
+  api: DockviewApi;
+  panels: Map<string, FakePanel>;
+  groups: FakeGroup[];
+  addPanel: ReturnType<typeof vi.fn>;
+  fireRemovePanel: (id: string) => void;
+  setActivePanelId: (id: string | undefined) => void;
+  lastAddOptions: AddPanelOpts[];
+}
+
+function createFakeApi(): FakeApiBundle {
+  const panels = new Map<string, FakePanel>();
+  const removeHandlers: Array<(e: { id: string }) => void> = [];
+  const defaultGroup: FakeGroup = { id: "group-0", panels: [] };
+  const groups: FakeGroup[] = [defaultGroup];
+  let activePanelId: string | undefined;
+  const lastAddOptions: AddPanelOpts[] = [];
+
+  const addPanel = vi.fn((opts: AddPanelOpts) => {
+    if (panels.has(opts.id)) {
+      throw new Error(`duplicate addPanel: ${opts.id}`);
+    }
+    lastAddOptions.push(opts);
+    // Resolve target group from position.referenceGroup, else default.
+    let group = defaultGroup;
+    if (opts.position?.referenceGroup) {
+      const found = groups.find((g) => g.id === opts.position!.referenceGroup);
+      if (found) group = found;
+    }
+    const panel: FakePanel = {
+      id: opts.id,
+      title: opts.title ?? "",
+      group,
+      api: {
+        isActive: false,
+        setActive: vi.fn(() => {
+          activePanelId = opts.id;
+        }),
+        setTitle: vi.fn(),
+        updateParameters: vi.fn(),
+        moveTo: vi.fn(),
+        close: vi.fn(),
+      },
+    };
+    const idx = opts.position?.index;
+    if (typeof idx === "number" && idx >= 0 && idx <= group.panels.length) {
+      group.panels.splice(idx, 0, panel);
+    } else {
+      group.panels.push(panel);
+    }
+    panels.set(opts.id, panel);
+    return panel;
+  });
+
+  const removePanel = vi.fn((p: FakePanel) => {
+    panels.delete(p.id);
+    p.group.panels = p.group.panels.filter((x) => x.id !== p.id);
+  });
+
+  const fake = {
+    addPanel,
+    getPanel: (id: string) => panels.get(id),
+    removePanel,
+    get panels() {
+      return [...panels.values()];
+    },
+    get groups() {
+      return groups;
+    },
+    get activePanel() {
+      return activePanelId ? panels.get(activePanelId) : undefined;
+    },
+    width: 800,
+    height: 600,
+    onDidActivePanelChange: () => ({ dispose: () => undefined }),
+    onDidRemovePanel: (h: (e: { id: string }) => void) => {
+      removeHandlers.push(h);
+      return { dispose: () => undefined };
+    },
+  };
+
+  return {
+    api: fake as unknown as DockviewApi,
+    panels,
+    groups,
+    addPanel,
+    lastAddOptions,
+    setActivePanelId: (id) => {
+      activePanelId = id;
+      for (const p of panels.values()) p.api.isActive = p.id === id;
+    },
+    fireRemovePanel: (id: string) => {
+      const panel = panels.get(id);
+      if (panel) removePanel(panel);
+      for (const h of removeHandlers) h({ id });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stateful tab-manager mock that mimics dirty/clean closeTab semantics
+// ---------------------------------------------------------------------------
+
+interface MutableTabModel {
+  tabs: TabState[];
+  activeTabId: string;
+  /** Mirrors useTabState.closeTab: dirty editor tab is kept (pending dialog). */
+  closeTab: (id: string) => void;
+  /** Mirrors forceCloseTab/discard: removes the tab. */
+  forceCloseTab: (id: string) => void;
+}
+
+function makeTabManager(model: MutableTabModel): UseTabManagerReturn {
+  return {
+    tabs: model.tabs,
+    activeTabId: model.activeTabId,
+    switchTab: vi.fn(),
+    closeTab: model.closeTab,
+    cloneTab: vi.fn(),
+    updateTab: vi.fn(),
+    setTabContent: vi.fn(),
+    content: "",
+    setContent: vi.fn(),
+  } as unknown as UseTabManagerReturn;
+}
+
+const resultRef: { current: UseDockviewAdapterReturn | null } = { current: null };
+
+function Harness({ tabManager }: { tabManager: UseTabManagerReturn }): null {
+  const result = useDockviewAdapter({
+    tabManager,
+    editorKey: 0,
+    searchOpenTrigger: 0,
+    windowKey: null,
+    projectLayout: null,
+  });
+  useEffect(() => {
+    resultRef.current = result;
+  });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  resultRef.current = null;
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("#1875 — dirty-tab close-cancel keeps the editor panel", () => {
+  it("recreates the panel for a dirty editor tab that survives closeTab (cancel flow)", async () => {
+    const tabA = { ...createNewTab("a"), isDirty: true };
+    const fake = createFakeApi();
+
+    // dirty closeTab keeps the tab — exactly like useTabState.closeTab.
+    const model: MutableTabModel = {
+      tabs: [tabA],
+      activeTabId: tabA.id,
+      closeTab: vi.fn(), // dirty → no-op on the tab list (dialog opens)
+      forceCloseTab: vi.fn(),
+    };
+
+    await act(async () => {
+      root.render(<Harness tabManager={makeTabManager(model)} />);
+    });
+    await act(async () => {
+      resultRef.current!.handleDockviewReady({ api: fake.api });
+    });
+
+    expect(fake.panels.has(tabA.id)).toBe(true);
+    fake.setActivePanelId(tabA.id);
+
+    // User clicks close on the dirty tab → dockview removes the panel and fires
+    // onDidRemovePanel. closeTab keeps the tab (dialog). The heal effect must
+    // recreate the panel.
+    await act(async () => {
+      fake.fireRemovePanel(tabA.id);
+    });
+
+    expect(fake.panels.has(tabA.id)).toBe(true);
+  });
+
+  it("does NOT recreate a panel when the tab was genuinely removed (discard / clean close)", async () => {
+    const tabA = { ...createNewTab("a"), isDirty: true };
+    const tabB = createNewTab("b");
+    const fake = createFakeApi();
+
+    const model: MutableTabModel = {
+      tabs: [tabA, tabB],
+      activeTabId: tabA.id,
+      closeTab: vi.fn(),
+      forceCloseTab: vi.fn(),
+    };
+
+    await act(async () => {
+      root.render(<Harness tabManager={makeTabManager(model)} />);
+    });
+    await act(async () => {
+      resultRef.current!.handleDockviewReady({ api: fake.api });
+    });
+
+    // Simulate discard: the tab is removed from the list, THEN the panel is
+    // removed. After removal the heal pass sees the tab is gone → no re-add.
+    model.tabs = [tabB];
+    await act(async () => {
+      root.render(<Harness tabManager={makeTabManager(model)} />);
+    });
+    await act(async () => {
+      fake.fireRemovePanel(tabA.id);
+    });
+
+    expect(fake.panels.has(tabA.id)).toBe(false);
+    expect(fake.panels.has(tabB.id)).toBe(true);
+  });
+
+  it("restores the recreated panel into its original group and tab index", async () => {
+    const tabA = createNewTab("a");
+    const tabB = { ...createNewTab("b"), isDirty: true };
+    const fake = createFakeApi();
+
+    const model: MutableTabModel = {
+      tabs: [tabA, tabB],
+      activeTabId: tabB.id,
+      closeTab: vi.fn(),
+      forceCloseTab: vi.fn(),
+    };
+
+    await act(async () => {
+      root.render(<Harness tabManager={makeTabManager(model)} />);
+    });
+    await act(async () => {
+      resultRef.current!.handleDockviewReady({ api: fake.api });
+    });
+
+    // Both panels live in group-0; tabB at index 1.
+    const group0 = fake.groups[0];
+    expect(group0.panels.map((p) => p.id)).toEqual([tabA.id, tabB.id]);
+    fake.setActivePanelId(tabB.id);
+
+    fake.lastAddOptions.length = 0;
+    await act(async () => {
+      fake.fireRemovePanel(tabB.id);
+    });
+
+    // Heal re-added tabB into the same group at the same index, and re-activated
+    // it (it was the active panel on removal).
+    const healAdd = fake.lastAddOptions.find((o) => o.id === tabB.id);
+    expect(healAdd?.position?.referenceGroup).toBe("group-0");
+    expect(healAdd?.position?.index).toBe(1);
+    expect(group0.panels.map((p) => p.id)).toEqual([tabA.id, tabB.id]);
+    expect(fake.panels.get(tabB.id)!.api.setActive).toHaveBeenCalled();
+  });
+});

--- a/lib/dockview/panel-heal.ts
+++ b/lib/dockview/panel-heal.ts
@@ -1,0 +1,68 @@
+/**
+ * Panel-heal invariant (#1875)
+ * ----------------------------
+ *
+ * Dockview removes a panel as soon as its tab close button (or middle-click /
+ * context menu "閉じる") is clicked — there is no veto / before-close hook in
+ * the dockview API. The removal fires `onDidRemovePanel`, which calls
+ * `closeTab(id)`. For a *dirty* editor tab, `closeTab` does NOT remove the tab
+ * from the tab list; it only opens the unsaved-changes confirmation dialog
+ * (sets `pendingCloseTabId`).
+ *
+ * That leaves a broken invariant: the tab still exists in `tabs`, but its
+ * dockview panel is already gone. If the user then cancels the dialog (or the
+ * save is cancelled / fails / is locked / conflicted), the tab stays in `tabs`
+ * but no panel is ever recreated — the editor disappears and the unsaved work
+ * becomes unreachable.
+ *
+ * Fix: enforce the invariant "every editor tab in `tabs` has a dockview panel".
+ * After each sync pass, recreate panels for editor tabs whose panel is missing.
+ * To keep the restored panel in its original split group / tab order, the
+ * adapter records each panel's placement just before removal and replays it
+ * here.
+ *
+ * This module holds the pure decision logic so it can be unit-tested without a
+ * live dockview instance.
+ */
+
+import type { TabId, TabState } from "@/lib/tab-manager/tab-types";
+import { isEditorTab } from "@/lib/tab-manager/tab-types";
+
+/**
+ * Where a panel lived before it was removed, so it can be recreated in the same
+ * group and tab position on heal.
+ */
+export interface PanelPlacement {
+  /** dockview group id the panel belonged to. */
+  groupId: string;
+  /** Index of the panel within its group's tab strip. */
+  index: number;
+  /** Whether the panel was the active panel when it was removed. */
+  wasActive: boolean;
+}
+
+/**
+ * Compute the editor tabs that exist in `tabs` but have no corresponding
+ * dockview panel. These are the tabs whose panels must be recreated to restore
+ * the tab ⇆ panel invariant (#1875).
+ *
+ * Only editor tabs are healed: terminal and diff tabs are removed eagerly by
+ * `forceCloseTab` (they never enter the dirty-confirm flow), so a missing
+ * terminal/diff panel means the tab is genuinely closing, not pending.
+ *
+ * @param tabs             Current tab list (source of truth).
+ * @param existingPanelIds Set of panel ids currently present in dockview.
+ * @returns Editor tabs (in tab order) that need a panel recreated.
+ */
+export function computeMissingEditorPanels(
+  tabs: readonly TabState[],
+  existingPanelIds: ReadonlySet<TabId>,
+): TabState[] {
+  const missing: TabState[] = [];
+  for (const tab of tabs) {
+    if (!isEditorTab(tab)) continue;
+    if (existingPanelIds.has(tab.id)) continue;
+    missing.push(tab);
+  }
+  return missing;
+}

--- a/lib/dockview/use-dockview-adapter.ts
+++ b/lib/dockview/use-dockview-adapter.ts
@@ -25,6 +25,7 @@ import type {
 } from "./types";
 import type { WorkspaceDockviewLayout } from "@/lib/project/project-types";
 import { loadDockviewLayout } from "./use-dockview-persistence";
+import { computeMissingEditorPanels, type PanelPlacement } from "./panel-heal";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -285,6 +286,129 @@ export function useDockviewAdapter({
   const panelParamsRef = useRef({ editorKey, searchOpenTrigger, searchInitialTerm });
   panelParamsRef.current = { editorKey, searchOpenTrigger, searchInitialTerm };
 
+  // -- Panel-heal placement tracking (#1875) --------------------------------
+  // Dockview has no panel close-veto. Closing a dirty tab removes its panel
+  // immediately, but closeTab() keeps the tab (opening the unsaved dialog).
+  // To recreate the panel on cancel/failure without losing its split group or
+  // tab order, we keep a continuously-refreshed snapshot of every editor
+  // panel's placement (lastPlacementRef). When a panel is removed we promote
+  // its last-known placement into healPlacementRef so the heal pass can replay
+  // it.
+  const lastPlacementRef = useRef<Map<TabId, PanelPlacement>>(new Map());
+  const healPlacementRef = useRef<Map<TabId, PanelPlacement>>(new Map());
+  // Bumped whenever a panel removal leaves a tab without a panel, to trigger
+  // the dedicated heal effect (the sync effect alone does not fire because the
+  // tab list is unchanged on cancel).
+  const [healTick, setHealTick] = useState(0);
+
+  // Refresh the placement snapshot from the live dockview state. Called at the
+  // start of each sync pass while panels are still healthy.
+  const refreshPlacementSnapshot = useCallback((api: DockviewApi): void => {
+    const snapshot = new Map<TabId, PanelPlacement>();
+    const activeId = api.activePanel?.id;
+    for (const group of api.groups) {
+      group.panels.forEach((panel, index) => {
+        snapshot.set(panel.id, {
+          groupId: group.id,
+          index,
+          wasActive: panel.id === activeId,
+        });
+      });
+    }
+    lastPlacementRef.current = snapshot;
+  }, []);
+
+  // Promote a removed panel's last-known placement so the next heal can restore
+  // it to the same group / tab position / active state.
+  const capturePanelPlacement = useCallback((tabId: TabId): void => {
+    const placement = lastPlacementRef.current.get(tabId);
+    if (placement) {
+      healPlacementRef.current.set(tabId, placement);
+    }
+  }, []);
+  const capturePanelPlacementRef = useRef(capturePanelPlacement);
+  capturePanelPlacementRef.current = capturePanelPlacement;
+
+  // Recreate panels for editor tabs that exist in `tabs` but lost their panel
+  // (dirty-close cancelled, or save cancelled / failed / locked / conflicted).
+  // Reads the latest state via refs so its identity stays stable (#1875).
+  const healMissingPanels = useCallback((api: DockviewApi): void => {
+    const currentTabs = tabsRef.current;
+    const currentActiveTabId = activeTabIdLiveRef.current;
+    const {
+      editorKey: liveEditorKey,
+      searchOpenTrigger: liveSearchOpenTrigger,
+      searchInitialTerm: liveSearchInitialTerm,
+    } = panelParamsRef.current;
+
+    const existingPanelIds = new Set(api.panels.map((p) => p.id));
+    const missingEditorTabs = computeMissingEditorPanels(currentTabs, existingPanelIds);
+
+    for (const tab of missingEditorTabs) {
+      if (!isEditorTab(tab)) continue;
+      const placement = healPlacementRef.current.get(tab.id);
+      // Re-add into the original group at the original index when that group
+      // still exists; otherwise let dockview place the panel freely.
+      const groupStillExists =
+        placement != null && api.groups.some((g) => g.id === placement.groupId);
+      let restored = false;
+      try {
+        api.addPanel<EditorPanelParams>({
+          id: tab.id,
+          component: "editor",
+          title: tab.file?.name ?? `新規ファイル${tab.fileType}`,
+          params: {
+            bufferId: tab.id,
+            isPreview: tab.isPreview,
+            filePath: tab.file?.path ?? "",
+            fileType: tab.fileType,
+            editorKey: liveEditorKey,
+            activeTabId: currentActiveTabId,
+            searchOpenTrigger: liveSearchOpenTrigger,
+            searchInitialTerm: liveSearchInitialTerm,
+            pendingExternalContent: tab.pendingExternalContent ?? null,
+          },
+          ...(groupStillExists && placement
+            ? {
+                position: {
+                  referenceGroup: placement.groupId,
+                  direction: "within" as const,
+                  index: placement.index,
+                },
+              }
+            : {}),
+        });
+        restored = true;
+      } catch (err) {
+        console.warn(`[dockview-adapter] panel heal failed for tab ${tab.id}:`, err);
+      }
+
+      // Restore active state when this panel was active before removal. Guard
+      // with isActive: dockview setActive() is NOT idempotent (#1457).
+      if (restored && placement?.wasActive) {
+        const healed = api.getPanel(tab.id);
+        if (healed && !healed.api.isActive) {
+          try {
+            healed.api.setActive();
+          } catch {
+            // Active sync in the main effect is a backstop.
+          }
+        }
+      }
+
+      // Consume the placement so a later genuine close doesn't resurrect it.
+      healPlacementRef.current.delete(tab.id);
+    }
+
+    // Drop heal placements for tabs that no longer exist (genuine closes).
+    const currentTabIds = new Set(currentTabs.map((t) => t.id));
+    for (const tabId of [...healPlacementRef.current.keys()]) {
+      if (!currentTabIds.has(tabId)) {
+        healPlacementRef.current.delete(tabId);
+      }
+    }
+  }, []);
+
   // -- onReady callback -----------------------------------------------------
 
   const handleDockviewReady = useCallback((event: { api: DockviewApi }): void => {
@@ -358,12 +482,22 @@ export function useDockviewAdapter({
       }
     });
 
-    // Listen for dockview panel close → close tab
+    // Listen for dockview panel close → close tab.
+    // #1875: dockview has no close-veto, so the panel is already gone here.
+    // closeTab() keeps a *dirty* editor tab in the tab list (opening the
+    // unsaved dialog) but a clean tab is removed. We record the panel's
+    // placement before closing, then bump healTick so the heal effect runs:
+    // it recreates a panel only for editor tabs that are STILL in the tab list
+    // (i.e. the dirty tab whose dialog is open), restoring the tab ⇆ panel
+    // invariant. The tab list itself does not change on a dirty close, so the
+    // sync effect would never re-fire — the healTick bump is what drives it.
     api.onDidRemovePanel((e) => {
       if (isSyncingRef.current) return;
+      capturePanelPlacementRef.current(e.id);
       isSyncingRef.current = true;
       closeTabRef.current(e.id);
       isSyncingRef.current = false;
+      setHealTick((t) => t + 1);
     });
   }, []);
 
@@ -435,6 +569,11 @@ export function useDockviewAdapter({
     if (!api || isSyncingRef.current) return;
 
     isSyncingRef.current = true;
+
+    // #1875: snapshot every live panel's placement before we mutate the layout,
+    // so a panel removed between now and the next sync can be recreated in the
+    // same group / tab position by the heal pass below.
+    refreshPlacementSnapshot(api);
 
     const prevTabs = prevTabsRef.current;
     const prevTabIds = new Set(prevTabs.map((t) => t.id));
@@ -558,6 +697,9 @@ export function useDockviewAdapter({
       pendingSplitRef.current = null;
     }
 
+    // -- Panel-heal pass (#1875): restore the tab ⇆ panel invariant ---------
+    healMissingPanels(api);
+
     // Sync active tab
     if (activeTabId !== prevActiveTabRef.current) {
       const activePanel = api.getPanel(activeTabId);
@@ -569,7 +711,32 @@ export function useDockviewAdapter({
     prevTabsRef.current = tabs;
     prevActiveTabRef.current = activeTabId;
     isSyncingRef.current = false;
-  }, [tabs, activeTabId, editorKey, searchOpenTrigger, searchInitialTerm, dockviewApi]);
+  }, [
+    tabs,
+    activeTabId,
+    editorKey,
+    searchOpenTrigger,
+    searchInitialTerm,
+    dockviewApi,
+    refreshPlacementSnapshot,
+    healMissingPanels,
+  ]);
+
+  // -- Panel-heal effect (#1875) --------------------------------------------
+  // Driven by healTick (bumped from onDidRemovePanel). A dirty-tab close
+  // removes the panel without changing the tab list, so the sync effect above
+  // never re-fires — this effect recreates the still-needed panel so cancelling
+  // the unsaved dialog (or a cancelled/failed/locked/conflicted save) leaves the
+  // editor intact instead of an invisible orphaned tab.
+  useEffect(() => {
+    const api = apiRef.current;
+    if (!api || isSyncingRef.current) return;
+    if (healTick === 0) return;
+
+    isSyncingRef.current = true;
+    healMissingPanels(api);
+    isSyncingRef.current = false;
+  }, [healTick, dockviewApi, healMissingPanels]);
 
   // -- Restore saved layout (separate effect to avoid sync effect interference) --
   // Using a dedicated effect prevents savedLayout changes from re-triggering


### PR DESCRIPTION
Closes #1875

## 根本原因

Dockview には panel の **close-veto / before-close API が無い**（`onDidRemovePanel` は削除後にしか発火しない）。

1. タブの閉じるボタン → `panel.api.close()` → dockview が即座に panel を削除。
2. `onDidRemovePanel` → `closeTab(id)`。
3. dirty な editor タブの `closeTab()` は **タブを削除せず** `pendingCloseTabId` を立てるだけ（未保存ダイアログを開く）。
4. 結果、`tabs` にタブは残るが panel は既に消えている。
5. ダイアログでキャンセル／Save As キャンセル／保存失敗／lock／競合になると、タブだけ残り panel が再生成されず、未保存内容が UI から消えて操作不能になる。

sync effect は `tabs` の ID 差分でしか panel を追加しないため、ID が残ったままのタブは再追加対象にならなかった。

## 修正

tab ⇆ panel の不変条件「`tabs` にある editor タブは必ず panel を持つ」を強制する self-heal を導入。

- **`lib/dockview/panel-heal.ts`** (新規): `computeMissingEditorPanels()` で panel を失った editor タブを抽出する純粋ロジックを分離。terminal/diff は eager close（dirty フローに乗らない）のため対象外。
- **`lib/dockview/use-dockview-adapter.ts`**:
  - sync 毎に全 editor panel の placement（group id / tab index / active 状態）を snapshot。
  - `onDidRemovePanel` で削除直前の placement を退避し `healTick` を bump。
  - `healTick` 駆動の専用 effect で、`tabs` に残るが panel を失った editor タブの panel を **元の group / tab 位置 / active 状態で再生成**。
  - dirty close は `tabs` を変えないため sync effect は再発火しない → `healTick` 駆動が必須。discard / clean close はタブが消えるので再生成されない（誤復活しない）。

これによりキャンセル・保存キャンセル・保存失敗・lock・競合のいずれでも panel が維持され、保存成功／破棄時だけ panel とタブ状態が共に削除される。

## テスト（必須・同梱）

- `panel-heal.test.ts`: 抽出ロジックの単体テスト（dirty 残存 / 全 panel 有 / 非 editor 無視 / 順序保持 / 空）。
- `use-dockview-adapter-panel-heal.test.tsx`: 実フックを `createRoot + act`（リポジトリの既存パターン）で駆動し、fake DockviewApi（group/placement/`onDidRemovePanel` モデル）で検証:
  - dirty close → cancel で panel 復元
  - discard（タブ削除済み）では非復元
  - 元 group・index・active 状態の復元

`npx tsc --noEmit` green、`npx vitest run lib/dockview/`（16 件）・`lib/tab-manager/`（241 件）全 pass。

## 既知の限界

- 分割 group の位置復元は記録した group id / index に基づくベストエフォート。heal 時点で元 group が消えている場合は dockview の自由配置にフォールバックする（panel の喪失は防ぐが、ごく稀なレイアウト崩壊ケースでは元位置に戻らない可能性がある）。スクロール位置は `#1457` の `isActive` ガード方針を踏襲し、active 復元のみで明示的なスクロール復元は行わない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)