### PR TITLE
fix(vfs): 新規プロジェクト作成時の set-root パス不一致エラーを解消

### DIFF
--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -6,7 +6,7 @@
 const { ipcMain, dialog, app, BrowserWindow, webContents } = require("electron");
 const fs = require("fs/promises");
 const path = require("path");
-const { createApprovedPathRegistry } = require("../lib/approved-paths");
+const { createApprovedPathRegistry, isWithinApprovedTree } = require("../lib/approved-paths");
 const {
   toForwardSlash,
   assertPathInsideRoot,
@@ -389,7 +389,25 @@ function registerVFSHandlers() {
 
     // 4. Check approval: in-session dialog approval OR persisted project approval
     // #1476: rehydration — load persisted approvals so re-prompting is skipped on restart
-    const alreadyApprovedInSession = dialogApprovedPaths.has(event.sender.id, resolved);
+    let alreadyApprovedInSession = dialogApprovedPaths.has(event.sender.id, resolved);
+
+    // A path inside an already-approved tree is itself approved. The new-project
+    // flow approves the *parent* via openDirectory(), then creates a child folder
+    // and promotes it to root — that child is legitimately accessible (the VFS
+    // already grants read/write to the whole approved tree), so re-prompting is
+    // both unnecessary and broken: on macOS the second dialog returns the NFD
+    // on-disk name while the requested path is NFC, so the exact-match check at
+    // step 5 would reject it ("選択されたディレクトリが要求されたパスと一致しません").
+    if (!alreadyApprovedInSession) {
+      const approvedTrees = dialogApprovedPaths
+        .listWindowPaths(event.sender.id)
+        .map((approved) => normalizePath(approved));
+      if (isWithinApprovedTree(approvedTrees, normalizedResolved)) {
+        approveDialogPath(event.sender.id, resolved);
+        alreadyApprovedInSession = true;
+      }
+    }
+
     let alreadyApprovedFromDisk = false;
     if (!alreadyApprovedInSession && effectiveProjectId) {
       const persistedSet = await loadApprovals(APPROVED_PATHS_FILE, effectiveProjectId);

--- a/electron/lib/__tests__/approved-paths.test.ts
+++ b/electron/lib/__tests__/approved-paths.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect } from "vitest";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
-const { createApprovedPathRegistry, DEFAULT_MAX_APPROVED_PATHS } =
+const { createApprovedPathRegistry, isWithinApprovedTree, DEFAULT_MAX_APPROVED_PATHS } =
   require("../../../electron/lib/approved-paths") as {
     createApprovedPathRegistry: (maxEntries?: number) => {
       approve: (webContentsId: number, p: string) => void;
@@ -21,6 +21,7 @@ const { createApprovedPathRegistry, DEFAULT_MAX_APPROVED_PATHS } =
       listWindowPaths: (webContentsId: number) => string[];
       revokeWindow: (webContentsId: number) => void;
     };
+    isWithinApprovedTree: (approvedPaths: readonly string[], normalizedPath: string) => boolean;
     DEFAULT_MAX_APPROVED_PATHS: number;
   };
 
@@ -112,5 +113,39 @@ describe("createApprovedPathRegistry()", () => {
     registry.approve(1, "/p/c");
     expect(registry.has(1, "/p/a")).toBe(false);
     expect(registry.has(1, "/p/c")).toBe(true);
+  });
+});
+
+describe("isWithinApprovedTree()", () => {
+  it("returns true for the exact approved path", () => {
+    expect(isWithinApprovedTree(["/Users/foo/Documents"], "/Users/foo/Documents")).toBe(true);
+  });
+
+  it("returns true for a child of an approved tree (new-project flow)", () => {
+    // openDirectory() approves the parent; createProject promotes the new child.
+    expect(isWithinApprovedTree(["/Users/foo/Documents"], "/Users/foo/Documents/缶詰")).toBe(true);
+  });
+
+  it("returns true for a deeply nested descendant", () => {
+    expect(isWithinApprovedTree(["/Users/foo/Documents"], "/Users/foo/Documents/a/b/c")).toBe(true);
+  });
+
+  it("returns false for a sibling that merely shares a name prefix", () => {
+    // Must not treat "/Users/foo/Documents-evil" as inside "/Users/foo/Documents".
+    expect(isWithinApprovedTree(["/Users/foo/Documents"], "/Users/foo/Documents-evil")).toBe(false);
+  });
+
+  it("returns false for a parent of an approved path (no upward escape)", () => {
+    expect(isWithinApprovedTree(["/Users/foo/Documents"], "/Users/foo")).toBe(false);
+  });
+
+  it("returns false when there are no approved paths", () => {
+    expect(isWithinApprovedTree([], "/Users/foo/Documents")).toBe(false);
+  });
+
+  it("matches against any of multiple approved trees", () => {
+    const trees = ["/a/b", "/Users/foo/Documents"];
+    expect(isWithinApprovedTree(trees, "/Users/foo/Documents/proj")).toBe(true);
+    expect(isWithinApprovedTree(trees, "/c/d/proj")).toBe(false);
   });
 });

--- a/electron/lib/approved-paths.js
+++ b/electron/lib/approved-paths.js
@@ -96,4 +96,27 @@ function createApprovedPathRegistry(maxEntries = DEFAULT_MAX_APPROVED_PATHS) {
   };
 }
 
-module.exports = { createApprovedPathRegistry, DEFAULT_MAX_APPROVED_PATHS };
+/**
+ * Determine whether a normalized path is contained within (or equal to) any of
+ * the given approved paths. Used by vfs:set-root so that promoting a child of an
+ * already-approved tree to root does not trigger a redundant native dialog.
+ *
+ * All inputs MUST be pre-normalized to forward slashes with trailing slashes
+ * trimmed (the caller's normalizePath), so the comparison is a pure prefix test
+ * and is immune to NFC/NFD differences introduced by native dialogs.
+ *
+ * @param {readonly string[]} approvedPaths - Normalized approved paths
+ * @param {string} normalizedPath - Normalized candidate path
+ * @returns {boolean} true if the candidate is within an approved tree
+ */
+function isWithinApprovedTree(approvedPaths, normalizedPath) {
+  return approvedPaths.some(
+    (approved) => normalizedPath === approved || normalizedPath.startsWith(`${approved}/`),
+  );
+}
+
+module.exports = {
+  createApprovedPathRegistry,
+  isWithinApprovedTree,
+  DEFAULT_MAX_APPROVED_PATHS,
+};


### PR DESCRIPTION
## 問題

新規プロジェクト作成時、フォルダ名に日本語（例: `缶詰`）を含むと `Error invoking remote method 'vfs:set-root': Error: 選択されたディレクトリが要求されたパスと一致しません` が発生し、プロジェクトを作成できない。

## 根本原因

`createProject` は `openDirectory()` で**親フォルダ**を承認した後、その配下に新フォルダを作成して `vfs:set-root` でルート昇格する。しかし承認レジストリ（`approved-paths.js`）の `has()` は**完全一致のみ**でツリー内包を見ないため、新フォルダは未承認扱いとなり**2 度目のダイアログ**が表示される。

macOS は日本語ファイル名をディスク上で **NFD 正規化**するため、ダイアログ返却値（NFD）と JS 文字列由来の要求パス（NFC）が `vfs-ipc.js` の完全一致チェックで不一致となり、エラーが発生していた。

## 修正

セッション内で既に承認済みのツリー配下なら、再ダイアログなしで自動承認する。これにより不要な 2 度目のダイアログと NFC/NFD 不一致の両方を解消する。

VFS は承認済みツリー全体に既に読み書きを許可しているため、その子をルートに昇格しても権限拡大にはならない。親の承認自体は引き続きネイティブダイアログ経由でのみ得られる。

- `approved-paths.js`: 純粋関数 `isWithinApprovedTree()` を追加（兄弟プレフィックス誤マッチ・親への上昇を防止）
- `vfs-ipc.js`: `vfs:set-root` で承認済みツリー配下を自動承認
- `approved-paths.test.ts`: containment 判定テスト 7 件追加

## テスト

- `electron/` テストスイート 全 287 件 pass
- 日本語子フォルダ・深いネスト・兄弟プレフィックス・親への上昇拒否・複数ツリーを網羅

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)