### PR TITLE
feat(lint): 辞書外語マークからユーザー辞書・他辞書RS登録語を除外

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,6 +55,7 @@ import { useModeConfigMigration } from "@/lib/editor-page/use-mode-config-migrat
 import type { CorrectionModeId } from "@/lib/linting/correction-config";
 import { usePowerSaving } from "@/lib/editor-page/use-power-saving";
 import { useIgnoredCorrections } from "@/lib/editor-page/use-ignored-corrections";
+import { useKnownTerms } from "@/lib/editor-page/use-known-terms";
 import { useKeyboardShortcuts } from "@/lib/editor-page/use-keyboard-shortcuts";
 import { usePanelState } from "@/lib/editor-page/use-panel-state";
 import { findSearchMatches, type SearchRange } from "@/lib/editor-page/find-search-matches";
@@ -1235,6 +1236,10 @@ export default function EditorPage() {
   const { ignoredCorrections, ignoreCorrection, unignoreCorrection, clearIgnoredCorrections } =
     useIgnoredCorrections(editorMode);
 
+  // Known terms (user dictionary + dictionary-ruleset sources) that
+  // dictionary-matching lint rules must not flag as 辞書外語.
+  const knownTerms = useKnownTerms(editorMode);
+
   const ignoredCorrectionsContextValue = useMemo(
     () => ({
       items: ignoredCorrections,
@@ -1256,6 +1261,19 @@ export default function EditorPage() {
         console.error("[page] Failed to sync ignored corrections:", err);
       });
   }, [editorViewInstance, ignoredCorrections]);
+
+  // Sync known terms to ProseMirror plugin
+  useEffect(() => {
+    if (!editorViewInstance) return;
+
+    import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
+      .then(({ updateLintingSettings }) => {
+        updateLintingSettings(editorViewInstance, { knownTerms }, "known-terms-change");
+      })
+      .catch((err) => {
+        console.error("[page] Failed to sync known terms:", err);
+      });
+  }, [editorViewInstance, knownTerms]);
 
   // --- Lint handlers hook ---
   const {

--- a/lib/editor-page/use-known-terms.ts
+++ b/lib/editor-page/use-known-terms.ts
@@ -1,0 +1,60 @@
+/**
+ * React hook exposing the set of "known" terms for the current editor mode —
+ * words that dictionary-matching lint rules must not flag as 辞書外語.
+ *
+ * Mirrors use-ignored-corrections: loads on mount / mode change with a stale
+ * guard, and additionally reloads whenever the user dictionary is written
+ * (subscribe via user-dictionary-service) so adding/removing a word refreshes
+ * the editor marks instantly.
+ *
+ * 辞書照合ルールがマークすべきでない「既知語」集合を提供するフック。
+ */
+
+import { useEffect, useState } from "react";
+
+import { collectKnownTerms } from "@/lib/linting/known-terms";
+import { subscribeUserDictionaryChange } from "@/lib/services/user-dictionary-service";
+import type { EditorMode } from "@/lib/project/project-types";
+
+const EMPTY: ReadonlySet<string> = new Set();
+
+/**
+ * Collect known terms (user dictionary + any registered dictionary-ruleset
+ * sources) for the given editor mode.
+ *
+ * @param editorMode Current editor mode (project / standalone / null)
+ */
+export function useKnownTerms(editorMode: EditorMode): ReadonlySet<string> {
+  const [knownTerms, setKnownTerms] = useState<ReadonlySet<string>>(EMPTY);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const reload = (): void => {
+      if (!editorMode) {
+        setKnownTerms(EMPTY);
+        return;
+      }
+      collectKnownTerms({ editorMode })
+        .then((terms) => {
+          if (!cancelled) setKnownTerms(terms);
+        })
+        .catch((err) => {
+          console.warn("[useKnownTerms] Failed to collect known terms:", err);
+          if (!cancelled) setKnownTerms(EMPTY);
+        });
+    };
+
+    reload();
+    // User dictionary writes happen through Dictionary.tsx; reload so marks
+    // appear/disappear without a manual refresh.
+    const unsubscribe = subscribeUserDictionaryChange(reload);
+
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [editorMode]);
+
+  return knownTerms;
+}

--- a/lib/linting/__tests__/known-terms.test.ts
+++ b/lib/linting/__tests__/known-terms.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for the known-terms registry that suppresses 辞書外語 marks for words
+ * the user (or another dictionary ruleset) has registered.
+ *
+ * Locks:
+ * - applyKnownTermsToSnapshot overrides only candidate terms in the known set,
+ *   leaves misses untouched, and is a no-op for an empty known set.
+ * - collectKnownTerms unions every registered source and is fail-safe (one
+ *   throwing source does not break the others).
+ * - The built-in user-dictionary source reads from the right storage key for
+ *   project vs standalone mode (standalone uses filePath, falling back to
+ *   fileName).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { DictLookup } from "@/lib/dict/dict-types";
+import type { EditorMode } from "@/lib/project/project-types";
+
+const loadEntries = vi.fn();
+const loadEntriesStandalone = vi.fn();
+
+vi.mock("@/lib/services/user-dictionary-service", () => ({
+  getUserDictionaryService: () => ({ loadEntries, loadEntriesStandalone }),
+  subscribeUserDictionaryChange: () => () => {},
+}));
+
+import {
+  applyKnownTermsToSnapshot,
+  collectKnownTerms,
+  registerKnownTermsSource,
+  unregisterKnownTermsSource,
+} from "../known-terms";
+
+describe("applyKnownTermsToSnapshot", () => {
+  it("overrides candidate terms present in the known set to found:true", () => {
+    const map = new Map<string, DictLookup>([
+      ["造語", { found: false }],
+      ["普通", { found: true }],
+    ]);
+    applyKnownTermsToSnapshot(map, ["造語", "普通"], new Set(["造語"]));
+    expect(map.get("造語")).toEqual({ found: true });
+  });
+
+  it("leaves misses not in the known set untouched", () => {
+    const map = new Map<string, DictLookup>([["未知", { found: false }]]);
+    applyKnownTermsToSnapshot(map, ["未知"], new Set(["別の語"]));
+    expect(map.get("未知")).toEqual({ found: false });
+  });
+
+  it("is a no-op for an empty known set", () => {
+    const map = new Map<string, DictLookup>([["x", { found: false }]]);
+    applyKnownTermsToSnapshot(map, ["x"], new Set());
+    expect(map.get("x")).toEqual({ found: false });
+  });
+
+  it("ignores known terms that are not lookup candidates", () => {
+    const map = new Map<string, DictLookup>([["x", { found: false }]]);
+    applyKnownTermsToSnapshot(map, ["x"], new Set(["not-a-candidate"]));
+    expect(map.has("not-a-candidate")).toBe(false);
+  });
+});
+
+describe("collectKnownTerms", () => {
+  beforeEach(() => {
+    loadEntries.mockReset();
+    loadEntriesStandalone.mockReset();
+    loadEntries.mockResolvedValue([]);
+    loadEntriesStandalone.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    unregisterKnownTermsSource("test-a");
+    unregisterKnownTermsSource("test-b");
+    unregisterKnownTermsSource("test-throws");
+  });
+
+  it("unions terms from every registered source", async () => {
+    registerKnownTermsSource("test-a", () => ["甲", "乙"]);
+    registerKnownTermsSource("test-b", () => ["乙", "丙"]);
+    // null mode → built-in user-dictionary source contributes nothing.
+    const terms = await collectKnownTerms({ editorMode: null });
+    expect(terms).toEqual(new Set(["甲", "乙", "丙"]));
+  });
+
+  it("is fail-safe: a throwing source does not break the others", async () => {
+    registerKnownTermsSource("test-throws", () => {
+      throw new Error("boom");
+    });
+    registerKnownTermsSource("test-a", () => ["生存"]);
+    const terms = await collectKnownTerms({ editorMode: null });
+    expect(terms.has("生存")).toBe(true);
+  });
+
+  it("drops empty strings and non-strings", async () => {
+    registerKnownTermsSource("test-a", () => ["有効", ""]);
+    const terms = await collectKnownTerms({ editorMode: null });
+    expect(terms.has("有効")).toBe(true);
+    expect(terms.has("")).toBe(false);
+  });
+
+  it("user-dictionary source reads project entries in project mode", async () => {
+    loadEntries.mockResolvedValue([
+      { id: "1", word: "幻燈" },
+      { id: "2", word: "" },
+    ]);
+    const mode: EditorMode = {
+      type: "project",
+      projectId: "p1",
+    } as EditorMode;
+    const terms = await collectKnownTerms({ editorMode: mode });
+    expect(loadEntries).toHaveBeenCalled();
+    expect(terms.has("幻燈")).toBe(true);
+    expect(terms.has("")).toBe(false);
+  });
+
+  it("user-dictionary source uses filePath as the standalone key", async () => {
+    loadEntriesStandalone.mockResolvedValue([{ id: "1", word: "造語" }]);
+    const mode: EditorMode = {
+      type: "standalone",
+      fileName: "a.txt",
+      filePath: "/abs/a.txt",
+    } as EditorMode;
+    const terms = await collectKnownTerms({ editorMode: mode });
+    expect(loadEntriesStandalone).toHaveBeenCalledWith("/abs/a.txt");
+    expect(terms.has("造語")).toBe(true);
+  });
+
+  it("user-dictionary source falls back to fileName when filePath is absent", async () => {
+    loadEntriesStandalone.mockResolvedValue([]);
+    const mode: EditorMode = {
+      type: "standalone",
+      fileName: "a.txt",
+    } as EditorMode;
+    await collectKnownTerms({ editorMode: mode });
+    expect(loadEntriesStandalone).toHaveBeenCalledWith("a.txt");
+  });
+});

--- a/lib/linting/__tests__/known-terms.test.ts
+++ b/lib/linting/__tests__/known-terms.test.ts
@@ -15,6 +15,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { DictLookup } from "@/lib/dict/dict-types";
 import type { EditorMode } from "@/lib/project/project-types";
+import type { Token } from "@/lib/nlp-client/types";
+import { createSnapshotDictToolkit } from "@/lib/linting/toolkit";
+import { collectDictCandidateTerms } from "@/lib/linting/dict-candidate-terms";
 
 const loadEntries = vi.fn();
 const loadEntriesStandalone = vi.fn();
@@ -57,6 +60,60 @@ describe("applyKnownTermsToSnapshot", () => {
     const map = new Map<string, DictLookup>([["x", { found: false }]]);
     applyKnownTermsToSnapshot(map, ["x"], new Set(["not-a-candidate"]));
     expect(map.has("not-a-candidate")).toBe(false);
+  });
+
+  it("preserves projection fields on entries it does not override", () => {
+    const map = new Map<string, DictLookup>([
+      ["猫", { found: true, freqRank: 10 } as DictLookup],
+      ["造語", { found: false }],
+    ]);
+    applyKnownTermsToSnapshot(map, ["猫", "造語"], new Set(["造語"]));
+    expect(map.get("猫")).toEqual({ found: true, freqRank: 10 });
+  });
+});
+
+/**
+ * End-to-end contract: the override must be visible through the exact surface the
+ * out-of-dict rule reads — `createSnapshotDictToolkit().lookupCached`. The rule
+ * flags a term only when lookupCached returns `{ found: false }`, so a known term
+ * appearing as `{ found: true }` here proves it will NOT be flagged.
+ */
+describe("known terms suppress out-of-dict via the snapshot toolkit", () => {
+  it("a known miss reads back as found:true; an unknown miss stays found:false", () => {
+    // Genji reported both as absent...
+    const map = new Map<string, DictLookup>([
+      ["造語", { found: false }],
+      ["誤変換", { found: false }],
+    ]);
+    // ...but the user registered 「造語」.
+    applyKnownTermsToSnapshot(map, map.keys(), new Set(["造語"]));
+
+    const dict = createSnapshotDictToolkit();
+    dict.setSnapshot([...map.entries()], true);
+
+    // 造語 → not flagged (rule skips found:true); 誤変換 → still flagged.
+    expect(dict.lookupCached("造語")).toEqual({ found: true });
+    expect(dict.lookupCached("誤変換")).toEqual({ found: false });
+  });
+
+  it("suppresses a conjugated verb when its basic form is a known term", () => {
+    // The rule queries the basic form (dictCandidateTerm), so the user must
+    // register the basic form 「走る」, not the surface 「走っ」.
+    const token = {
+      surface: "走っ",
+      pos: "動詞",
+      pos_detail_1: "自立",
+      basic_form: "走る",
+    } as unknown as Token;
+    const terms = collectDictCandidateTerms([token]);
+    expect(terms).toContain("走る");
+
+    const map = new Map<string, DictLookup>(terms.map((t) => [t, { found: false } as DictLookup]));
+    applyKnownTermsToSnapshot(map, terms, new Set(["走る"]));
+
+    const dict = createSnapshotDictToolkit();
+    dict.setSnapshot([...map.entries()], true);
+    expect(dict.lookupCached("走る")).toEqual({ found: true });
   });
 });
 

--- a/lib/linting/correction-config.ts
+++ b/lib/linting/correction-config.ts
@@ -16,6 +16,7 @@ export type ConfigChangeReason =
   | "mode-change" // clear all caches, full re-run
   | "guideline-change" // clear issue + validation cache
   | "ignored-correction" // rebuild decorations only (no re-run)
+  | "known-terms-change" // known-terms set changed: clear issue cache, full re-run
   | "manual-refresh"; // clear all caches, force re-run
 
 /** Correction mode identifiers */

--- a/lib/linting/known-terms.ts
+++ b/lib/linting/known-terms.ts
@@ -1,0 +1,133 @@
+/**
+ * Known-terms registry — words that dictionary-matching lint rules
+ * (e.g. genji-vocab's `genji-out-of-dict`) must treat as "known" and therefore
+ * never flag as 辞書外語 (out-of-dictionary).
+ *
+ * Why this exists:
+ *   The out-of-dict rule flags a term ONLY when the prewarm snapshot reports it
+ *   `{ found: false }`. The snapshot is the single "is this word known?" oracle.
+ *   By forcing chosen terms to `{ found: true }` at snapshot-build time we
+ *   suppress the mark without touching the rule, the worker, or the protocol —
+ *   and the suppression automatically applies to every present/future
+ *   out-of-dict-style rule.
+ *
+ * Two requirements, one mechanism:
+ *   1. User dictionary words (built-in source, below).
+ *   2. Words registered in ANOTHER dictionary ruleset. This is the generic
+ *      extension point: a future dictionary ruleset registers its own source via
+ *      {@link registerKnownTermsSource} and its vocabulary is unioned in.
+ *
+ * Scope note — enumerable sets vs. backend dictionaries:
+ *   This registry unions *enumerable* term sets (the user dictionary, small
+ *   per-ruleset allow-lists). A large full-text dictionary (like Genji itself)
+ *   must NOT be enumerated here; it is queried by candidate term at prewarm time
+ *   as a membership resolver (see `getDictAccess().lookupBatch` in
+ *   decoration-plugin.ts). Adding a second backend dictionary means adding a
+ *   resolver call alongside that one — not dumping its headwords into a Set.
+ *
+ * IMPORTANT: this is wired into the lint prewarm path ONLY. Do NOT fold these
+ * terms into `dict-access` itself, or analysis features (語彙統計「辞書外語数」,
+ * ルビ, etc.) would silently treat user words as dictionary entries.
+ */
+import type { DictLookup } from "@/lib/dict/dict-types";
+import type { EditorMode } from "@/lib/project/project-types";
+import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
+import { getUserDictionaryService } from "@/lib/services/user-dictionary-service";
+
+/** Context handed to every {@link KnownTermsSource} when collecting terms. */
+export interface KnownTermsContext {
+  editorMode: EditorMode;
+}
+
+/**
+ * A contributor of "known" terms. May be sync or async. Errors are swallowed by
+ * {@link collectKnownTerms} (one bad source must not break linting or other
+ * sources), so a source should still prefer returning an empty iterable on
+ * partial failure.
+ */
+export type KnownTermsSource = (
+  ctx: KnownTermsContext,
+) => Promise<Iterable<string>> | Iterable<string>;
+
+const sources = new Map<string, KnownTermsSource>();
+
+/**
+ * Register (or replace) a known-terms source under a stable id. A future
+ * dictionary ruleset calls this with its ruleset id to contribute its
+ * vocabulary; calling again with the same id replaces the previous source.
+ */
+export function registerKnownTermsSource(id: string, source: KnownTermsSource): void {
+  sources.set(id, source);
+}
+
+/** Remove a previously registered source. No-op if the id is unknown. */
+export function unregisterKnownTermsSource(id: string): void {
+  sources.delete(id);
+}
+
+/**
+ * Union the terms from every registered source for the given context. Sources
+ * run in parallel; a source that throws (or rejects) contributes nothing and is
+ * logged — it never fails the whole collection.
+ */
+export async function collectKnownTerms(ctx: KnownTermsContext): Promise<Set<string>> {
+  const out = new Set<string>();
+  const results = await Promise.allSettled(
+    [...sources.entries()].map(async ([id, source]) => {
+      try {
+        return await source(ctx);
+      } catch (err) {
+        console.warn(`[known-terms] source "${id}" failed:`, err);
+        return [] as string[];
+      }
+    }),
+  );
+  for (const result of results) {
+    if (result.status !== "fulfilled") continue;
+    for (const term of result.value) {
+      if (typeof term === "string" && term.length > 0) out.add(term);
+    }
+  }
+  return out;
+}
+
+/**
+ * Override `map` so every term in `terms` that is also in `known` reports as a
+ * dictionary hit (`{ found: true }`). Pure helper used by the lint prewarm right
+ * after the Genji `lookupBatch`, before the snapshot is serialized.
+ *
+ * Only terms already present as lookup candidates matter — a known term that
+ * never appears as a candidate would not be flagged anyway, so it is ignored.
+ */
+export function applyKnownTermsToSnapshot(
+  map: Map<string, DictLookup>,
+  terms: Iterable<string>,
+  known: ReadonlySet<string>,
+): void {
+  if (known.size === 0) return;
+  for (const term of terms) {
+    if (known.has(term)) map.set(term, { found: true });
+  }
+}
+
+/** Built-in source: the user dictionary for the current editor mode. */
+const userDictionarySource: KnownTermsSource = async ({ editorMode }) => {
+  if (!editorMode) return [];
+  const service = getUserDictionaryService();
+  let entries;
+  if (isProjectMode(editorMode)) {
+    entries = await service.loadEntries();
+  } else if (isStandaloneMode(editorMode)) {
+    // Match the storage key Dictionary.tsx writes under (#1921): prefer the full
+    // path, fall back to fileName on Web where filePath is unavailable.
+    const stableKey = editorMode.filePath ?? editorMode.fileName;
+    entries = await service.loadEntriesStandalone(stableKey);
+  } else {
+    return [];
+  }
+  return entries
+    .map((e) => e.word)
+    .filter((w): w is string => typeof w === "string" && w.length > 0);
+};
+
+registerKnownTermsSource("user-dictionary", userDictionarySource);

--- a/lib/services/user-dictionary-service.ts
+++ b/lib/services/user-dictionary-service.ts
@@ -23,6 +23,35 @@ const USER_DICTIONARY_FILENAME = "user-dictionary.json";
 const STANDALONE_STORAGE_PREFIX = "illusions-user-dictionary:";
 
 // -----------------------------------------------------------------------
+// Change notification
+// -----------------------------------------------------------------------
+
+/**
+ * Listeners notified after any successful write to the user dictionary. Lets the
+ * lint pipeline (see use-known-terms) re-read the dictionary and refresh
+ * 辞書外語 marks the instant the user adds/removes a word — no reload needed.
+ */
+const changeListeners = new Set<() => void>();
+
+/** Subscribe to user-dictionary writes. Returns an unsubscribe function. */
+export function subscribeUserDictionaryChange(listener: () => void): () => void {
+  changeListeners.add(listener);
+  return () => {
+    changeListeners.delete(listener);
+  };
+}
+
+function notifyUserDictionaryChange(): void {
+  for (const listener of changeListeners) {
+    try {
+      listener();
+    } catch (err) {
+      console.warn("[user-dictionary] change listener failed:", err);
+    }
+  }
+}
+
+// -----------------------------------------------------------------------
 // Domain mutations (identity / dedupe policy)
 // -----------------------------------------------------------------------
 
@@ -91,7 +120,8 @@ class UserDictionaryService {
    * Creates .illusions directory if it does not exist.
    */
   async saveEntries(entries: UserDictionaryEntry[]): Promise<void> {
-    return this.store.saveProject(entries);
+    await this.store.saveProject(entries);
+    notifyUserDictionaryChange();
   }
 
   /**
@@ -99,7 +129,9 @@ class UserDictionaryService {
    * Guarded by the store mutex to prevent concurrent read-modify-write races.
    */
   async addEntry(entry: UserDictionaryEntry): Promise<UserDictionaryEntry[]> {
-    return this.store.mutateProject((entries) => insertEntry(entries, entry));
+    const result = await this.store.mutateProject((entries) => insertEntry(entries, entry));
+    notifyUserDictionaryChange();
+    return result;
   }
 
   /**
@@ -110,7 +142,9 @@ class UserDictionaryService {
     id: string,
     updates: Partial<UserDictionaryEntry>,
   ): Promise<UserDictionaryEntry[]> {
-    return this.store.mutateProject((entries) => applyUpdate(entries, id, updates));
+    const result = await this.store.mutateProject((entries) => applyUpdate(entries, id, updates));
+    notifyUserDictionaryChange();
+    return result;
   }
 
   /**
@@ -118,7 +152,9 @@ class UserDictionaryService {
    * Guarded by the store mutex to prevent concurrent read-modify-write races.
    */
   async removeEntry(id: string): Promise<UserDictionaryEntry[]> {
-    return this.store.mutateProject((entries) => removeById(entries, id));
+    const result = await this.store.mutateProject((entries) => removeById(entries, id));
+    notifyUserDictionaryChange();
+    return result;
   }
 
   // -------------------------------------------------------------------
@@ -139,7 +175,8 @@ class UserDictionaryService {
    * @param filePath - Full path to the file (used as storage key to avoid basename collisions).
    */
   async saveEntriesStandalone(filePath: string, entries: UserDictionaryEntry[]): Promise<void> {
-    return this.store.saveStandalone(filePath, entries);
+    await this.store.saveStandalone(filePath, entries);
+    notifyUserDictionaryChange();
   }
 
   /**
@@ -150,7 +187,11 @@ class UserDictionaryService {
     fileName: string,
     entry: UserDictionaryEntry,
   ): Promise<UserDictionaryEntry[]> {
-    return this.store.mutateStandalone(fileName, (entries) => insertEntry(entries, entry));
+    const result = await this.store.mutateStandalone(fileName, (entries) =>
+      insertEntry(entries, entry),
+    );
+    notifyUserDictionaryChange();
+    return result;
   }
 
   /**
@@ -162,7 +203,11 @@ class UserDictionaryService {
     id: string,
     updates: Partial<UserDictionaryEntry>,
   ): Promise<UserDictionaryEntry[]> {
-    return this.store.mutateStandalone(fileName, (entries) => applyUpdate(entries, id, updates));
+    const result = await this.store.mutateStandalone(fileName, (entries) =>
+      applyUpdate(entries, id, updates),
+    );
+    notifyUserDictionaryChange();
+    return result;
   }
 
   /**
@@ -170,7 +215,11 @@ class UserDictionaryService {
    * Guarded by the store mutex to prevent concurrent read-modify-write races.
    */
   async removeEntryStandalone(fileName: string, id: string): Promise<UserDictionaryEntry[]> {
-    return this.store.mutateStandalone(fileName, (entries) => removeById(entries, id));
+    const result = await this.store.mutateStandalone(fileName, (entries) =>
+      removeById(entries, id),
+    );
+    notifyUserDictionaryChange();
+    return result;
   }
 }
 

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -77,6 +77,10 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
   // Ignored corrections list (updated dynamically via setMeta)
   let currentIgnoredCorrections: IgnoredCorrection[] = options.ignoredCorrections ?? [];
 
+  // Known terms — words dictionary-matching rules must not flag as 辞書外語
+  // (user dictionary + registered dictionary-ruleset sources). Updated via setMeta.
+  let currentKnownTerms: ReadonlySet<string> = options.knownTerms ?? new Set();
+
   // NLP error state: tracks whether tokenization has failed.
   // When true, L2 (morphological) rules are explicitly disabled
   // and the user has been notified via onNlpError callback.
@@ -161,7 +165,10 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
                 break;
               case "rule-config-change":
               case "guideline-change":
-                // Clear issue cache and force re-run (keep token cache)
+              case "known-terms-change":
+                // Known terms feed the prewarm snapshot, which the rule consumes
+                // at run time — so a re-run is required (not just a re-filter).
+                // Clear issue cache and force re-run (keep token cache).
                 issueCache.clear();
                 documentIssueCache = null;
                 pendingFullScan = true;
@@ -183,6 +190,10 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           // Update ignoredCorrections list if provided
           if ("ignoredCorrections" in meta) {
             currentIgnoredCorrections = meta.ignoredCorrections ?? [];
+          }
+          // Update known terms if provided
+          if ("knownTerms" in meta) {
+            currentKnownTerms = meta.knownTerms ?? new Set();
           }
           // enabled/disabled change
           if (meta.enabled !== undefined) {
@@ -330,6 +341,15 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
               if (ready && terms.size > 0) {
                 const map = await access.lookupBatch([...terms]);
                 if (version !== processingVersion) return;
+                // Treat known terms (user dictionary + other dictionary rulesets)
+                // as dictionary hits so out-of-dict rules never flag them. Mirrors
+                // applyKnownTermsToSnapshot in @/lib/linting/known-terms, inlined
+                // here to keep this package free of application-root imports.
+                if (currentKnownTerms.size > 0) {
+                  for (const term of terms) {
+                    if (currentKnownTerms.has(term)) map.set(term, { found: true });
+                  }
+                }
                 entries = [...map.entries()];
               }
               dictPayload = { ready, entries };

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/types.ts
@@ -21,6 +21,11 @@ export interface LintingPluginOptions {
   ruleRunner: RuleRunnerLike | null;
   nlpClient?: INlpClient | null;
   ignoredCorrections?: IgnoredCorrection[];
+  /**
+   * Terms that dictionary-matching rules must treat as known (never flag as
+   * 辞書外語). Unioned into the prewarm snapshot as dictionary hits.
+   */
+  knownTerms?: ReadonlySet<string>;
   onIssuesUpdated?: (issues: LintIssue[]) => void;
   /** Callback fired when NLP tokenization fails (e.g., kuromoji init error).
    *  Called once per failure episode (not per-paragraph). */
@@ -47,6 +52,8 @@ export interface LintingSettingsUpdate {
   /** @deprecated Use changeReason instead */
   forceFullScan?: boolean;
   ignoredCorrections?: IgnoredCorrection[];
+  /** Terms to treat as known by dictionary-matching rules (see LintingPluginOptions). */
+  knownTerms?: ReadonlySet<string>;
   /** Identifies the trigger for this change, enabling precise cache invalidation */
   changeReason?: ConfigChangeReason;
 }


### PR DESCRIPTION
## 概要

辞書照合ルール（幻辞 `genji-out-of-dict`）が「辞書外語」としてマークしてしまう以下を除外する：

1. **ユーザー辞書に登録した語**（固有名詞・造語・専門用語など）— **完全実装**
2. **別の辞書ルールセットに登録がある語** — 将来の辞書RS横断の**汎用機構として土台整備**

## 仕組み

`genji-out-of-dict` ルールは prewarm snapshot が `{ found: false }` を返す語だけを叩く。
snapshot は「この語は既知か」の**唯一のオラクル**なので、snapshot 構築時に「既知とみなす語」を
`{ found: true }` で上書きすれば、**ルール・worker・protocol を一切変えずに**抑制できる
（現在/将来の out-of-dict 系ルール全てに自動適用）。

上書きは **lint prewarm 経路に限定**。`dict-access` 本体には混ぜないため、分析機能
（語彙統計の「辞書外語数」・ルビ等）には影響しない。

## 変更点

**新規**
- `lib/linting/known-terms.ts` — 「既知語」源レジストリ（`registerKnownTermsSource`）+
  `collectKnownTerms`（全源を union・fail-safe）+ `applyKnownTermsToSnapshot`（純粋ヘルパ）。
  組み込み源としてユーザー辞書を登録。将来の辞書ルールセットは自分の収録語を寄与すれば自動で効く
- `lib/editor-page/use-known-terms.ts` — `use-ignored-corrections` を踏襲したフック。
  ユーザー辞書の変更通知を購読し、登録/削除でマークが即座に消失/出現（再起動不要）
- `lib/linting/__tests__/known-terms.test.ts` — ユニット10件

**変更**
- `lib/services/user-dictionary-service.ts` — 書き込み後に変更通知を発火（`subscribeUserDictionaryChange`）
- `decoration-plugin.ts` — prewarm snapshot に known terms を `{found:true}` で上書き（境界規約のため import せずインライン）
- `types.ts` / `correction-config.ts` — `knownTerms` フィールド + `known-terms-change` reason 追加
- `app/page.tsx` — フック配線（`updateLintingSettings`）

standalone モードのユーザー辞書は UI（Dictionary.tsx, #1921）と同じ `filePath ?? fileName` キーで読む。

## 検証

- `npm run type-check` ✅
- `npm run test` ✅（209 ファイル / 2451 件）
- `npm run lint` ✅ / import 境界チェック ✅
- 手動E2E（要確認）: 幻辞インストール済みで造語に辞書外語マーク → 辞書登録 → 即マーク消失 → 削除で再出現（project / standalone 両モード）

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)