### PR TITLE
fix(inspector): 選択語パネルの前方一致HITを完全一致と区別表示

### DIFF
--- a/components/inspector/GenjiWordInfoSection.tsx
+++ b/components/inspector/GenjiWordInfoSection.tsx
@@ -53,9 +53,19 @@ export default function GenjiWordInfoSection({
 
       {state.status === "found" && (
         <div className="space-y-2">
+          {/* 完全一致がない（前方一致のみヒット）場合の注記。誤って「選択語が辞書にある」と
+              読めてしまうのを防ぐ（例：「青い」を選択 → 見出し「青い鳥」が前方一致でヒット）。 */}
+          {!state.viewModel.isExactMatch && (
+            <p className="text-xs text-foreground-tertiary">
+              「{state.viewModel.word}
+              」に完全一致する項目はありません。前方一致する見出しを表示しています。
+            </p>
+          )}
           {/* 見出し・読み・品詞 */}
           <div className="flex items-baseline gap-2 flex-wrap">
-            <span className="text-sm font-semibold text-foreground">{state.viewModel.word}</span>
+            <span className="text-sm font-semibold text-foreground">
+              {state.viewModel.matchedHeadword}
+            </span>
             {state.viewModel.reading && (
               <span className="text-xs text-foreground-secondary">{state.viewModel.reading}</span>
             )}

--- a/lib/utils/__tests__/genji-word-info.test.ts
+++ b/lib/utils/__tests__/genji-word-info.test.ts
@@ -151,4 +151,23 @@ describe("buildGenjiWordInfoViewModel", () => {
     const vm = buildGenjiWordInfoViewModel("QUERY", makeResult());
     expect(vm!.word).toBe("QUERY");
   });
+
+  it("exposes the matched headword and marks an exact match", () => {
+    const vm = buildGenjiWordInfoViewModel("雪", makeResult());
+    expect(vm!.matchedHeadword).toBe("雪");
+    expect(vm!.isExactMatch).toBe(true);
+  });
+
+  it("marks a prefix-only match as not exact and surfaces the real headword", () => {
+    // Querying 「青い」 hits the longer headword 「青い鳥」 via prefix match — the
+    // panel must NOT imply the queried word itself is in the dictionary.
+    const entry = makeEntry({
+      entry: "青い鳥",
+      reading: { primary: "あおいとり", alternatives: [] },
+    });
+    const vm = buildGenjiWordInfoViewModel("青い", makeResult([entry]));
+    expect(vm!.word).toBe("青い");
+    expect(vm!.matchedHeadword).toBe("青い鳥");
+    expect(vm!.isExactMatch).toBe(false);
+  });
 });

--- a/lib/utils/genji-word-info.ts
+++ b/lib/utils/genji-word-info.ts
@@ -35,6 +35,13 @@ export interface GenjiWordInfoViewModel {
   glosses: string[];
   /** Up to MAX_SYNONYMS synonym strings */
   synonyms: string[];
+  /**
+   * The actual headword that matched. On a prefix-only match (e.g. querying
+   * 「青い」 hits the entry 「青い鳥」) this differs from `word`.
+   */
+  matchedHeadword: string;
+  /** True when `matchedHeadword` exactly equals the queried `word`. */
+  isExactMatch: boolean;
 }
 
 /**
@@ -67,6 +74,13 @@ export function buildGenjiWordInfoViewModel(
 
   const entry = result.entries[0];
 
+  // queryByEntry matches "entry = term OR entry LIKE term%", so a query with no
+  // exact headword still returns the shortest prefix hit (querying 「青い」 returns
+  // 「青い鳥」). Surface this so the panel never implies the queried word itself is
+  // in the dictionary when only a longer headword shares its prefix.
+  const matchedHeadword = entry.entry.trim() || word;
+  const isExactMatch = matchedHeadword === word;
+
   const reading = entry.reading.primary.trim() || null;
   const partOfSpeech = entry.partOfSpeech?.trim() || null;
   const register = extractRegister(entry);
@@ -79,7 +93,16 @@ export function buildGenjiWordInfoViewModel(
     .filter((s) => s.length > 0)
     .slice(0, MAX_SYNONYMS);
 
-  return { word, reading, partOfSpeech, register, glosses, synonyms };
+  return {
+    word,
+    matchedHeadword,
+    isExactMatch,
+    reading,
+    partOfSpeech,
+    register,
+    glosses,
+    synonyms,
+  };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

エディタで「青い」を選択すると右パネル「選択語の辞書情報」は **「青い／あおいとり／bluebird of happiness」と HIT 表示** する一方、同じパネル下部の校正検出リストは同じ「青い」を **「幻辞（辞書）に未収録」と MISS 表示** していた。同一語が HIT と MISS で食い違う。

### 根本原因

2 つの辞書 lookup 経路が異なる検索方式を使っていた:

| 経路 | 検索 | 結果 |
|---|---|---|
| 選択語パネル `query()→queryByEntry` | `entry = term OR entry LIKE term%`（**前方一致**） | 「青い」→ 見出し「青い鳥」を拾い HIT |
| 辞書外語ルール `lookupBatch` | `entry IN(...)`（**完全一致**） | exact「青い」なし → MISS |

辞書に exact「青い」エントリは無く、前方一致で「青い鳥」が引っかかって *HIT に見えていた* だけ。パネルがクエリ語そのもの（`word`）を見出しとして描画していたため、「青い」が辞書にあるかのような誤解を生んでいた。

## 変更

- `GenjiWordInfoViewModel` に `matchedHeadword`（実際にヒットした見出し語）と `isExactMatch` を追加。
- 完全一致でない場合は見出しに **実エントリ（青い鳥）** を表示し、「『青い』に完全一致する項目はありません。前方一致する見出しを表示しています。」と注記。

## テスト

- `buildGenjiWordInfoViewModel`: exact 一致の `matchedHeadword`/`isExactMatch=true`、前方一致のみの `isExactMatch=false`＋実見出し露出を追加検証。
- `npm run type-check` green / vitest 16 件全 pass。

## 関連

- 関連 issue なし（画像報告からの調査で特定）。
- 校正側の誤検出（青い・旨い・測る等の動詞・形容詞）は別 PR で対応: illusions-lab/illusions-ruleset-genji-vocab#7（既定スコープを名詞のみに変更）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)