### PR TITLE
fix(persistence): 復元失敗時のバッファ救済 + popstate ガード (#1966 H-2, #1968 J-3)

### DIFF
--- a/lib/tab-manager/__tests__/recovery-loss-rescue.test.tsx
+++ b/lib/tab-manager/__tests__/recovery-loss-rescue.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Web クラッシュ復元の損失救済テスト（#1966 H-2）。
+ *
+ * 修正前: 自動復元時に保存済みファイルを fileHandle.getFile() で再オープンできない
+ * （移動/削除/権限取消）と、バッファを黙って破棄し未保存内容がサイレントに消えていた。
+ *
+ * 修正後: 再オープン失敗時はバッファに残る内容を無題タブとして救済し、損失をユーザーへ
+ * 通知する。バッファが空なら復元できる内容が無い旨を通知する。成功時は従来どおり。
+ *
+ * REAL フックを createRoot + act で駆動。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { useTabPersistence } from "../use-tab-persistence";
+import type { TabState, TabId, EditorTabState } from "../tab-types";
+
+const { getItemMock, loadEditorBufferMock, clearEditorBufferMock } = vi.hoisted(() => ({
+  getItemMock: vi.fn(async () => "manuscript.mdi" as string | null),
+  loadEditorBufferMock: vi.fn(async () => null as unknown),
+  clearEditorBufferMock: vi.fn(async () => undefined),
+}));
+
+const { warningMock, infoMock, errorMock } = vi.hoisted(() => ({
+  warningMock: vi.fn((_m: string) => "id"),
+  infoMock: vi.fn((_m: string) => "id"),
+  errorMock: vi.fn((_m: string) => "id"),
+}));
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { warning: warningMock, info: infoMock, error: errorMock },
+}));
+
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({
+    initialize: vi.fn(async () => undefined),
+    loadAppState: vi.fn(async () => null),
+    getItem: getItemMock,
+    loadEditorBuffer: loadEditorBufferMock,
+    clearEditorBuffer: clearEditorBufferMock,
+  }),
+}));
+
+vi.mock("@/lib/storage/app-state-manager", () => ({
+  fetchWindowState: vi.fn(async () => null),
+  persistWindowState: vi.fn(async () => undefined),
+  persistAppState: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/project/workspace-persistence", () => ({
+  persistWorkspaceJson: vi.fn(async () => undefined),
+  toRelativePath: (p: string) => p,
+  toAbsolutePath: (p: string) => p,
+}));
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => ({ readFile: vi.fn(async () => "") }),
+}));
+
+// ---------------------------------------------------------------------------
+// Harness (Web standalone: isElectron=false)
+// ---------------------------------------------------------------------------
+
+function Harness({
+  setTabs,
+  setActiveTabId,
+}: {
+  setTabs: (a: React.SetStateAction<TabState[]>) => void;
+  setActiveTabId: (a: React.SetStateAction<TabId>) => void;
+}): null {
+  const tabsRef = useRef<TabState[]>([]);
+  const activeTabIdRef = useRef<TabId>("");
+  const isProjectRef = useRef(false);
+  useTabPersistence({
+    tabs: [],
+    setTabs: setTabs as never,
+    activeTabId: "",
+    setActiveTabId: setActiveTabId as never,
+    tabsRef,
+    activeTabIdRef,
+    isProjectRef,
+    isElectron: false,
+    skipAutoRestore: false,
+    windowKey: null,
+  });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  getItemMock.mockReset();
+  getItemMock.mockResolvedValue("manuscript.mdi");
+  loadEditorBufferMock.mockReset();
+  loadEditorBufferMock.mockResolvedValue(null);
+  clearEditorBufferMock.mockReset();
+  clearEditorBufferMock.mockResolvedValue(undefined);
+  warningMock.mockClear();
+  infoMock.mockClear();
+  errorMock.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+function tabFrom(setTabs: ReturnType<typeof vi.fn>): EditorTabState | null {
+  if (setTabs.mock.calls.length === 0) return null;
+  const updater = setTabs.mock.calls[0][0] as (prev: TabState[]) => TabState[];
+  const result = updater([]);
+  return (result[0] ?? null) as EditorTabState | null;
+}
+
+async function mountAndSettle(
+  setTabs: ReturnType<typeof vi.fn>,
+  setActiveTabId: ReturnType<typeof vi.fn>,
+): Promise<void> {
+  await act(async () => {
+    root.render(<Harness setTabs={setTabs as never} setActiveTabId={setActiveTabId as never} />);
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(50);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("#1966 H-2 — Web 復元失敗時の損失救済", () => {
+  it("getFile() 失敗 + バッファに内容あり → 無題 dirty タブで救済し warning 通知", async () => {
+    loadEditorBufferMock.mockResolvedValue({
+      content: "未保存の原稿本文",
+      timestamp: 1,
+      fileHandle: { getFile: vi.fn(async () => Promise.reject(new Error("NotFoundError"))) },
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle(setTabs, setActiveTabId);
+
+    const tab = tabFrom(setTabs);
+    expect(tab).not.toBeNull();
+    expect(tab!.content).toBe("未保存の原稿本文");
+    expect(tab!.isDirty).toBe(true);
+    expect(tab!.file).toBeNull(); // 無題（保存先未指定）
+    expect(warningMock).toHaveBeenCalledTimes(1);
+    expect(warningMock.mock.calls[0][0]).toContain("無題タブとして復元");
+    expect(infoMock).not.toHaveBeenCalled();
+    // バッファはタブへ移したので破棄してよい。
+    expect(clearEditorBufferMock).toHaveBeenCalled();
+  });
+
+  it("getFile() 失敗 + バッファ空 → 復元できない旨を info 通知（救済タブ無し）", async () => {
+    loadEditorBufferMock.mockResolvedValue({
+      content: "",
+      timestamp: 1,
+      fileHandle: { getFile: vi.fn(async () => Promise.reject(new Error("NotFoundError"))) },
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle(setTabs, setActiveTabId);
+
+    // 救済内容が無いので、フォールバックの空 new タブが作られる（content 空）。
+    const tab = tabFrom(setTabs);
+    expect(tab?.content ?? "").toBe("");
+    expect(infoMock).toHaveBeenCalledTimes(1);
+    expect(infoMock.mock.calls[0][0]).toContain("再オープンできませんでした");
+    expect(warningMock).not.toHaveBeenCalled();
+  });
+
+  it("consistency — getFile() 成功時はディスク内容で復元し損失通知を出さない", async () => {
+    loadEditorBufferMock.mockResolvedValue({
+      content: "古いバッファ",
+      timestamp: 1,
+      fileHandle: {
+        getFile: vi.fn(async () => ({
+          text: async () => "ディスク最新内容",
+          name: "manuscript.mdi",
+        })),
+      },
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle(setTabs, setActiveTabId);
+
+    const tab = tabFrom(setTabs);
+    expect(tab!.content).toBe("ディスク最新内容");
+    expect(tab!.isDirty).toBe(false);
+    expect(tab!.file?.name).toBe("manuscript.mdi");
+    expect(warningMock).not.toHaveBeenCalled();
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+
+  it("consistency — バッファ自体が無ければ通知も救済もしない", async () => {
+    loadEditorBufferMock.mockResolvedValue(null);
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle(setTabs, setActiveTabId);
+
+    expect(warningMock).not.toHaveBeenCalled();
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+});

--- a/lib/tab-manager/__tests__/unsaved-tabs.test.ts
+++ b/lib/tab-manager/__tests__/unsaved-tabs.test.ts
@@ -1,0 +1,44 @@
+/**
+ * hasUnsavedEditorTabs のエッジケーステスト（#1968 J-3 ダーティガードの判定中核）。
+ *
+ * beforeunload / popstate のダーティ警告はこの判定で発火する。誤判定は
+ * 「未保存なのに警告が出ない＝データ損失」または「保存済みなのに毎回警告＝UX劣化」に
+ * 直結するため、境界を固定する。
+ */
+
+import { describe, it, expect } from "vitest";
+import { hasUnsavedEditorTabs } from "../unsaved-tabs";
+import { createNewTab } from "../types";
+import type { TabState, EditorTabState, TerminalTabState } from "../tab-types";
+
+function editorTab(isDirty: boolean): EditorTabState {
+  return { ...createNewTab("x"), isDirty };
+}
+
+function terminalTab(): TerminalTabState {
+  // dirty 概念を持たない非編集タブ（最小形）。
+  return { tabKind: "terminal", id: "term-1" } as unknown as TerminalTabState;
+}
+
+describe("hasUnsavedEditorTabs", () => {
+  it("空配列は false", () => {
+    expect(hasUnsavedEditorTabs([])).toBe(false);
+  });
+
+  it("全タブ clean は false", () => {
+    expect(hasUnsavedEditorTabs([editorTab(false), editorTab(false)])).toBe(false);
+  });
+
+  it("1つでも dirty な編集タブがあれば true", () => {
+    expect(hasUnsavedEditorTabs([editorTab(false), editorTab(true)])).toBe(true);
+  });
+
+  it("非編集タブ（ターミナル）は dirty 判定の対象外", () => {
+    // ターミナルのみ → false。
+    expect(hasUnsavedEditorTabs([terminalTab() as TabState])).toBe(false);
+    // ターミナル + clean 編集タブ → false。
+    expect(hasUnsavedEditorTabs([terminalTab() as TabState, editorTab(false)])).toBe(false);
+    // ターミナル + dirty 編集タブ → true。
+    expect(hasUnsavedEditorTabs([terminalTab() as TabState, editorTab(true)])).toBe(true);
+  });
+});

--- a/lib/tab-manager/unsaved-tabs.ts
+++ b/lib/tab-manager/unsaved-tabs.ts
@@ -1,0 +1,12 @@
+import { isEditorTab } from "./tab-types";
+import type { TabState } from "./tab-types";
+
+/**
+ * 開いているタブのうち、未保存（dirty）の編集タブが1つでもあるか判定する。
+ *
+ * beforeunload / popstate のダーティガードが共通で使う単一の真実
+ * （ターミナル等の非編集タブは dirty 概念を持たないため除外する）。
+ */
+export function hasUnsavedEditorTabs(tabs: readonly TabState[]): boolean {
+  return tabs.some((t) => isEditorTab(t) && t.isDirty);
+}

--- a/lib/tab-manager/use-electron-menu-bindings.ts
+++ b/lib/tab-manager/use-electron-menu-bindings.ts
@@ -5,6 +5,7 @@ import { getProjectFileService } from "../services/project-file-service";
 import { notificationManager } from "../services/notification-manager";
 import { executeTabSave } from "./save-executor";
 import { isEditorTab } from "./tab-types";
+import { hasUnsavedEditorTabs } from "./unsaved-tabs";
 import { getErrorMessage } from "./types";
 import type { SnapshotType } from "../services/history-policy";
 import type { SupportedFileExtension } from "../project/project-types";
@@ -350,14 +351,32 @@ export function useElectronMenuBindings(params: UseElectronMenuBindingsParams): 
   useEffect(() => {
     if (isElectron) return;
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      const anyDirty = tabsRef.current.some((t) => isEditorTab(t) && t.isDirty);
-      if (anyDirty) {
+      if (hasUnsavedEditorTabs(tabsRef.current)) {
         event.preventDefault();
         event.returnValue = "";
       }
     };
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, [isElectron, tabsRef]);
+
+  // Web: SPA 内のクライアントサイド history back(popstate)では beforeunload が発火しない。
+  // 将来 history エントリを push する画面遷移を追加したときにダーティ内容が無警告で
+  // 失われないよう、popstate でも保留中の状態を flush し、未保存があれば警告する(#1968 J-3)。
+  // ナビゲーション自体はブロックしない（単一ルート構成のため history 改変の副作用を避け、
+  // データ保全＝flush を最優先する）。
+  useEffect(() => {
+    if (isElectron) return;
+    const handlePopState = () => {
+      // まず保留中の debounce 状態を確実に永続化する（データ保全）。
+      void flushTabStateRef.current?.();
+      void flushLayoutStateRef.current?.();
+      if (hasUnsavedEditorTabs(tabsRef.current)) {
+        notificationManager.warning("未保存の変更があります。移動する前に保存してください。");
+      }
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
   }, [isElectron, tabsRef]);
 
   // Web: flush tab/layout state when page becomes hidden (covers tab close, navigate away)

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -371,7 +371,20 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
               };
               setWasAutoRecovered(true);
             } catch (error) {
+              // #1966 H-2: ディスクのファイルを再オープンできない（移動/削除/権限取消）。
+              // 旧実装はバッファを黙って破棄し、未保存内容がサイレントに消えていた。
+              // バッファに残る内容を無題タブとして救済し、損失をユーザーへ通知する。
               console.warn("前回のファイルを復元できませんでした:", error);
+              const bufferedContent = buffer.content ?? "";
+              if (bufferedContent.length > 0) {
+                const rescued = createNewTab(bufferedContent, inferFileType(lastFileKey ?? ""));
+                initialTab = { ...rescued, isDirty: true, fileSyncStatus: "dirty" };
+                notificationManager.warning(
+                  "前回開いていたファイルを再オープンできなかったため、未保存の内容を無題タブとして復元しました。保存先を指定して保存してください。",
+                );
+              } else {
+                notificationManager.info("前回開いていたファイルを再オープンできませんでした。");
+              }
               await storage.clearEditorBuffer(lastFileKey ?? undefined);
             }
           }


### PR DESCRIPTION
> **スタック PR**: base は #1980（Phase 3）。先行PR(#1978→#1980)が dev にマージされると本PRは自動的に dev へ retarget されます。差分は本PRの1コミットのみ。

## 根本原因 R4「復元の受動性」の残ギャップ2件（業務非破壊で解消）

### #1966 H-2 — Web 復元失敗時の損失救済
自動復元で保存済みファイルを `fileHandle.getFile()` で再オープンできない（移動/削除/
権限取消）と、**旧実装はバッファを黙って破棄し未保存内容がサイレントに消えていた**。
- 再オープン失敗時はバッファに残る内容を**無題 dirty タブとして救済** + `warning` 通知。
- 内容が空なら復元不能の旨を `info` 通知。
- **成功時は従来どおりディスク内容で復元（挙動不変）**。

### #1968 J-3 — popstate ダーティガード
SPA 内 history back（`popstate`）では `beforeunload` が発火しないため、将来 history を
push する画面遷移を追加するとダーティ内容が無警告で失われうる。
- `popstate` でも保留中の tab/layout 状態を flush し、未保存があれば警告。
- **ナビゲーション自体はブロックしない**（単一ルート構成のため history 改変の副作用を避け、
  flush＝データ保全を最優先）。
- `beforeunload`/`popstate` 共通のダーティ判定を `hasUnsavedEditorTabs()` に集約。

## 据え置き（follow-up）
完全な「このバッファを使用／破棄」選択 UI（#1966 H-5/H-6）は、バッファ適用 vs ディスクの
**意味設計**と**実機 File System Access 検証**が必要な UX 機能のため follow-up。現状データは
復元済み＝安全であり、ハーフ実装でユーザーを誤認させないための判断。

## テスト（エッジケース網羅）
- `unsaved-tabs.test.ts`: 空 / 全 clean / 一部 dirty / 非編集タブ除外。
- `recovery-loss-rescue.test.tsx`: getFile 失敗+内容あり→救済+warning ／ 空→info ／
  成功→ディスク復元・無通知 ／ バッファ無→無通知。
- 既存 `lib/tab-manager` + `lib/editor-page` 全 560 テスト green（退行なし）。

## 関連 issue
- #1966 の H-2 損失通知を解消（H-5/H-6 選択 UI は follow-up のため close せず部分対応）。
- #1968 の J-3 popstate を解消（K-4-3 は #1978 で対応済み。両者解決後に #1968 を close 可能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)