### PR TITLE
fix(persistence): スタンドアロン file-backed タブを承認済みパス IPC で復元 (#1965)

### DIFF
--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -1,6 +1,6 @@
 // File-related IPC handlers: open, save, export, and file security utilities
 
-const { ipcMain, dialog } = require("electron");
+const { ipcMain, dialog, app } = require("electron");
 const path = require("path");
 const fs = require("fs/promises");
 const log = require("electron-log");
@@ -9,6 +9,31 @@ const { normalizeSeparators } = require("../lib/path-utils");
 const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
 const { FILE_CHANNELS, EXPORT_CHANNELS } = require("../lib/ipc-channels");
 const { readFileStrictUtf8 } = require("../lib/text-decode");
+const { addStandalonePath, hasStandalonePath } = require("../lib/standalone-files");
+
+/**
+ * Absolute path to the persisted standalone-opened-paths allowlist (#1965).
+ * Resolved lazily so tests/headless contexts without an Electron `app` don't
+ * crash at module load.
+ * @returns {string}
+ */
+function getStandalonePathsFile() {
+  return path.join(app.getPath("userData"), "approved-standalone-paths.json");
+}
+
+/**
+ * Record a standalone-opened file in the persisted allowlist so it can be
+ * re-read on the next launch (session restore). Failures are non-fatal: opening
+ * the file must still succeed even if the allowlist write fails.
+ * @param {string} resolvedPath - Already path.resolve()'d absolute path
+ */
+async function rememberStandalonePath(resolvedPath) {
+  try {
+    await addStandalonePath(getStandalonePathsFile(), resolvedPath);
+  } catch (err) {
+    log.warn("standalone パスの永続化に失敗しました:", err);
+  }
+}
 
 // --- save-file path security validation ---
 // Tracks file paths that have been approved via native dialog or system file association,
@@ -180,7 +205,10 @@ async function handleMdiFileOpen(filePath) {
       // Open as standalone file
       log.info("Opening as standalone file:", filePath);
       // Approve system-opened file path for future saves, scoped to the target window
-      approveDialogPath(targetWindow.webContents.id, path.resolve(filePath));
+      const resolved = path.resolve(filePath);
+      approveDialogPath(targetWindow.webContents.id, resolved);
+      // Persist to the standalone allowlist so it can be restored after a restart (#1965).
+      await rememberStandalonePath(resolved);
       // Read as strict UTF-8: non-UTF-8 manuscripts throw instead of opening
       // with lossy U+FFFD that would later be saved back over the original (#1888).
       // BOM is stripped inside readFileStrictUtf8 (#1842).
@@ -225,13 +253,44 @@ function registerFileHandlers() {
     const filePath = filePaths[0];
     // Approve opened file path so it can be saved back without a new dialog.
     // Scoped to the requesting window to prevent cross-window reuse.
-    approveDialogPath(event.sender.id, path.resolve(filePath));
+    const resolved = path.resolve(filePath);
+    approveDialogPath(event.sender.id, resolved);
+    // Persist to the standalone allowlist so it can be restored after a restart (#1965).
+    await rememberStandalonePath(resolved);
     // Read as strict UTF-8: non-UTF-8 files throw (surfaced to the renderer as
     // a "UTF-8 へ変換してから開いてください" notice) instead of opening with
     // lossy U+FFFD that a later save would write back over the original (#1888).
     // BOM is stripped inside readFileStrictUtf8 (#1842).
     const content = await readFileStrictUtf8(filePath);
     return { path: filePath, content };
+  });
+
+  // Re-read a standalone file for session restore (#1965). Unlike `open-file`
+  // (which prompts a dialog) this reads silently — but ONLY for paths the user
+  // previously opened in standalone mode (persisted allowlist). This is the safe
+  // restore path for Electron standalone, where `vfs:read-file` always fails
+  // because no VFS root is set. A successful read re-approves the path for the
+  // requesting window so subsequent saves work without a fresh dialog.
+  ipcMain.handle(FILE_CHANNELS.invoke.readStandaloneFile, async (event, filePath) => {
+    if (typeof filePath !== "string" || !filePath) {
+      return { success: false, code: "INVALID_INPUT", error: "Invalid file path" };
+    }
+    const resolved = path.resolve(filePath);
+    // Gate on the persisted allowlist: never read a path the user did not open.
+    if (!(await hasStandalonePath(getStandalonePathsFile(), resolved))) {
+      return { success: false, code: "NOT_APPROVED", error: "未承認のパスです" };
+    }
+    try {
+      // BOM is stripped inside readFileStrictUtf8 (#1842); non-UTF-8 throws (#1888).
+      const content = await readFileStrictUtf8(resolved);
+      // Re-approve for this window so the restored tab can be saved back.
+      approveDialogPath(event.sender.id, resolved);
+      return { success: true, path: resolved, content };
+    } catch (err) {
+      const code = err && err.code ? String(err.code) : "READ_FAILED";
+      log.warn(`standalone ファイルの復元読み込みに失敗しました (${resolved}):`, err);
+      return { success: false, code, error: String((err && err.message) || err) };
+    }
   });
 
   ipcMain.handle(FILE_CHANNELS.invoke.saveFile, async (event, filePath, content, fileType) => {

--- a/electron/lib/__tests__/ipc-bridge.test.ts
+++ b/electron/lib/__tests__/ipc-bridge.test.ts
@@ -120,6 +120,7 @@ describe("ipc-channels: pinned channel names (public IPC contract)", () => {
       openFile: "open-file",
       saveFile: "save-file",
       getPendingFile: "get-pending-file",
+      readStandaloneFile: "read-standalone-file",
     });
     expect(FILE_CHANNELS.event).toEqual({
       openFileFromSystem: "open-file-from-system",

--- a/electron/lib/__tests__/standalone-files.test.ts
+++ b/electron/lib/__tests__/standalone-files.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for the persisted standalone-opened-paths allowlist (#1965).
+ *
+ * This is the security boundary for session restore of file-backed standalone
+ * tabs: only paths the user actually opened (recorded here) may be re-read by
+ * the `read-standalone-file` IPC.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+
+// CommonJS module under test.
+import {
+  loadStandalonePaths,
+  hasStandalonePath,
+  addStandalonePath,
+  clearStandalonePathsCache,
+  MAX_STANDALONE_PATHS,
+} from "../standalone-files";
+
+let dir: string;
+let file: string;
+
+beforeEach(async () => {
+  clearStandalonePathsCache();
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "standalone-files-"));
+  file = path.join(dir, "approved-standalone-paths.json");
+});
+
+afterEach(async () => {
+  clearStandalonePathsCache();
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe("standalone-files (#1965 persisted allowlist)", () => {
+  it("returns empty set / false when the file does not exist", async () => {
+    expect(await loadStandalonePaths(file)).toEqual(new Set());
+    expect(await hasStandalonePath(file, "/abs/never.mdi")).toBe(false);
+  });
+
+  it("records a path and reports membership after a fresh process (cache cleared)", async () => {
+    await addStandalonePath(file, "/abs/novel.mdi");
+    clearStandalonePathsCache(); // simulate restart: forget in-memory cache
+    expect(await hasStandalonePath(file, "/abs/novel.mdi")).toBe(true);
+    expect(await loadStandalonePaths(file)).toEqual(new Set(["/abs/novel.mdi"]));
+  });
+
+  it("persists to disk in the documented schema", async () => {
+    await addStandalonePath(file, "/abs/a.mdi");
+    const raw = JSON.parse(await fs.readFile(file, "utf-8"));
+    expect(raw.version).toBe(1);
+    expect(Array.isArray(raw.paths)).toBe(true);
+    expect(raw.paths[0].path).toBe("/abs/a.mdi");
+    expect(typeof raw.paths[0].openedAt).toBe("string");
+  });
+
+  it("is idempotent and does not duplicate an existing path", async () => {
+    await addStandalonePath(file, "/abs/a.mdi");
+    await addStandalonePath(file, "/abs/a.mdi");
+    const set = await loadStandalonePaths(file);
+    expect(set.size).toBe(1);
+  });
+
+  it("rejects non-approved paths (fail closed)", async () => {
+    await addStandalonePath(file, "/abs/a.mdi");
+    expect(await hasStandalonePath(file, "/abs/other.mdi")).toBe(false);
+    expect(await hasStandalonePath(file, "")).toBe(false);
+    // @ts-expect-error — defensive: non-string input
+    expect(await hasStandalonePath(file, null)).toBe(false);
+  });
+
+  it("evicts oldest entries past the cap", async () => {
+    for (let i = 0; i < MAX_STANDALONE_PATHS + 5; i++) {
+      await addStandalonePath(file, `/abs/file-${i}.mdi`);
+    }
+    const set = await loadStandalonePaths(file);
+    expect(set.size).toBe(MAX_STANDALONE_PATHS);
+    // The 5 oldest should have been evicted; the newest must remain.
+    expect(set.has("/abs/file-0.mdi")).toBe(false);
+    expect(set.has(`/abs/file-${MAX_STANDALONE_PATHS + 4}.mdi`)).toBe(true);
+  });
+
+  it("tolerates a corrupt JSON file (treats as empty)", async () => {
+    await fs.writeFile(file, "{ not valid json", "utf-8");
+    clearStandalonePathsCache();
+    expect(await loadStandalonePaths(file)).toEqual(new Set());
+    // ...and can still record new paths afterwards.
+    await addStandalonePath(file, "/abs/recovered.mdi");
+    clearStandalonePathsCache();
+    expect(await hasStandalonePath(file, "/abs/recovered.mdi")).toBe(true);
+  });
+
+  it("drops malformed entries on load", async () => {
+    await fs.writeFile(
+      file,
+      JSON.stringify({ version: 1, paths: [{ path: "/abs/ok.mdi" }, { nope: true }, null, 42] }),
+      "utf-8",
+    );
+    clearStandalonePathsCache();
+    expect(await loadStandalonePaths(file)).toEqual(new Set(["/abs/ok.mdi"]));
+  });
+});

--- a/electron/lib/ipc-channels.js
+++ b/electron/lib/ipc-channels.js
@@ -71,6 +71,7 @@ const FILE_CHANNELS = Object.freeze({
     openFile: "open-file",
     saveFile: "save-file",
     getPendingFile: "get-pending-file",
+    readStandaloneFile: "read-standalone-file",
   }),
   event: Object.freeze({
     openFileFromSystem: "open-file-from-system",

--- a/electron/lib/standalone-files.js
+++ b/electron/lib/standalone-files.js
@@ -1,0 +1,128 @@
+"use strict";
+/**
+ * Persistence for standalone-opened file paths (#1965).
+ *
+ * Standalone mode (no project) opens single files via the native open dialog or
+ * the OS file association. Those approvals normally live only in the per-window
+ * in-memory registry (electron/lib/approved-paths.js) and are lost on restart,
+ * so after a restart/crash the renderer has no safe way to re-read a previously
+ * open file — `vfs:read-file` always fails because standalone has no VFS root.
+ *
+ * This module records the set of paths the user actually opened in standalone
+ * mode to a JSON file in userData, so the `read-standalone-file` IPC can re-read
+ * exactly those paths (and nothing else) when restoring the previous session.
+ *
+ * Schema (approved-standalone-paths.json):
+ * {
+ *   "version": 1,
+ *   "paths": [ { "path": "/Users/.../novel.mdi", "openedAt": "2026-..." } ]
+ * }
+ *
+ * Security properties:
+ * - Append-only allowlist: a path is added ONLY when the user opens it through a
+ *   native dialog or OS file association (a genuine user action). A compromised
+ *   renderer cannot add arbitrary paths here, so the restore-read IPC cannot be
+ *   coerced into reading files the user never opened.
+ * - Bounded: capped at MAX_STANDALONE_PATHS with oldest-first eviction so the
+ *   list cannot grow without bound.
+ * - TOCTOU: existence is NOT checked here; the read path validates membership and
+ *   then reads, surfacing ENOENT to the caller.
+ */
+
+const fs = require("fs/promises");
+
+/** Maximum standalone paths retained before oldest-first eviction. */
+const MAX_STANDALONE_PATHS = 500;
+
+/**
+ * In-memory cache so we don't re-read the JSON file on every check.
+ * Invalidated (replaced) whenever addStandalonePath() writes new data, and
+ * resettable via clearStandalonePathsCache() (tests / fresh-process simulation).
+ * @type {Array<{path: string, openedAt: string}> | null}
+ */
+let pathsCache = null;
+
+/**
+ * Load the entire paths array from disk (or return the in-memory cache).
+ * Returns an empty array when the file is missing or corrupt.
+ *
+ * @param {string} filePath - Absolute path to approved-standalone-paths.json
+ * @returns {Promise<Array<{path: string, openedAt: string}>>}
+ */
+async function loadAll(filePath) {
+  if (pathsCache !== null) return pathsCache;
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const data = JSON.parse(raw);
+    if (data?.version !== 1 || !Array.isArray(data.paths)) {
+      pathsCache = [];
+    } else {
+      // Defensive: keep only well-formed entries.
+      pathsCache = data.paths.filter(
+        (e) => e !== null && typeof e === "object" && typeof e.path === "string",
+      );
+    }
+  } catch {
+    pathsCache = [];
+  }
+  return pathsCache;
+}
+
+/**
+ * Load the set of approved standalone paths.
+ *
+ * @param {string} filePath - Absolute path to approved-standalone-paths.json
+ * @returns {Promise<Set<string>>}
+ */
+async function loadStandalonePaths(filePath) {
+  const all = await loadAll(filePath);
+  return new Set(all.map((e) => e.path));
+}
+
+/**
+ * Check whether a path was previously opened in standalone mode.
+ *
+ * @param {string} filePath - Absolute path to approved-standalone-paths.json
+ * @param {string} p - Candidate absolute path (caller should pre-resolve)
+ * @returns {Promise<boolean>}
+ */
+async function hasStandalonePath(filePath, p) {
+  if (typeof p !== "string" || !p) return false;
+  const all = await loadAll(filePath);
+  return all.some((e) => e.path === p);
+}
+
+/**
+ * Record a standalone-opened path (idempotent; refreshes recency). Persists to
+ * disk and updates the cache. Applies oldest-first eviction past the cap.
+ *
+ * @param {string} filePath - Absolute path to approved-standalone-paths.json
+ * @param {string} p - Resolved absolute path the user opened
+ */
+async function addStandalonePath(filePath, p) {
+  if (typeof p !== "string" || !p) return;
+  const all = await loadAll(filePath);
+  // Move-to-end recency: drop any existing entry, then append fresh.
+  const next = all.filter((e) => e.path !== p);
+  next.push({ path: p, openedAt: new Date().toISOString() });
+  // Evict oldest (front) entries past the cap.
+  const capped =
+    next.length > MAX_STANDALONE_PATHS ? next.slice(next.length - MAX_STANDALONE_PATHS) : next;
+  pathsCache = capped;
+  await fs.writeFile(filePath, JSON.stringify({ version: 1, paths: capped }, null, 2), "utf-8");
+}
+
+/**
+ * Invalidate the in-memory cache. Used in tests to simulate a fresh process start.
+ */
+function clearStandalonePathsCache() {
+  pathsCache = null;
+}
+
+module.exports = {
+  loadStandalonePaths,
+  hasStandalonePath,
+  addStandalonePath,
+  clearStandalonePathsCache,
+  MAX_STANDALONE_PATHS,
+};

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -57,6 +57,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onOpenFileFromSystem: eventChannel(FILE_CHANNELS.event.openFileFromSystem),
   onOpenAsProject: eventChannel(FILE_CHANNELS.event.openAsProject),
   getPendingFile: invokeChannel(FILE_CHANNELS.invoke.getPendingFile, { arity: 0 }),
+  // #1965: re-read a previously-opened standalone file for session restore.
+  readStandaloneFile: invokeChannel(FILE_CHANNELS.invoke.readStandaloneFile, { arity: 1 }),
   onPasteAsPlaintext: eventChannel(MENU_CHANNELS.event.pasteAsPlaintext, { arity: 0 }),
   showInFileManager: invokeChannel(SHELL_CHANNELS.invoke.showInFileManager, { arity: 1 }),
   revealInFileManager: invokeChannel(SHELL_CHANNELS.invoke.revealInFileManager, { arity: 1 }),

--- a/lib/tab-manager/__tests__/standalone-restore-untitled.test.tsx
+++ b/lib/tab-manager/__tests__/standalone-restore-untitled.test.tsx
@@ -1,13 +1,14 @@
 /**
- * Electron スタンドアロン無題タブ復元のテスト（#1965 の安全サブセット）。
+ * Electron スタンドアロンタブ復元のテスト（#1965）。
  *
  * 背景: スタンドアロンは VFS ルート未設定で起動するため、保存済み file-backed タブを
  * `getProjectFileService().readFile(絶対パス)` で再読込しようとすると main 側
- * validateVFSPath が必ず失敗する。よってファイル本体復元は Phase 9 の IO 抽象まで据え置き、
- * ここでは **filePath を持たない無題/未保存タブのバッファのみ** を VFS 非依存で復元する。
+ * validateVFSPath が必ず失敗する。よって file-backed タブは VFS ではなく main プロセスの
+ * 承認済みパス再読込 IPC `window.electronAPI.readStandaloneFile` で復元する。無題/未保存
+ * タブは VFS 非依存でバッファ (unsavedContent) から復元する。
  *
- * 最重要(業務非破壊): file-backed タブに対して readFile を**呼ばない**こと
- *  = 毎起動の復元失敗エラーを誘発しないこと。
+ * 最重要(業務非破壊): file-backed タブに対して VFS の readFile を**呼ばない**こと
+ *  = 毎起動の validateVFSPath 失敗エラーを誘発しないこと。復元は readStandaloneFile 経由。
  *
  * REAL フックを createRoot + act で駆動（electron-gate テストと同じパターン）。
  */
@@ -28,6 +29,16 @@ const { fetchWindowStateMock, persistWindowStateMock, persistAppStateMock, loadA
   }));
 
 const { readFileSpy } = vi.hoisted(() => ({ readFileSpy: vi.fn(async () => "DISK") }));
+
+// #1965: main プロセスの承認済みパス再読込 IPC のモック。
+const { readStandaloneFileMock } = vi.hoisted(() => ({
+  readStandaloneFileMock: vi.fn(
+    async (filePath: string) =>
+      ({ success: true, path: filePath, content: "DISK" }) as
+        | { success: true; path: string; content: string }
+        | { success: false; code?: string; error?: string },
+  ),
+}));
 
 vi.mock("@/lib/services/notification-manager", () => ({
   notificationManager: { error: vi.fn(), warning: vi.fn(), info: vi.fn() },
@@ -127,6 +138,15 @@ beforeEach(() => {
   persistAppStateMock.mockResolvedValue(undefined);
   readFileSpy.mockReset();
   readFileSpy.mockResolvedValue("DISK");
+  readStandaloneFileMock.mockReset();
+  readStandaloneFileMock.mockImplementation(async (filePath: string) => ({
+    success: true,
+    path: filePath,
+    content: "DISK",
+  }));
+  (window as unknown as { electronAPI?: unknown }).electronAPI = {
+    readStandaloneFile: readStandaloneFileMock,
+  };
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -137,6 +157,7 @@ afterEach(async () => {
     root.unmount();
   });
   container.remove();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
   vi.useRealTimers();
 });
 
@@ -194,33 +215,17 @@ describe("#1965 — スタンドアロン無題タブの復元（安全サブセ
     expect(readFileSpy).not.toHaveBeenCalled();
   });
 
-  it("【業務非破壊】file-backed タブのみのときは復元せず readFile を呼ばない", async () => {
+  it("file-backed タブを readStandaloneFile 経由で復元する（VFS readFile は呼ばない）", async () => {
     loadAppStateMock.mockResolvedValue({
       openTabs: {
         tabs: [serialized({ filePath: "/abs/manuscript.mdi", fileName: "manuscript.mdi" })],
         activeIndex: 0,
       },
     });
-    const setTabs = vi.fn();
-    const setActiveTabId = vi.fn();
-
-    await mountAndSettle({ setTabs, setActiveTabId, windowKey: null });
-
-    // file-backed は据え置き → restore 由来の setTabs は呼ばれない。
-    expect(restoredTabsFrom(setTabs)).toBeNull();
-    // 毎起動エラー(validateVFSPath 失敗)を誘発しないことの保証。
-    expect(readFileSpy).not.toHaveBeenCalled();
-  });
-
-  it("file-backed + 無題 混在では無題のみ復元し activeIndex をクランプする", async () => {
-    loadAppStateMock.mockResolvedValue({
-      openTabs: {
-        tabs: [
-          serialized({ filePath: "/abs/a.mdi", fileName: "a.mdi" }),
-          serialized({ unsavedContent: "下書き", fileType: ".mdi" }),
-        ],
-        activeIndex: 0, // file-backed を指していても、復元後リストにクランプ。
-      },
+    readStandaloneFileMock.mockResolvedValue({
+      success: true,
+      path: "/abs/manuscript.mdi",
+      content: "本文ディスク内容",
     });
     const setTabs = vi.fn();
     const setActiveTabId = vi.fn();
@@ -229,10 +234,64 @@ describe("#1965 — スタンドアロン無題タブの復元（安全サブセ
 
     const restored = restoredTabsFrom(setTabs);
     expect(restored).toHaveLength(1);
-    expect(restored![0].content).toBe("下書き");
-    // setActiveTabId updater("") は復元済みリストの範囲内 id を返す（範囲外参照しない）。
+    expect(restored![0].file?.path).toBe("/abs/manuscript.mdi");
+    expect(restored![0].file?.name).toBe("manuscript.mdi");
+    expect(restored![0].content).toBe("本文ディスク内容");
+    expect(restored![0].isDirty).toBe(false);
+    expect(restored![0].fileSyncStatus).toBe("clean");
+    // 復元は承認済みパス IPC 経由。VFS の readFile は呼ばない（validateVFSPath 失敗回避）。
+    expect(readStandaloneFileMock).toHaveBeenCalledWith("/abs/manuscript.mdi");
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("読込失敗(移動/削除/未承認)の file-backed は復元せずエラーを通知する", async () => {
+    loadAppStateMock.mockResolvedValue({
+      openTabs: {
+        tabs: [serialized({ filePath: "/abs/gone.mdi", fileName: "gone.mdi" })],
+        activeIndex: 0,
+      },
+    });
+    readStandaloneFileMock.mockResolvedValue({ success: false, code: "ENOENT" });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle({ setTabs, setActiveTabId, windowKey: null });
+
+    // 復元できる対象が無いので restore 由来の setTabs は呼ばれない。
+    expect(restoredTabsFrom(setTabs)).toBeNull();
+    expect(readStandaloneFileMock).toHaveBeenCalledWith("/abs/gone.mdi");
+    expect(readFileSpy).not.toHaveBeenCalled();
+  });
+
+  it("file-backed + 無題 混在では両方を元の順序で復元する", async () => {
+    loadAppStateMock.mockResolvedValue({
+      openTabs: {
+        tabs: [
+          serialized({ filePath: "/abs/a.mdi", fileName: "a.mdi" }),
+          serialized({ unsavedContent: "下書き", fileType: ".mdi" }),
+        ],
+        activeIndex: 1,
+      },
+    });
+    readStandaloneFileMock.mockResolvedValue({
+      success: true,
+      path: "/abs/a.mdi",
+      content: "Aの本文",
+    });
+    const setTabs = vi.fn();
+    const setActiveTabId = vi.fn();
+
+    await mountAndSettle({ setTabs, setActiveTabId, windowKey: null });
+
+    const restored = restoredTabsFrom(setTabs);
+    expect(restored).toHaveLength(2);
+    expect(restored![0].file?.path).toBe("/abs/a.mdi");
+    expect(restored![0].content).toBe("Aの本文");
+    expect(restored![1].file).toBeNull();
+    expect(restored![1].content).toBe("下書き");
+    // activeIndex=1 は復元済みリスト範囲内の id を指す。
     const idUpdater = setActiveTabId.mock.calls[0][0] as (prev: TabId) => TabId;
-    expect(idUpdater("")).toBe(restored![0].id);
+    expect(idUpdater("")).toBe(restored![1].id);
     expect(readFileSpy).not.toHaveBeenCalled();
   });
 
@@ -288,13 +347,15 @@ describe("#1965 — スタンドアロン無題タブの復元（安全サブセ
 });
 
 describe("#1965 — 永続化ゲートは復元有無に関わらず開く（#1567 退行防止）", () => {
-  it("file-backed のみで復元なしでも、その後の空タブ状態を永続化できる", async () => {
+  it("file-backed の復元に失敗しても、その後の空タブ状態を永続化できる", async () => {
     loadAppStateMock.mockResolvedValue({
       openTabs: {
         tabs: [serialized({ filePath: "/abs/a.mdi", fileName: "a.mdi" })],
         activeIndex: 0,
       },
     });
+    // 復元失敗（移動/削除）でも永続化ゲートは開く（#1567）。
+    readStandaloneFileMock.mockResolvedValue({ success: false, code: "ENOENT" });
     const setTabs = vi.fn();
     const setActiveTabId = vi.fn();
 

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -426,18 +426,20 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
   // restoreProjectTabs() is called explicitly by the project-open handler,
   // replacing the old mount-time restore that had a race condition with windowKey.
   //
-  // #1965: マウント時に保存済み openTabs を読み、**filePath を持たない無題/未保存タブ**の
-  // バッファのみを復元する。
+  // #1965: マウント時に保存済み openTabs を読み、無題/未保存タブと file-backed タブの
+  // 両方を復元する。
   //
-  // なぜ file-backed タブを復元しないか:
-  //   Electron スタンドアロンは VFS ルート (allowedRoots) が未設定のまま起動するため、
-  //   `getProjectFileService().readFile(絶対パス)` は main 側の validateVFSPath で必ず
-  //   「ディレクトリが開かれていません」で失敗する (electron/ipc/vfs-ipc.js)。よって
-  //   再起動時にファイル本体を再読込する経路は存在せず、無理に呼ぶと毎起動エラーになる。
-  //   file-backed タブ本体の復元は main プロセス側の承認済みファイル再読込 (Phase 9 の
-  //   新 IO 抽象) を前提とするため据え置く。ファイル実体は auto-save でディスク保護される。
+  // file-backed タブの復元経路:
+  //   Electron スタンドアロンは VFS ルート (allowedRoots) 未設定で起動するため、
+  //   `getProjectFileService().readFile(絶対パス)` は main 側 validateVFSPath で必ず
+  //   失敗する (electron/ipc/vfs-ipc.js)。そこで main プロセスの承認済みパス再読込 IPC
+  //   `readStandaloneFile` を使う。これはユーザーがダイアログ/システムで実際に開いた
+  //   パス (永続 allowlist: electron/lib/standalone-files.js) のみを読み込み、成功時に
+  //   当該パスをウィンドウへ再承認するため、復元後の保存もダイアログ無しで行える。
+  //   読込失敗 (移動/削除/未承認) は failedFileBacked として通知し、サイレント欠落を防ぐ。
+  //   ファイル実体は auto-save でディスク保護される。
   //
-  // 無題タブは VFS を一切使わずバッファ (unsavedContent) から復元できるため、ここで救済する。
+  // 無題タブは VFS を一切使わずバッファ (unsavedContent) から復元する。
   // 復元有無に関わらず、永続化ゲート (storageInitializedRef) は旧実装の finally と同じ
   // タイミングで必ず開く。開かないと「全タブを閉じた」等の空タブ状態が永続化されず、
   // 次回起動時に古いタブ状態が残留する (#1567)。
@@ -462,10 +464,53 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
         if (cancelled) return;
 
         if (savedOpenTabs && savedOpenTabs.tabs.length > 0) {
+          // #1965: file-backed スタンドアロンタブは、main プロセスの承認済みパス
+          // 再読込 IPC (readStandaloneFile) で復元する。VFS (getProjectFileService)
+          // はスタンドアロンでは root 未設定で必ず失敗するため使えず、これが唯一の
+          // 安全な復元経路。ユーザーがダイアログ/システムで開いたパスのみ読み込める。
+          const readStandaloneFile = window.electronAPI?.readStandaloneFile;
           const restored: EditorTabState[] = [];
+          let failedFileBacked = 0;
           for (const saved of savedOpenTabs.tabs) {
-            // file-backed タブはここでは復元しない (上記の VFS 制約による)。
-            if (saved.filePath) continue;
+            if (cancelled) return;
+            if (saved.filePath) {
+              if (!readStandaloneFile) {
+                failedFileBacked++;
+                continue;
+              }
+              try {
+                const res = await readStandaloneFile(saved.filePath);
+                if (cancelled) return;
+                if (res?.success) {
+                  restored.push({
+                    tabKind: "editor",
+                    id: generateTabId(),
+                    file: { path: res.path, handle: null, name: saved.fileName },
+                    content: res.content,
+                    lastSavedContent: res.content,
+                    isDirty: false,
+                    lastSavedTime: Date.now(),
+                    lastSaveWasAuto: false,
+                    isSaving: false,
+                    isPreview: saved.isPreview ?? false,
+                    fileType: saved.fileType ?? inferFileType(saved.fileName),
+                    fileSyncStatus: "clean",
+                    conflictDiskContent: null,
+                  });
+                } else {
+                  // 未承認 / 移動・削除 / 読込失敗。ファイル実体は失われていない
+                  // （auto-save 済み）が、このセッションでは個別復元できない。
+                  failedFileBacked++;
+                }
+              } catch (error) {
+                console.warn(
+                  `スタンドアロン file-backed タブの復元に失敗しました (${saved.filePath}):`,
+                  error,
+                );
+                failedFileBacked++;
+              }
+              continue;
+            }
             const unsaved = saved.unsavedContent ?? "";
             const tab = createNewTab(unsaved, saved.fileType ?? ".mdi");
             // 内容を持つ無題タブは dirty として復元し、保存を促す。空なら clean。
@@ -480,6 +525,13 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
             setTabs((prev) => (prev.length > 0 ? prev : restored));
             setActiveTabId((prev) => (prev === "" ? restored[activeIdx].id : prev));
           }
+
+          if (!cancelled && failedFileBacked > 0) {
+            // 一部の file-backed タブが復元できなかったことを明示（サイレント欠落を防ぐ）。
+            setRestoreError?.(
+              "前回開いていた一部のファイルを復元できませんでした。ファイルが移動または削除された可能性があります。",
+            );
+          }
         }
       } catch (error) {
         // 復元失敗はゲートを塞がず空起動で継続する (データ自体は失われない)。
@@ -493,7 +545,7 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     return () => {
       cancelled = true;
     };
-  }, [isElectron, skipAutoRestore, vfsReadyPromise, setTabs, setActiveTabId]);
+  }, [isElectron, skipAutoRestore, vfsReadyPromise, setTabs, setActiveTabId, setRestoreError]);
 
   return { wasAutoRecovered, flushTabState, restoreProjectTabs };
 }

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -53,6 +53,17 @@ declare global {
         | { type: "standalone"; path: string; content: string }
       >
     >;
+    /**
+     * #1965: re-read a previously-opened standalone file for session restore.
+     * Succeeds only for paths the user opened in standalone mode (persisted
+     * allowlist); a successful read re-approves the path for this window.
+     */
+    readStandaloneFile?: (
+      filePath: string,
+    ) => Promise<
+      | { success: true; path: string; content: string }
+      | { success: false; code?: string; error?: string }
+    >;
     onMenuNew?: (callback: () => void) => (() => void) | void;
     onMenuOpen?: (callback: () => void) => (() => void) | void;
     onMenuSave?: (callback: () => void) => (() => void) | void;


### PR DESCRIPTION
## 概要

Electron スタンドアロンモード（プロジェクト未オープン）で再起動・クラッシュ後に **file-backed タブが復元されない** 問題 (#1965 の Phase 9 据え置き分) を解消します。#1984 で無題タブのみ復元する安全サブセットを出荷済みでしたが、本 PR でディスク上ファイルに紐づくタブの本文復元を実装します。

## 背景

スタンドアロンは VFS ルート（allowedRoots）未設定で起動するため、`getProjectFileService().readFile(絶対パス)` は main 側 `validateVFSPath` で必ず失敗し、file-backed タブの本体を再読込できませんでした。

## 実装

- **`electron/lib/standalone-files.js`** — ユーザーがダイアログ/システムで**実際に開いた**スタンドアロンパスを userData に永続化する allowlist（`vfs-approvals.js` と同型、oldest-first 上限 500、破損/不正エントリ耐性）。
- **`file-ipc.js`** — `open-file` / システムオープン時に allowlist へ記録。新 IPC **`read-standalone-file`** を追加 — allowlist に載るパスのみサイレント再読込し、成功時に当該パスを当ウィンドウへ**再承認**（復元後の保存もダイアログ不要）。未承認パスは `NOT_APPROVED` で拒否。
- **配線** — ipc-channels / preload / electron.d.ts。
- **`use-tab-persistence.ts`** `restoreStandaloneTabs` — file-backed タブを `window.electronAPI.readStandaloneFile` 経由で復元。読込失敗（移動/削除/未承認）は `setRestoreError` で通知しサイレント欠落を防止。無題タブは従来どおりバッファ復元。

## セキュリティ境界

レンダラは任意パスを読めません。`read-standalone-file` は「ユーザーがダイアログ/システムで開いたパス（main が記録した永続 allowlist）」のみ読込可。compromised renderer は allowlist に追加できない（追加はネイティブダイアログ/OS ファイル関連付けという実ユーザー操作を要する）ため、復元読込を悪用して任意ファイルを読ませることはできません。

## テスト

- `electron/lib/__tests__/standalone-files.test.ts`（永続化/membership/cap/破損耐性/不正エントリ 9件）
- `standalone-restore-untitled.test.tsx` を file-backed 復元仕様に更新（IPC 経由復元 / 失敗通知 / 混在順序保持 / 永続化ゲート開放）
- ipc-bridge 契約テストに新チャネルを pin
- 全 220 files / 2545 tests green、type-check・import-boundaries green

Closes #1965