### PR TITLE
chore(lint): #1964 packaged fallback 0件回帰の切り分け診断ログ

### DIFF
--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -485,6 +485,19 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           const tr = view.state.tr.setMeta(lintingKey, { decorations });
           view.dispatch(tr);
 
+          // Diagnostics for #1964: a packaged lint pass that re-lints paragraphs
+          // yet yields nothing is the exact symptom. Logging only this case keeps
+          // the console quiet on normal (clean) passes while capturing the flags
+          // needed to pinpoint where the zero comes from.
+          if (allIssues.length === 0 && uncachedParagraphs.length > 0) {
+            console.info(
+              `[lint] 0 issues for ${uncachedParagraphs.length} relinted paragraph(s) (#1964 diag): ` +
+                `dict=${currentRuleRunner.hasDictRules()}, ` +
+                `morph=${currentRuleRunner.hasMorphologicalRules()}, ` +
+                `dictReady=${dictPayload?.ready ?? "n/a"}`,
+            );
+          }
+
           // Notify parent of all issues
           onIssuesUpdated?.(allIssues);
         }, delay);

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/worker/rule-runner-proxy.ts
@@ -604,6 +604,18 @@ export class RuleRunnerProxy implements RuleRunnerLike {
       });
       this.fallbackRunner = runner;
       this.workerHasMorphRules = runnerHasRegisteredMorphRules(runner);
+      // Diagnostics for #1964 (packaged main-thread fallback returns 0 issues).
+      // The proxy/runner pipeline is verified correct in unit tests, so a
+      // packaged-only zero must come from upstream — this line distinguishes
+      // "rulesets failed to import" (modules=0), "createRules quarantined"
+      // (registered=0), or "mode/config disabled everything" (enabled=0) from
+      // an actual rule/lint-pass problem (enabled>0).
+      const registered = runner.getRegisteredRules().length;
+      const enabled = runner.getEnabledRules().length;
+      console.info(
+        `[lint] fallback runner built: ${this.fallbackModules.size} module(s), ` +
+          `${registered} registered rule(s), ${enabled} enabled (#1964 diag)`,
+      );
     } catch (e) {
       console.error("[lint] fallback runner build failed:", e);
     }


### PR DESCRIPTION
## 背景

#1964（packaged の main-thread fallback 発火後、公式ルールセットが全件0件）の調査。

proxy / runner / build-ruleset-runner / mode-config の各層を unit テストで検証し、**fallback で L1(句読点)と L2(辞書外語)が両方正しく発火する**ことを確認済み（前回の「再現」は `AbstractL1Rule` のコンストラクタ未充足によるテスト artifact だった）。したがって packaged 固有の 0件は**上流のランタイム要因**（①ルールセットが fallback runner に未ロード ②lint pass が runBatch に未到達 ③NLP/dict-access IPC）のいずれか。

これは packaged file:// 環境（worker が null-origin で起動失敗 → fallback）でしか起きず、jsdom/dev では worker が動くため再現不能。よって次 beta 実機で原因を一発特定できる診断ログを追加する。

## 変更（挙動不変・ログのみ）

- `rule-runner-proxy.ts`: fallback runner 構築後に `module数 / 登録ルール数 / 有効ルール数` を出力。
  - `0 module` → blob import 失敗（ロード経路）
  - `0 registered` → createRules quarantine
  - `0 enabled` → mode/config が全無効化
  - `enabled>0` → ルール/lint pass 側の問題
- `decoration-plugin.ts`: 段落を再 lint したのに 0件の時のみ `dict/morph/dictReady` を出力（正常パスは無ログ＝低ノイズ）。

## 確認手順（次 beta 実機）
1. プロジェクトを開き校正 ON。
2. `これは、、テストです。。…「未閉じ` を入力 → 5秒待ち → 全文を再検査。
3. devtools console の `[lint] fallback runner built: ...` と `[lint] 0 issues for ... (#1964 diag)` を確認 → 原因切り分け。

Refs #1964

🤖 Generated with [Claude Code](https://claude.com/claude-code)