### PR TITLE
fix(layout): ライトテーマで右パネルのボーダーを左右対称化

### DIFF
--- a/shared/ui/ResizablePanel.tsx
+++ b/shared/ui/ResizablePanel.tsx
@@ -90,11 +90,15 @@ export default function ResizablePanel({
         !isResizing && "transition-all duration-300 ease-in-out",
         // 左ナビゲーション側は ActivityBar(bg-background-tertiary rgb 30,30,30)の
         // 背景ブロックが境界を明瞭にするが、右インスペクタは隣接ブロックが無く
-        // 1px の border-border(rgb 45,45,45)は暗いエディタ背景(rgb 8,8,8)に紛れて
-        // 「境界線が無い」ように見える。右側は 2px かつより明るい
-        // border-border-secondary(rgb 60,60,60)で明確な縦線にして左右の視認性を揃える。
+        // ダークテーマでは 1px の border-border(rgb 45,45,45)が暗いエディタ背景
+        // (rgb 8,8,8)に紛れて「境界線が無い」ように見える。そのためダーク時のみ
+        // 右側を 2px かつより明るい border-border-secondary(rgb 60,60,60)で強調する。
+        // ライトテーマでは border-border(rgb 210)が 1px でも十分視認でき、2px だと
+        // 左ボーダー(1px)と太さ・濃さが食い違って不揃いに見えるため左右対称に揃える。
         !isCollapsed &&
-          (side === "right" ? "border-l-2 border-border-secondary" : "border-r border-border"),
+          (side === "right"
+            ? "border-l border-border dark:border-l-2 dark:border-border-secondary"
+            : "border-r border-border"),
         className,
       )}
       style={{ width: isCollapsed ? "0px" : `${width}px` }}


### PR DESCRIPTION
## Summary

- 右インスペクタ（ファイル情報）パネルのボーダーがライトテーマで左ファイルツリー側より太く・濃く見える不揃いを解消
- ピクセル実測：左境界 = 1px rgb(210) / 右境界 = 2px rgb(188) と非対称だった

## 原因

`shared/ui/ResizablePanel.tsx` で右パネルのみ `border-l-2 border-border-secondary`（2px・濃いめ）を適用していた。これはダークテーマで 1px の `border-border`(rgb45) が暗いエディタ背景(rgb8)に溶けて「境界線が消える」対策（#1798 系）だったが、ライトテーマでは `border-border`(rgb210) が 1px でも十分視認でき、2px・濃色が過剰で左ボーダー(1px)とアンバランスに見えていた。

## Changes

| File | 変更 |
| --- | --- |
| `shared/ui/ResizablePanel.tsx` | 右ボーダーを `border-l border-border dark:border-l-2 dark:border-border-secondary` に変更。ライトは左右対称(1px)、ダークは従来通り(2px/secondary)を `dark:` バリアントで維持 |

`darkMode: "class"`（tailwind.config.ts）方式のため `dark:` バリアントでテーマ別に切り分け。

## Test plan

- [ ] ライトテーマ：右パネルと左ファイルツリーのボーダーが同じ太さ・濃さで揃う
- [ ] ダークテーマ：右パネルのボーダーが従来通り視認できる（暗背景に溶けない）
- [ ] パネル折りたたみ時にボーダーが消える挙動が従来通り

🤖 Generated with [Claude Code](https://claude.com/claude-code)