### PR TITLE
feat(dict): 異表記を照合キー化し旧字体/旧仮名の原稿語を見出し解決 (#1958)

### DIFF
--- a/electron/__tests__/dict-manager-access.test.ts
+++ b/electron/__tests__/dict-manager-access.test.ts
@@ -26,7 +26,12 @@ vi.mock("electron", () => ({
 
 type DbMode = "healthy" | "no-table" | "malformed";
 
-type FakeRow = { entry: string; reading_primary: string; raw_json: string };
+type FakeRow = {
+  entry: string;
+  reading_primary: string;
+  raw_json: string;
+  variantWritings?: string[];
+};
 
 class FakeStatement {
   constructor(
@@ -56,6 +61,24 @@ class FakeStatement {
         .filter((r) => wanted.has(r.reading_primary))
         .map((r) => ({ reading_primary: r.reading_primary, raw_json: r.raw_json }));
     }
+    // #1958 variant_lookup JOIN — batch form: WHERE vl.variant IN (...)
+    if (this.sql.includes("variant_lookup") && this.sql.includes("vl.variant IN")) {
+      const wanted = new Set(args as string[]);
+      const out: Array<{ variant: string; raw_json: string }> = [];
+      for (const r of this.rows) {
+        for (const v of r.variantWritings ?? []) {
+          if (wanted.has(v)) out.push({ variant: v, raw_json: r.raw_json });
+        }
+      }
+      return out;
+    }
+    // #1958 variant_lookup JOIN — single form: WHERE vl.variant = ? LIMIT ?
+    if (this.sql.includes("variant_lookup") && this.sql.includes("vl.variant = ?")) {
+      const [term] = args as string[];
+      return this.rows
+        .filter((r) => (r.variantWritings ?? []).includes(term))
+        .map((r) => ({ raw_json: r.raw_json }));
+    }
     return [];
   }
   run(): void {}
@@ -82,9 +105,15 @@ interface RawJsonInput {
   pos?: string[];
   register?: string;
   freqRank?: number;
+  variantWritings?: string[];
+  needsGloss?: boolean;
 }
 
 function rawJson(input: RawJsonInput): string {
+  const meta: Record<string, unknown> = {};
+  if (input.freqRank !== undefined) meta.freq_rank = input.freqRank;
+  if (input.variantWritings) meta.variant_writings = input.variantWritings;
+  if (input.needsGloss !== undefined) meta.needs_gloss = input.needsGloss;
   return JSON.stringify({
     uuid: `uuid-${input.entry}`,
     entry: input.entry,
@@ -94,7 +123,7 @@ function rawJson(input: RawJsonInput): string {
       ? [{ index: 0, gloss: "x", register: input.register }]
       : [{ index: 0, gloss: "x" }],
     relations: { homophones: [], synonyms: [], antonyms: [], related: [] },
-    meta: input.freqRank !== undefined ? { freq_rank: input.freqRank } : {},
+    meta,
   });
 }
 
@@ -127,6 +156,7 @@ async function freshManager(dictDir: string, opts: ManagerOptions = {}): Promise
     entry: r.entry,
     reading_primary: r.reading,
     raw_json: rawJson(r),
+    variantWritings: r.variantWritings,
   }));
   const { getDictManager } = await import("../dict-manager.js");
   const mgr = getDictManager() as unknown as TestableManager;
@@ -263,6 +293,54 @@ describe("DictManager analysis access (#1624)", () => {
       fs.writeFileSync(dbPath, "sqlite");
       const mgr = await freshManager(dictDir, { rows: NORMALIZE_ROWS });
       expect(mgr.lookupBatch(["ある"], false)).toEqual([]);
+    });
+  });
+
+  describe("variant-writings resolution (#1958)", () => {
+    // 居る absorbs the historical-kana writing ゐる; 来 absorbs the old-kanji 來.
+    const VARIANT_ROWS: RawJsonInput[] = [
+      { entry: "居る", reading: "いる", pos: ["動詞"], variantWritings: ["ゐる"] },
+      { entry: "来", reading: "く", pos: ["動詞"], variantWritings: ["來"] },
+      { entry: "雪", reading: "ゆき", pos: ["名詞"] },
+    ];
+
+    it("resolves a variant writing to its canonical headword in lookupBatch (ゐる→居る)", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: VARIANT_ROWS });
+      const hit = mgr.lookupBatch(["ゐる"]);
+      // Keyed by the requested term; found:true so the 辞書外語 rule won't flag it.
+      expect(hit).toEqual([{ entry: "ゐる", found: true, reading: "いる", pos: "動詞" }]);
+    });
+
+    it("does NOT flag old-kanji/old-kana manuscript words as out-of-dictionary", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: VARIANT_ROWS });
+      const found = new Set(mgr.lookupBatch(["ゐる", "來"]).map((r) => r.entry));
+      expect(found.has("ゐる")).toBe(true);
+      expect(found.has("來")).toBe(true);
+    });
+
+    it("prefers an exact headword hit over the variant fallback", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: VARIANT_ROWS });
+      // 居る matches the headword directly — must resolve there, not via variant.
+      const hit = mgr.lookupBatch(["居る"]);
+      expect(hit).toEqual([{ entry: "居る", found: true, reading: "いる", pos: "動詞" }]);
+    });
+
+    it("normalize:false disables the variant fallback", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: VARIANT_ROWS });
+      expect(mgr.lookupBatch(["ゐる"], false)).toEqual([]);
+    });
+
+    it("query() resolves a variant writing to the canonical entry (panel path)", async () => {
+      fs.writeFileSync(dbPath, "sqlite");
+      const mgr = await freshManager(dictDir, { rows: VARIANT_ROWS });
+      const entries = (
+        mgr as unknown as { query: (t: string, l?: number) => Array<{ entry: string }> }
+      ).query("ゐる");
+      expect(entries.map((e) => e.entry)).toEqual(["居る"]);
     });
   });
 });

--- a/electron/dict-manager.js
+++ b/electron/dict-manager.js
@@ -278,6 +278,32 @@ class DictManager {
       } catch (readingIdxErr) {
         console.warn("[DictManager] reading index create skipped:", readingIdxErr.message);
       }
+      // Variant-writings index (#1958): resolves a manuscript word written in
+      // an absorbed variant form — old kanji / historical kana (e.g. ゐる→居る,
+      // 來→来) — to its canonical headword so the 辞書外語 rule does not flag it
+      // as unknown. `meta.variant_writings` lives inside raw_json (un-indexable
+      // directly), so we materialize a (variant → entry) table once via json_each
+      // and index it. Built only when absent; it persists in the DB file until a
+      // dict update replaces the file, then rebuilds. Best-effort — guarded so a
+      // DB lacking the field / JSON support (older DB) does not fail the open.
+      try {
+        const variantTbl = rwDb
+          .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='variant_lookup'")
+          .get();
+        if (!variantTbl) {
+          rwDb.exec(
+            `CREATE TABLE variant_lookup AS
+               SELECT je.value AS variant, e.entry AS entry
+               FROM entries e,
+                    json_each(json_extract(e.raw_json, '$.meta.variant_writings')) je
+               WHERE json_valid(e.raw_json)
+                 AND json_type(e.raw_json, '$.meta.variant_writings') = 'array';`,
+          );
+          rwDb.exec("CREATE INDEX IF NOT EXISTS idx_variant_lookup ON variant_lookup(variant);");
+        }
+      } catch (variantIdxErr) {
+        console.warn("[DictManager] variant index create skipped:", variantIdxErr.message);
+      }
     } catch (err) {
       // Index creation is best-effort; don't fail the whole open
       console.warn("[DictManager] Index check/create failed:", err);
@@ -318,10 +344,44 @@ class DictManager {
         )
         .all(term, `${escaped}%`, term, limit);
 
-      return rows.map((row) => this._rawJsonToEntry(row.raw_json)).filter(Boolean);
+      const entries = rows.map((row) => this._rawJsonToEntry(row.raw_json)).filter(Boolean);
+      // #1958: when neither an exact nor a prefix match exists, the term may be
+      // an absorbed variant writing (旧字体/歴史的仮名遣い). Resolve it to the
+      // canonical headword so the lookup panel shows the real entry (e.g. ゐる→居る)
+      // instead of "not found".
+      if (entries.length === 0) {
+        const resolved = this._resolveHeadwordByVariant(db, term, limit);
+        if (resolved.length > 0) return resolved;
+      }
+      return entries;
     } catch (err) {
       console.error("[DictManager] query error:", err);
       if (this._isCorruptionError(err)) this._corrupt = true;
+      return [];
+    }
+  }
+
+  /**
+   * Resolve a term that is an absorbed variant writing to its canonical entries
+   * via the `variant_lookup` table (#1958). Best-effort — returns [] when the
+   * table is absent (older DB) or the query fails.
+   * @private
+   * @returns {import("../lib/dict/dict-types").DictEntry[]}
+   */
+  _resolveHeadwordByVariant(db, term, limit = 20) {
+    try {
+      const rows = db
+        .prepare(
+          `SELECT e.raw_json AS raw_json
+             FROM variant_lookup vl
+             JOIN entries e ON e.entry = vl.entry
+            WHERE vl.variant = ?
+            LIMIT ?`,
+        )
+        .all(term, limit);
+      return rows.map((row) => this._rawJsonToEntry(row.raw_json)).filter(Boolean);
+    } catch (err) {
+      console.warn("[DictManager] variant headword resolve failed:", err);
       return [];
     }
   }
@@ -400,8 +460,45 @@ class DictManager {
 
     if (normalize) {
       this._resolveKanaByReading(db, unique, byEntry);
+      this._resolveByVariantWriting(db, unique, byEntry);
     }
     return [...byEntry.values()];
+  }
+
+  /**
+   * Variant-writings fallback (#1958) for terms that missed both the headword
+   * and reading indexes. Resolves an absorbed variant form (旧字体・歴史的仮名遣い,
+   * e.g. ゐる, 來) to the canonical entry via the materialized `variant_lookup`
+   * table, keying the hit by the original requested term so out-of-dict callers
+   * see it as found. Isolated try/catch: a missing `variant_lookup` table (older
+   * DB / build skipped) degrades silently to no variant resolution.
+   * @private
+   */
+  _resolveByVariantWriting(db, unique, byEntry) {
+    const misses = unique.filter((t) => !byEntry.has(t));
+    if (misses.length === 0) return;
+
+    try {
+      const placeholders = misses.map(() => "?").join(",");
+      const rows = db
+        .prepare(
+          `SELECT vl.variant AS variant, e.raw_json AS raw_json
+             FROM variant_lookup vl
+             JOIN entries e ON e.entry = vl.entry
+            WHERE vl.variant IN (${placeholders})`,
+        )
+        .all(...misses);
+
+      for (const row of rows) {
+        if (byEntry.has(row.variant)) continue;
+        const proj = this._rawJsonToLookup(row.raw_json);
+        if (proj) byEntry.set(row.variant, { entry: row.variant, ...proj });
+      }
+    } catch (err) {
+      // variant_lookup may not exist (older DB / build skipped). Best-effort —
+      // never mark corrupt, never clear existing results.
+      console.warn("[DictManager] variant fallback failed:", err);
+    }
   }
 
   /**


### PR DESCRIPTION
## 概要

#1973（フィールド露出・表示・needs_gloss）に続く #1958 の本丸：**`variant_writings` を実際の照合キーとして使い、旧字体・歴史的仮名遣いで書かれた原稿語を見出しへ解決**する。`ゐる`→`居る`、`來`→`来` 等が辞書外語ルールで誤検出（未知語扱い）されなくなる。

## 設計（reading-index #1935 と同型の best-effort）

`variant_writings` は `raw_json` 内の配列で直接索引できないため、**DB オープン時に `json_each` で `(variant → entry)` の materialized table `variant_lookup` を一度生成し索引化**する。

- テーブルは DB ファイル置換（＝辞書更新）まで永続。無ければ再生成。
- JSON 非対応／フィールド未収録の旧 DB では guard で skip（開けなくならない）。
- DB は init 時 read-write で開かれるため索引作成可（既存の reading-index と同じ箇所）。

## 変更（`electron/dict-manager.js`）

- `_ensureIndexes`: `variant_lookup` テーブル + 索引を guarded 生成。
- `lookupBatch`: reading フォールバック後に `_resolveByVariantWriting` でミス語を変異解決。要求語キーで `found:true`（lint 出典外ルールが flag しない）。`normalize=false` で無効化。
- `query()`: 完全／前方一致が無いとき変異から見出しを解決（選択語パネル `ゐる`→`居る`）。

## テスト（`dict-manager-access.test.ts`、FakeDatabase に variant_lookup パターン追加）
- lookupBatch: ゐる→居る 解決 / 旧字体・旧仮名を out-of-dict にしない / exact 優先 / normalize:false 無効化（4件）
- query(): 変異→canonical 解決（1件）
- 全 17 件 green。type-check / eslint clean。

## 補足
実際の解決は DB の `variant_writings` データに依存（illusions-lab/Genji で生成途上）。データが入れば自動で効く。索引生成は best-effort なので、データ未収録でも既存挙動に影響なし。

Closes #1958

🤖 Generated with [Claude Code](https://claude.com/claude-code)