### PR TITLE
fix(lint): モード切替でルール options を保持し動詞・形容詞の誤検出を解消 (#1975)

### DIFF
--- a/lib/linting/__tests__/rule-runner.test.ts
+++ b/lib/linting/__tests__/rule-runner.test.ts
@@ -109,6 +109,41 @@ describe("RuleRunner", () => {
       const runner = new RuleRunner();
       expect(runner.getConfig("nonexistent")).toBeUndefined();
     });
+
+    it("preserves manifest rule options when a later setConfig omits them (#1962)", () => {
+      // A rule registered with options (e.g. genji-out-of-dict noun-only scope).
+      class OptionRule extends AbstractLintRule {
+        readonly id = "opt-rule";
+        readonly name = "Opt";
+        readonly nameJa = "Opt";
+        readonly description = "";
+        readonly descriptionJa = "";
+        readonly level = "L2" as const;
+        readonly defaultConfig: LintRuleConfig = {
+          enabled: true,
+          severity: "info",
+          options: { includeVerbsAdjectives: false },
+        };
+        lint(): LintIssue[] {
+          return [];
+        }
+      }
+      const runner = new RuleRunner();
+      runner.registerRule(new OptionRule());
+
+      // The renderer pushes a mode config carrying only enabled/severity.
+      runner.setConfig("opt-rule", { enabled: true, severity: "info" });
+
+      // Options must survive — otherwise the rule reverts to its internal default.
+      expect(runner.getConfig("opt-rule")?.options).toEqual({ includeVerbsAdjectives: false });
+    });
+
+    it("lets an explicit options object override the preserved one (#1962)", () => {
+      const runner = new RuleRunner();
+      runner.setConfig("r", { enabled: true, severity: "info", options: { a: 1 } });
+      runner.setConfig("r", { enabled: true, severity: "info", options: { b: 2 } });
+      expect(runner.getConfig("r")?.options).toEqual({ b: 2 });
+    });
   });
 
   // -----------------------------------------------------------------------

--- a/lib/linting/rule-runner.ts
+++ b/lib/linting/rule-runner.ts
@@ -26,6 +26,19 @@ export class RuleRunner {
 
   /** Update the config for a specific rule. */
   setConfig(ruleId: string, config: LintRuleConfig): void {
+    // Preserve rule-specific `options` from the registered manifest defaultConfig
+    // when the caller omits them. The renderer's config pipeline only carries
+    // enabled/severity/skipDialogue (mode switching rebuilds the whole config
+    // map), so without this an option-driven rule — e.g. genji-out-of-dict's
+    // noun-only `includeVerbsAdjectives:false` — would revert to its internal
+    // default and over-detect verbs/adjectives after every mode switch (#1962).
+    if (config.options === undefined) {
+      const prev = this.configs.get(ruleId);
+      if (prev?.options !== undefined) {
+        this.configs.set(ruleId, { ...config, options: prev.options });
+        return;
+      }
+    }
     this.configs.set(ruleId, config);
   }
 


### PR DESCRIPTION
## 概要

#1962 C-1 検証で発覚：校正モード選択時、`genji-out-of-dict`（幻辞 辞書外語）が**動詞・形容詞を誤検出**（実機で「観る」「澄みきる」が辞書外語に）。genji-vocab v0.3.0 は名詞限定（`includeVerbsAdjectives:false`）が既定のはずだが効いていなかった。

## 根本原因

ルールの `options`（manifest `defaultConfig.options`）がレンダラ設定パイプライン全体で運ばれず、モード切替/初期化の `setConfig(id, {enabled,severity,skipDialogue})` が registerRule 由来の manifest options を**上書き消失**。`genji-out-of-dict` は options 未指定時 `includeVerbsAdjectives !== false`（=true）にフォールバックし、動詞・形容詞を照合してしまう。

（options を落としていた箇所: buildModeRuleConfigsFromRules / use-installed-rule-metas / use-mode-config-migration / use-ai-settings の state型・sanitize / use-linting:158）

## 修正（最小・移行不要・既存インストールで即有効）

`RuleRunner.setConfig` で **incoming が `options` を省略した場合は登録済み（manifest defaultConfig 由来）の options を保持**。`buildRulesetRunner` の register→config-replay 順により、manifest options がモード切替後も生存する。明示 options（将来のユーザー設定 UI）は従来どおり上書き。

- `lib/linting/rule-runner.ts`: setConfig の options 保持
- `lib/linting/__tests__/rule-runner.test.ts`: options 保持 / 明示上書き の2ケース

## テスト
- rule-runner 17件 + worker/proxy/mode-config/dict-toolkit 52件 green
- type-check / eslint clean
- 実機 C-1 再確認は次 beta で実施

Closes #1975

🤖 Generated with [Claude Code](https://claude.com/claude-code)