### PR TITLE
feat(lint): 辞書外語をワンクリックでユーザー辞書に追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import {
   getWindowActivitySnapshot,
 } from "@/lib/editor-page/window-activity";
 import { useLintHandlers } from "@/lib/editor-page/use-lint-handlers";
+import { useUserDictionaryActions } from "@/lib/editor-page/use-user-dictionary-actions";
 import { useTabManager } from "@/lib/tab-manager";
 import { useUnsavedWarning } from "@/lib/hooks/use-unsaved-warning";
 import { useDockviewAdapter } from "@/lib/dockview/use-dockview-adapter";
@@ -213,6 +214,14 @@ export default function EditorPage() {
   // external rulesets). The inspector's correction-mode dropdown derives its
   // per-rule config map from these, mirroring the settings ModeSelector (#1817).
   const loadedRules = useInstalledRuleMetas();
+
+  // Rules whose detections can be resolved by adding the flagged word to the
+  // user dictionary (manifest `suggestsDictionaryEntry`). Drives the "辞書に追加"
+  // action on correction cards and the squiggle context menu.
+  const dictEntryRuleIds = useMemo(
+    () => new Set(loadedRules.filter((r) => r.suggestsDictionaryEntry).map((r) => r.ruleId)),
+    [loadedRules],
+  );
 
   // One-time recovery: re-derive the rule-config map from the current mode for
   // installs whose persisted config predates mode-aware derivation (fresh
@@ -1240,6 +1249,9 @@ export default function EditorPage() {
   // dictionary-matching lint rules must not flag as 辞書外語.
   const knownTerms = useKnownTerms(editorMode);
 
+  // Quick "add to user dictionary" action for 辞書外語 detections.
+  const { addWordToUserDictionary } = useUserDictionaryActions(editorMode);
+
   const ignoredCorrectionsContextValue = useMemo(
     () => ({
       items: ignoredCorrections,
@@ -1282,11 +1294,13 @@ export default function EditorPage() {
     handleNavigateToIssue,
     handleShowLintHint,
     handleIgnoreCorrection,
+    handleAddToUserDictionary,
     handleApplyFix,
   } = useLintHandlers({
     editorViewInstance,
     lintIssues,
     ignoreCorrection,
+    addWordToUserDictionary,
     triggerSwitchToCorrections,
   });
 
@@ -1565,6 +1579,8 @@ export default function EditorPage() {
     onNavigateToIssue: handleNavigateToIssue,
     onApplyFix: handleApplyFix,
     onIgnoreCorrection: handleIgnoreCorrection,
+    onAddToUserDictionary: handleAddToUserDictionary,
+    dictEntryRuleIds,
     onRefreshLinting: refreshLinting,
     isLinting,
     activeLintIssueIndex,
@@ -1725,6 +1741,8 @@ export default function EditorPage() {
           handleOpenDictionary,
           handleShowLintHint,
           handleIgnoreCorrection,
+          handleAddToUserDictionary,
+          dictEntryRuleIds,
           switchTab,
           updateTab,
           registerFlush,

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -53,6 +53,10 @@ interface EditorProps {
   onShowLintHint?: (issue: LintIssue) => void;
   // 校正無視コールバック
   onIgnoreCorrection?: (issue: LintIssue, ignoreAll: boolean) => void;
+  // ユーザー辞書追加コールバック（辞書外語の検出に対して）
+  onAddToUserDictionary?: (issue: LintIssue) => void;
+  /** 辞書追加を示唆するルール ID 集合（辞書系ルールのみメニュー表示） */
+  dictEntryRuleIds?: ReadonlySet<string>;
   // Editor mode controls
   mdiExtensionsEnabled?: boolean;
   gfmEnabled?: boolean;
@@ -87,6 +91,8 @@ export default function NovelEditor({
   onOpenDictionary,
   onShowLintHint,
   onIgnoreCorrection,
+  onAddToUserDictionary,
+  dictEntryRuleIds,
   mdiExtensionsEnabled = true,
   gfmEnabled = true,
   externalContent,
@@ -550,6 +556,8 @@ export default function NovelEditor({
               onOpenDictionary={onOpenDictionary}
               onShowLintHint={onShowLintHint}
               onIgnoreCorrection={onIgnoreCorrection}
+              onAddToUserDictionary={onAddToUserDictionary}
+              dictEntryRuleIds={dictEntryRuleIds}
               mdiExtensionsEnabled={mdiExtensionsEnabled}
               gfmEnabled={gfmEnabled}
               onStartSpeech={startSpeechFromCursor}

--- a/components/EditorContextMenu.tsx
+++ b/components/EditorContextMenu.tsx
@@ -11,6 +11,7 @@ import {
   ALargeSmall,
   Globe,
   BookOpen,
+  BookmarkPlus,
   AlertCircle,
   EyeOff,
   Play,
@@ -36,6 +37,7 @@ export type ContextMenuAction =
   | "show-lint-hint"
   | "ignore-correction"
   | "ignore-correction-all"
+  | "add-to-user-dict"
   | "start-speech";
 
 interface EditorContextMenuProps {
@@ -43,6 +45,8 @@ interface EditorContextMenuProps {
   onAction: (action: ContextMenuAction) => void;
   hasSelection?: boolean;
   lintIssueAtCursor?: LintIssue | null;
+  /** Whether the lint issue under the cursor supports adding its word to the user dictionary. */
+  canAddLintIssueToDict?: boolean;
   onContextMenuOpen?: (e: MouseEvent) => void;
   /** Whether MDI extensions (ruby / tcy) are enabled for this document */
   mdiExtensionsEnabled?: boolean;
@@ -87,6 +91,7 @@ export default function EditorContextMenu({
   onAction,
   hasSelection = false,
   lintIssueAtCursor,
+  canAddLintIssueToDict = false,
   onContextMenuOpen,
   mdiExtensionsEnabled = true,
   onStartSpeech,
@@ -130,6 +135,14 @@ export default function EditorContextMenu({
                 shortcut=""
                 onClick={() => onAction("ignore-correction-all")}
               />
+              {canAddLintIssueToDict && (
+                <MenuItem
+                  icon={<BookmarkPlus className="w-4 h-4" />}
+                  label="この語をユーザー辞書に追加"
+                  shortcut=""
+                  onClick={() => onAction("add-to-user-dict")}
+                />
+              )}
               <Separator />
             </>
           )}

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -205,6 +205,10 @@ interface EditorLayoutProps {
     handleIgnoreCorrection: NonNullable<
       React.ComponentProps<typeof NovelEditor>["onIgnoreCorrection"]
     >;
+    handleAddToUserDictionary: NonNullable<
+      React.ComponentProps<typeof NovelEditor>["onAddToUserDictionary"]
+    >;
+    dictEntryRuleIds: React.ComponentProps<typeof NovelEditor>["dictEntryRuleIds"];
     switchTab: (tabId: string) => void;
     updateTab: (tabId: string, updates: Partial<EditorTabState>) => void;
     registerFlush: NonNullable<React.ComponentProps<typeof NovelEditor>["registerFlush"]>;
@@ -582,6 +586,8 @@ export default function EditorLayout({
                                   onOpenDictionary={mainArea.handleOpenDictionary}
                                   onShowLintHint={mainArea.handleShowLintHint}
                                   onIgnoreCorrection={mainArea.handleIgnoreCorrection}
+                                  onAddToUserDictionary={mainArea.handleAddToUserDictionary}
+                                  dictEntryRuleIds={mainArea.dictEntryRuleIds}
                                   mdiExtensionsEnabled={panelMdiEnabled}
                                   gfmEnabled={panelGfmEnabled}
                                   externalContent={panelPendingExternalContent}

--- a/components/Inspector.tsx
+++ b/components/Inspector.tsx
@@ -61,6 +61,8 @@ export default function Inspector({
   onNavigateToIssue,
   onApplyFix,
   onIgnoreCorrection,
+  onAddToUserDictionary,
+  dictEntryRuleIds,
   onRefreshLinting,
   isLinting = false,
   activeLintIssueIndex,
@@ -376,6 +378,8 @@ export default function Inspector({
             onNavigateToIssue={onNavigateToIssue}
             onApplyFix={onApplyFix}
             onIgnoreCorrection={onIgnoreCorrection}
+            onAddToUserDictionary={onAddToUserDictionary}
+            dictEntryRuleIds={dictEntryRuleIds}
             onRefreshLinting={onRefreshLinting}
             isLinting={isLinting}
             activeLintIssueIndex={activeLintIssueIndex}

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -73,6 +73,9 @@ interface MilkdownEditorProps {
   onOpenDictionary?: (searchTerm?: string) => void;
   onShowLintHint?: (issue: LintIssue) => void;
   onIgnoreCorrection?: (issue: LintIssue, ignoreAll: boolean) => void;
+  onAddToUserDictionary?: (issue: LintIssue) => void;
+  /** Rule ids whose detections support adding the flagged word to the user dictionary. */
+  dictEntryRuleIds?: ReadonlySet<string>;
   mdiExtensionsEnabled?: boolean;
   gfmEnabled?: boolean;
   onStartSpeech?: () => void;
@@ -113,6 +116,8 @@ export default function MilkdownEditor({
   onOpenDictionary,
   onShowLintHint,
   onIgnoreCorrection,
+  onAddToUserDictionary,
+  dictEntryRuleIds,
   mdiExtensionsEnabled = true,
   gfmEnabled = true,
   onStartSpeech,
@@ -828,6 +833,11 @@ export default function MilkdownEditor({
             onIgnoreCorrection?.(lintIssueAtCursor, true);
           }
           break;
+        case "add-to-user-dict":
+          if (lintIssueAtCursor) {
+            onAddToUserDictionary?.(lintIssueAtCursor);
+          }
+          break;
         case "start-speech":
           onStartSpeech?.();
           break;
@@ -843,6 +853,7 @@ export default function MilkdownEditor({
       lintIssueAtCursor,
       onShowLintHint,
       onIgnoreCorrection,
+      onAddToUserDictionary,
       onStartSpeech,
       onFind,
     ],
@@ -860,6 +871,9 @@ export default function MilkdownEditor({
               { label: "校正提示を表示", action: "show-lint-hint" },
               { label: "この指摘を無視", action: "ignore-correction" },
               { label: "同じ指摘をすべて無視", action: "ignore-correction-all" },
+              ...(dictEntryRuleIds?.has(issue.ruleId)
+                ? [{ label: "この語をユーザー辞書に追加", action: "add-to-user-dict" }]
+                : []),
               { label: "-", action: "_separator" },
             ]
           : []),
@@ -903,6 +917,7 @@ export default function MilkdownEditor({
       handleContextMenuAction,
       mdiExtensionsEnabled,
       selectionState.hasSelection,
+      dictEntryRuleIds,
     ],
   );
 
@@ -1103,6 +1118,9 @@ export default function MilkdownEditor({
           onAction={handleContextMenuAction}
           hasSelection={selectionState.hasSelection}
           lintIssueAtCursor={lintIssueAtCursor}
+          canAddLintIssueToDict={
+            !!(lintIssueAtCursor && dictEntryRuleIds?.has(lintIssueAtCursor.ruleId))
+          }
           onContextMenuOpen={(e) =>
             setLintIssueAtCursor(getLintIssueAtCoords(e.clientX, e.clientY))
           }

--- a/components/inspector/CorrectionsPanel.tsx
+++ b/components/inspector/CorrectionsPanel.tsx
@@ -47,6 +47,9 @@ interface CorrectionsPanelProps {
   onNavigateToIssue?: (issue: LintIssue) => void;
   onApplyFix?: (issue: LintIssue) => void;
   onIgnoreCorrection?: (issue: LintIssue, ignoreAll: boolean) => void;
+  onAddToUserDictionary?: (issue: LintIssue) => void;
+  /** Rule ids whose detections support adding the flagged word to the user dictionary. */
+  dictEntryRuleIds?: ReadonlySet<string>;
   onRefreshLinting?: () => void;
   isLinting?: boolean;
   activeLintIssueIndex?: number | null;
@@ -91,6 +94,8 @@ export default function CorrectionsPanel({
   onNavigateToIssue,
   onApplyFix,
   onIgnoreCorrection,
+  onAddToUserDictionary,
+  dictEntryRuleIds,
   onRefreshLinting,
   isLinting = false,
   activeLintIssueIndex,
@@ -281,6 +286,8 @@ export default function CorrectionsPanel({
               onNavigateToIssue={onNavigateToIssue}
               onApplyFix={onApplyFix}
               onIgnoreCorrection={onIgnoreCorrection}
+              onAddToUserDictionary={onAddToUserDictionary}
+              canAddToUserDictionary={!!dictEntryRuleIds?.has(issue.ruleId)}
             />
           </div>
         );
@@ -344,6 +351,8 @@ export default function CorrectionsPanel({
                         onNavigateToIssue={onNavigateToIssue}
                         onApplyFix={onApplyFix}
                         onIgnoreCorrection={onIgnoreCorrection}
+                        onAddToUserDictionary={onAddToUserDictionary}
+                        canAddToUserDictionary={!!dictEntryRuleIds?.has(issue.ruleId)}
                       />
                     </div>
                   );

--- a/components/inspector/IssueCard.tsx
+++ b/components/inspector/IssueCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type React from "react";
-import { EyeOff, Info, Lightbulb } from "lucide-react";
+import { BookmarkPlus, EyeOff, Info, Lightbulb } from "lucide-react";
 import clsx from "clsx";
 
 import { LINT_RULES_META } from "@/lib/linting/lint-presets";
@@ -48,6 +48,9 @@ export interface IssueCardProps {
   onNavigateToIssue?: (issue: LintIssue) => void;
   onApplyFix?: (issue: LintIssue) => void;
   onIgnoreCorrection?: (issue: LintIssue, ignoreAll: boolean) => void;
+  onAddToUserDictionary?: (issue: LintIssue) => void;
+  /** Whether this issue's rule supports adding the flagged word to the user dictionary. */
+  canAddToUserDictionary?: boolean;
 }
 
 /** Renders a single issue card */
@@ -57,6 +60,8 @@ export default function IssueCard({
   onNavigateToIssue,
   onApplyFix,
   onIgnoreCorrection,
+  onAddToUserDictionary,
+  canAddToUserDictionary,
 }: IssueCardProps): React.JSX.Element {
   const enriched = issue as EnrichedLintIssue;
   const hasOriginal = !!enriched.originalText;
@@ -98,6 +103,32 @@ export default function IssueCard({
           >
             置換
           </span>
+        )}
+        {canAddToUserDictionary && onAddToUserDictionary && (
+          <InfoTooltip
+            content="この語をユーザー辞書に追加"
+            className="text-foreground-tertiary hover:text-foreground-secondary"
+          >
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label="この語をユーザー辞書に追加"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddToUserDictionary(issue);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onAddToUserDictionary(issue);
+                }
+              }}
+              className="inline-flex items-center p-0.5 rounded transition-colors cursor-pointer hover:bg-hover"
+            >
+              <BookmarkPlus className="w-3.5 h-3.5" />
+            </span>
+          </InfoTooltip>
         )}
         {onIgnoreCorrection && (
           <InfoTooltip

--- a/components/inspector/types.ts
+++ b/components/inspector/types.ts
@@ -93,6 +93,9 @@ export interface InspectorProps {
   onNavigateToIssue?: (issue: LintIssue) => void;
   onApplyFix?: (issue: LintIssue) => void;
   onIgnoreCorrection?: (issue: LintIssue, ignoreAll: boolean) => void;
+  onAddToUserDictionary?: (issue: LintIssue) => void;
+  /** Rule ids whose detections support adding the flagged word to the user dictionary. */
+  dictEntryRuleIds?: ReadonlySet<string>;
   onRefreshLinting?: () => void;
   isLinting?: boolean;
   activeLintIssueIndex?: number | null;

--- a/lib/editor-page/__tests__/use-installed-rule-metas.test.ts
+++ b/lib/editor-page/__tests__/use-installed-rule-metas.test.ts
@@ -112,6 +112,35 @@ describe("loadInstalledRuleMetas", () => {
     expect(metas.map((m) => m.ruleId)).toEqual(["ok-1"]);
   });
 
+  it("carries the suggestsDictionaryEntry flag through to the metas (#1962 quick-add)", async () => {
+    setRulesetsApi({
+      listInstalled: vi.fn(async () => [{ id: "dict-pack", version: "1.0.0", tag: null }]),
+      readModule: vi.fn(async (id: string) => ({
+        ok: true,
+        id,
+        tag: null,
+        code: "",
+        manifest: {
+          rules: [
+            {
+              ruleId: "genji-out-of-dict",
+              applicableModes: ["novel"],
+              suggestsDictionaryEntry: true,
+            },
+            { ruleId: "double-kuten", applicableModes: ["novel"] }, // no flag
+          ],
+        },
+      })),
+    });
+
+    const metas = await loadInstalledRuleMetas();
+    const dictEntryRuleIds = new Set(
+      metas.filter((m) => m.suggestsDictionaryEntry).map((m) => m.ruleId),
+    );
+    expect(dictEntryRuleIds.has("genji-out-of-dict")).toBe(true);
+    expect(dictEntryRuleIds.has("double-kuten")).toBe(false);
+  });
+
   it("returns [] (never throws) when the API rejects", async () => {
     setRulesetsApi({
       listInstalled: vi.fn(async () => {

--- a/lib/editor-page/__tests__/use-user-dictionary-actions.test.ts
+++ b/lib/editor-page/__tests__/use-user-dictionary-actions.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for useUserDictionaryActions — the quick "add to user dictionary"
+ * action invoked from lint UI (#1962 quick-add). Verifies project/standalone
+ * routing, word-level dedup, and the entry shape passed to the service.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import type { EditorMode, UserDictionaryEntry } from "@/lib/project/project-types";
+
+const addEntry = vi.fn(async (_entry: UserDictionaryEntry) => [] as UserDictionaryEntry[]);
+const addEntryStandalone = vi.fn(
+  async (_fileName: string, _entry: UserDictionaryEntry) => [] as UserDictionaryEntry[],
+);
+const loadEntries = vi.fn(async () => [] as UserDictionaryEntry[]);
+const loadEntriesStandalone = vi.fn(async (_fileName: string) => [] as UserDictionaryEntry[]);
+
+vi.mock("@/lib/services/user-dictionary-service", () => ({
+  getUserDictionaryService: () => ({
+    addEntry,
+    addEntryStandalone,
+    loadEntries,
+    loadEntriesStandalone,
+  }),
+}));
+
+const info = vi.fn();
+const success = vi.fn();
+const error = vi.fn();
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: {
+    info: (m: string) => info(m),
+    success: (m: string) => success(m),
+    error: (m: string) => error(m),
+  },
+}));
+
+import { useUserDictionaryActions } from "../use-user-dictionary-actions";
+
+const PROJECT_MODE = { type: "project" } as unknown as EditorMode;
+const STANDALONE_MODE = {
+  type: "standalone",
+  fileName: "novel.mdi",
+} as unknown as EditorMode;
+
+// Minimal hook harness via createRoot + act (no @testing-library/react).
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+function setup(mode: EditorMode): { addWordToUserDictionary: (word: string) => Promise<void> } {
+  const capturedRef: { current: ReturnType<typeof useUserDictionaryActions> | null } = {
+    current: null,
+  };
+  function Probe() {
+    // Capture the hook return into an outer ref so the test can drive it.
+    // Not a production render pattern.
+    // eslint-disable-next-line react-hooks/immutability
+    capturedRef.current = useUserDictionaryActions(mode);
+    return null;
+  }
+  container = document.createElement("div");
+  root = createRoot(container);
+  act(() => {
+    root!.render(React.createElement(Probe));
+  });
+  return capturedRef.current!;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadEntries.mockResolvedValue([]);
+  loadEntriesStandalone.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = null;
+  container = null;
+});
+
+describe("useUserDictionaryActions", () => {
+  it("adds a word via addEntry in project mode with a generated id", async () => {
+    const { addWordToUserDictionary } = setup(PROJECT_MODE);
+    await addWordToUserDictionary("フガピヨ");
+
+    expect(addEntry).toHaveBeenCalledTimes(1);
+    const entry = addEntry.mock.calls[0][0] as UserDictionaryEntry;
+    expect(entry.word).toBe("フガピヨ");
+    expect(typeof entry.id).toBe("string");
+    expect(entry.id.length).toBeGreaterThan(0);
+    expect(addEntryStandalone).not.toHaveBeenCalled();
+    expect(success).toHaveBeenCalled();
+  });
+
+  it("adds a word via addEntryStandalone in standalone mode, keyed by fileName", async () => {
+    const { addWordToUserDictionary } = setup(STANDALONE_MODE);
+    await addWordToUserDictionary("フガピヨ");
+
+    expect(addEntryStandalone).toHaveBeenCalledTimes(1);
+    expect(addEntryStandalone.mock.calls[0][0]).toBe("novel.mdi");
+    expect((addEntryStandalone.mock.calls[0][1] as UserDictionaryEntry).word).toBe("フガピヨ");
+    expect(addEntry).not.toHaveBeenCalled();
+  });
+
+  it("skips when the word is already registered (project)", async () => {
+    loadEntries.mockResolvedValue([{ id: "x", word: "フガピヨ" }]);
+    const { addWordToUserDictionary } = setup(PROJECT_MODE);
+    await addWordToUserDictionary("フガピヨ");
+
+    expect(addEntry).not.toHaveBeenCalled();
+    expect(info).toHaveBeenCalled();
+    expect(success).not.toHaveBeenCalled();
+  });
+
+  it("trims and ignores blank words", async () => {
+    const { addWordToUserDictionary } = setup(PROJECT_MODE);
+    await addWordToUserDictionary("   ");
+
+    expect(loadEntries).not.toHaveBeenCalled();
+    expect(addEntry).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no editor mode", async () => {
+    const { addWordToUserDictionary } = setup(null);
+    await addWordToUserDictionary("フガピヨ");
+
+    expect(addEntry).not.toHaveBeenCalled();
+    expect(addEntryStandalone).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast when the service throws", async () => {
+    addEntry.mockRejectedValueOnce(new Error("disk full"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { addWordToUserDictionary } = setup(PROJECT_MODE);
+    await addWordToUserDictionary("フガピヨ");
+
+    expect(error).toHaveBeenCalled();
+    expect(success).not.toHaveBeenCalled();
+  });
+});

--- a/lib/editor-page/use-installed-rule-metas.ts
+++ b/lib/editor-page/use-installed-rule-metas.ts
@@ -25,6 +25,7 @@ interface ManifestRule {
   ruleId: string;
   applicableModes?: string[];
   defaultConfig?: { enabled?: boolean; severity?: string; skipDialogue?: boolean };
+  suggestsDictionaryEntry?: boolean;
 }
 
 function getRulesetsAPI(): NonNullable<Window["electronAPI"]>["rulesets"] | undefined {
@@ -53,6 +54,7 @@ export async function loadInstalledRuleMetas(): Promise<ModeRuleMetaInput[]> {
           ruleId: rule.ruleId,
           applicableModes: rule.applicableModes,
           defaultConfig: rule.defaultConfig,
+          suggestsDictionaryEntry: rule.suggestsDictionaryEntry,
         });
       }
     }

--- a/lib/editor-page/use-lint-handlers.ts
+++ b/lib/editor-page/use-lint-handlers.ts
@@ -8,6 +8,7 @@ interface UseLintHandlersOptions {
   editorViewInstance: EditorView | null;
   lintIssues: LintIssue[];
   ignoreCorrection: (ruleId: string, text: string, paragraphText?: string) => void;
+  addWordToUserDictionary: (word: string) => Promise<void>;
   triggerSwitchToCorrections: () => void;
 }
 
@@ -15,6 +16,7 @@ export function useLintHandlers({
   editorViewInstance,
   lintIssues,
   ignoreCorrection,
+  addWordToUserDictionary,
   triggerSwitchToCorrections,
 }: UseLintHandlersOptions) {
   // Enrich lint issues with original text from the document
@@ -120,6 +122,25 @@ export function useLintHandlers({
     [editorViewInstance, ignoreCorrection],
   );
 
+  /** Add the flagged word of a dictionary-membership issue to the user dictionary */
+  const handleAddToUserDictionary = useCallback(
+    (issue: LintIssue) => {
+      if (!editorViewInstance) return;
+      let issueText: string;
+      try {
+        issueText = editorViewInstance.state.doc.textBetween(
+          issue.from,
+          Math.min(issue.to, editorViewInstance.state.doc.content.size),
+        );
+      } catch {
+        return;
+      }
+      if (!issueText) return;
+      void addWordToUserDictionary(issueText);
+    },
+    [editorViewInstance, addWordToUserDictionary],
+  );
+
   /** Apply a lint fix by replacing the text range */
   const handleApplyFix = useCallback(
     (issue: LintIssue & { originalText?: string }) => {
@@ -146,6 +167,7 @@ export function useLintHandlers({
     handleNavigateToIssue,
     handleShowLintHint,
     handleIgnoreCorrection,
+    handleAddToUserDictionary,
     handleApplyFix,
   };
 }

--- a/lib/editor-page/use-user-dictionary-actions.ts
+++ b/lib/editor-page/use-user-dictionary-actions.ts
@@ -1,0 +1,69 @@
+/**
+ * React hook for quick user-dictionary actions invoked from lint UI.
+ *
+ * Adds a word to the user dictionary (project or standalone scope) so that the
+ * known-terms pipeline (#1888) immediately suppresses its "out of dictionary"
+ * squiggle. The host owns this write; rulesets only declare intent via the
+ * `suggestsDictionaryEntry` manifest flag.
+ *
+ * ユーザー辞書への語追加（校正カード／波線メニューから）を担うフック。
+ */
+
+import { useCallback } from "react";
+
+import { getUserDictionaryService } from "@/lib/services/user-dictionary-service";
+import { notificationManager } from "@/lib/services/notification-manager";
+import { isProjectMode, isStandaloneMode } from "@/lib/project/project-types";
+import type { EditorMode } from "@/lib/project/project-types";
+
+export interface UseUserDictionaryActionsResult {
+  /**
+   * Add a word to the user dictionary for the current editor mode. No-ops on a
+   * blank word; skips with an info toast when the word is already registered.
+   */
+  addWordToUserDictionary: (word: string) => Promise<void>;
+}
+
+/**
+ * Provides user-dictionary mutation actions scoped to the current editor mode.
+ *
+ * @param editorMode Current editor mode (project / standalone / null).
+ */
+export function useUserDictionaryActions(editorMode: EditorMode): UseUserDictionaryActionsResult {
+  const addWordToUserDictionary = useCallback(
+    async (rawWord: string): Promise<void> => {
+      const word = rawWord.trim();
+      if (!word) return;
+      if (!editorMode) return;
+
+      const service = getUserDictionaryService();
+      try {
+        if (isProjectMode(editorMode)) {
+          const existing = await service.loadEntries();
+          if (existing.some((e) => e.word === word)) {
+            notificationManager.info(`「${word}」は既にユーザー辞書に登録されています`);
+            return;
+          }
+          await service.addEntry({ id: crypto.randomUUID(), word });
+        } else if (isStandaloneMode(editorMode)) {
+          const fileName = editorMode.fileName;
+          const existing = await service.loadEntriesStandalone(fileName);
+          if (existing.some((e) => e.word === word)) {
+            notificationManager.info(`「${word}」は既にユーザー辞書に登録されています`);
+            return;
+          }
+          await service.addEntryStandalone(fileName, { id: crypto.randomUUID(), word });
+        } else {
+          return;
+        }
+        notificationManager.success(`「${word}」をユーザー辞書に追加しました`);
+      } catch (err) {
+        console.error("[useUserDictionaryActions] Failed to add word:", err);
+        notificationManager.error("ユーザー辞書への追加に失敗しました");
+      }
+    },
+    [editorMode],
+  );
+
+  return { addWordToUserDictionary };
+}

--- a/lib/linting/mode-rule-configs.ts
+++ b/lib/linting/mode-rule-configs.ts
@@ -37,6 +37,8 @@ export interface ModeRuleMetaInput {
   /** Modes this rule opts into. Missing/empty = never auto-enabled by a mode. */
   applicableModes?: readonly string[];
   defaultConfig?: { enabled?: boolean; severity?: string; skipDialogue?: boolean };
+  /** Declares that the rule's issues can be resolved by adding the word to the user dictionary. */
+  suggestsDictionaryEntry?: boolean;
 }
 
 const VALID_SEVERITIES = new Set<Severity>(["error", "warning", "info"]);

--- a/lib/linting/sdk/ruleset-types.ts
+++ b/lib/linting/sdk/ruleset-types.ts
@@ -90,6 +90,13 @@ export interface RulesetRuleMeta {
   /** Whether this rule honors the skipDialogue option. */
   supportsSkipDialogue?: boolean;
   /**
+   * Declares that issues from this rule can be resolved by adding the flagged
+   * word to the user dictionary. Pure data (no UI): the host renders an
+   * "add to dictionary" action and owns the write. Used by dictionary-membership
+   * rules such as `genji-out-of-dict`. Default (absent) = no such action.
+   */
+  suggestsDictionaryEntry?: boolean;
+  /**
    * Correction modes (校正モード) this rule opts into. When the user switches to
    * one of these modes, the rule is automatically enabled. An empty array means
    * the rule is never auto-enabled by any mode (manual toggle only).


### PR DESCRIPTION
## 概要
辞書系ルールセット（`genji-out-of-dict` 等）が検出した「辞書外語（未収録語）」に対し、**検出カードのボタン**と**波線の右クリックメニュー**から、その語をワンクリックでユーザー辞書へ追加できるようにする。追加後は既存の known-terms パイプライン（#1888）経由で即座に再 lint され、波線が自動的に消える。

## 設計（C 案：capability flag 方式）
- **SDK は UI 接口を開けない**（意図的に「ロジックのみ」設計／Electron セキュリティ整合）。代わりに `RulesetRuleMeta` に**純データのフラグ** `suggestsDictionaryEntry?: boolean` を追加（既存 `supportsSkipDialogue?` と同性質）。
- ルールセットは「この検出は辞書追加で解決できる」と**意図だけ宣言**。ホスト（illusions）が**ボタン描画と辞書書き込みを所有**。
- 表示は `dictEntryRuleIds`（installed manifest から構築した Set）で `issue.ruleId` をゲート。句読点系など非辞書ルールにはボタンを出さない。
- 書き込みは新規 `useUserDictionaryActions`（project/standalone 分岐＋word 重複ガード）→ 既存 `addEntry`/`addEntryStandalone`。

## 変更
- SDK 型: `lib/linting/sdk/ruleset-types.ts`（フラグ追加）
- 集合供給: `use-installed-rule-metas.ts` / `mode-rule-configs.ts` / `app/page.tsx`（`dictEntryRuleIds`）
- 書き込み: `lib/editor-page/use-user-dictionary-actions.ts`（新規）/ `use-lint-handlers.ts`
- UI①カード: `IssueCard.tsx` / `CorrectionsPanel.tsx` / `Inspector.tsx` / `inspector/types.ts`
- UI②波線: `EditorContextMenu.tsx` / `MilkdownEditor.tsx` / `Editor.tsx` / `EditorLayout.tsx`

## テスト
- `use-user-dictionary-actions.test.ts`（新規 6 件）: project/standalone 分岐・word 重複スキップ・id 生成・エラートースト
- `use-installed-rule-metas.test.ts`（+1 件）: `suggestsDictionaryEntry` の Set 伝播
- `npm run test` 全 2484 green / type-check / lint クリーン

## 補足
- ルールセット側で `suggestsDictionaryEntry:true` が宣言されるまでボタンは出ない（グレースフル）。genji-vocab 側の宣言は別リポジトリで対応。
- 関連 issue なし（会話起点の機能追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)