### PR TITLE
fix(style): 左右パネル境界線の太さを対称化（左の二重ボーダーを解消）

### DIFF
--- a/components/Characters.tsx
+++ b/components/Characters.tsx
@@ -199,7 +199,7 @@ function Characters({ content }: CharactersProps) {
   }, []);
 
   return (
-    <div className="h-full bg-background-secondary border-r border-border flex flex-col">
+    <div className="h-full bg-background-secondary flex flex-col">
       {/* Header */}
       <div className="p-4 border-b border-border flex items-center justify-between">
         <h2 className="text-lg font-semibold text-foreground">登場人物</h2>

--- a/components/Dictionary.tsx
+++ b/components/Dictionary.tsx
@@ -325,7 +325,7 @@ function Dictionary({ content, initialSearchTerm, searchTriggerId, editorMode }:
   }, []);
 
   return (
-    <div className="h-full bg-background-secondary border-r border-border flex flex-col">
+    <div className="h-full bg-background-secondary flex flex-col">
       {/* Header */}
       <div className="px-4 py-2.5 border-b border-border">
         <div className="flex items-center justify-between mb-2">

--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -33,7 +33,7 @@ export default function Explorer({
   }, [activeTab]);
 
   return (
-    <aside className={clsx("h-full bg-background border-r border-border flex flex-col", className)}>
+    <aside className={clsx("h-full bg-background flex flex-col", className)}>
       {/* Tabs */}
       <div
         className={clsx("border-b border-border flex items-center", compactMode ? "h-10" : "h-12")}

--- a/components/Outline.tsx
+++ b/components/Outline.tsx
@@ -62,7 +62,7 @@ export default function Outline({
   );
 
   return (
-    <aside className={clsx("h-full bg-background border-r border-border flex flex-col", className)}>
+    <aside className={clsx("h-full bg-background flex flex-col", className)}>
       {/* ヘッダー */}
       <div className="h-12 border-b border-border flex items-center px-4">
         <h2 className="text-sm font-medium text-foreground flex-1">アウトライン</h2>

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -430,7 +430,7 @@ export default function SearchResults({
   };
 
   return (
-    <div className="h-full bg-background-secondary border-r border-border flex flex-col">
+    <div className="h-full bg-background-secondary flex flex-col">
       <div className="p-4 border-b border-border flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Search className="w-5 h-5 text-foreground-secondary" />

--- a/shared/ui/ResizablePanel.tsx
+++ b/shared/ui/ResizablePanel.tsx
@@ -88,17 +88,16 @@ export default function ResizablePanel({
       className={clsx(
         "relative flex-shrink-0",
         !isResizing && "transition-all duration-300 ease-in-out",
-        // 左ナビゲーション側は ActivityBar(bg-background-tertiary rgb 30,30,30)の
-        // 背景ブロックが境界を明瞭にするが、右インスペクタは隣接ブロックが無く
+        // 左右の境界線はこの ResizablePanel が唯一の発生源（内側のサイドバー各
+        // コンポーネントからは border を除去済み）。左右で同一の太さ・色で描画する。
         // ダークテーマでは 1px の border-border(rgb 45,45,45)が暗いエディタ背景
-        // (rgb 8,8,8)に紛れて「境界線が無い」ように見える。そのためダーク時のみ
-        // 右側を 2px かつより明るい border-border-secondary(rgb 60,60,60)で強調する。
-        // ライトテーマでは border-border(rgb 210)が 1px でも十分視認でき、2px だと
-        // 左ボーダー(1px)と太さ・濃さが食い違って不揃いに見えるため左右対称に揃える。
+        // (rgb 8,8,8)に紛れて見えづらいため、両側とも 2px かつより明るい
+        // border-border-secondary(rgb 60,60,60)で強調する。ライトテーマでは
+        // border-border(rgb 210)の 1px で左右とも十分視認でき、太さも揃う。
         !isCollapsed &&
           (side === "right"
             ? "border-l border-border dark:border-l-2 dark:border-border-secondary"
-            : "border-r border-border"),
+            : "border-r border-border dark:border-r-2 dark:border-border-secondary"),
         className,
       )}
       style={{ width: isCollapsed ? "0px" : `${width}px` }}


### PR DESCRIPTION
## 問題
左サイドバーとエディタの境界線が、右インスペクタ側の境界線より太く、何度調整しても太さが揃わなかった。

## 根本原因
左サイドバーの境界線が**二重**になっていた:
- 左: `ResizablePanel`(side=left) の `border-r` ＋ 内側コンポーネント（Outline / Dictionary / Characters / SearchResults / Explorer）各自の `border-r` → **2本重なって太い**
- 右: `ResizablePanel`(side=right) の `border-l` のみ（Inspector は border 無し）→ **1本で細い**

`ResizablePanel` のコメントには「左右対称に揃える」とあったが、実コードは dark で右のみ 2px 強調・左は常に 1px ＋内側二重、という非対称のままだった。

## 修正
1. 内側5コンポーネントから `border-r border-border` を削除（二重化を解消）
2. 境界線の発生源を `ResizablePanel` に一元化し左右を完全対称化
   - ライト: 両側とも `border-border` 1px
   - ダーク: 両側とも `border-border-secondary` 2px（`dark:border-r-2` を左にも追加）

## 確認
- 型チェック clean
- ローカル Electron dev で左右の境界線が同一太さになることを確認

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)