### PR TITLE
fix(vfs): 不在/stale な最近プロジェクトから復旧可能にする (#1969)

### DIFF
--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -378,7 +378,11 @@ function registerVFSHandlers() {
       }
     } catch (error) {
       if (error.code === "ENOENT") {
-        throw new Error("指定されたディレクトリが見つかりません");
+        // Prefix with the ENOENT marker so the renderer can classify this as a
+        // "folder not found" failure across the IPC boundary — ipcMain.handle
+        // serialization strips custom error properties like `.code`, but the
+        // message survives, so callers can offer recovery (remove from recent).
+        throw new Error("ENOENT: 指定されたディレクトリが見つかりません");
       }
       throw error;
     }

--- a/lib/editor-page/__tests__/project-open-errors.test.ts
+++ b/lib/editor-page/__tests__/project-open-errors.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+
+import { isProjectNotFoundError } from "../project-open-errors";
+
+describe("isProjectNotFoundError (#1965)", () => {
+  it("detects a native fs error with code ENOENT (Web / direct fs)", () => {
+    const err = Object.assign(new Error("no such file"), { code: "ENOENT" });
+    expect(isProjectNotFoundError(err)).toBe(true);
+  });
+
+  it("detects the ENOENT marker in the Electron IPC rejection message", () => {
+    // ipcMain.handle strips `.code`; only the prefixed message survives.
+    const err = new Error(
+      "Error invoking remote method 'vfs:set-root': Error: ENOENT: 指定されたディレクトリが見つかりません",
+    );
+    expect(isProjectNotFoundError(err)).toBe(true);
+  });
+
+  it("does not classify an unrelated set-root failure as not-found", () => {
+    // e.g. the NFC mismatch / permission errors must NOT offer recent removal.
+    const err = new Error("選択されたディレクトリが要求されたパスと一致しません");
+    expect(isProjectNotFoundError(err)).toBe(false);
+  });
+
+  it("does not classify a not-a-directory failure as not-found", () => {
+    const err = new Error("指定されたパスはディレクトリではありません");
+    expect(isProjectNotFoundError(err)).toBe(false);
+  });
+
+  it("handles non-error values safely", () => {
+    expect(isProjectNotFoundError(null)).toBe(false);
+    expect(isProjectNotFoundError(undefined)).toBe(false);
+    expect(isProjectNotFoundError("ENOENT")).toBe(false);
+    expect(isProjectNotFoundError({ code: "EACCES" })).toBe(false);
+  });
+});

--- a/lib/editor-page/project-open-errors.ts
+++ b/lib/editor-page/project-open-errors.ts
@@ -1,0 +1,19 @@
+/**
+ * Classification of project-open failures (#1965).
+ *
+ * Opening a recent project calls `vfs:set-root` in the Electron main process.
+ * When the stored folder is missing/moved, the handler rejects with an
+ * `ENOENT`-prefixed message. That rejection crosses the IPC boundary, where
+ * `ipcMain.handle` serialization strips custom error properties such as
+ * `.code` — only `.message` survives. So the renderer must detect the
+ * not-found case from BOTH a native `.code === "ENOENT"` (Web / direct fs) and
+ * the `ENOENT` marker embedded in the IPC error message (Electron).
+ */
+
+/** Whether a project-open failure means the project folder was not found. */
+export function isProjectNotFoundError(error: unknown): boolean {
+  if (error && typeof error === "object" && "code" in error) {
+    if ((error as { code?: unknown }).code === "ENOENT") return true;
+  }
+  return error instanceof Error && error.message.includes("ENOENT");
+}

--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -8,6 +8,7 @@ import { notificationManager } from "@/lib/services/notification-manager";
 
 import type { ProjectMode, StandaloneMode, WorkspaceTab } from "@/lib/project/project-types";
 import { ensureProjectFiles, readFileHandle } from "./project-file-utils";
+import { isProjectNotFoundError } from "./project-open-errors";
 
 interface UseFileOpeningParams {
   isElectron: boolean;
@@ -211,22 +212,23 @@ export function useFileOpening({
             console.error("Failed to load project:", error);
             console.error("Project path:", project.rootPath);
 
-            const isFileNotFound =
-              error &&
-              typeof error === "object" &&
-              "code" in error &&
-              (error as { code: string }).code === "ENOENT";
+            // set-root rejects across the Electron IPC boundary, which strips
+            // custom error props like `.code`; the helper detects the ENOENT
+            // marker in the message too so a missing/stale project folder is
+            // still classified as "not found" and offers recovery (#1965).
+            const isFileNotFound = isProjectNotFoundError(error);
 
             const message = isFileNotFound
               ? `プロジェクトが見つかりませんでした。\n\nパス: ${project.rootPath}\n\nフォルダが移動または削除された可能性があります。\n最近のプロジェクト一覧から削除しますか?`
               : "このプロジェクトを開けませんでした。フォルダが移動または削除された可能性があります。";
 
-            if (!isAutoRestoringRef.current) {
-              if (isFileNotFound) {
-                setConfirmRemoveRecent({ projectId, message });
-              } else {
-                notificationManager.error(message);
-              }
+            // A not-found project must offer removal even during auto-restore —
+            // otherwise the stale recent entry re-triggers the same failure on
+            // every launch and the app appears unable to open any project (#1965).
+            if (isFileNotFound) {
+              setConfirmRemoveRecent({ projectId, message });
+            } else if (!isAutoRestoringRef.current) {
+              notificationManager.error(message);
             }
             return false;
           }


### PR DESCRIPTION
## 概要

最近開いたプロジェクトのフォルダが実在しない場合（移動/削除、または重複等の不正パスが保存されている場合）、起動時 auto-restore の `vfs:set-root` が ENOENT で失敗するが**復旧導線が出ず**、毎起動同じ失敗を繰り返してアプリが「プロジェクトを全く開けない」状態になる問題を修正。

### 実例（報告）
- 保存 rootPath: `.../原稿/シックス・シーズン・ランド/シックス・シーズン・ランド`（末尾重複・不在）
- 実フォルダ: `.../原稿/シックス・シーズン・ランド`（単一）

## 根本原因

1. `vfs:set-root` の ENOENT エラーが Electron IPC (`ipcMain.handle`) で `.code` 等を落とすため、renderer の `isFileNotFound`（`error.code === "ENOENT"`）が常に false。
2. not-found が generic エラー扱いになり、かつ auto-restore 中は UI 抑制のため stale な recent エントリの削除導線が無く、毎起動再発。

## 変更

- `electron/ipc/vfs-ipc.js`: ENOENT メッセージに `ENOENT:` マーカー付与（message は IPC を越えて保持）。
- `lib/editor-page/project-open-errors.ts`（新規）: `isProjectNotFoundError()` — `.code === "ENOENT"` と message 内マーカーの双方を判定。
- `lib/editor-page/use-file-opening.ts`: 上記で分類し、**not-found 時は auto-restore 中でも「最近の一覧から削除しますか?」ダイアログを提示**して復旧可能に。

## テスト
- `lib/editor-page/__tests__/project-open-errors.test.ts` 5 ケース green（native code / IPC message marker / NFC mismatch非該当 / not-a-dir非該当 / 非Error値）
- `npm run type-check` clean / eslint clean

## 補足
rootPath が重複保存された一次原因（リネーム後の stale 等）は別途要調査。createProject / renameProjectFile のパス構築自体は健全であることを確認済み。本 PR は「不正/不在パスからの復旧不能」を解消する。

Closes #1969

🤖 Generated with [Claude Code](https://claude.com/claude-code)