### PR TITLE
fix(nlp): 形態素ハイライトの位置ずれ4種を修正し境界テストを追加

### DIFF
--- a/lib/nlp-backend/__tests__/nlp-processor.test.ts
+++ b/lib/nlp-backend/__tests__/nlp-processor.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit & edge-case tests for the morphological-analysis backend (NlpProcessor).
+ *
+ * Focus areas — the recurring source of "weird" highlight bugs:
+ *   1. Character-position correctness: every token's [start, end) must slice
+ *      back to its exact surface form in the ORIGINAL text.
+ *   2. Noise-character handling (\n, \r are stripped before kuromoji): a token
+ *      must not swallow a trailing stripped newline (regression for the
+ *      "改行\n" range over-extension).
+ *   3. Unicode edge cases: surrogate pairs (𠮷, emoji), full-width characters.
+ *   4. User-dictionary token merging keeps positions contiguous.
+ *
+ * These run against the real kuromoji dictionary shipped in `public/dict`.
+ */
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import path from "path";
+import { nlpProcessor } from "../nlp-processor";
+import type { Token } from "../../nlp-client/types";
+
+const DIC_PATH = path.join(process.cwd(), "public/dict");
+
+beforeAll(async () => {
+  if (!nlpProcessor.isInitialized()) {
+    await nlpProcessor.init(DIC_PATH);
+  }
+}, 30000);
+
+// Reset any user dictionary mutation a test introduced (also clears the cache).
+afterEach(() => {
+  nlpProcessor.setUserDictionary([]);
+});
+
+/** Assert tokens reconstruct the source and are well-ordered. */
+function expectExactCoverage(text: string, tokens: Token[]): void {
+  let cursor = 0;
+  for (const t of tokens) {
+    expect(t.start).toBeGreaterThanOrEqual(cursor);
+    expect(t.end).toBeGreaterThan(t.start);
+    // Each token slices back to exactly its surface form.
+    expect(text.slice(t.start, t.end)).toBe(t.surface);
+    cursor = t.end;
+  }
+  expect(cursor).toBeLessThanOrEqual(text.length);
+}
+
+describe("NlpProcessor.cleanTextForTokenization", () => {
+  it("is identity (with end sentinel) when there is no noise", () => {
+    const { cleanedText, positionMap } = nlpProcessor.cleanTextForTokenization("太平洋");
+    expect(cleanedText).toBe("太平洋");
+    // positionMap has one entry per char plus a trailing sentinel == text.length.
+    expect(positionMap).toEqual([0, 1, 2, 3]);
+  });
+
+  it("strips \\n and \\r and maps cleaned indices back to original", () => {
+    const text = "改行\nを\r含む";
+    const { cleanedText, positionMap } = nlpProcessor.cleanTextForTokenization(text);
+    expect(cleanedText).toBe("改行を含む");
+    // 改=0 行=1 (\n=2 stripped) を=3 (\r=4 stripped) 含=5 む=6, sentinel=7
+    expect(positionMap).toEqual([0, 1, 3, 5, 6, 7]);
+  });
+
+  it("handles all-noise and empty input", () => {
+    expect(nlpProcessor.cleanTextForTokenization("").cleanedText).toBe("");
+    expect(nlpProcessor.cleanTextForTokenization("\n\r\n").cleanedText).toBe("");
+    // Sentinel still present: maps cleaned length (0) -> original length.
+    expect(nlpProcessor.cleanTextForTokenization("\n\r").positionMap).toEqual([2]);
+  });
+});
+
+describe("NlpProcessor.tokenize — position correctness", () => {
+  const sentences = [
+    "太平洋のただ中に、面積およそ四十平方キロにも満たない環礁がひとつある。",
+    "そこに住む者たちは、十九世紀イギリスの訛りで言葉を交わし、たったひとつの姓を分かち合っている。",
+    "私がこの島に着いたのは、ちょうど一月だった。",
+  ];
+
+  for (const text of sentences) {
+    it(`every token slices back to its surface: ${text.slice(0, 12)}…`, async () => {
+      const tokens = await nlpProcessor.tokenize(text);
+      expect(tokens.length).toBeGreaterThan(0);
+      expectExactCoverage(text, tokens);
+      // Noise-free input → contiguous coverage of the entire string.
+      expect(tokens[0].start).toBe(0);
+      expect(tokens[tokens.length - 1].end).toBe(text.length);
+    });
+  }
+
+  it("returns an empty array for empty input", async () => {
+    expect(await nlpProcessor.tokenize("")).toEqual([]);
+  });
+
+  it("keeps positions aligned across surrogate pairs (CJK ext-B & emoji)", async () => {
+    const text = "𠮷野家で🔥した。";
+    const tokens = await nlpProcessor.tokenize(text);
+    expectExactCoverage(text, tokens);
+    // The very first token must start at the surrogate pair, length 2 (UTF-16).
+    expect(tokens[0].start).toBe(0);
+    expect(text.slice(tokens[0].start, tokens[0].end)).toBe(tokens[0].surface);
+  });
+
+  it("keeps positions aligned across full-width characters", async () => {
+    const text = "ＡＢＣ１２３です";
+    const tokens = await nlpProcessor.tokenize(text);
+    expectExactCoverage(text, tokens);
+  });
+
+  it("keeps positions aligned across ZWJ / variation-selector sequences", async () => {
+    for (const text of ["家族👨‍👩‍👧です", "邉0山さん", "ゼロ​幅あり"]) {
+      const tokens = await nlpProcessor.tokenize(text);
+      expectExactCoverage(text, tokens);
+    }
+  });
+
+  it("does NOT drift later tokens when kuromoji drops a flag-emoji region", async () => {
+    // Regional-indicator flags (🇯🇵) make kuromoji emit inconsistent internal
+    // positions and drop surrounding tokens. Re-anchoring must keep every
+    // emitted token aligned; the dropped region is simply left uncovered.
+    const text = "国旗🇯🇵を見た。";
+    const tokens = await nlpProcessor.tokenize(text);
+    expectExactCoverage(text, tokens); // invariant: each token slices to its surface
+    // The token after the flag must map to real text, never a shifted neighbor.
+    const flag = tokens.find((t) => t.surface.includes("🇯🇵"));
+    expect(flag).toBeDefined();
+    expect(text.slice(flag!.start, flag!.end)).toBe(flag!.surface);
+  });
+});
+
+describe("NlpProcessor.tokenize — noise-character regression", () => {
+  it("does NOT extend a token's range over a trailing stripped newline", async () => {
+    const text = "改行\nテスト";
+    const tokens = await nlpProcessor.tokenize(text);
+    const kaigyo = tokens.find((t) => t.surface === "改行");
+    expect(kaigyo).toBeDefined();
+    // Bug was: end mapped to positionMap[end] → "改行\n". Must be exactly "改行".
+    expect(text.slice(kaigyo!.start, kaigyo!.end)).toBe("改行");
+    expect(kaigyo!.end).toBe(2);
+  });
+
+  it("maps tokens after a leading newline to their true offsets", async () => {
+    const text = "\n先頭";
+    const tokens = await nlpProcessor.tokenize(text);
+    const sento = tokens.find((t) => t.surface === "先頭");
+    expect(sento).toBeDefined();
+    expect(sento!.start).toBe(1);
+    expect(text.slice(sento!.start, sento!.end)).toBe("先頭");
+  });
+});
+
+describe("NlpProcessor — token caching", () => {
+  it("returns equal results for repeated identical input", async () => {
+    const text = "同じ文を二度。";
+    const a = await nlpProcessor.tokenize(text);
+    const b = await nlpProcessor.tokenize(text);
+    expect(b).toEqual(a);
+  });
+});
+
+describe("NlpProcessor.tokenizeBatch", () => {
+  it("preserves paragraph pos and tokenizes each independently", async () => {
+    const paragraphs = [
+      { pos: 5, text: "一つ目。" },
+      { pos: 42, text: "二つ目の段落。" },
+    ];
+    const results = await nlpProcessor.tokenizeBatch(paragraphs);
+    expect(results.map((r) => r.pos)).toEqual([5, 42]);
+    for (const r of results) {
+      const source = paragraphs.find((p) => p.pos === r.pos)!.text;
+      expectExactCoverage(source, r.tokens);
+    }
+  });
+});
+
+describe("NlpProcessor — user dictionary merging", () => {
+  it("merges consecutive tokens into one user-defined word with contiguous positions", async () => {
+    const text = "彼は六季島へ向かった。";
+    const before = await nlpProcessor.tokenize(text);
+    // Baseline: "六季島" is normally split into multiple tokens.
+    const mergedBaseline = before.find((t) => t.surface === "六季島");
+    expect(mergedBaseline).toBeUndefined();
+
+    nlpProcessor.setUserDictionary([
+      { id: "u1", word: "六季島", reading: "ロッキトウ", partOfSpeech: "名詞" },
+    ]);
+    const after = await nlpProcessor.tokenize(text);
+
+    const merged = after.find((t) => t.surface === "六季島");
+    expect(merged).toBeDefined();
+    expect(text.slice(merged!.start, merged!.end)).toBe("六季島");
+    expect(merged!.pos).toBe("名詞");
+    // The merge must not corrupt surrounding coverage.
+    expectExactCoverage(text, after);
+  });
+
+  it("clears cached tokens when the dictionary changes", async () => {
+    const text = "六季島は遠い。";
+    const plain = await nlpProcessor.tokenize(text);
+    expect(plain.find((t) => t.surface === "六季島")).toBeUndefined();
+
+    nlpProcessor.setUserDictionary([{ id: "u2", word: "六季島" }]);
+    const merged = await nlpProcessor.tokenize(text);
+    expect(merged.find((t) => t.surface === "六季島")).toBeDefined();
+  });
+
+  it("ignores empty / whitespace-only headwords without crashing or hanging", async () => {
+    // A zero-length word previously matched immediately, read tokens[-1] and
+    // never advanced the cursor → crash or infinite loop on the first token.
+    nlpProcessor.setUserDictionary([
+      { id: "e1", word: "" },
+      { id: "e2", word: "   " },
+      { id: "e3", word: "島" },
+    ]);
+    const text = "島へ行く。";
+    const tokens = await nlpProcessor.tokenize(text);
+    expectExactCoverage(text, tokens);
+    expect(tokens.find((t) => t.surface === "島")).toBeDefined();
+  });
+
+  it("keeps surrounding coverage intact when a user word appears mid-sentence", async () => {
+    nlpProcessor.setUserDictionary([{ id: "m1", word: "六季島" }]);
+    const text = "遠い六季島の話。";
+    const tokens = await nlpProcessor.tokenize(text);
+    expectExactCoverage(text, tokens);
+    const merged = tokens.find((t) => t.surface === "六季島")!;
+    expect(text.slice(merged.start, merged.end)).toBe("六季島");
+  });
+});

--- a/lib/nlp-backend/nlp-processor.ts
+++ b/lib/nlp-backend/nlp-processor.ts
@@ -58,7 +58,12 @@ class NlpProcessor {
    * Clears cache since tokenization results may change.
    */
   setUserDictionary(entries: UserDictionaryEntry[]): void {
-    this.userDictionary = [...entries].sort((a, b) => b.word.length - a.word.length);
+    // Drop entries with an empty/whitespace-only headword: a zero-length word
+    // matches the empty combined string immediately, which would read
+    // `tokens[-1]` and fail to advance the merge cursor (crash / infinite loop).
+    this.userDictionary = entries
+      .filter((e) => e.word.trim().length > 0)
+      .sort((a, b) => b.word.length - a.word.length);
     this.cache.clear();
   }
 
@@ -78,6 +83,7 @@ class NlpProcessor {
 
       for (const dictEntry of this.userDictionary) {
         const word = dictEntry.word;
+        if (!word) continue; // defensive: never match a zero-length word
         // Try to match starting from token i
         let combined = "";
         let j = i;
@@ -200,11 +206,24 @@ class NlpProcessor {
     // Step 2: Tokenize cleaned text
     const rawTokens = this.tokenizer.tokenize(cleanedText);
 
-    // Step 3: Build tokens with correct character positions
-    let charPosition = 0;
+    // Step 3: Build tokens with correct character positions.
+    //
+    // Re-anchor each token by locating its surface form in the cleaned text from
+    // a running cursor, rather than blindly accumulating `surface_form.length`.
+    // Kuromoji occasionally fails to cover certain code-point sequences (e.g.
+    // regional-indicator flag emoji like 🇯🇵, which it drops surrounding tokens
+    // for), leaving its internal positions inconsistent. Blind accumulation lets
+    // that single mismatch drift EVERY subsequent token's highlight; anchoring on
+    // the surface form self-heals — the un-analyzed gap is simply left uncolored.
+    let cursor = 0;
     const tokens: Token[] = rawTokens.map((t) => {
+      const surface = t.surface_form;
+      const found = cleanedText.indexOf(surface, cursor);
+      const start = found >= 0 ? found : cursor;
+      const end = start + surface.length;
+      cursor = end;
       const token: Token = {
-        surface: t.surface_form,
+        surface,
         pos: t.pos,
         pos_detail_1: t.pos_detail_1,
         pos_detail_2: t.pos_detail_2,
@@ -215,18 +234,26 @@ class NlpProcessor {
         reading: t.reading,
         pronunciation: t.pronunciation,
         // Character positions in cleaned text
-        start: charPosition,
-        end: charPosition + t.surface_form.length,
+        start,
+        end,
       };
-      charPosition += t.surface_form.length;
       return token;
     });
 
-    // Step 4: Remap positions back to original text coordinates
+    // Step 4: Remap positions back to original text coordinates.
+    //
+    // `start` is inclusive: map the first character directly.
+    //
+    // `end` is exclusive. Mapping it as `positionMap[end]` (the next character's
+    // origin) would swallow any noise characters that were stripped between this
+    // token and the next one — e.g. "改行\n" would extend the "改行" token's
+    // range over the newline. Instead, anchor on the token's LAST character and
+    // add one: `positionMap[end - 1] + 1`.
     const remappedTokens = tokens.map((t) => ({
       ...t,
       start: positionMap[t.start] ?? t.start,
-      end: positionMap[t.end] ?? t.end,
+      end:
+        t.end > t.start ? (positionMap[t.end - 1] ?? t.end - 1) + 1 : (positionMap[t.end] ?? t.end),
     }));
 
     // Step 5: Apply user dictionary (merge matching token sequences)

--- a/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-helpers.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/__tests__/paragraph-helpers.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the shared paragraph-processing helpers used by both the
+ * POS-highlight and linting decoration plugins.
+ *
+ * These exercise the textContent-offset → ProseMirror-position mapping in
+ * isolation, with special attention to the atom-node boundary case (ruby /
+ * mdibreak) that previously bled a token's color/underline onto the following
+ * atom node.
+ */
+import { describe, it, expect } from "vitest";
+import { Schema } from "@milkdown/prose/model";
+import type { Node as ProseMirrorNode } from "@milkdown/prose/model";
+import { getAtomOffset, collectParagraphs, type AtomAdjustment } from "../shared/paragraph-helpers";
+
+/**
+ * Minimal schema mirroring the editor's relevant shape: a paragraph of inline
+ * content where `ruby` is an inline atom node whose base text is NOT part of
+ * `textContent` (matches the real ruby node — it defines no `leafText`).
+ */
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: {
+      group: "block",
+      content: "inline*",
+      toDOM: () => ["p", 0],
+    },
+    text: { group: "inline" },
+    ruby: {
+      group: "inline",
+      inline: true,
+      atom: true,
+      attrs: { base: { default: "" }, text: { default: "" } },
+      toDOM: (node) => ["ruby", node.attrs.base, ["rt", node.attrs.text]],
+    },
+  },
+});
+
+function para(...children: ProseMirrorNode[]): ProseMirrorNode {
+  return schema.nodes.doc.create(null, schema.nodes.paragraph.create(null, children));
+}
+const t = (s: string) => schema.text(s);
+const ruby = (base = "海", text = "うみ") => schema.nodes.ruby.create({ base, text });
+
+/**
+ * Recompute a token decoration range exactly as the plugins do, so the tests
+ * pin the real mapping arithmetic rather than a paraphrase of it.
+ */
+function tokenRange(
+  paragraph: { pos: number; atomAdjustments: AtomAdjustment[] },
+  start: number,
+  end: number,
+): { from: number; to: number } {
+  const from = paragraph.pos + 1 + start + getAtomOffset(paragraph.atomAdjustments, start);
+  const to = paragraph.pos + 1 + end + getAtomOffset(paragraph.atomAdjustments, end, true);
+  return { from, to };
+}
+
+describe("getAtomOffset", () => {
+  const adjustments: AtomAdjustment[] = [{ textPos: 3, cumulativeOffset: 1 }];
+
+  it("returns 0 before any atom", () => {
+    expect(getAtomOffset(adjustments, 0)).toBe(0);
+    expect(getAtomOffset(adjustments, 2)).toBe(0);
+  });
+
+  it("treats a position AT an atom boundary as after the atom (inclusive start)", () => {
+    // A token that STARTS where an atom sits must be pushed past the atom.
+    expect(getAtomOffset(adjustments, 3)).toBe(1);
+    expect(getAtomOffset(adjustments, 4)).toBe(1);
+  });
+
+  it("treats an exclusive END at an atom boundary as before the atom", () => {
+    // A token that ENDS just before an atom must NOT swallow it.
+    expect(getAtomOffset(adjustments, 3, true)).toBe(0);
+    // Past the atom, the exclusive end still accumulates it.
+    expect(getAtomOffset(adjustments, 4, true)).toBe(1);
+  });
+
+  it("accumulates multiple atoms monotonically", () => {
+    const multi: AtomAdjustment[] = [
+      { textPos: 2, cumulativeOffset: 1 },
+      { textPos: 5, cumulativeOffset: 2 },
+    ];
+    expect(getAtomOffset(multi, 1)).toBe(0);
+    expect(getAtomOffset(multi, 2)).toBe(1);
+    expect(getAtomOffset(multi, 5)).toBe(2);
+    expect(getAtomOffset(multi, 5, true)).toBe(1);
+  });
+});
+
+describe("collectParagraphs", () => {
+  it("records textContent without atom base text", () => {
+    const doc = para(t("太平洋の"), ruby(), t("だ"));
+    const [p] = collectParagraphs(doc);
+    expect(p.text).toBe("太平洋のだ"); // ruby base excluded
+    expect(p.atomAdjustments).toEqual([{ textPos: 4, cumulativeOffset: 1 }]);
+  });
+
+  it("skips empty paragraphs", () => {
+    const doc = schema.nodes.doc.create(null, [
+      schema.nodes.paragraph.create(null, []),
+      schema.nodes.paragraph.create(null, [t("本文")]),
+    ]);
+    const ps = collectParagraphs(doc);
+    expect(ps).toHaveLength(1);
+    expect(ps[0].text).toBe("本文");
+  });
+});
+
+describe("token → ProseMirror range mapping (atom boundaries)", () => {
+  it("does NOT extend a token's range onto a trailing atom node", () => {
+    // children: text "ABC", ruby (atom), text "DEF"  → textContent "ABCDEF"
+    const doc = para(t("ABC"), ruby(), t("DEF"));
+    const [p] = collectParagraphs(doc);
+
+    // PM positions: A=1 B=2 C=3, ruby atom occupies [4,5), D=5 E=6 F=7.
+    // Token "ABC" (textContent [0,3)) must map to [1,4) — NOT [1,5).
+    expect(tokenRange(p, 0, 3)).toEqual({ from: 1, to: 4 });
+    // Token "DEF" (textContent [3,6)) starts after the atom → [5,8).
+    expect(tokenRange(p, 3, 6)).toEqual({ from: 5, to: 8 });
+  });
+
+  it("handles a token sandwiched between two atoms", () => {
+    // children: ruby, text "XY", ruby → textContent "XY"
+    const doc = para(ruby(), t("XY"), ruby());
+    const [p] = collectParagraphs(doc);
+    // PM: ruby0 [1,2), X=2 Y=3, ruby1 [4,5). Token "XY" → [2,4).
+    expect(tokenRange(p, 0, 2)).toEqual({ from: 2, to: 4 });
+  });
+
+  it("maps a plain paragraph (no atoms) identically", () => {
+    const doc = para(t("太平洋のただ中"));
+    const [p] = collectParagraphs(doc);
+    expect(tokenRange(p, 0, 3)).toEqual({ from: 1, to: 4 }); // 太平洋
+    expect(tokenRange(p, 4, 7)).toEqual({ from: 5, to: 8 }); // ただ中
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -432,7 +432,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
               }
 
               const extraFrom = getAtomOffset(paragraph.atomAdjustments, issue.from);
-              const extraTo = getAtomOffset(paragraph.atomAdjustments, issue.to);
+              const extraTo = getAtomOffset(paragraph.atomAdjustments, issue.to, true);
               const from = paragraph.pos + 1 + issue.from + extraFrom;
               const to = paragraph.pos + 1 + issue.to + extraTo;
 

--- a/packages/milkdown-plugin-japanese-novel/pos-highlight/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/pos-highlight/decoration-plugin.ts
@@ -175,7 +175,7 @@ export function createPosHighlightPlugin(
 
               if (color) {
                 const extraFrom = getAtomOffset(paragraph.atomAdjustments, token.start);
-                const extraTo = getAtomOffset(paragraph.atomAdjustments, token.end);
+                const extraTo = getAtomOffset(paragraph.atomAdjustments, token.end, true);
                 const from = paragraph.pos + 1 + token.start + extraFrom;
                 const to = paragraph.pos + 1 + token.end + extraTo;
 

--- a/packages/milkdown-plugin-japanese-novel/shared/paragraph-helpers.ts
+++ b/packages/milkdown-plugin-japanese-novel/shared/paragraph-helpers.ts
@@ -29,12 +29,29 @@ export interface ParagraphInfo {
 }
 
 /**
- * Get additional offset for converting textContent position to ProseMirror paragraph offset.
+ * Get additional offset for converting a textContent position to a ProseMirror
+ * paragraph offset.
+ *
+ * An atom adjustment records `textPos` as the textContent position *just before*
+ * the atom node. Whether a position sitting exactly on that boundary should
+ * include the atom's offset depends on the kind of position:
+ *
+ * - **Inclusive (token START, default)**: a token that begins where an atom
+ *   sits comes *after* the atom, so its offset must include the atom.
+ * - **Exclusive (token END)**: a token whose exclusive end lands on the atom
+ *   boundary ends *just before* the atom, so it must NOT include it — otherwise
+ *   the decoration over-extends and bleeds onto the atom node (e.g. coloring a
+ *   ruby base or underlining it as a lint issue).
  */
-export function getAtomOffset(adjustments: AtomAdjustment[], textPos: number): number {
+export function getAtomOffset(
+  adjustments: AtomAdjustment[],
+  textPos: number,
+  exclusive = false,
+): number {
   let offset = 0;
   for (const adj of adjustments) {
-    if (adj.textPos <= textPos) {
+    const isBefore = exclusive ? adj.textPos < textPos : adj.textPos <= textPos;
+    if (isBefore) {
       offset = adj.cumulativeOffset;
     } else {
       break;


### PR DESCRIPTION
## 概要
品詞ハイライト/校正下線が単語境界からずれる・解析が壊れる「経常的な奇妙なエラー」の根本原因を調査し、**4 種の position bug** を修正。実 ProseMirror schema と実 kuromoji 辞書による網羅的なエッジケーステストを追加。

きっかけは品詞ハイライトが「乱れる」スクリーンショット報告。可視範囲の純テキストは正しかったが、調査の過程で offset 変換パイプライン全体に 4 つの実バグを発見・実証した。

## 修正したバグ
| # | 根因 | 触発条件 | 影響 |
|---|------|----------|------|
| 1 | `getAtomOffset` の end が inclusive 比較 | token/issue がちょうど ruby/縦中横/改行等 atom の直前で終わる | 色/下線が atom ノードに滲む |
| 2 | noise 終端を `positionMap[end]` で戻す | token 直後に剥がされた `\n`/`\r` | 改行を範囲に飲み込む |
| 3 | `surface_form.length` の盲目累積 | 国旗 emoji 🇯🇵 等 kuromoji のカバレッジ欠落 | **以降の全トークンがドリフト** |
| 4 | 空 headword が即マッチ | ユーザー辞書の空/空白のみ語 | **crash / 無限ループ** |

### 1. atom 境界の排他 end
`shared/paragraph-helpers.ts` の `getAtomOffset()` に `exclusive` 引数を追加。token の**排他的 end** が atom 境界に一致するとき atom offset を足さないようにし、デコレーションの過延伸を防止。pos-highlight と linting 両 decoration-plugin の end 側を `exclusive` 呼び出しへ。

### 2. noise 文字の終端マップ
`nlp-processor.tokenize` の終端を token 最後の文字基点 `positionMap[end-1]+1` に変更。

### 3. kuromoji カバレッジ欠落での全ドリフト
位置算出を `cleanedText.indexOf(surface, cursor)` の**再アンカー方式**に変更。kuromoji が取りこぼした領域は未着色ギャップとして残るだけになり、後続トークンはずれない。通常テキストでは挙動不変（indexOf は常に cursor を返す）。

### 4. ユーザー辞書 空 headword
`setUserDictionary` で空/空白のみ語を除外＋merge ループに防御ガード。

## 検証済みで安全だったもの
- inline atom ノード全 5 種（ruby / tcy / mdibreak / nobreak / kern）はすべて `atom:true`・`leafText` なし・`content` なし → textContent から除外で整合。非 atom の content inline ノードは存在しない。
- surrogate pair（𠮷/🔥）・ZWJ 家族 emoji・異体字選択子・半角カナ・ゼロ幅空白・Tab/全角空白・純記号はすべて整合（`slice===surface`）。

## テスト
- `packages/milkdown-plugin-japanese-novel/__tests__/paragraph-helpers.test.ts`（新規）— 実 PM schema で atom 境界マッピング
- `lib/nlp-backend/__tests__/nlp-processor.test.ts`（新規）— 実 kuromoji 辞書で位置正当性・noise・surrogate/ZWJ/異体字・国旗emoji・空headword・ユーザー辞書 merge
- 全トークン invariant `text.slice(start,end)===surface` を検証
- ローカル: 関連スイート 37 項全緑、`tsc --noEmit` クリーン

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)