### PR TITLE
fix(persistence): 回復バナーにバッファ使用/破棄アクションを追加し Electron でも表示 (#1966)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -367,6 +367,8 @@ export default function EditorPage() {
     newFile: tabNewFile,
     updateFileName,
     wasAutoRecovered,
+    recoveredBuffer,
+    clearRecoveredBuffer,
     onSystemFileOpen,
     _loadSystemFile: tabLoadSystemFile,
     tabs,
@@ -683,6 +685,21 @@ export default function EditorPage() {
       incrementEditorKey();
     }
   }, [wasAutoRecovered, incrementEditorKey]);
+
+  // #1966 H-5: 復元バッファをエディタへ適用する。setContent が active タブ内容を
+  // 差し替え dirty を自動判定し、incrementEditorKey で Milkdown を再マウントして
+  // 反映する（自動復元と同じ remount 機構）。適用後は永続バッファを破棄する。
+  const applyRecoveredBuffer = useCallback(async () => {
+    if (!recoveredBuffer) return;
+    setContent(recoveredBuffer.content);
+    incrementEditorKey();
+    await clearRecoveredBuffer?.();
+  }, [recoveredBuffer, setContent, incrementEditorKey, clearRecoveredBuffer]);
+
+  // #1966 H-6: ディスク内容を維持し、復元バッファを破棄する（既定で読込済み）。
+  const discardRecoveredBuffer = useCallback(async () => {
+    await clearRecoveredBuffer?.();
+  }, [clearRecoveredBuffer]);
 
   // With tabs, open/new don't need unsaved warnings (they create new tabs)
   const openFile = useCallback(async () => {
@@ -1168,6 +1185,8 @@ export default function EditorPage() {
     recoveryExiting,
     setDismissedRecovery,
     setRecoveryExiting,
+    // #1966 H-5/H-6: バッファ選択待ちの間はバナーを自動フェードアウトさせない。
+    recoveryActionPending: recoveredBuffer != null,
     editorViewInstance,
     contentRef,
     setContent,
@@ -1661,6 +1680,9 @@ export default function EditorPage() {
           recoveryExiting,
           setRecoveryExiting,
           currentFileName: currentFile?.name,
+          recoveredBuffer,
+          applyRecoveredBuffer,
+          discardRecoveredBuffer,
         }}
         upgrade={{
           showUpgradeBanner,

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -131,6 +131,12 @@ interface EditorLayoutProps {
     recoveryExiting: boolean;
     setRecoveryExiting: Dispatch<SetStateAction<boolean>>;
     currentFileName?: string;
+    /** #1966 H-5/H-6: 復元バッファがディスクと食い違う場合の選択肢データ。 */
+    recoveredBuffer?: { content: string; fileName: string } | null;
+    /** バッファ内容をエディタへ適用する（H-5）。 */
+    applyRecoveredBuffer?: () => void;
+    /** バッファを破棄しディスク内容を維持する（H-6）。 */
+    discardRecoveredBuffer?: () => void;
   };
   upgrade: {
     showUpgradeBanner: boolean;
@@ -350,29 +356,65 @@ export default function EditorLayout({
                 fileType={dialogs.printDialog.fileType}
               />
 
-              {!chrome.isElectron && recovery.wasAutoRecovered && !recovery.dismissedRecovery && (
-                <div
-                  className={`fixed left-0 top-10 right-0 z-50 bg-background-elevated border-b border-border px-4 py-3 flex items-center justify-between shadow-lg ${recovery.recoveryExiting ? "animate-slide-out-up" : "animate-slide-in-down"}`}
-                >
-                  <div className="flex items-center gap-3">
-                    <div className="w-3 h-3 bg-success rounded-full flex-shrink-0 animate-pulse-glow"></div>
-                    <p className="text-sm text-foreground">
-                      <span className="font-semibold text-foreground">
-                        ✓ 前回編集したファイルを復元しました：
-                      </span>{" "}
-                      <span className="font-mono text-success">{recovery.currentFileName}</span>
-                    </p>
+              {/* #1966 H-5/H-6: 復元バッファがディスクと食い違う場合は「使用 / 破棄」を
+                  選択させる（自動フェードアウトしない）。食い違いが無ければ従来どおり
+                  情報バナー（自動フェードアウト + ✕）。Electron でも表示する。 */}
+              {recovery.wasAutoRecovered &&
+                !recovery.dismissedRecovery &&
+                (recovery.recoveredBuffer ? (
+                  <div className="fixed left-0 top-10 right-0 z-50 bg-background-elevated border-b border-border px-4 py-3 flex items-center justify-between shadow-lg animate-slide-in-down">
+                    <div className="flex items-center gap-3">
+                      <div className="w-3 h-3 bg-warning rounded-full flex-shrink-0 animate-pulse-glow"></div>
+                      <p className="text-sm text-foreground">
+                        <span className="font-semibold text-foreground">
+                          未保存の変更が見つかりました：
+                        </span>{" "}
+                        <span className="font-mono text-warning">
+                          {recovery.recoveredBuffer.fileName}
+                        </span>{" "}
+                        <span className="text-foreground-secondary">
+                          前回終了時の未保存内容を使用しますか？
+                        </span>
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-2 flex-shrink-0 ml-4">
+                      <button
+                        onClick={() => recovery.applyRecoveredBuffer?.()}
+                        className="px-3 py-1 text-sm font-medium rounded bg-accent text-accent-foreground hover:opacity-90 transition-all duration-200"
+                      >
+                        このバッファを使用
+                      </button>
+                      <button
+                        onClick={() => recovery.discardRecoveredBuffer?.()}
+                        className="px-3 py-1 text-sm font-medium rounded border border-border text-foreground hover:bg-hover transition-all duration-200"
+                      >
+                        破棄
+                      </button>
+                    </div>
                   </div>
-                  <button
-                    onClick={() => {
-                      recovery.setRecoveryExiting(true);
-                    }}
-                    className="text-foreground-secondary hover:text-foreground hover:bg-hover text-lg font-medium flex-shrink-0 ml-4 w-8 h-8 rounded flex items-center justify-center transition-all duration-200 hover:scale-110"
+                ) : (
+                  <div
+                    className={`fixed left-0 top-10 right-0 z-50 bg-background-elevated border-b border-border px-4 py-3 flex items-center justify-between shadow-lg ${recovery.recoveryExiting ? "animate-slide-out-up" : "animate-slide-in-down"}`}
                   >
-                    ✕
-                  </button>
-                </div>
-              )}
+                    <div className="flex items-center gap-3">
+                      <div className="w-3 h-3 bg-success rounded-full flex-shrink-0 animate-pulse-glow"></div>
+                      <p className="text-sm text-foreground">
+                        <span className="font-semibold text-foreground">
+                          ✓ 前回編集したファイルを復元しました：
+                        </span>{" "}
+                        <span className="font-mono text-success">{recovery.currentFileName}</span>
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => {
+                        recovery.setRecoveryExiting(true);
+                      }}
+                      className="text-foreground-secondary hover:text-foreground hover:bg-hover text-lg font-medium flex-shrink-0 ml-4 w-8 h-8 rounded flex items-center justify-center transition-all duration-200 hover:scale-110"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                ))}
 
               <div className="flex-1 flex overflow-hidden">
                 <ActivityBar

--- a/lib/editor-page/use-editor-lifecycle.ts
+++ b/lib/editor-page/use-editor-lifecycle.ts
@@ -18,6 +18,11 @@ interface UseEditorLifecycleParams {
   recoveryExiting: boolean;
   setDismissedRecovery: Dispatch<SetStateAction<boolean>>;
   setRecoveryExiting: Dispatch<SetStateAction<boolean>>;
+  /**
+   * #1966 H-5/H-6: true while the user has a pending 「このバッファを使用」/「破棄」
+   * choice. The recovery banner must stay visible (no auto-fadeout) until resolved.
+   */
+  recoveryActionPending?: boolean;
   editorViewInstance: EditorView | null;
   contentRef: MutableRefObject<string>;
   setContent: (content: string) => void;
@@ -42,6 +47,7 @@ export function useEditorLifecycle({
   recoveryExiting,
   setDismissedRecovery,
   setRecoveryExiting,
+  recoveryActionPending,
   editorViewInstance,
   contentRef,
   setContent,
@@ -80,7 +86,9 @@ export function useEditorLifecycle({
   // Phase 3: getPendingFile 経路は削除。Phase 8 で再導入する。
 
   useEffect(() => {
-    if (wasAutoRecovered && !dismissedRecovery && !recoveryExiting) {
+    // #1966 H-5/H-6: バッファ選択待ちの間は自動フェードアウトしない（ユーザーの
+    // 明示的な「使用 / 破棄」操作を待つ）。
+    if (wasAutoRecovered && !dismissedRecovery && !recoveryExiting && !recoveryActionPending) {
       const fadeoutTimer = setTimeout(() => {
         setRecoveryExiting(true);
       }, 5000);
@@ -99,6 +107,7 @@ export function useEditorLifecycle({
     wasAutoRecovered,
     dismissedRecovery,
     recoveryExiting,
+    recoveryActionPending,
     setDismissedRecovery,
     setRecoveryExiting,
   ]);

--- a/lib/tab-manager/__tests__/recovery-buffer-conflict.test.tsx
+++ b/lib/tab-manager/__tests__/recovery-buffer-conflict.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Web クラッシュ復元の「バッファ vs ディスク」選択検出テスト（#1966 H-5/H-6）。
+ *
+ * ディスク内容を既定で読み込みつつ、前回終了時の永続バッファがディスクと食い違う
+ * 場合は recoveredBuffer を立て、UI が「このバッファを使用 / 破棄」を提示できるように
+ * する。食い違いが無ければ recoveredBuffer は null。clearRecoveredBuffer は永続バッファを
+ * 破棄し状態をクリアする（使用適用後 / 破棄時）。
+ *
+ * REAL フックを createRoot + act で駆動し、フックの返り値を捕捉する。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+import { useTabPersistence, type UseTabPersistenceReturn } from "../use-tab-persistence";
+import type { TabState, TabId, EditorTabState } from "../tab-types";
+
+const { getItemMock, loadEditorBufferMock, clearEditorBufferMock } = vi.hoisted(() => ({
+  getItemMock: vi.fn(async () => "manuscript.mdi" as string | null),
+  loadEditorBufferMock: vi.fn(async () => null as unknown),
+  clearEditorBufferMock: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { warning: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/storage/storage-service", () => ({
+  getStorageService: () => ({
+    initialize: vi.fn(async () => undefined),
+    loadAppState: vi.fn(async () => null),
+    getItem: getItemMock,
+    loadEditorBuffer: loadEditorBufferMock,
+    clearEditorBuffer: clearEditorBufferMock,
+  }),
+}));
+
+vi.mock("@/lib/storage/app-state-manager", () => ({
+  fetchWindowState: vi.fn(async () => null),
+  persistWindowState: vi.fn(async () => undefined),
+  persistAppState: vi.fn(async () => undefined),
+}));
+
+vi.mock("@/lib/project/workspace-persistence", () => ({
+  persistWorkspaceJson: vi.fn(async () => undefined),
+  toRelativePath: (p: string) => p,
+  toAbsolutePath: (p: string) => p,
+}));
+
+vi.mock("@/lib/services/project-file-service", () => ({
+  getProjectFileService: () => ({ readFile: vi.fn(async () => "") }),
+}));
+
+// ---------------------------------------------------------------------------
+// Harness — captures the hook return so we can assert recoveredBuffer
+// ---------------------------------------------------------------------------
+
+function Harness({ onReturn }: { onReturn: (r: UseTabPersistenceReturn) => void }): null {
+  const tabsRef = useRef<TabState[]>([]);
+  const activeTabIdRef = useRef<TabId>("");
+  const isProjectRef = useRef(false);
+  // 安定した setter 参照（毎レンダー新規生成すると復元 effect の deps が変わり無限ループ）。
+  const setTabs = useRef(vi.fn()).current;
+  const setActiveTabId = useRef(vi.fn()).current;
+  const ret = useTabPersistence({
+    tabs: [],
+    setTabs: setTabs as never,
+    activeTabId: "",
+    setActiveTabId: setActiveTabId as never,
+    tabsRef,
+    activeTabIdRef,
+    isProjectRef,
+    isElectron: false,
+    skipAutoRestore: false,
+    windowKey: null,
+  });
+  onReturn(ret);
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+let lastReturn: UseTabPersistenceReturn | null = null;
+
+function diskHandle(content: string, name = "manuscript.mdi") {
+  return { getFile: vi.fn(async () => ({ text: async () => content, name })) };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  lastReturn = null;
+  getItemMock.mockReset();
+  getItemMock.mockResolvedValue("manuscript.mdi");
+  loadEditorBufferMock.mockReset();
+  loadEditorBufferMock.mockResolvedValue(null);
+  clearEditorBufferMock.mockReset();
+  clearEditorBufferMock.mockResolvedValue(undefined);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+async function mountAndSettle(): Promise<void> {
+  await act(async () => {
+    root.render(<Harness onReturn={(r) => (lastReturn = r)} />);
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(50);
+  });
+}
+
+describe("#1966 H-5/H-6 — バッファ vs ディスクの選択検出", () => {
+  it("バッファ内容がディスクと食い違うと recoveredBuffer を立てる（既定はディスク）", async () => {
+    loadEditorBufferMock.mockResolvedValue({
+      content: "未保存のバッファ内容",
+      timestamp: 1,
+      fileHandle: diskHandle("ディスク内容"),
+    });
+
+    await mountAndSettle();
+
+    expect(lastReturn!.wasAutoRecovered).toBe(true);
+    expect(lastReturn!.recoveredBuffer).not.toBeNull();
+    expect(lastReturn!.recoveredBuffer!.content).toBe("未保存のバッファ内容");
+    expect(lastReturn!.recoveredBuffer!.fileName).toBe("manuscript.mdi");
+  });
+
+  it("バッファ内容がディスクと一致すれば recoveredBuffer は立てない", async () => {
+    loadEditorBufferMock.mockResolvedValue({
+      content: "同じ内容",
+      timestamp: 1,
+      fileHandle: diskHandle("同じ内容"),
+    });
+
+    await mountAndSettle();
+
+    expect(lastReturn!.wasAutoRecovered).toBe(true);
+    expect(lastReturn!.recoveredBuffer).toBeNull();
+  });
+
+  it("バッファ content が無ければ recoveredBuffer は立てない", async () => {
+    loadEditorBufferMock.mockResolvedValue({
+      content: undefined,
+      timestamp: 1,
+      fileHandle: diskHandle("ディスク内容"),
+    });
+
+    await mountAndSettle();
+
+    expect(lastReturn!.recoveredBuffer).toBeNull();
+  });
+
+  it("clearRecoveredBuffer は永続バッファを破棄し状態をクリアする", async () => {
+    loadEditorBufferMock.mockResolvedValue({
+      content: "未保存のバッファ内容",
+      timestamp: 1,
+      fileHandle: diskHandle("ディスク内容"),
+    });
+
+    await mountAndSettle();
+    expect(lastReturn!.recoveredBuffer).not.toBeNull();
+
+    await act(async () => {
+      await lastReturn!.clearRecoveredBuffer();
+    });
+
+    expect(clearEditorBufferMock).toHaveBeenCalledWith("manuscript.mdi");
+    expect(lastReturn!.recoveredBuffer).toBeNull();
+  });
+});

--- a/lib/tab-manager/__tests__/standalone-restore-untitled.test.tsx
+++ b/lib/tab-manager/__tests__/standalone-restore-untitled.test.tsx
@@ -88,6 +88,9 @@ function Harness({ tabs, activeTabId, windowKey, setTabs, setActiveTabId }: Harn
   const activeTabIdRef = useRef<TabId>(activeTabId);
   activeTabIdRef.current = activeTabId;
   const isProjectRef = useRef(false);
+  // 安定した promise（毎レンダー新規生成すると復元 effect の deps が変わり再実行される。
+  // 本番の vfsGate.promise は安定参照なので、テストでも安定させて挙動を一致させる）。
+  const vfsReadyPromiseRef = useRef(Promise.resolve());
 
   useTabPersistence({
     tabs,
@@ -99,7 +102,7 @@ function Harness({ tabs, activeTabId, windowKey, setTabs, setActiveTabId }: Harn
     isProjectRef,
     isElectron: true,
     skipAutoRestore: false,
-    vfsReadyPromise: Promise.resolve(),
+    vfsReadyPromise: vfsReadyPromiseRef.current,
     windowKey: windowKey ?? null,
   });
   return null;

--- a/lib/tab-manager/index.ts
+++ b/lib/tab-manager/index.ts
@@ -158,6 +158,8 @@ export function useTabManager(options?: {
 
   const {
     wasAutoRecovered,
+    recoveredBuffer,
+    clearRecoveredBuffer,
     flushTabState: _flushTabState,
     restoreProjectTabs,
   } = useTabPersistence({
@@ -247,6 +249,8 @@ export function useTabManager(options?: {
     newFile,
     updateFileName: tabState.updateFileName,
     wasAutoRecovered,
+    recoveredBuffer,
+    clearRecoveredBuffer,
     onSystemFileOpen,
     _loadSystemFile: fileIO.loadSystemFile,
 

--- a/lib/tab-manager/types.ts
+++ b/lib/tab-manager/types.ts
@@ -50,6 +50,10 @@ export interface UseTabManagerReturn {
   newFile: (fileType?: SupportedFileExtension) => void;
   updateFileName: (newName: string) => void;
   wasAutoRecovered?: boolean;
+  /** #1966 H-5/H-6: 復元バッファがディスクと食い違う場合の選択肢データ（無ければ null）。 */
+  recoveredBuffer?: { content: string; fileName: string } | null;
+  /** 復元バッファの選択を解消し永続バッファを破棄する（使用適用後 / 破棄時に呼ぶ）。 */
+  clearRecoveredBuffer?: () => Promise<void>;
   onSystemFileOpen?: (handler: (path: string, content: string) => void) => void;
   _loadSystemFile: (path: string, content: string) => void;
 

--- a/lib/tab-manager/use-tab-persistence.ts
+++ b/lib/tab-manager/use-tab-persistence.ts
@@ -55,9 +55,33 @@ export interface UseTabPersistenceParams extends TabManagerCore {
 // Return type
 // ---------------------------------------------------------------------------
 
+/**
+ * A persisted editor buffer whose crash-time content differs from the file on
+ * disk (#1966 H-5/H-6). Disk content is loaded by default; this lets the UI offer
+ * 「このバッファを使用」/「破棄」instead of silently discarding the buffer.
+ */
+export interface RecoveredBufferInfo {
+  /** The crash-time buffer content (differs from the loaded disk content). */
+  content: string;
+  /** Display name of the recovered file. */
+  fileName: string;
+}
+
 export interface UseTabPersistenceReturn {
   /** Whether the session was auto-recovered from a saved buffer. */
   wasAutoRecovered: boolean;
+  /**
+   * #1966 H-5/H-6: pending buffer-vs-disk recovery choice. Non-null only when a
+   * recovered file's persisted buffer differs from its on-disk content. Null when
+   * there is no conflict (the disk content was loaded as the safe default).
+   */
+  recoveredBuffer: RecoveredBufferInfo | null;
+  /**
+   * Clear the pending recovered-buffer choice and drop the persisted editor
+   * buffer. Called after the user picks 使用 (content already applied to the tab
+   * by the caller) or 破棄 (keep the disk content).
+   */
+  clearRecoveredBuffer: () => Promise<void>;
   /** Immediately flush pending tab state to storage (cancels debounce). */
   flushTabState: () => Promise<void>;
   /**
@@ -113,6 +137,24 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
   windowKeyRef.current = windowKey ?? null;
 
   const [wasAutoRecovered, setWasAutoRecovered] = useState(false);
+
+  // #1966 H-5/H-6: pending buffer-vs-disk recovery choice (Web). The disk content
+  // is loaded by default; when the crash-time buffer differs, this state drives the
+  // 「このバッファを使用」/「破棄」banner. The fileKey is kept in a ref so the eventual
+  // clearEditorBuffer targets the right key without re-rendering.
+  const [recoveredBuffer, setRecoveredBuffer] = useState<RecoveredBufferInfo | null>(null);
+  const recoveredBufferKeyRef = useRef<string | null>(null);
+
+  const clearRecoveredBuffer = useCallback(async () => {
+    setRecoveredBuffer(null);
+    const key = recoveredBufferKeyRef.current;
+    recoveredBufferKeyRef.current = null;
+    try {
+      await getStorageService().clearEditorBuffer(key ?? undefined);
+    } catch (error) {
+      console.warn("回復バッファのクリアに失敗しました:", error);
+    }
+  }, []);
 
   // Gate persistence until after the initial restore has completed to
   // prevent the empty initial tabs state from overwriting saved tab data
@@ -370,6 +412,14 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
                 conflictDiskContent: null,
               };
               setWasAutoRecovered(true);
+              // #1966 H-5/H-6: disk is the safe default, but if the crash-time
+              // buffer differs from disk, surface a choice instead of silently
+              // discarding the unsaved buffer. Empty/identical buffers need no choice.
+              const bufferContent = buffer.content;
+              if (typeof bufferContent === "string" && bufferContent !== fileContent) {
+                recoveredBufferKeyRef.current = lastFileKey ?? null;
+                setRecoveredBuffer({ content: bufferContent, fileName: file.name });
+              }
             } catch (error) {
               // #1966 H-2: ディスクのファイルを再オープンできない（移動/削除/権限取消）。
               // 旧実装はバッファを黙って破棄し、未保存内容がサイレントに消えていた。
@@ -524,6 +574,8 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
             // ユーザーが待機中に開いたタブを上書きしないよう、空のときだけ反映する。
             setTabs((prev) => (prev.length > 0 ? prev : restored));
             setActiveTabId((prev) => (prev === "" ? restored[activeIdx].id : prev));
+            // #1966: Electron でも復元状態をバナーで提示する（旧実装は Web 限定で非表示）。
+            setWasAutoRecovered(true);
           }
 
           if (!cancelled && failedFileBacked > 0) {
@@ -547,5 +599,11 @@ export function useTabPersistence(params: UseTabPersistenceParams): UseTabPersis
     };
   }, [isElectron, skipAutoRestore, vfsReadyPromise, setTabs, setActiveTabId, setRestoreError]);
 
-  return { wasAutoRecovered, flushTabState, restoreProjectTabs };
+  return {
+    wasAutoRecovered,
+    recoveredBuffer,
+    clearRecoveredBuffer,
+    flushTabState,
+    restoreProjectTabs,
+  };
 }


### PR DESCRIPTION
## 概要

クラッシュ／自動復元バナーが**情報表示のみ**で「このバッファを使用」「破棄」の選択肢が無く、さらに **Web 限定**（`!chrome.isElectron`）で Electron では非表示だった問題 (#1966 H-5/H-6) を解消します。H-2（復元失敗時のバッファ救済）は #1981 で対応済みです。

## 実装

- **`use-tab-persistence.ts`**: Web 復元時にディスク内容を既定で読み込みつつ、前回終了時の永続バッファがディスクと**食い違う場合**は `recoveredBuffer` を立てる（食い違いが無ければ `null`）。`clearRecoveredBuffer` で永続バッファ破棄＋状態クリア。Electron スタンドアロン復元成功時に `wasAutoRecovered` を立て、バナーで復元状態を提示。
- **`app/page.tsx`**: `applyRecoveredBuffer`（H-5: `setContent` でバッファ内容を適用し dirty 化、`incrementEditorKey` で再マウント反映、永続バッファ破棄）/ `discardRecoveredBuffer`（H-6: ディスク維持しバッファ破棄）を配線。
- **`use-editor-lifecycle.ts`**: バッファ選択待ちの間はバナーを自動フェードアウトさせない。
- **`EditorLayout.tsx`**: `!chrome.isElectron` ガードを撤去し **Electron でも表示**。食い違い時は「このバッファを使用 / 破棄」ボタン（自動フェードアウト無し）、それ以外は従来の情報バナー。
- **`index.ts` / `types.ts`**: `recoveredBuffer` / `clearRecoveredBuffer` を `useTabManager` 経由で公開。

## 設計上のポイント

「ディスク vs バッファ」の選択は両者が**存在し食い違う**場合のみ意味を持ちます。ディスクが安全な既定として常に読み込まれ、バッファはユーザーが明示的に「使用」を選んだ時のみ適用されます（サイレントなバッファ破棄を解消）。適用は既存の自動復元と同じ `setContent` + `incrementEditorKey` 再マウント機構を再利用しています。

## テスト

- `recovery-buffer-conflict.test.tsx`（食い違い検出 / 一致時 null / content 無し / clearRecoveredBuffer 4件）
- `standalone-restore-untitled.test.tsx` の harness を安定 promise 化（再レンダー耐性。本番の vfsGate.promise は安定参照）
- 全 221 files / 2549 tests green、type-check・import-boundaries green

Closes #1966