### PR TITLE
fix(vfs): set-root のパス照合を NFC 正規化し日本語名プロジェクトを最近一覧から開けるようにする

### DIFF
--- a/electron/ipc/__tests__/vfs-path-validation.test.ts
+++ b/electron/ipc/__tests__/vfs-path-validation.test.ts
@@ -26,13 +26,19 @@ import { createRequire } from "module";
 
 // Load the CommonJS path-utils module via createRequire so vitest can import it
 const require = createRequire(import.meta.url);
-const { toForwardSlash, assertPathInsideRoot, getWindowsDenyPrefixes, resolveRealPath } =
-  require("../../../electron/lib/path-utils") as {
-    toForwardSlash: (p: string) => string;
-    assertPathInsideRoot: (resolvedPath: string, rootPath: string) => void;
-    getWindowsDenyPrefixes: () => string[];
-    resolveRealPath: (p: string) => Promise<string>;
-  };
+const {
+  toForwardSlash,
+  assertPathInsideRoot,
+  getWindowsDenyPrefixes,
+  resolveRealPath,
+  normalizeForCompare,
+} = require("../../../electron/lib/path-utils") as {
+  toForwardSlash: (p: string) => string;
+  assertPathInsideRoot: (resolvedPath: string, rootPath: string) => void;
+  getWindowsDenyPrefixes: () => string[];
+  resolveRealPath: (p: string) => Promise<string>;
+  normalizeForCompare: (p: string) => string;
+};
 
 // -----------------------------------------------------------------------
 // toForwardSlash
@@ -266,5 +272,40 @@ describe("resolveRealPath()", () => {
     fsSync.symlinkSync(path.join(outsideDir, "does-not-exist.txt"), link);
 
     await expect(resolveRealPath(link)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+// -----------------------------------------------------------------------
+// normalizeForCompare — the canonical comparison form used by vfs:set-root.
+// This is what fixes opening a Japanese-named project from the recent list
+// (#1955 follow-up): macOS dialogs return the on-disk NFD form while the
+// renderer / recent-projects list supplies NFC, and they must compare equal.
+// -----------------------------------------------------------------------
+describe("normalizeForCompare()", () => {
+  // 「が」: NFC = U+30AC (が), NFD = U+30AB U+3099 (か + combining dakuten).
+  const NFC = "ガ";
+  const NFD = "ガ";
+
+  it("folds NFD and NFC encodings of the same Japanese path to an equal value", () => {
+    // Pre-condition: the two strings are genuinely different byte sequences.
+    expect(NFC).not.toBe(NFD);
+    const nfcPath = `/Users/u/${NFC}`;
+    const nfdPath = `/Users/u/${NFD}`;
+    // Without NFC folding these would compare unequal and set-root would throw
+    // "選択されたディレクトリが要求されたパスと一致しません".
+    expect(normalizeForCompare(nfdPath)).toBe(normalizeForCompare(nfcPath));
+    expect(normalizeForCompare(nfdPath)).toBe(nfcPath);
+  });
+
+  it("still trims trailing slashes and converts backslashes while folding NFC", () => {
+    const nfdWithCruft = `\\Users\\u\\${NFD}\\\\`;
+    expect(normalizeForCompare(nfdWithCruft)).toBe(`/Users/u/${NFC}`);
+  });
+
+  it("does NOT collapse genuinely different directories to equal (no false match)", () => {
+    expect(normalizeForCompare(`/Users/u/${NFC}`)).not.toBe(
+      normalizeForCompare(`/Users/u/${NFC}2`),
+    );
+    expect(normalizeForCompare("/a/b")).not.toBe(normalizeForCompare("/a/c"));
   });
 });

--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -10,8 +10,7 @@ const { createApprovedPathRegistry, isWithinApprovedTree } = require("../lib/app
 const {
   toForwardSlash,
   assertPathInsideRoot,
-  normalizeSeparators,
-  trimTrailingSlashes,
+  normalizeForCompare,
   resolveRealPath,
 } = require("../lib/path-utils");
 const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
@@ -100,14 +99,18 @@ function registerVFSHandlers() {
   }
 
   /**
-   * Normalize path separators to forward slashes for cross-platform compatibility.
-   * Intentional difference vs file-ipc.js: trailing slashes are trimmed here
-   * because VFS roots are prefix-matched (`${root}/`) by assertPathInsideRoot.
+   * Normalize a path to the canonical comparison form (forward slashes, no
+   * trailing slash, NFC). Delegates to the shared path-utils primitive so the
+   * NFC-immunity contract documented in approved-paths.js actually holds: macOS
+   * dialogs return the on-disk NFD form for Japanese names while the renderer /
+   * recent-projects list supplies NFC, and set-root must treat them as equal
+   * (#1955 follow-up). Trailing slashes are trimmed because VFS roots are
+   * prefix-matched (`${root}/`) by assertPathInsideRoot.
    * @param {string} p
    * @returns {string}
    */
   function normalizePath(p) {
-    return trimTrailingSlashes(normalizeSeparators(p));
+    return normalizeForCompare(p);
   }
 
   /**
@@ -411,7 +414,13 @@ function registerVFSHandlers() {
     let alreadyApprovedFromDisk = false;
     if (!alreadyApprovedInSession && effectiveProjectId) {
       const persistedSet = await loadApprovals(APPROVED_PATHS_FILE, effectiveProjectId);
-      alreadyApprovedFromDisk = persistedSet.has(resolvedReal) || persistedSet.has(resolved);
+      // Persisted entries were written from earlier dialog confirmations, so on
+      // macOS they may carry the on-disk NFD form while the requested path is
+      // NFC (or vice versa). Fold both sides to NFC so a Japanese-named project
+      // matches its stored approval regardless of Unicode encoding (#1955).
+      const persistedNFC = new Set([...persistedSet].map((p) => normalizePath(p)));
+      alreadyApprovedFromDisk =
+        persistedNFC.has(resolvedReal) || persistedNFC.has(normalizedResolved);
       if (alreadyApprovedFromDisk) {
         // Restore in-session approval so subsequent calls are fast
         approveDialogPath(event.sender.id, resolved);

--- a/electron/lib/path-utils.js
+++ b/electron/lib/path-utils.js
@@ -30,6 +30,24 @@ function trimTrailingSlashes(p) {
 }
 
 /**
+ * Canonical comparison form for VFS root-path matching: forward slashes,
+ * trailing slashes trimmed, and Unicode folded to NFC.
+ *
+ * NFC folding is the critical part. `path.resolve` and plain separator
+ * normalization do NOT fold Unicode, so on macOS the native dialog returns the
+ * on-disk (NFD) form of a Japanese name while the renderer / recent-projects
+ * list supplies the NFC form. Without this fold, the same directory compares
+ * unequal and set-root rejects it ("選択されたディレクトリが要求されたパスと
+ * 一致しません", #1955 follow-up). Use this for every path equality/containment
+ * comparison in the set-root approval flow.
+ * @param {string} p
+ * @returns {string}
+ */
+function normalizeForCompare(p) {
+  return trimTrailingSlashes(normalizeSeparators(p)).normalize("NFC");
+}
+
+/**
  * Resolves a path and normalizes all separators to forward slashes.
  * Also strips Windows extended-path prefix (\\?\, //./), and UNC paths become //server/share/...
  * @param {string} p
@@ -133,6 +151,7 @@ async function resolveRealPath(p) {
 module.exports = {
   normalizeSeparators,
   trimTrailingSlashes,
+  normalizeForCompare,
   toForwardSlash,
   assertPathInsideRoot,
   getWindowsDenyPrefixes,


### PR DESCRIPTION
## 背景

日本語名のプロジェクトを「最近開いたプロジェクト」一覧から開くと
「選択されたディレクトリが要求されたパスと一致しません」で開けない（BLOCKER）。

macOS はネイティブダイアログの返却値をディスク上の **NFD** 形で返す一方、
renderer / 最近一覧は **NFC** 形を供給する。`vfs:set-root` の承認照合
（ダイアログ確認比較・永続化承認チェック）が両者を別文字列として扱うため、
同一ディレクトリでも不一致と判定されていた。

#1955 は新規作成フローの自動承認のみ対応しており、既存プロジェクトを最近一覧
から開く経路（`senderProjectId` 未登録で `effectiveProjectId` が undefined →
永続化承認チェックを飛ばしダイアログ経路に落ちる）は未対応だった。
`approved-paths.js` のコメントが主張する「NFC 不変」は、実際には
`normalizeSeparators` が NFC 正規化しないため成立していなかった。

## 変更

- **path-utils.js**: 比較用正準形 `normalizeForCompare(p)`（forward slash +
  trailing slash trim + **NFC**）を追加。set-root 承認フローの全パス比較で使う。
- **vfs-ipc.js**: 局所 `normalizePath` を `normalizeForCompare` に委譲。
  永続化承認チェックは永続セットを NFC 正規化してから照合し、
  `realpath`(NFD) 一致が現状 HIT しているケースの回帰を防止。
- **vfs-path-validation.test.ts**: `normalizeForCompare` の
  ① NFC/NFD 等価 ② 約物・区切り正規化 ③ 別ディレクトリ非一致 の3ケースを追加。

## テスト

- `vfs-path-validation` / `vfs-approved-paths-persist` / `approved-paths` 計62件 pass
- `npm run type-check` clean / eslint clean

関連 issue なし（#1955 follow-up）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)