### PR TITLE
fix(lint): main-thread fallback の前処理 IPC をタイムボックス化し0件回帰を解消 (#1964)

### DIFF
--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/__tests__/with-timeout.test.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/__tests__/with-timeout.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for `withTimeout` — the time-boxing helper that keeps a stalled IPC
+ * pre-step (NLP tokenization / dictionary prewarm) from blocking the lint batch
+ * and zeroing out L1 detection in the packaged main-thread fallback (#1964).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { withTimeout } from "../decoration-plugin";
+
+describe("withTimeout (#1964 lint fallback guard)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves to the promise value when it settles within the budget", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), 1000, "fallback");
+    expect(result).toBe("ok");
+  });
+
+  it("resolves to the fallback when the promise never settles (stall)", async () => {
+    vi.useFakeTimers();
+    // A promise that never resolves — the packaged-renderer IPC hang scenario.
+    const neverSettles = new Promise<string>(() => {});
+    const raced = withTimeout(neverSettles, 5000, "fallback");
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(raced).resolves.toBe("fallback");
+  });
+
+  it("does not resolve before the budget elapses on a stall", async () => {
+    vi.useFakeTimers();
+    const neverSettles = new Promise<string>(() => {});
+    const raced = withTimeout(neverSettles, 5000, "fallback");
+    let settled = false;
+    void raced.then(() => {
+      settled = true;
+    });
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await expect(raced).resolves.toBe("fallback");
+  });
+
+  it("resolves to the fallback when the promise rejects", async () => {
+    const result = await withTimeout(Promise.reject(new Error("boom")), 1000, "fallback");
+    expect(result).toBe("fallback");
+  });
+
+  it("resolves to the fallback immediately when ms <= 0", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), 0, "fallback");
+    expect(result).toBe("fallback");
+  });
+
+  it("ignores a late resolution after the timeout has already fired", async () => {
+    vi.useFakeTimers();
+    let resolveLate!: (value: string) => void;
+    const late = new Promise<string>((resolve) => {
+      resolveLate = resolve;
+    });
+    const raced = withTimeout(late, 1000, "fallback");
+    await vi.advanceTimersByTimeAsync(1000);
+    // The underlying promise settles after the race already returned the fallback.
+    resolveLate("too-late");
+    await expect(raced).resolves.toBe("fallback");
+  });
+
+  it("works with a unique sentinel fallback (tokenize-timeout pattern)", async () => {
+    vi.useFakeTimers();
+    const TIMED_OUT = Symbol("timeout");
+    const neverSettles = new Promise<number[]>(() => {});
+    const raced = withTimeout<number[] | typeof TIMED_OUT>(neverSettles, 5000, TIMED_OUT);
+    await vi.advanceTimersByTimeAsync(5000);
+    await expect(raced).resolves.toBe(TIMED_OUT);
+  });
+});

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -17,7 +17,13 @@ import { LRUCache } from "@/shared/lib/lru-cache";
 import { hashString } from "@/shared/lib/hash-string";
 import { getAtomOffset, collectParagraphs } from "../shared/paragraph-helpers";
 import { getDictAccess } from "@/lib/dict/dict-access";
+import type { GenjiHealth } from "@/lib/dict/dict-access";
 import { collectDictCandidateTerms } from "@/lib/linting/dict-candidate-terms";
+
+// Derived from the already-allowed getDictAccess import so this package does not
+// reach into @/lib/dict/dict-types directly (import-boundary rule). Equals
+// Map<string, DictLookup>, the resolved value of DictAccess.lookupBatch().
+type DictLookupMap = Awaited<ReturnType<ReturnType<typeof getDictAccess>["lookupBatch"]>>;
 import type {
   LintingPluginState,
   LintingPluginOptions,
@@ -28,6 +34,58 @@ import { isSilentCancelError } from "./worker/protocol";
 import type { DictSnapshotPayload } from "./worker/protocol";
 
 export const lintingKey = new PluginKey<LintingPluginState>("linting");
+
+/**
+ * Time budget for the pre-`runBatch` IPC steps (NLP tokenization and dictionary
+ * prewarm). These steps depend on Electron IPC (`window.electronAPI.nlp.*` /
+ * dict-access), which can stall indefinitely in the packaged `file://` renderer
+ * — the exact environment where the lint worker already fails to start and the
+ * pass falls back to the main thread (#1964). A stalled pre-step would block the
+ * subsequent `runBatch`, so even regex (L1) rules — which need neither tokens nor
+ * the dictionary — never run, and the panel reports "0 件" despite enabled rules.
+ *
+ * Time-boxing each await guarantees we always reach `runBatch`: on timeout we
+ * degrade gracefully (skip L2 tokens / treat dict as not-ready) while L1 keeps
+ * detecting. The budget is generous so it never fires in normal operation
+ * (IPC resolves in milliseconds; even a first-time kuromoji dictionary load
+ * completes well within it) and only trips on a genuine hang.
+ */
+const PRESTEP_TIMEOUT_MS = 5000;
+
+/**
+ * Race a promise against a timeout. Resolves to `fallback` if `promise` does not
+ * settle within `ms`, or if it rejects. The underlying promise is left pending
+ * (it cannot be cancelled) but its eventual result is ignored. Used to keep a
+ * stalled IPC pre-step from blocking the synchronous lint batch (#1964).
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T> {
+  if (ms <= 0) return Promise.resolve(fallback);
+  return new Promise<T>((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        resolve(fallback);
+      }
+    }, ms);
+    promise.then(
+      (value) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(value);
+        }
+      },
+      () => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          resolve(fallback);
+        }
+      },
+    );
+  });
+}
 
 /**
  * Map severity to CSS class name for decoration styling.
@@ -277,15 +335,37 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           const useTokens = hasMorphRules && nlp && !nlpErrorFired;
           const tokensByText = new Map<string, ReadonlyArray<Token>>();
 
+          // Per-batch flag: set when a tokenization IPC call exceeds the budget.
+          // Unlike `nlpErrorFired` (a hard, session-sticky failure on throw), a
+          // timeout is treated as transient — we skip L2 for the rest of this
+          // pass so a hung NLP backend can't block L1, but the next pass retries
+          // (#1964). A unique sentinel distinguishes "timed out" from a real
+          // (always non-undefined) token array result.
+          let nlpTimedOut = false;
+          const TOKENIZE_TIMED_OUT = Symbol("tokenize-timeout");
+
           async function tokenizeIfNeeded(text: string): Promise<ReadonlyArray<Token> | undefined> {
-            // Re-check `nlpErrorFired` on every call so the first failure
-            // in a batch short-circuits the rest — otherwise a long doc
-            // with a broken NLP backend incurs one failed IPC per paragraph.
-            if (!useTokens || nlpErrorFired) return undefined;
+            // Re-check `nlpErrorFired`/`nlpTimedOut` on every call so the first
+            // failure or stall in a batch short-circuits the rest — otherwise a
+            // long doc with a broken/hung NLP backend incurs one failed or
+            // budget-length IPC per paragraph.
+            if (!useTokens || nlpErrorFired || nlpTimedOut) return undefined;
             const cached = tokenCache.get(text);
             if (cached) return cached;
             try {
-              const fresh = await nlp!.tokenizeParagraph(text);
+              const fresh = await withTimeout<Token[] | typeof TOKENIZE_TIMED_OUT>(
+                nlp!.tokenizeParagraph(text),
+                PRESTEP_TIMEOUT_MS,
+                TOKENIZE_TIMED_OUT,
+              );
+              if (fresh === TOKENIZE_TIMED_OUT) {
+                // Stall (not a throw): degrade L2 for this pass but let L1 run.
+                nlpTimedOut = true;
+                console.warn(
+                  "[Linting] NLP tokenization timed out — L2 rules skipped this pass (#1964)",
+                );
+                return undefined;
+              }
               tokenCache.set(text, fresh);
               return fresh;
             } catch (err) {
@@ -334,25 +414,47 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
             }
             try {
               const access = getDictAccess();
-              const health = await access.getHealth();
+              // Time-box dict IPC so a stalled getHealth/lookupBatch cannot block
+              // `runBatch` and zero out L1 detection (#1964). On timeout we degrade
+              // to "dict not ready", which is the fail-safe state for out-of-dict
+              // rules (they skip rather than flag every term as unknown).
+              const health = await withTimeout<GenjiHealth | null>(
+                access.getHealth(),
+                PRESTEP_TIMEOUT_MS,
+                null,
+              );
               if (version !== processingVersion) return;
-              const ready = health.state === "ready";
-              let entries: DictSnapshotPayload["entries"] = [];
+              const ready = health?.state === "ready";
               if (ready && terms.size > 0) {
-                const map = await access.lookupBatch([...terms]);
+                const map = await withTimeout<DictLookupMap | null>(
+                  access.lookupBatch([...terms]),
+                  PRESTEP_TIMEOUT_MS,
+                  null,
+                );
                 if (version !== processingVersion) return;
-                // Treat known terms (user dictionary + other dictionary rulesets)
-                // as dictionary hits so out-of-dict rules never flag them. Mirrors
-                // applyKnownTermsToSnapshot in @/lib/linting/known-terms, inlined
-                // here to keep this package free of application-root imports.
-                if (currentKnownTerms.size > 0) {
-                  for (const term of terms) {
-                    if (currentKnownTerms.has(term)) map.set(term, { found: true });
+                if (!map) {
+                  // lookup stalled: ship dict as not-ready so out-of-dict rules
+                  // stay fail-safe (an empty entries list with ready=true would
+                  // make every term look unknown → false positives).
+                  console.warn(
+                    "[Linting] dictionary lookup timed out — dict treated as not ready (#1964)",
+                  );
+                  dictPayload = { ready: false, entries: [] };
+                } else {
+                  // Treat known terms (user dictionary + other dictionary rulesets)
+                  // as dictionary hits so out-of-dict rules never flag them. Mirrors
+                  // applyKnownTermsToSnapshot in @/lib/linting/known-terms, inlined
+                  // here to keep this package free of application-root imports.
+                  if (currentKnownTerms.size > 0) {
+                    for (const term of terms) {
+                      if (currentKnownTerms.has(term)) map.set(term, { found: true });
+                    }
                   }
+                  dictPayload = { ready, entries: [...map.entries()] };
                 }
-                entries = [...map.entries()];
+              } else {
+                dictPayload = { ready, entries: [] };
               }
-              dictPayload = { ready, entries };
             } catch (err) {
               console.error("[Linting] dictionary prewarm failed:", err);
               dictPayload = { ready: false, entries: [] };


### PR DESCRIPTION
## 概要

packaged macOS Beta で lint worker が起動失敗し main-thread fallback に切り替わった後、公式ルールセットが有効表示にもかかわらず **検出結果が常に0件** になる P0 回帰 (#1964) を修正します。校正機能全体が実質停止する回帰でした。

## 根本原因

#1628 で `genji-vocab`（L2 形態素 + 辞書ルール）が公式ルールセットに追加された結果、main-thread fallback でも `hasMorphologicalRules()` / `hasDictRules()` が `true` を返すようになりました。これにより `runBatch` の手前で走る以下2つの **Electron IPC 前処理** が有効化されます:

1. NLP tokenize (`nlp.tokenizeParagraph` / `window.electronAPI.nlp.*`)
2. dict prewarm (`getDictAccess().getHealth()` / `lookupBatch()`)

packaged `file://` renderer ではこれらの IPC が stall することがあり（lint worker が起動失敗するのと同じ環境要因）、`await` が返らないため後続の `runBatch` に到達せず、**L1（正規表現）ルールを含むバッチ全体が実行されず0件**になります。#1831 時点では fallback に非辞書 L1 ルールのみが載っていたため両前処理が skip され、L1 が NLP/辞書の可用性から独立して動いていました。

## 修正

`withTimeout` ヘルパーで tokenize / dict `getHealth` / `lookupBatch` の各 `await` をタイムボックス化（5秒）。stall 時は:
- tokenize → L2 トークンを諦め（当パスのみ、次パスで再試行）
- dict → **not-ready 扱いに degrade**（fail-safe。`ready=true` で空 entries だと辞書外語が全語を未知判定し誤検出するため、stall 時は必ず `ready=false`）

いずれの場合も **必ず `runBatch` に到達**させ、L1 検出を NLP/辞書の可用性から切り離します（#1831 の挙動を復元）。timeout は通常時（IPC は ms で解決、初回 kuromoji ロードも budget 内）には発火せず、真の hang 時のみトリップします。

## テスト

- 新規 `with-timeout.test.ts`（7件）: settle / stall→fallback / budget 前は未解決 / reject→fallback / ms<=0 / late-resolve 無視 / sentinel パターン
- 既存スイート全 green（219 files / 2536 tests）、type-check・import-boundaries green

## 補足

#1972 の診断ログ（N/M/K, dict/morph/dictReady）はそのまま残し、packaged 実機で degrade 発火を観測可能にしています。本修正は「どの IPC が stall するか」に依存しない防御的修正で、通常動作を退行させません。

Closes #1964