### PR TITLE
fix(style): Tailwind content glob に shared/ を追加しダーク境界線の purge を防ぐ

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,10 @@ const config: Config = {
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    // shared/ のコンポーネント(ResizablePanel 等)も走査対象に含める。
+    // ここに無いと shared/ でしか使われない dark: バリアント等が purge され、
+    // 右インスペクタの境界線が消える等の再発を招く (#1956 の dark:border-* 退行根因)。
+    "./shared/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
## 概要
`shared/` 配下（`ResizablePanel` 等）でのみ使われる `dark:` バリアントが Tailwind の purge で削除され、右インスペクタの境界線が消える退行（#1956 系）を再発防止する。`content` glob に `./shared/**/*` を追加。

## 変更
- `tailwind.config.ts`: content glob に `./shared/**/*.{js,ts,jsx,tsx,mdx}` を追加

## テスト
- ビルド時の class 走査対象が増えるのみ。型/lint クリーン。

関連 issue なし（#1956 は既にマージ済み・本修正はその恒久対策）

🤖 Generated with [Claude Code](https://claude.com/claude-code)