### PR TITLE
fix(persistence): 永続化のサイレント失敗を通知化 (#1967, #1968 K-4-3)

### DIFF
--- a/lib/tab-manager/__tests__/get-error-message.test.ts
+++ b/lib/tab-manager/__tests__/get-error-message.test.ts
@@ -1,0 +1,107 @@
+/**
+ * getErrorMessage / isQuotaExceededError の挙動テスト。
+ *
+ * 目的は2つ:
+ * 1. consistency — 既存の Node `ErrnoException` 分岐（EACCES/ENOSPC/...）の
+ *    メッセージを「現行の正しい挙動」として固定し、リファクタで退行させない。
+ * 2. new (#1967) — Web の `QuotaExceededError`（`DOMException`）を専用メッセージへ
+ *    マッピングする新分岐を検証する。`DOMException` は環境によって
+ *    `instanceof Error` が false になるため、その場合でも判定できることを保証する。
+ */
+
+import { describe, it, expect } from "vitest";
+import { getErrorMessage, isQuotaExceededError } from "../types";
+
+function errnoError(code: string, message = "boom"): Error {
+  const e = new Error(message) as NodeJS.ErrnoException;
+  e.code = code;
+  return e;
+}
+
+describe("getErrorMessage — consistency (既存 Errno 分岐の固定)", () => {
+  it("Error 以外（文字列 / null / 数値 / name を持たないオブジェクト）は『不明なエラー』", () => {
+    expect(getErrorMessage("boom")).toBe("不明なエラー");
+    expect(getErrorMessage(null)).toBe("不明なエラー");
+    expect(getErrorMessage(42)).toBe("不明なエラー");
+    expect(getErrorMessage({ foo: "bar" })).toBe("不明なエラー");
+  });
+
+  it("code の無い Error は message をそのまま返す", () => {
+    expect(getErrorMessage(new Error("そのまま"))).toBe("そのまま");
+  });
+
+  it("EACCES / EPERM は権限エラーメッセージ", () => {
+    const expected =
+      "ファイルへのアクセス権限がありません。ファイルが他のプログラムで開かれていないか、または書き込み権限があるかを確認してください。";
+    expect(getErrorMessage(errnoError("EACCES"))).toBe(expected);
+    expect(getErrorMessage(errnoError("EPERM"))).toBe(expected);
+  });
+
+  it("ENOSPC は容量不足メッセージ", () => {
+    expect(getErrorMessage(errnoError("ENOSPC"))).toBe("ディスクの空き容量が不足しています。");
+  });
+
+  it("ENOENT は保存先フォルダ不明メッセージ", () => {
+    expect(getErrorMessage(errnoError("ENOENT"))).toBe("保存先のフォルダが見つかりません。");
+  });
+
+  it("EINVAL は無効パスメッセージ", () => {
+    expect(getErrorMessage(errnoError("EINVAL"))).toBe(
+      "ファイル名またはパスが無効です。使用できない文字が含まれている可能性があります。",
+    );
+  });
+
+  it("ENAMETOOLONG は名前過長メッセージ", () => {
+    expect(getErrorMessage(errnoError("ENAMETOOLONG"))).toBe("ファイル名またはパスが長すぎます。");
+  });
+
+  it("未知の code は message にフォールバック", () => {
+    expect(getErrorMessage(errnoError("EUNKNOWNXYZ", "原文メッセージ"))).toBe("原文メッセージ");
+  });
+});
+
+describe("getErrorMessage — #1967 QuotaExceededError 新分岐", () => {
+  const QUOTA_MSG =
+    "保存容量が不足しています。不要なデータを削除するか、別の保存先をご利用ください。";
+
+  it("実 DOMException(QuotaExceededError) を容量メッセージへマップ", () => {
+    const e = new DOMException("quota", "QuotaExceededError");
+    expect(getErrorMessage(e)).toBe(QUOTA_MSG);
+  });
+
+  it("instanceof Error をすり抜ける duck-typed {name:'QuotaExceededError'} も判定", () => {
+    expect(getErrorMessage({ name: "QuotaExceededError", message: "x" })).toBe(QUOTA_MSG);
+  });
+
+  it("legacy Firefox の NS_ERROR_DOM_QUOTA_REACHED も判定", () => {
+    expect(getErrorMessage({ name: "NS_ERROR_DOM_QUOTA_REACHED" })).toBe(QUOTA_MSG);
+  });
+
+  it("旧仕様の数値コード 22 も判定", () => {
+    expect(getErrorMessage({ code: 22 })).toBe(QUOTA_MSG);
+  });
+
+  it("quota は ENOSPC より優先しないが、両者が独立に容量系メッセージを返す", () => {
+    // ENOSPC（Electron 経路）と QuotaExceeded（Web 経路）は別メッセージだが
+    // どちらも「容量不足」をユーザーへ伝える。退行検知のため両方を固定。
+    expect(getErrorMessage(errnoError("ENOSPC"))).toContain("空き容量");
+    expect(getErrorMessage(new DOMException("q", "QuotaExceededError"))).toContain("容量");
+  });
+});
+
+describe("isQuotaExceededError", () => {
+  it("quota 系は true", () => {
+    expect(isQuotaExceededError(new DOMException("q", "QuotaExceededError"))).toBe(true);
+    expect(isQuotaExceededError({ name: "QuotaExceededError" })).toBe(true);
+    expect(isQuotaExceededError({ name: "NS_ERROR_DOM_QUOTA_REACHED" })).toBe(true);
+    expect(isQuotaExceededError({ code: 22 })).toBe(true);
+  });
+
+  it("非 quota は false", () => {
+    expect(isQuotaExceededError(new Error("boom"))).toBe(false);
+    expect(isQuotaExceededError(errnoError("ENOSPC"))).toBe(false);
+    expect(isQuotaExceededError(null)).toBe(false);
+    expect(isQuotaExceededError("QuotaExceededError")).toBe(false);
+    expect(isQuotaExceededError({ code: 23 })).toBe(false);
+  });
+});

--- a/lib/tab-manager/__tests__/tab-persistence-failure-notify.test.tsx
+++ b/lib/tab-manager/__tests__/tab-persistence-failure-notify.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * 永続化のサイレント失敗が通知へ変換されることのテスト（#1967 / #1968 K-4-3）。
+ *
+ * 修正前: タブ状態の永続化失敗（容量不足など）と DB ロック起動時の初期化失敗は
+ * `console.error` のみで、ユーザーは保存できていると誤認したままだった。
+ *
+ * 修正後:
+ * - debounce 永続化が失敗したら `notificationManager.error` で一度だけ通知し、
+ *   成功で失敗ストリークを解除して再通知できるようにする（連発しない）。
+ * - storage 初期化失敗（DB ロック等）は `setRestoreError` バナー + トーストで明示する。
+ *
+ * REAL フックを createRoot + act で駆動（リポジトリのパターン、testing-library 不使用）。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { useTabPersistence } from "../use-tab-persistence";
+import { createNewTab } from "../types";
+import type { TabState, TabId } from "../tab-types";
+
+const { persistAppStateMock, persistWindowStateMock, fetchWindowStateMock, initializeMock } =
+  vi.hoisted(() => ({
+    persistAppStateMock: vi.fn(async () => undefined),
+    persistWindowStateMock: vi.fn(async () => undefined),
+    fetchWindowStateMock: vi.fn(async () => null),
+    initializeMock: vi.fn(async () => undefined),
+  }));
+
+const { errorMock, warningMock, infoMock } = vi.hoisted(() => ({
+  errorMock: vi.fn((_msg: string) => "id"),
+  warningMock: vi.fn((_msg: string) => "id"),
+  infoMock: vi.fn((_msg: string) => "id"),
+}));
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { error: errorMock, warning: warningMock, info: infoMock },
+}));
+
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({
+    initialize: initializeMock,
+    loadAppState: vi.fn(async () => null),
+    getItem: vi.fn(async () => null),
+    loadEditorBuffer: vi.fn(async () => null),
+    clearEditorBuffer: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("@/lib/storage/app-state-manager", () => ({
+  fetchWindowState: fetchWindowStateMock,
+  persistWindowState: persistWindowStateMock,
+  persistAppState: persistAppStateMock,
+}));
+
+vi.mock("@/lib/project/workspace-persistence", () => ({
+  persistWorkspaceJson: vi.fn(async () => undefined),
+  toRelativePath: (p: string) => p,
+  toAbsolutePath: (p: string) => p,
+}));
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => ({ readFile: vi.fn(async () => "") }),
+}));
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface HarnessProps {
+  tabs: TabState[];
+  activeTabId: TabId;
+  isElectron?: boolean;
+  skipAutoRestore?: boolean;
+  setRestoreError?: (value: string | null) => void;
+}
+
+function Harness({
+  tabs,
+  activeTabId,
+  isElectron = false,
+  skipAutoRestore = true,
+  setRestoreError,
+}: HarnessProps): null {
+  const tabsRef = useRef<TabState[]>(tabs);
+  tabsRef.current = tabs;
+  const activeTabIdRef = useRef<TabId>(activeTabId);
+  activeTabIdRef.current = activeTabId;
+  const isProjectRef = useRef(false);
+
+  useTabPersistence({
+    tabs,
+    setTabs: vi.fn(),
+    activeTabId,
+    setActiveTabId: vi.fn(),
+    tabsRef,
+    activeTabIdRef,
+    isProjectRef,
+    isElectron,
+    skipAutoRestore,
+    setRestoreError: setRestoreError as never,
+    windowKey: null,
+  });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  persistAppStateMock.mockReset();
+  persistAppStateMock.mockResolvedValue(undefined);
+  persistWindowStateMock.mockReset();
+  persistWindowStateMock.mockResolvedValue(undefined);
+  fetchWindowStateMock.mockReset();
+  fetchWindowStateMock.mockResolvedValue(null);
+  initializeMock.mockReset();
+  initializeMock.mockResolvedValue(undefined);
+  errorMock.mockClear();
+  warningMock.mockClear();
+  infoMock.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+async function flush(ms = 1500): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// #1967 — 永続化失敗のサイレント握り潰し → 通知
+// ---------------------------------------------------------------------------
+
+describe("#1967 — タブ状態の永続化失敗を通知へ変換", () => {
+  it("QuotaExceededError で永続化が失敗したら容量メッセージで一度だけ通知し、成功で解除して再通知できる", async () => {
+    const tabA = createNewTab("a");
+    const tabB = createNewTab("b");
+
+    // 初期マウント（成功）でゲートを開く。
+    await act(async () => {
+      root.render(<Harness tabs={[tabA]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    errorMock.mockClear();
+
+    // 以降の永続化を QuotaExceededError で失敗させる。
+    persistAppStateMock.mockRejectedValue(new DOMException("quota", "QuotaExceededError"));
+
+    // 変更1 → 失敗 → 通知1回。
+    await act(async () => {
+      root.render(<Harness tabs={[tabA, tabB]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).toHaveBeenCalledTimes(1);
+    expect(errorMock.mock.calls[0][0]).toContain("容量");
+
+    // 変更2 → なお失敗 → 連発しない（ストリーク中は抑制）。
+    await act(async () => {
+      root.render(<Harness tabs={[tabB, tabA]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).toHaveBeenCalledTimes(1);
+
+    // 成功に戻すとストリーク解除。
+    persistAppStateMock.mockResolvedValue(undefined);
+    await act(async () => {
+      root.render(<Harness tabs={[tabA]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).toHaveBeenCalledTimes(1);
+
+    // 再び失敗すると改めて通知（2回目）。
+    persistAppStateMock.mockRejectedValue(new DOMException("quota", "QuotaExceededError"));
+    await act(async () => {
+      root.render(<Harness tabs={[tabA, tabB]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("consistency — 永続化が成功している間はエラー通知を一切出さない", async () => {
+    const tabA = createNewTab("a");
+    const tabB = createNewTab("b");
+    await act(async () => {
+      root.render(<Harness tabs={[tabA]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    await act(async () => {
+      root.render(<Harness tabs={[tabA, tabB]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1968 K-4-3 — DB ロック起動時の無通知フォールバック
+// ---------------------------------------------------------------------------
+
+describe("#1968 K-4-3 — storage 初期化失敗（DB ロック）を通知", () => {
+  it("storage.initialize() が throw したら setRestoreError バナー + error トーストを出す", async () => {
+    initializeMock.mockRejectedValue(
+      Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY" }),
+    );
+    const setRestoreError = vi.fn();
+    const tabA = createNewTab("a");
+
+    await act(async () => {
+      root.render(
+        <Harness tabs={[tabA]} activeTabId={tabA.id} setRestoreError={setRestoreError} />,
+      );
+    });
+    await flush();
+
+    expect(setRestoreError).toHaveBeenCalledTimes(1);
+    expect(setRestoreError.mock.calls[0][0]).toContain("読み込めませんでした");
+    expect(errorMock).toHaveBeenCalledTimes(1);
+    expect(errorMock.mock.calls[0][0]).toContain("セッションの読み込みに失敗");
+  });
+
+  it("consistency — 初期化が成功すれば restore エラー通知は出ない", async () => {
+    const setRestoreError = vi.fn();
+    const tabA = createNewTab("a");
+    await act(async () => {
+      root.render(
+        <Harness tabs={[tabA]} activeTabId={tabA.id} setRestoreError={setRestoreError} />,
+      );
+    });
+    await flush();
+    expect(setRestoreError).not.toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+});

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -216,7 +216,26 @@ export function sanitizeMdiContent(
   return MdiDocument.fromEditorOutput(content, options).toRawText();
 }
 
+/**
+ * Web の IndexedDB / localStorage 容量超過は `QuotaExceededError`（`DOMException`）で
+ * 投げられる。`DOMException` は実行環境によって `instanceof Error` が false になる
+ * （Chromium 等では Error を継承しない）ため、Error 判定より前に name/code で判別する。
+ * legacy Firefox は `NS_ERROR_DOM_QUOTA_REACHED`、旧仕様は数値コード 22 を使う（#1967）。
+ */
+export function isQuotaExceededError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as { name?: unknown; code?: unknown };
+  return (
+    e.name === "QuotaExceededError" || e.name === "NS_ERROR_DOM_QUOTA_REACHED" || e.code === 22
+  );
+}
+
 export function getErrorMessage(error: unknown): string {
+  // 容量不足はプラットフォーム横断（Web=DOMException / Electron=ENOSPC）で
+  // 専用メッセージにまとめる。DOMException は instanceof Error をすり抜けるため先に判定。
+  if (isQuotaExceededError(error)) {
+    return "保存容量が不足しています。不要なデータを削除するか、別の保存先をご利用ください。";
+  }
   if (!(error instanceof Error)) return "不明なエラー";
   let message = error.message;
   const errorCode = (error as NodeJS.ErrnoException).code;

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -7,8 +7,15 @@ import { fetchWindowState, persistWindowState } from "../storage/app-state-manag
 import type { TabState, SerializedTab, TabPersistenceState, EditorTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
 import type { TabManagerCore } from "./types";
-import { TAB_PERSIST_DEBOUNCE, createNewTab, generateTabId, inferFileType } from "./types";
+import {
+  TAB_PERSIST_DEBOUNCE,
+  createNewTab,
+  generateTabId,
+  getErrorMessage,
+  inferFileType,
+} from "./types";
 import { getProjectFileService } from "../services/project-file-service";
+import { notificationManager } from "../services/notification-manager";
 import type { WorkspaceTab } from "../project/project-types";
 import {
   persistWorkspaceJson,
@@ -122,6 +129,11 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
 
   const tabPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // タブ状態の永続化が失敗した際、ユーザーに一度だけ通知するためのゲート。
+  // 永続化は debounce で頻繁に走るため、失敗が続く間トーストを連発しないよう
+  // 失敗ストリーク中は通知を抑制し、次に成功したら解除する（#1967）。
+  const persistErrorNotifiedRef = useRef(false);
+
   /** Build and persist the current tab state immediately. */
   const persistTabStateNow = useCallback(async () => {
     const currentTabs = tabsRef.current;
@@ -194,9 +206,20 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     }
 
     tabPersistTimerRef.current = setTimeout(() => {
-      void persistTabStateNow().catch((error) => {
-        console.error("タブ状態の保存に失敗しました:", error);
-      });
+      void persistTabStateNow()
+        .then(() => {
+          // 成功したら失敗ストリークを解除し、次の失敗で再び通知できるようにする。
+          persistErrorNotifiedRef.current = false;
+        })
+        .catch((error) => {
+          console.error("タブ状態の保存に失敗しました:", error);
+          // 容量不足等の永続化失敗は「保存できているはず」という誤認を招くため、
+          // ストリークの先頭で一度だけ通知する（#1967）。
+          if (!persistErrorNotifiedRef.current) {
+            persistErrorNotifiedRef.current = true;
+            notificationManager.error(`セッションの保存に失敗しました: ${getErrorMessage(error)}`);
+          }
+        });
     }, TAB_PERSIST_DEBOUNCE);
 
     return () => {
@@ -352,6 +375,13 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
         }
       } catch (error) {
         console.error("ストレージの初期化に失敗しました:", error);
+        // DB がロック中（別プロセス起動など）/破損で初期化に失敗すると、空タブで
+        // 起動しつつセッションが読めなかったことをユーザーへ伝えていなかった（#1968 K-4-3）。
+        // バナー（setRestoreError）とトーストの両方で明示し、サイレント失敗を解消する。
+        setRestoreError?.(
+          "前回のセッションを読み込めませんでした。アプリが多重起動していないかを確認してください。",
+        );
+        notificationManager.error(`セッションの読み込みに失敗しました: ${getErrorMessage(error)}`);
         const errorTab = createNewTab();
         setTabs((prev) => (prev.length > 0 ? prev : [errorTab]));
         setActiveTabId((prev) => (prev === "" ? errorTab.id : prev));
@@ -363,7 +393,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     };
 
     void initializeStorage();
-  }, [isElectron, skipAutoRestore, setTabs, setActiveTabId]);
+  }, [isElectron, skipAutoRestore, setTabs, setActiveTabId, setRestoreError]);
 
   // --- Standalone-mode restore from AppState (Electron only) -------------
   // This ONLY handles standalone mode (no project). In project mode,


### PR DESCRIPTION
## 背景 — 保存系バグの根本原因 R1「サイレント失敗」

#1837 データ保全テストで検出された保存系バグ群を調査した結果、根本原因の一つは
**永続化層がエラーを握り潰す**点にあった。各 catch が `console.error` のみで通知に
変換せず、ユーザーは保存できていると誤認したまま編集を続けてしまう。

## 変更

1. **`getErrorMessage` に `QuotaExceededError`(DOMException) 分岐を追加** (#1967)
   `DOMException` は環境により `instanceof Error` をすり抜けるため、Error 判定より前に
   `name`/`code`(`QuotaExceededError` / `NS_ERROR_DOM_QUOTA_REACHED` / 数値 `22`) で判別。
2. **タブ状態の debounce 永続化失敗を通知化** (#1967)
   失敗ストリークの先頭で `notificationManager.error` を一度だけ出し、成功で解除して
   再通知できるようにする（debounce 連発でトーストを溢れさせない）。
3. **storage 初期化失敗(DB ロック/破損)を明示** (#1968 K-4-3)
   `setRestoreError` バナー + `error` トーストの両方で通知し、空タブ起動の
   サイレントフォールバックを解消。

## テスト（退行防止重視）

- `get-error-message.test.ts` — 既存 Errno 全分岐(EACCES/EPERM/ENOSPC/ENOENT/EINVAL/
  ENAMETOOLONG/未知code/非Error)を **consistency 固定** + 新 quota 分岐 + `isQuotaExceededError`。
- `tab-persistence-failure-notify.test.ts` — 失敗→1回通知/ストリーク抑制/成功で解除/
  再失敗で再通知、DB ロック起動→バナー+トースト、成功時は無通知。
- 既存 `lib/tab-manager` `lib/editor-page` `components/editor` 全 553 テスト green（退行なし）。

## 関連 issue

- Closes #1967
- #1968 は K-4-3（DB ロック無通知）のみ対応。J-3（SPA popstate）は別フェーズで対応予定のため本PRでは close しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)