### PR TITLE
fix(editor): 保存/flush 経路に IME composition ガードを追加 (#1971)

### DIFF
--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -41,6 +41,7 @@ import { speechHighlightPlugin } from "@/lib/editor-page/speech-highlight-plugin
 import type { EditorSelectionState } from "@/lib/editor-page/use-selection-tracking";
 import EditorContextMenu, { type ContextMenuAction } from "../EditorContextMenu";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
+import { commitPendingComposition } from "@/lib/editor-page/commit-pending-composition";
 import { useCharWidth, MEASURE_TEXT } from "@/lib/editor-page/use-char-width";
 import {
   getScrollProgress,
@@ -386,7 +387,11 @@ export default function MilkdownEditor({
     try {
       let result: string | null = null;
       editor.action((ctx) => {
-        const doc = ctx.get(editorViewCtx).state.doc;
+        const view = ctx.get(editorViewCtx);
+        // IME 変換中なら未確定文字を取りこぼさないよう、シリアライズ前に
+        // composition を best-effort でコミットする（#1971）。通常経路は no-op。
+        commitPendingComposition(view);
+        const doc = view.state.doc;
         if (isPlainText) {
           // listener の plain-text 経路（行 = node.textContent）と同一ロジック。
           const lines: string[] = [];

--- a/lib/editor-page/__tests__/commit-pending-composition.test.ts
+++ b/lib/editor-page/__tests__/commit-pending-composition.test.ts
@@ -1,0 +1,78 @@
+/**
+ * commitPendingComposition の挙動テスト（#1971 IME composition ガード）。
+ *
+ * - consistency: composition 中でない通常経路では DOMObserver.forceFlush を一切呼ばず、
+ *   既存の保存挙動（state.doc を直接シリアライズ）を変えない。
+ * - new: composition 中（view.composing もしくは view.input.composing）のとき forceFlush を
+ *   呼び、未確定入力のコミットを試みる。例外や欠落 API でも throw せず保存を継続する。
+ *
+ * EditorView の `composing` は公開プロパティ、`input` / `domObserver` は内部実装のため、
+ * テストでは最小のフェイク view を構築して branch を決定的に検証する。
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import type { EditorView } from "@milkdown/prose/view";
+import { commitPendingComposition } from "../commit-pending-composition";
+
+interface FakeViewOptions {
+  composing?: boolean;
+  inputComposing?: boolean;
+  forceFlush?: () => void;
+  omitObserver?: boolean;
+}
+
+function fakeView(opts: FakeViewOptions = {}): EditorView {
+  const view: Record<string, unknown> = {
+    composing: opts.composing ?? false,
+    input: { composing: opts.inputComposing ?? false },
+  };
+  if (!opts.omitObserver) {
+    view.domObserver = { forceFlush: opts.forceFlush ?? vi.fn() };
+  }
+  return view as unknown as EditorView;
+}
+
+describe("commitPendingComposition — consistency（通常経路は no-op）", () => {
+  it("composition 中でなければ false を返し forceFlush を呼ばない", () => {
+    const forceFlush = vi.fn();
+    const view = fakeView({ composing: false, inputComposing: false, forceFlush });
+    expect(commitPendingComposition(view)).toBe(false);
+    expect(forceFlush).not.toHaveBeenCalled();
+  });
+
+  it("null / undefined view は false を返し throw しない", () => {
+    expect(commitPendingComposition(null)).toBe(false);
+    expect(commitPendingComposition(undefined)).toBe(false);
+  });
+});
+
+describe("commitPendingComposition — #1971（変換中はコミットを試みる）", () => {
+  it("view.composing=true のとき forceFlush を 1 回呼び true を返す", () => {
+    const forceFlush = vi.fn();
+    const view = fakeView({ composing: true, forceFlush });
+    expect(commitPendingComposition(view)).toBe(true);
+    expect(forceFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("view.input.composing=true（公開プロパティが false でも）でも検出して forceFlush", () => {
+    const forceFlush = vi.fn();
+    const view = fakeView({ composing: false, inputComposing: true, forceFlush });
+    expect(commitPendingComposition(view)).toBe(true);
+    expect(forceFlush).toHaveBeenCalledTimes(1);
+  });
+
+  it("domObserver が無い環境でも throw せず true を返す", () => {
+    const view = fakeView({ composing: true, omitObserver: true });
+    expect(() => commitPendingComposition(view)).not.toThrow();
+    expect(commitPendingComposition(view)).toBe(true);
+  });
+
+  it("forceFlush が throw しても握り潰して true を返す（保存を中断しない）", () => {
+    const forceFlush = vi.fn(() => {
+      throw new Error("flush failed");
+    });
+    const view = fakeView({ composing: true, forceFlush });
+    expect(() => commitPendingComposition(view)).not.toThrow();
+    expect(commitPendingComposition(view)).toBe(true);
+  });
+});

--- a/lib/editor-page/commit-pending-composition.ts
+++ b/lib/editor-page/commit-pending-composition.ts
@@ -1,0 +1,41 @@
+import type { EditorView } from "@milkdown/prose/view";
+
+/**
+ * IME 変換中（composition 中）に保存 / flush が呼ばれたときのデータ整合性ガード（#1971）。
+ *
+ * ProseMirror は composition 中、未確定の変換テキストをブラウザ DOM に保持したまま
+ * `state.doc` へ反映しない（compositionend で初めて反映する）。そのため保存経路が
+ * `state.doc` を直接シリアライズすると、変換途中の未確定文字が抜け落ちる／挙動が不定に
+ * なる（L-1 Cmd+S / L-2 自動保存 / L-3 Cmd+Q）。
+ *
+ * このヘルパーは保存直前に呼ばれ、composition 中であれば DOMObserver を強制フラッシュして
+ * 未確定入力を可能な限り `state.doc` へ取り込む。
+ *
+ * 設計上の保証と限界:
+ * - **composing でない通常経路は完全な no-op**（forceFlush を呼ばない）。既存の保存挙動を
+ *   1 バイトも変えないため、#1840 / #1878 で安定した経路に退行を持ち込まない。
+ * - composition のコミット可否は最終的にブラウザ / IME 実装に依存するため、これは
+ *   best-effort であり完全な保証ではない。実機 IME（macOS / Windows）の手動 UI 検証が別途必要。
+ *
+ * @param view 対象の EditorView（未 ready なら null/undefined）
+ * @returns composition のコミットを試みた（= 変換中だった）場合 true、通常経路は false
+ */
+export function commitPendingComposition(view: EditorView | null | undefined): boolean {
+  if (!view) return false;
+
+  // `composing` は EditorView の公開プロパティ。`input.composing` は内部実装だが、
+  // 取りこぼしを避けるため両方を確認する（どちらかが true なら変換中とみなす）。
+  const composing =
+    view.composing === true ||
+    (view as { input?: { composing?: boolean } }).input?.composing === true;
+  if (!composing) return false;
+
+  const observer = (view as { domObserver?: { forceFlush?: () => void } }).domObserver;
+  try {
+    observer?.forceFlush?.();
+  } catch {
+    // forceFlush に失敗しても保存自体は継続する（state.doc にフォールバック）。
+    // ここで throw すると保存全体が中断し、かえってデータ保全を損なうため握り潰す。
+  }
+  return true;
+}


### PR DESCRIPTION
## 背景 — 保存系バグの根本原因 R2「保存経路がライブ状態を取りこぼす」

ProseMirror は IME 変換中(composition 中)、未確定の変換テキストをブラウザ DOM に
保持したまま `state.doc` へ反映しない（compositionend で初めて反映）。そのため保存経路が
`state.doc` を直接シリアライズすると、変換途中の未確定文字が抜け落ち挙動が不定になる
（L-1 Cmd+S / L-2 自動保存 / L-3 Cmd+Q）。これは #1840（debounce で tab.content が古くなる）
で塞いだ「保存時点のライブ状態を正しく取る」系譜の最後の穴。

## 変更

- **`commitPendingComposition(view)` を新設**（`lib/editor-page/commit-pending-composition.ts`）。
  保存直前に呼ばれ、composition 中なら `DOMObserver.forceFlush()` で未確定入力を
  best-effort で `state.doc` に取り込む。
- `MilkdownEditor.flushContent` がシリアライズ前に呼び出す。

### 設計上の保証と限界
- **composing でない通常経路は完全な no-op**（forceFlush を呼ばない）。#1840/#1878 で
  安定した保存経路を 1 バイトも変えず、退行を持ち込まない。
- composition のコミット可否は最終的にブラウザ/IME 実装依存のため **best-effort**。
  完全な保証ではなく、実機 IME（macOS/Windows）の手動 UI 検証が別途必要
  （L-1〜L-3 は別 ui-test issue で追跡）。

## テスト

- `commit-pending-composition.test.ts`
  - *consistency*: 非 composing は forceFlush 不呼び出し・`false` 返却、null/undefined view も安全。
  - *new*: composing(`view.composing` / `input.composing`)で forceFlush 1 回・`true` 返却、
    `domObserver` 欠落や forceFlush 例外でも throw せず保存を継続。
- 既存 `components/editor` `lib/editor-page` `lib/tab-manager` 全 553 テスト green（退行なし）。

## 関連 issue

- #1971（L-1/L-2/L-3 のコード側ガード）。実機 IME 検証が残るため、検証完了まで close せず本PRで部分対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)