### PR TITLE
fix(persistence): スタンドアロン無題タブを再起動後に復元 (#1965 安全サブセット)

### DIFF
--- a/lib/tab-manager/__tests__/get-error-message.test.ts
+++ b/lib/tab-manager/__tests__/get-error-message.test.ts
@@ -1,0 +1,107 @@
+/**
+ * getErrorMessage / isQuotaExceededError の挙動テスト。
+ *
+ * 目的は2つ:
+ * 1. consistency — 既存の Node `ErrnoException` 分岐（EACCES/ENOSPC/...）の
+ *    メッセージを「現行の正しい挙動」として固定し、リファクタで退行させない。
+ * 2. new (#1967) — Web の `QuotaExceededError`（`DOMException`）を専用メッセージへ
+ *    マッピングする新分岐を検証する。`DOMException` は環境によって
+ *    `instanceof Error` が false になるため、その場合でも判定できることを保証する。
+ */
+
+import { describe, it, expect } from "vitest";
+import { getErrorMessage, isQuotaExceededError } from "../types";
+
+function errnoError(code: string, message = "boom"): Error {
+  const e = new Error(message) as NodeJS.ErrnoException;
+  e.code = code;
+  return e;
+}
+
+describe("getErrorMessage — consistency (既存 Errno 分岐の固定)", () => {
+  it("Error 以外（文字列 / null / 数値 / name を持たないオブジェクト）は『不明なエラー』", () => {
+    expect(getErrorMessage("boom")).toBe("不明なエラー");
+    expect(getErrorMessage(null)).toBe("不明なエラー");
+    expect(getErrorMessage(42)).toBe("不明なエラー");
+    expect(getErrorMessage({ foo: "bar" })).toBe("不明なエラー");
+  });
+
+  it("code の無い Error は message をそのまま返す", () => {
+    expect(getErrorMessage(new Error("そのまま"))).toBe("そのまま");
+  });
+
+  it("EACCES / EPERM は権限エラーメッセージ", () => {
+    const expected =
+      "ファイルへのアクセス権限がありません。ファイルが他のプログラムで開かれていないか、または書き込み権限があるかを確認してください。";
+    expect(getErrorMessage(errnoError("EACCES"))).toBe(expected);
+    expect(getErrorMessage(errnoError("EPERM"))).toBe(expected);
+  });
+
+  it("ENOSPC は容量不足メッセージ", () => {
+    expect(getErrorMessage(errnoError("ENOSPC"))).toBe("ディスクの空き容量が不足しています。");
+  });
+
+  it("ENOENT は保存先フォルダ不明メッセージ", () => {
+    expect(getErrorMessage(errnoError("ENOENT"))).toBe("保存先のフォルダが見つかりません。");
+  });
+
+  it("EINVAL は無効パスメッセージ", () => {
+    expect(getErrorMessage(errnoError("EINVAL"))).toBe(
+      "ファイル名またはパスが無効です。使用できない文字が含まれている可能性があります。",
+    );
+  });
+
+  it("ENAMETOOLONG は名前過長メッセージ", () => {
+    expect(getErrorMessage(errnoError("ENAMETOOLONG"))).toBe("ファイル名またはパスが長すぎます。");
+  });
+
+  it("未知の code は message にフォールバック", () => {
+    expect(getErrorMessage(errnoError("EUNKNOWNXYZ", "原文メッセージ"))).toBe("原文メッセージ");
+  });
+});
+
+describe("getErrorMessage — #1967 QuotaExceededError 新分岐", () => {
+  const QUOTA_MSG =
+    "保存容量が不足しています。不要なデータを削除するか、別の保存先をご利用ください。";
+
+  it("実 DOMException(QuotaExceededError) を容量メッセージへマップ", () => {
+    const e = new DOMException("quota", "QuotaExceededError");
+    expect(getErrorMessage(e)).toBe(QUOTA_MSG);
+  });
+
+  it("instanceof Error をすり抜ける duck-typed {name:'QuotaExceededError'} も判定", () => {
+    expect(getErrorMessage({ name: "QuotaExceededError", message: "x" })).toBe(QUOTA_MSG);
+  });
+
+  it("legacy Firefox の NS_ERROR_DOM_QUOTA_REACHED も判定", () => {
+    expect(getErrorMessage({ name: "NS_ERROR_DOM_QUOTA_REACHED" })).toBe(QUOTA_MSG);
+  });
+
+  it("旧仕様の数値コード 22 も判定", () => {
+    expect(getErrorMessage({ code: 22 })).toBe(QUOTA_MSG);
+  });
+
+  it("quota は ENOSPC より優先しないが、両者が独立に容量系メッセージを返す", () => {
+    // ENOSPC（Electron 経路）と QuotaExceeded（Web 経路）は別メッセージだが
+    // どちらも「容量不足」をユーザーへ伝える。退行検知のため両方を固定。
+    expect(getErrorMessage(errnoError("ENOSPC"))).toContain("空き容量");
+    expect(getErrorMessage(new DOMException("q", "QuotaExceededError"))).toContain("容量");
+  });
+});
+
+describe("isQuotaExceededError", () => {
+  it("quota 系は true", () => {
+    expect(isQuotaExceededError(new DOMException("q", "QuotaExceededError"))).toBe(true);
+    expect(isQuotaExceededError({ name: "QuotaExceededError" })).toBe(true);
+    expect(isQuotaExceededError({ name: "NS_ERROR_DOM_QUOTA_REACHED" })).toBe(true);
+    expect(isQuotaExceededError({ code: 22 })).toBe(true);
+  });
+
+  it("非 quota は false", () => {
+    expect(isQuotaExceededError(new Error("boom"))).toBe(false);
+    expect(isQuotaExceededError(errnoError("ENOSPC"))).toBe(false);
+    expect(isQuotaExceededError(null)).toBe(false);
+    expect(isQuotaExceededError("QuotaExceededError")).toBe(false);
+    expect(isQuotaExceededError({ code: 23 })).toBe(false);
+  });
+});

--- a/lib/tab-manager/__tests__/standalone-persist-untitled-gate.test.tsx
+++ b/lib/tab-manager/__tests__/standalone-persist-untitled-gate.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * スタンドアロン永続化で unsavedContent を保存する条件のテスト（#1965 / Codex P2 修正）。
+ *
+ * unsavedContent は「真の無題タブ（ファイル記述子が一切無い）」だけに保存しなければならない。
+ * Web の File System Access で開いたファイルは `file.path === null` だが `file.handle` を
+ * 持つため、`!t.file?.path` で判定すると保存済みファイルを無題と誤判定し、全文を AppState に
+ * 重複保存してしまう（容量肥大 + QuotaExceeded リスク増）。`!t.file` で判定することを固定する。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { useTabPersistence } from "../use-tab-persistence";
+import { createNewTab } from "../types";
+import type { TabState, TabId, EditorTabState, SerializedTab } from "../tab-types";
+
+const { persistAppStateMock } = vi.hoisted(() => ({
+  persistAppStateMock: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({
+    initialize: vi.fn(async () => undefined),
+    loadAppState: vi.fn(async () => null),
+    getItem: vi.fn(async () => null),
+    loadEditorBuffer: vi.fn(async () => null),
+    clearEditorBuffer: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("@/lib/storage/app-state-manager", () => ({
+  fetchWindowState: vi.fn(async () => null),
+  persistWindowState: vi.fn(async () => undefined),
+  persistAppState: persistAppStateMock,
+}));
+
+vi.mock("@/lib/project/workspace-persistence", () => ({
+  persistWorkspaceJson: vi.fn(async () => undefined),
+  toRelativePath: (p: string) => p,
+  toAbsolutePath: (p: string) => p,
+}));
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => ({ readFile: vi.fn(async () => "") }),
+}));
+
+function Harness({ tabs }: { tabs: TabState[] }): null {
+  const tabsRef = useRef<TabState[]>(tabs);
+  tabsRef.current = tabs;
+  const activeTabIdRef = useRef<TabId>(tabs[0]?.id ?? "");
+  activeTabIdRef.current = tabs[0]?.id ?? "";
+  const isProjectRef = useRef(false);
+  useTabPersistence({
+    tabs,
+    setTabs: vi.fn(),
+    activeTabId: tabs[0]?.id ?? "",
+    setActiveTabId: vi.fn(),
+    tabsRef,
+    activeTabIdRef,
+    isProjectRef,
+    isElectron: false, // Web standalone → persistAppState
+    skipAutoRestore: true,
+    windowKey: null,
+  });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  persistAppStateMock.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+function untitledDirty(content: string): EditorTabState {
+  return { ...createNewTab(content), isDirty: true };
+}
+
+function webFileBackedDirty(content: string, name: string): EditorTabState {
+  return {
+    ...createNewTab(content),
+    file: { path: null, handle: {} as unknown as FileSystemFileHandle, name },
+    isDirty: true,
+  };
+}
+
+function electronFileBackedDirty(content: string, path: string, name: string): EditorTabState {
+  return { ...createNewTab(content), file: { path, handle: null, name }, isDirty: true };
+}
+
+async function persistAndRead(tabs: TabState[]): Promise<SerializedTab[]> {
+  await act(async () => {
+    root.render(<Harness tabs={tabs} />);
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1500); // > TAB_PERSIST_DEBOUNCE
+  });
+  const calls = persistAppStateMock.mock.calls as unknown as Array<
+    [{ openTabs: { tabs: SerializedTab[] } }]
+  >;
+  const lastArg = calls[calls.length - 1]?.[0];
+  if (!lastArg) throw new Error("persistAppState が呼ばれませんでした");
+  return lastArg.openTabs.tabs;
+}
+
+describe("#1965 / Codex P2 — unsavedContent は真の無題タブだけに保存する", () => {
+  it("真の無題 dirty タブは unsavedContent を保存する", async () => {
+    const serialized = await persistAndRead([untitledDirty("未保存の下書き")]);
+    expect(serialized).toHaveLength(1);
+    expect(serialized[0].filePath).toBeNull();
+    expect(serialized[0].unsavedContent).toBe("未保存の下書き");
+  });
+
+  it("【回帰】Web file-backed(handle あり/path null) dirty タブは unsavedContent を保存しない", async () => {
+    const serialized = await persistAndRead([webFileBackedDirty("ファイル全文", "a.mdi")]);
+    expect(serialized).toHaveLength(1);
+    expect(serialized[0].filePath).toBeNull(); // Web は path を持たない
+    // 全文を AppState に重複保存しない（容量肥大 / quota 回避）。
+    expect(serialized[0].unsavedContent).toBeUndefined();
+  });
+
+  it("Electron file-backed(path あり) dirty タブも unsavedContent を保存しない", async () => {
+    const serialized = await persistAndRead([
+      electronFileBackedDirty("本文", "/abs/b.mdi", "b.mdi"),
+    ]);
+    expect(serialized).toHaveLength(1);
+    expect(serialized[0].filePath).toBe("/abs/b.mdi");
+    expect(serialized[0].unsavedContent).toBeUndefined();
+  });
+
+  it("混在: 無題のみ unsavedContent、file-backed は持たない", async () => {
+    const serialized = await persistAndRead([
+      untitledDirty("無題内容"),
+      webFileBackedDirty("Web全文", "w.mdi"),
+      electronFileBackedDirty("Electron全文", "/abs/e.mdi", "e.mdi"),
+    ]);
+    expect(serialized).toHaveLength(3);
+    expect(serialized[0].unsavedContent).toBe("無題内容");
+    expect(serialized[1].unsavedContent).toBeUndefined();
+    expect(serialized[2].unsavedContent).toBeUndefined();
+  });
+});

--- a/lib/tab-manager/__tests__/standalone-restore-untitled.test.tsx
+++ b/lib/tab-manager/__tests__/standalone-restore-untitled.test.tsx
@@ -1,0 +1,321 @@
+/**
+ * Electron スタンドアロン無題タブ復元のテスト（#1965 の安全サブセット）。
+ *
+ * 背景: スタンドアロンは VFS ルート未設定で起動するため、保存済み file-backed タブを
+ * `getProjectFileService().readFile(絶対パス)` で再読込しようとすると main 側
+ * validateVFSPath が必ず失敗する。よってファイル本体復元は Phase 9 の IO 抽象まで据え置き、
+ * ここでは **filePath を持たない無題/未保存タブのバッファのみ** を VFS 非依存で復元する。
+ *
+ * 最重要(業務非破壊): file-backed タブに対して readFile を**呼ばない**こと
+ *  = 毎起動の復元失敗エラーを誘発しないこと。
+ *
+ * REAL フックを createRoot + act で駆動（electron-gate テストと同じパターン）。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { useTabPersistence } from "../use-tab-persistence";
+import type { TabState, TabId, EditorTabState, SerializedTab } from "../tab-types";
+
+const { fetchWindowStateMock, persistWindowStateMock, persistAppStateMock, loadAppStateMock } =
+  vi.hoisted(() => ({
+    fetchWindowStateMock: vi.fn(async () => null as unknown),
+    persistWindowStateMock: vi.fn(async () => undefined),
+    persistAppStateMock: vi.fn(async () => undefined),
+    loadAppStateMock: vi.fn(async () => null as unknown),
+  }));
+
+const { readFileSpy } = vi.hoisted(() => ({ readFileSpy: vi.fn(async () => "DISK") }));
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { error: vi.fn(), warning: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({
+    initialize: vi.fn(async () => undefined),
+    loadAppState: loadAppStateMock,
+    getItem: vi.fn(async () => null),
+    loadEditorBuffer: vi.fn(async () => null),
+    clearEditorBuffer: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("@/lib/storage/app-state-manager", () => ({
+  fetchWindowState: fetchWindowStateMock,
+  persistWindowState: persistWindowStateMock,
+  persistAppState: persistAppStateMock,
+}));
+
+vi.mock("@/lib/project/workspace-persistence", () => ({
+  persistWorkspaceJson: vi.fn(async () => undefined),
+  toRelativePath: (p: string) => p,
+  toAbsolutePath: (p: string) => p,
+}));
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => ({ readFile: readFileSpy }),
+}));
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface HarnessProps {
+  tabs: TabState[];
+  activeTabId: TabId;
+  windowKey?: string | null;
+  setTabs: (action: React.SetStateAction<TabState[]>) => void;
+  setActiveTabId: (action: React.SetStateAction<TabId>) => void;
+}
+
+function Harness({ tabs, activeTabId, windowKey, setTabs, setActiveTabId }: HarnessProps): null {
+  const tabsRef = useRef<TabState[]>(tabs);
+  tabsRef.current = tabs;
+  const activeTabIdRef = useRef<TabId>(activeTabId);
+  activeTabIdRef.current = activeTabId;
+  const isProjectRef = useRef(false);
+
+  useTabPersistence({
+    tabs,
+    setTabs: setTabs as never,
+    activeTabId,
+    setActiveTabId: setActiveTabId as never,
+    tabsRef,
+    activeTabIdRef,
+    isProjectRef,
+    isElectron: true,
+    skipAutoRestore: false,
+    vfsReadyPromise: Promise.resolve(),
+    windowKey: windowKey ?? null,
+  });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+function serialized(partial: Partial<SerializedTab>): SerializedTab {
+  return {
+    filePath: null,
+    fileName: "新規ファイル",
+    fileType: ".mdi",
+    ...partial,
+  };
+}
+
+/** restore がゲート越しに反映した EditorTabState[] を取り出す（updater を空 prev で評価）。 */
+function restoredTabsFrom(setTabs: ReturnType<typeof vi.fn>): EditorTabState[] | null {
+  if (setTabs.mock.calls.length === 0) return null;
+  const updater = setTabs.mock.calls[setTabs.mock.calls.length - 1][0] as (
+    prev: TabState[],
+  ) => TabState[];
+  return updater([]) as EditorTabState[];
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  fetchWindowStateMock.mockReset();
+  fetchWindowStateMock.mockResolvedValue(null);
+  loadAppStateMock.mockReset();
+  loadAppStateMock.mockResolvedValue(null);
+  persistWindowStateMock.mockReset();
+  persistWindowStateMock.mockResolvedValue(undefined);
+  persistAppStateMock.mockReset();
+  persistAppStateMock.mockResolvedValue(undefined);
+  readFileSpy.mockReset();
+  readFileSpy.mockResolvedValue("DISK");
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+async function mountAndSettle(props: Omit<HarnessProps, "tabs" | "activeTabId">): Promise<void> {
+  await act(async () => {
+    root.render(<Harness tabs={[]} activeTabId="" {...props} />);
+  });
+  // VFS race (Promise.resolve) + async state reads を消化。
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(100);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("#1965 — スタンドアロン無題タブの復元（安全サブセット）", () => {
+  it("内容を持つ無題タブを dirty として復元する（AppState 経路 / windowKey なし）", async () => {
+    loadAppStateMock.mockResolvedValue({
+      openTabs: {
+        tabs: [serialized({ unsavedContent: "未保存の本文", fileType: ".mdi" })],
+        activeIndex: 0,
+      },
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle({ setTabs, setActiveTabId, windowKey: null });
+
+    const restored = restoredTabsFrom(setTabs);
+    expect(restored).not.toBeNull();
+    expect(restored).toHaveLength(1);
+    expect(restored![0].content).toBe("未保存の本文");
+    expect(restored![0].isDirty).toBe(true);
+    expect(restored![0].file).toBeNull();
+    // 無題タブ復元は VFS を一切使わない（業務非破壊の核心）。
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("空の無題タブは clean として復元する（windowKey 経路）", async () => {
+    fetchWindowStateMock.mockResolvedValue({
+      openTabs: { tabs: [serialized({ unsavedContent: "", fileType: ".txt" })], activeIndex: 0 },
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle({ setTabs, setActiveTabId, windowKey: "/win/key" });
+
+    const restored = restoredTabsFrom(setTabs);
+    expect(restored).toHaveLength(1);
+    expect(restored![0].content).toBe("");
+    expect(restored![0].isDirty).toBe(false);
+    expect(restored![0].fileType).toBe(".txt");
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("【業務非破壊】file-backed タブのみのときは復元せず readFile を呼ばない", async () => {
+    loadAppStateMock.mockResolvedValue({
+      openTabs: {
+        tabs: [serialized({ filePath: "/abs/manuscript.mdi", fileName: "manuscript.mdi" })],
+        activeIndex: 0,
+      },
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle({ setTabs, setActiveTabId, windowKey: null });
+
+    // file-backed は据え置き → restore 由来の setTabs は呼ばれない。
+    expect(restoredTabsFrom(setTabs)).toBeNull();
+    // 毎起動エラー(validateVFSPath 失敗)を誘発しないことの保証。
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("file-backed + 無題 混在では無題のみ復元し activeIndex をクランプする", async () => {
+    loadAppStateMock.mockResolvedValue({
+      openTabs: {
+        tabs: [
+          serialized({ filePath: "/abs/a.mdi", fileName: "a.mdi" }),
+          serialized({ unsavedContent: "下書き", fileType: ".mdi" }),
+        ],
+        activeIndex: 0, // file-backed を指していても、復元後リストにクランプ。
+      },
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle({ setTabs, setActiveTabId, windowKey: null });
+
+    const restored = restoredTabsFrom(setTabs);
+    expect(restored).toHaveLength(1);
+    expect(restored![0].content).toBe("下書き");
+    // setActiveTabId updater("") は復元済みリストの範囲内 id を返す（範囲外参照しない）。
+    const idUpdater = setActiveTabId.mock.calls[0][0] as (prev: TabId) => TabId;
+    expect(idUpdater("")).toBe(restored![0].id);
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("保存状態が無ければ復元しない（setTabs 不呼び出し・readFile 不呼び出し）", async () => {
+    // mock は既定で null。
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle({ setTabs, setActiveTabId, windowKey: null });
+
+    expect(setTabs).not.toHaveBeenCalled();
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("待機中にユーザーがタブを開いた場合は復元で上書きしない（prev 優先）", async () => {
+    loadAppStateMock.mockResolvedValue({
+      openTabs: { tabs: [serialized({ unsavedContent: "復元候補" })], activeIndex: 0 },
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle({ setTabs, setActiveTabId, windowKey: null });
+
+    // restore は setTabs((prev)=>prev.length>0?prev:restored) を呼ぶ。
+    // 既存タブがある状況では prev を返す（= 上書きしない）。
+    const updater = setTabs.mock.calls[setTabs.mock.calls.length - 1][0] as (
+      prev: TabState[],
+    ) => TabState[];
+    const existing = [{ id: "existing" } as unknown as TabState];
+    expect(updater(existing)).toBe(existing);
+  });
+
+  it("状態読み込みが throw しても復元 effect はクラッシュせず readFile を呼ばない", async () => {
+    // 注: DB 読み込み失敗時の空起動 + 通知は Phase 1 の initializeStorage catch が担当する
+    // ため、そちらは別途 setTabs(エラータブ) を呼ぶ。ここでは「復元 effect が例外を
+    // 飲み込んで VFS 読込を誘発しない」ことだけを検証する。
+    loadAppStateMock.mockRejectedValue(new Error("DB read failed"));
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await expect(
+      mountAndSettle({ setTabs, setActiveTabId, windowKey: null }),
+    ).resolves.toBeUndefined();
+    // 復元 effect は file 本体を読まない（毎起動エラーを誘発しない）。
+    expect(readFileSpy).not.toHaveBeenCalled();
+    // 復元由来の無題タブ反映は無い（updater を空 prev で評価しても復元結果が出ない）。
+    const restored = restoredTabsFrom(setTabs);
+    // initializeStorage のエラータブ(空 createNewTab)か、未呼び出し(null)のいずれか。
+    if (restored) {
+      expect(restored.every((t) => t.content === "")).toBe(true);
+    }
+  });
+});
+
+describe("#1965 — 永続化ゲートは復元有無に関わらず開く（#1567 退行防止）", () => {
+  it("file-backed のみで復元なしでも、その後の空タブ状態を永続化できる", async () => {
+    loadAppStateMock.mockResolvedValue({
+      openTabs: {
+        tabs: [serialized({ filePath: "/abs/a.mdi", fileName: "a.mdi" })],
+        activeIndex: 0,
+      },
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle({ setTabs, setActiveTabId, windowKey: null });
+    persistAppStateMock.mockClear();
+
+    // ゲートが開いていれば、空タブ状態の永続化が走る（#1567）。
+    await act(async () => {
+      root.render(
+        <Harness
+          tabs={[]}
+          activeTabId=""
+          windowKey={null}
+          setTabs={setTabs}
+          setActiveTabId={setActiveTabId}
+        />,
+      );
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    expect(persistAppStateMock).toHaveBeenCalledWith({ openTabs: { tabs: [], activeIndex: 0 } });
+  });
+});

--- a/lib/tab-manager/__tests__/tab-persistence-failure-notify.test.tsx
+++ b/lib/tab-manager/__tests__/tab-persistence-failure-notify.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * 永続化のサイレント失敗が通知へ変換されることのテスト（#1967 / #1968 K-4-3）。
+ *
+ * 修正前: タブ状態の永続化失敗（容量不足など）と DB ロック起動時の初期化失敗は
+ * `console.error` のみで、ユーザーは保存できていると誤認したままだった。
+ *
+ * 修正後:
+ * - debounce 永続化が失敗したら `notificationManager.error` で一度だけ通知し、
+ *   成功で失敗ストリークを解除して再通知できるようにする（連発しない）。
+ * - storage 初期化失敗（DB ロック等）は `setRestoreError` バナー + トーストで明示する。
+ *
+ * REAL フックを createRoot + act で駆動（リポジトリのパターン、testing-library 不使用）。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { useTabPersistence } from "../use-tab-persistence";
+import { createNewTab } from "../types";
+import type { TabState, TabId } from "../tab-types";
+
+const { persistAppStateMock, persistWindowStateMock, fetchWindowStateMock, initializeMock } =
+  vi.hoisted(() => ({
+    persistAppStateMock: vi.fn(async () => undefined),
+    persistWindowStateMock: vi.fn(async () => undefined),
+    fetchWindowStateMock: vi.fn(async () => null),
+    initializeMock: vi.fn(async () => undefined),
+  }));
+
+const { errorMock, warningMock, infoMock } = vi.hoisted(() => ({
+  errorMock: vi.fn((_msg: string) => "id"),
+  warningMock: vi.fn((_msg: string) => "id"),
+  infoMock: vi.fn((_msg: string) => "id"),
+}));
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { error: errorMock, warning: warningMock, info: infoMock },
+}));
+
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({
+    initialize: initializeMock,
+    loadAppState: vi.fn(async () => null),
+    getItem: vi.fn(async () => null),
+    loadEditorBuffer: vi.fn(async () => null),
+    clearEditorBuffer: vi.fn(async () => undefined),
+  }),
+}));
+
+vi.mock("@/lib/storage/app-state-manager", () => ({
+  fetchWindowState: fetchWindowStateMock,
+  persistWindowState: persistWindowStateMock,
+  persistAppState: persistAppStateMock,
+}));
+
+vi.mock("@/lib/project/workspace-persistence", () => ({
+  persistWorkspaceJson: vi.fn(async () => undefined),
+  toRelativePath: (p: string) => p,
+  toAbsolutePath: (p: string) => p,
+}));
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => ({ readFile: vi.fn(async () => "") }),
+}));
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+interface HarnessProps {
+  tabs: TabState[];
+  activeTabId: TabId;
+  isElectron?: boolean;
+  skipAutoRestore?: boolean;
+  setRestoreError?: (value: string | null) => void;
+}
+
+function Harness({
+  tabs,
+  activeTabId,
+  isElectron = false,
+  skipAutoRestore = true,
+  setRestoreError,
+}: HarnessProps): null {
+  const tabsRef = useRef<TabState[]>(tabs);
+  tabsRef.current = tabs;
+  const activeTabIdRef = useRef<TabId>(activeTabId);
+  activeTabIdRef.current = activeTabId;
+  const isProjectRef = useRef(false);
+
+  useTabPersistence({
+    tabs,
+    setTabs: vi.fn(),
+    activeTabId,
+    setActiveTabId: vi.fn(),
+    tabsRef,
+    activeTabIdRef,
+    isProjectRef,
+    isElectron,
+    skipAutoRestore,
+    setRestoreError: setRestoreError as never,
+    windowKey: null,
+  });
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  persistAppStateMock.mockReset();
+  persistAppStateMock.mockResolvedValue(undefined);
+  persistWindowStateMock.mockReset();
+  persistWindowStateMock.mockResolvedValue(undefined);
+  fetchWindowStateMock.mockReset();
+  fetchWindowStateMock.mockResolvedValue(null);
+  initializeMock.mockReset();
+  initializeMock.mockResolvedValue(undefined);
+  errorMock.mockClear();
+  warningMock.mockClear();
+  infoMock.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+async function flush(ms = 1500): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// #1967 — 永続化失敗のサイレント握り潰し → 通知
+// ---------------------------------------------------------------------------
+
+describe("#1967 — タブ状態の永続化失敗を通知へ変換", () => {
+  it("QuotaExceededError で永続化が失敗したら容量メッセージで一度だけ通知し、成功で解除して再通知できる", async () => {
+    const tabA = createNewTab("a");
+    const tabB = createNewTab("b");
+
+    // 初期マウント（成功）でゲートを開く。
+    await act(async () => {
+      root.render(<Harness tabs={[tabA]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    errorMock.mockClear();
+
+    // 以降の永続化を QuotaExceededError で失敗させる。
+    persistAppStateMock.mockRejectedValue(new DOMException("quota", "QuotaExceededError"));
+
+    // 変更1 → 失敗 → 通知1回。
+    await act(async () => {
+      root.render(<Harness tabs={[tabA, tabB]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).toHaveBeenCalledTimes(1);
+    expect(errorMock.mock.calls[0][0]).toContain("容量");
+
+    // 変更2 → なお失敗 → 連発しない（ストリーク中は抑制）。
+    await act(async () => {
+      root.render(<Harness tabs={[tabB, tabA]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).toHaveBeenCalledTimes(1);
+
+    // 成功に戻すとストリーク解除。
+    persistAppStateMock.mockResolvedValue(undefined);
+    await act(async () => {
+      root.render(<Harness tabs={[tabA]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).toHaveBeenCalledTimes(1);
+
+    // 再び失敗すると改めて通知（2回目）。
+    persistAppStateMock.mockRejectedValue(new DOMException("quota", "QuotaExceededError"));
+    await act(async () => {
+      root.render(<Harness tabs={[tabA, tabB]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("consistency — 永続化が成功している間はエラー通知を一切出さない", async () => {
+    const tabA = createNewTab("a");
+    const tabB = createNewTab("b");
+    await act(async () => {
+      root.render(<Harness tabs={[tabA]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    await act(async () => {
+      root.render(<Harness tabs={[tabA, tabB]} activeTabId={tabA.id} />);
+    });
+    await flush();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1968 K-4-3 — DB ロック起動時の無通知フォールバック
+// ---------------------------------------------------------------------------
+
+describe("#1968 K-4-3 — storage 初期化失敗（DB ロック）を通知", () => {
+  it("storage.initialize() が throw したら setRestoreError バナー + error トーストを出す", async () => {
+    initializeMock.mockRejectedValue(
+      Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY" }),
+    );
+    const setRestoreError = vi.fn();
+    const tabA = createNewTab("a");
+
+    await act(async () => {
+      root.render(
+        <Harness tabs={[tabA]} activeTabId={tabA.id} setRestoreError={setRestoreError} />,
+      );
+    });
+    await flush();
+
+    expect(setRestoreError).toHaveBeenCalledTimes(1);
+    expect(setRestoreError.mock.calls[0][0]).toContain("読み込めませんでした");
+    expect(errorMock).toHaveBeenCalledTimes(1);
+    expect(errorMock.mock.calls[0][0]).toContain("セッションの読み込みに失敗");
+  });
+
+  it("consistency — 初期化が成功すれば restore エラー通知は出ない", async () => {
+    const setRestoreError = vi.fn();
+    const tabA = createNewTab("a");
+    await act(async () => {
+      root.render(
+        <Harness tabs={[tabA]} activeTabId={tabA.id} setRestoreError={setRestoreError} />,
+      );
+    });
+    await flush();
+    expect(setRestoreError).not.toHaveBeenCalled();
+    expect(errorMock).not.toHaveBeenCalled();
+  });
+});

--- a/lib/tab-manager/tab-types.ts
+++ b/lib/tab-manager/tab-types.ts
@@ -115,6 +115,15 @@ export interface SerializedTab {
   fileName: string;
   isPreview?: boolean;
   fileType?: SupportedFileExtension;
+  /**
+   * Editor buffer of an unsaved, non-file-backed (untitled) tab (#1965).
+   *
+   * Standalone-mode untitled tabs have no disk backing, so unless their buffer
+   * is persisted here it is permanently lost on restart. Mirrors the project-mode
+   * `WorkspaceTab.unsavedContent` mechanism (#1868). File-backed tabs are restored
+   * from disk instead, so their content is intentionally not duplicated here.
+   */
+  unsavedContent?: string;
 }
 
 /** Persisted state for open tabs (stored in AppState) */

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -216,7 +216,26 @@ export function sanitizeMdiContent(
   return MdiDocument.fromEditorOutput(content, options).toRawText();
 }
 
+/**
+ * Web の IndexedDB / localStorage 容量超過は `QuotaExceededError`（`DOMException`）で
+ * 投げられる。`DOMException` は実行環境によって `instanceof Error` が false になる
+ * （Chromium 等では Error を継承しない）ため、Error 判定より前に name/code で判別する。
+ * legacy Firefox は `NS_ERROR_DOM_QUOTA_REACHED`、旧仕様は数値コード 22 を使う（#1967）。
+ */
+export function isQuotaExceededError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const e = error as { name?: unknown; code?: unknown };
+  return (
+    e.name === "QuotaExceededError" || e.name === "NS_ERROR_DOM_QUOTA_REACHED" || e.code === 22
+  );
+}
+
 export function getErrorMessage(error: unknown): string {
+  // 容量不足はプラットフォーム横断（Web=DOMException / Electron=ENOSPC）で
+  // 専用メッセージにまとめる。DOMException は instanceof Error をすり抜けるため先に判定。
+  if (isQuotaExceededError(error)) {
+    return "保存容量が不足しています。不要なデータを削除するか、別の保存先をご利用ください。";
+  }
   if (!(error instanceof Error)) return "不明なエラー";
   let message = error.message;
   const errorCode = (error as NodeJS.ErrnoException).code;

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -7,8 +7,15 @@ import { fetchWindowState, persistWindowState } from "../storage/app-state-manag
 import type { TabState, SerializedTab, TabPersistenceState, EditorTabState } from "./tab-types";
 import { isEditorTab } from "./tab-types";
 import type { TabManagerCore } from "./types";
-import { TAB_PERSIST_DEBOUNCE, createNewTab, generateTabId, inferFileType } from "./types";
+import {
+  TAB_PERSIST_DEBOUNCE,
+  createNewTab,
+  generateTabId,
+  getErrorMessage,
+  inferFileType,
+} from "./types";
 import { getProjectFileService } from "../services/project-file-service";
+import { notificationManager } from "../services/notification-manager";
 import type { WorkspaceTab } from "../project/project-types";
 import {
   persistWorkspaceJson,
@@ -122,6 +129,11 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
 
   const tabPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // タブ状態の永続化が失敗した際、ユーザーに一度だけ通知するためのゲート。
+  // 永続化は debounce で頻繁に走るため、失敗が続く間トーストを連発しないよう
+  // 失敗ストリーク中は通知を抑制し、次に成功したら解除する（#1967）。
+  const persistErrorNotifiedRef = useRef(false);
+
   /** Build and persist the current tab state immediately. */
   const persistTabStateNow = useCallback(async () => {
     const currentTabs = tabsRef.current;
@@ -194,9 +206,20 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     }
 
     tabPersistTimerRef.current = setTimeout(() => {
-      void persistTabStateNow().catch((error) => {
-        console.error("タブ状態の保存に失敗しました:", error);
-      });
+      void persistTabStateNow()
+        .then(() => {
+          // 成功したら失敗ストリークを解除し、次の失敗で再び通知できるようにする。
+          persistErrorNotifiedRef.current = false;
+        })
+        .catch((error) => {
+          console.error("タブ状態の保存に失敗しました:", error);
+          // 容量不足等の永続化失敗は「保存できているはず」という誤認を招くため、
+          // ストリークの先頭で一度だけ通知する（#1967）。
+          if (!persistErrorNotifiedRef.current) {
+            persistErrorNotifiedRef.current = true;
+            notificationManager.error(`セッションの保存に失敗しました: ${getErrorMessage(error)}`);
+          }
+        });
     }, TAB_PERSIST_DEBOUNCE);
 
     return () => {
@@ -352,6 +375,13 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
         }
       } catch (error) {
         console.error("ストレージの初期化に失敗しました:", error);
+        // DB がロック中（別プロセス起動など）/破損で初期化に失敗すると、空タブで
+        // 起動しつつセッションが読めなかったことをユーザーへ伝えていなかった（#1968 K-4-3）。
+        // バナー（setRestoreError）とトーストの両方で明示し、サイレント失敗を解消する。
+        setRestoreError?.(
+          "前回のセッションを読み込めませんでした。アプリが多重起動していないかを確認してください。",
+        );
+        notificationManager.error(`セッションの読み込みに失敗しました: ${getErrorMessage(error)}`);
         const errorTab = createNewTab();
         setTabs((prev) => (prev.length > 0 ? prev : [errorTab]));
         setActiveTabId((prev) => (prev === "" ? errorTab.id : prev));
@@ -363,7 +393,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     };
 
     void initializeStorage();
-  }, [isElectron, skipAutoRestore, setTabs, setActiveTabId]);
+  }, [isElectron, skipAutoRestore, setTabs, setActiveTabId, setRestoreError]);
 
   // --- Standalone-mode restore from AppState (Electron only) -------------
   // This ONLY handles standalone mode (no project). In project mode,

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -174,6 +174,12 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
       fileName: t.file?.name ?? "新規ファイル",
       isPreview: t.isPreview || undefined,
       fileType: t.fileType,
+      // #1965: persist the buffer of unsaved, non-file-backed (untitled) tabs so
+      // their content survives a restart. Standalone untitled tabs have no disk
+      // backing, so this is their only data-safety path (mirrors project-mode #1868).
+      // File-backed tabs are intentionally NOT duplicated: their content lives on
+      // disk and is re-read on restore.
+      unsavedContent: !t.file?.path && t.isDirty ? t.content : undefined,
     }));
     const state: TabPersistenceState = {
       tabs: serializedTabs,
@@ -400,33 +406,74 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
   // restoreProjectTabs() is called explicitly by the project-open handler,
   // replacing the old mount-time restore that had a race condition with windowKey.
   //
-  // Phase 4-5: electronAPI.vfs は削除済みのため、Electron スタンドアロンの
-  // マウント時自動復元は Phase 9 で新 IO 抽象に再配線するまで停止中。
-  // 旧復元ロジック (fetchWindowState → vfs.readFile → setTabs) は git 履歴を参照。
+  // #1965: マウント時に保存済み openTabs を読み、**filePath を持たない無題/未保存タブ**の
+  // バッファのみを復元する。
   //
-  // 復元はスキップするが、永続化ゲート (storageInitializedRef) は旧実装の
-  // finally と同じタイミングで必ず開く。開かないと「全タブを閉じた」等の
-  // 空タブ状態が永続化されず、次回起動時に古いタブ状態が残留する (#1567)。
+  // なぜ file-backed タブを復元しないか:
+  //   Electron スタンドアロンは VFS ルート (allowedRoots) が未設定のまま起動するため、
+  //   `getProjectFileService().readFile(絶対パス)` は main 側の validateVFSPath で必ず
+  //   「ディレクトリが開かれていません」で失敗する (electron/ipc/vfs-ipc.js)。よって
+  //   再起動時にファイル本体を再読込する経路は存在せず、無理に呼ぶと毎起動エラーになる。
+  //   file-backed タブ本体の復元は main プロセス側の承認済みファイル再読込 (Phase 9 の
+  //   新 IO 抽象) を前提とするため据え置く。ファイル実体は auto-save でディスク保護される。
+  //
+  // 無題タブは VFS を一切使わずバッファ (unsavedContent) から復元できるため、ここで救済する。
+  // 復元有無に関わらず、永続化ゲート (storageInitializedRef) は旧実装の finally と同じ
+  // タイミングで必ず開く。開かないと「全タブを閉じた」等の空タブ状態が永続化されず、
+  // 次回起動時に古いタブ状態が残留する (#1567)。
 
   useEffect(() => {
     if (!isElectron || skipAutoRestore) return;
 
     let cancelled = false;
-    const openPersistenceGate = async (): Promise<void> => {
+    const restoreStandaloneTabs = async (): Promise<void> => {
       // 旧実装と同様に VFS 準備 (最大 5 秒) を待ってからゲートを開き、
       // マウント直後の空タブ状態が保存済みデータを上書きする競合を避ける。
       if (vfsReadyPromise) {
         await Promise.race([vfsReadyPromise, new Promise<void>((r) => setTimeout(r, 5000))]);
       }
       if (cancelled) return;
-      storageInitializedRef.current = true;
+
+      try {
+        const key = windowKeyRef.current;
+        const windowState = key ? await fetchWindowState(key) : null;
+        const appState = windowState ? null : await getStorageService().loadAppState();
+        const savedOpenTabs = windowState?.openTabs ?? appState?.openTabs;
+        if (cancelled) return;
+
+        if (savedOpenTabs && savedOpenTabs.tabs.length > 0) {
+          const restored: EditorTabState[] = [];
+          for (const saved of savedOpenTabs.tabs) {
+            // file-backed タブはここでは復元しない (上記の VFS 制約による)。
+            if (saved.filePath) continue;
+            const unsaved = saved.unsavedContent ?? "";
+            const tab = createNewTab(unsaved, saved.fileType ?? ".mdi");
+            // 内容を持つ無題タブは dirty として復元し、保存を促す。空なら clean。
+            restored.push(
+              unsaved.length > 0 ? { ...tab, isDirty: true, fileSyncStatus: "dirty" } : tab,
+            );
+          }
+
+          if (!cancelled && restored.length > 0) {
+            const activeIdx = Math.min(Math.max(0, savedOpenTabs.activeIndex), restored.length - 1);
+            // ユーザーが待機中に開いたタブを上書きしないよう、空のときだけ反映する。
+            setTabs((prev) => (prev.length > 0 ? prev : restored));
+            setActiveTabId((prev) => (prev === "" ? restored[activeIdx].id : prev));
+          }
+        }
+      } catch (error) {
+        // 復元失敗はゲートを塞がず空起動で継続する (データ自体は失われない)。
+        console.warn("スタンドアロンタブの復元に失敗しました:", error);
+      } finally {
+        if (!cancelled) storageInitializedRef.current = true;
+      }
     };
 
-    void openPersistenceGate();
+    void restoreStandaloneTabs();
     return () => {
       cancelled = true;
     };
-  }, [isElectron, skipAutoRestore, vfsReadyPromise]);
+  }, [isElectron, skipAutoRestore, vfsReadyPromise, setTabs, setActiveTabId]);
 
   return { wasAutoRecovered, flushTabState, restoreProjectTabs };
 }

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -179,7 +179,14 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
       // backing, so this is their only data-safety path (mirrors project-mode #1868).
       // File-backed tabs are intentionally NOT duplicated: their content lives on
       // disk and is re-read on restore.
-      unsavedContent: !t.file?.path && t.isDirty ? t.content : undefined,
+      //
+      // Gate on the absence of ANY file descriptor (`!t.file`), not just a missing
+      // path. A browser File System Access tab has `file.path === null` but a
+      // non-null `file.handle`; using `!t.file?.path` would misclassify such a
+      // saved, handle-backed file as untitled and duplicate its full content into
+      // AppState (bloat + raises QuotaExceeded risk). Web file-backed tabs already
+      // recover via the editor-buffer path (Codex review).
+      unsavedContent: !t.file && t.isDirty ? t.content : undefined,
     }));
     const state: TabPersistenceState = {
       tabs: serializedTabs,


### PR DESCRIPTION
> 旧 #1980 はスタック base 削除に伴い GitHub が自動 close したため、同一ブランチで dev 宛に再作成。Codex 指摘(P2)修正済み。

## 根本原因 R3「復元の実装欠落」(#1965)

Electron スタンドアロンは再起動後にタブが復元されず、ディスク裏付けの無い**無題/未保存タブの内容が恒久的に失われる**。

### 根本制約（Phase 9 延期の真因）
スタンドアロンは VFS ルート未設定で起動するため、保存済み絶対パスの `readFile` は `electron/ipc/vfs-ipc.js:128-132` の `validateVFSPath` で**必ず失敗**。ナイーブ実装は毎起動エラー＝業務破壊。

## 安全サブセット（VFS 非依存）
- `SerializedTab.unsavedContent` 追加。**真の無題タブ（`!t.file`）**のバッファのみ保存。
- マウント時復元 stub を実装し無題タブのみ復元（内容あり=dirty/空=clean）。file-backed は据え置き＝`readFile` を呼ばない。
- 永続化ゲートは復元有無に関わらず従来タイミングで開く（#1567 退行防止）。

### Codex レビュー反映（P2）
`!t.file?.path` 判定は Web の File System Access タブ（`path=null` だが `handle` あり）を無題と誤判定し全文を AppState に重複保存していた → `!t.file`（記述子の不在）で判定するよう修正。

## テスト（エッジ網羅）
- `standalone-restore-untitled.test.tsx`: 内容あり→dirty / 空→clean / **file-backed のみ→readFile 不呼出** / 混在クランプ / 保存なし / prev 優先 / throw 非クラッシュ / ゲート開放(#1567)。
- `standalone-persist-untitled-gate.test.tsx`: 真の無題のみ unsavedContent 保存 / **Web file-backed 不保存(回帰)** / Electron file-backed 不保存 / 混在。
- 既存 `lib/tab-manager`+`lib/editor-page` 全 564 テスト green。

## 関連 issue
- #1965 の無題タブ損失部分を解消（file-backed 本体復元は Phase 9 依存のため close せず部分対応）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)