### PR TITLE
feat(analytics): add aptabase usage tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
 # illusions Environment Variables Example
 # Copy this file to .env.local and fill in your values
+
+# Aptabase App Key (anonymous desktop usage analytics). Not a secret in the
+# strict sense (comparable to a Sentry DSN — it ships inside the built app),
+# but kept out of source control per CLAUDE.md. Baked into dist-main/main.js
+# at build time by scripts/bundle-electron.mjs via esbuild `define`.
+APTABASE_APP_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,2 @@
 # illusions Environment Variables Example
 # Copy this file to .env.local and fill in your values
-
-# Aptabase App Key (anonymous desktop usage analytics). Not a secret in the
-# strict sense (comparable to a Sentry DSN — it ships inside the built app),
-# but kept out of source control per CLAUDE.md. Baked into dist-main/main.js
-# at build time by scripts/bundle-electron.mjs via esbuild `define`.
-APTABASE_APP_KEY=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,6 +245,7 @@ jobs:
       TEAM_ID: ${{ vars.TEAM_ID }}
       CSC_LINK: ${{ secrets.CSC_LINK }}
       CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
 
@@ -337,6 +338,7 @@ jobs:
       needs.detect-changes.outputs.desktop_changed == 'true'
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'windows-latest' }}
     env:
+      APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
 
@@ -433,6 +435,7 @@ jobs:
       matrix:
         arch: [x64, arm64]
     env:
+      APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
 
@@ -557,6 +560,7 @@ jobs:
     outputs:
       version: ${{ needs.compute-version.outputs.full }}
     env:
+      APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
 
@@ -672,6 +676,7 @@ jobs:
       needs.detect-changes.outputs.desktop_changed == 'true'
     runs-on: ubuntu-latest
     env:
+      APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
 

--- a/components/settings/PrivacySettingsTab.tsx
+++ b/components/settings/PrivacySettingsTab.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type React from "react";
+
+import { useAnalyticsSettings } from "@/contexts/EditorSettingsContext";
+import { SettingsField, SettingsSection, SettingsToggle } from "./primitives";
+
+/**
+ * Settings tab for privacy / usage analytics consent (Electron only).
+ */
+export default function PrivacySettingsTab(): React.ReactElement {
+  const { usageAnalyticsConsent, onUsageAnalyticsConsentChange } = useAnalyticsSettings();
+
+  return (
+    <SettingsSection
+      title="使用統計"
+      description="どの機能がよく使われているかを把握し、今後の改善に活かすため、匿名の使用統計を送信します。本文・ファイル名・ファイルパス・検索文字列など、内容に関わる情報は一切含まれません。"
+    >
+      <SettingsField label="匿名の使用統計を送信する" htmlFor="usage-analytics-consent" inline>
+        <SettingsToggle
+          id="usage-analytics-consent"
+          checked={usageAnalyticsConsent ?? true}
+          onChange={(next) => onUsageAnalyticsConsentChange?.(next)}
+        />
+      </SettingsField>
+
+      <div className="text-xs text-foreground-secondary space-y-1">
+        <p>・送信されるのは起動回数や機能利用状況などの匿名データのみです</p>
+        <p>・いつでもオフに切り替えられます</p>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/components/settings/__tests__/tab-registry.test.ts
+++ b/components/settings/__tests__/tab-registry.test.ts
@@ -6,21 +6,41 @@
  * plugins). These tests only verify the shape of the registry.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+
+function MockSettingsTab(): null {
+  return null;
+}
+
+vi.mock("../AboutSection", () => ({ default: MockSettingsTab }));
+vi.mock("../AccountSettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../AiApiSettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../DictSettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../KeymapSettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../LintingSettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../PosHighlightSettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../PowerSettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../PrivacySettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../SpeechSettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../TerminalSettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../TypographySettingsTab", () => ({ default: MockSettingsTab }));
+vi.mock("../VerticalSettingsTab", () => ({ default: MockSettingsTab }));
 
 import { buildSettingsTabRegistry } from "../tab-registry";
 
 describe("buildSettingsTabRegistry — platform gating", () => {
-  it("includes terminal and power on Electron", () => {
+  it("includes Electron-only tabs on Electron", () => {
     const registry = buildSettingsTabRegistry({ isElectron: true });
     expect(registry.terminal).toBeDefined();
     expect(registry.power).toBeDefined();
+    expect(registry.privacy).toBeDefined();
   });
 
-  it("omits terminal and power on Web", () => {
+  it("omits Electron-only tabs on Web", () => {
     const registry = buildSettingsTabRegistry({ isElectron: false });
     expect(registry.terminal).toBeUndefined();
     expect(registry.power).toBeUndefined();
+    expect(registry.privacy).toBeUndefined();
   });
 });
 

--- a/components/settings/nav-config.ts
+++ b/components/settings/nav-config.ts
@@ -10,6 +10,7 @@ import {
   AudioLines,
   Terminal,
   BatteryMedium,
+  ShieldCheck,
   Info,
 } from "lucide-react";
 
@@ -60,7 +61,10 @@ export function buildSettingsNavConfig(): ReadonlyArray<SettingsNavGroup<Setting
     },
     {
       label: "システム",
-      items: [{ id: "power", label: "省電力", icon: BatteryMedium, hidden: !isElectron }],
+      items: [
+        { id: "power", label: "省電力", icon: BatteryMedium, hidden: !isElectron },
+        { id: "privacy", label: "プライバシー", icon: ShieldCheck, hidden: !isElectron },
+      ],
     },
     {
       label: "ヘルプ",

--- a/components/settings/settings-category.ts
+++ b/components/settings/settings-category.ts
@@ -13,6 +13,7 @@ export type SettingsCategory =
   | "terminal"
   | "power"
   | "dictionary"
+  | "privacy"
   | "about";
 
 /**
@@ -25,7 +26,10 @@ export function resolveLegacyCategory(
   options: { isElectron: boolean } = { isElectron: true },
 ): SettingsCategory {
   const normalized: SettingsCategory = category ?? "typography";
-  if (!options.isElectron && (normalized === "terminal" || normalized === "power")) {
+  if (
+    !options.isElectron &&
+    (normalized === "terminal" || normalized === "power" || normalized === "privacy")
+  ) {
     return "account";
   }
   return normalized;

--- a/components/settings/tab-registry.ts
+++ b/components/settings/tab-registry.ts
@@ -8,6 +8,7 @@ import KeymapSettingsTab from "./KeymapSettingsTab";
 import LintingSettingsTab from "./LintingSettingsTab";
 import PosHighlightSettingsTab from "./PosHighlightSettingsTab";
 import PowerSettingsTab from "./PowerSettingsTab";
+import PrivacySettingsTab from "./PrivacySettingsTab";
 import SpeechSettingsTab from "./SpeechSettingsTab";
 import TerminalSettingsTab from "./TerminalSettingsTab";
 import TypographySettingsTab from "./TypographySettingsTab";
@@ -26,8 +27,8 @@ export interface TabRegistryEntry {
 
 /**
  * Registry of settings tabs. `Partial<Record<...>>` because Electron-only
- * tabs (`terminal`, `power`) may be absent in the Web build; callers must
- * normalize unavailable categories via `resolveLegacyCategory`.
+ * tabs (`terminal`, `power`, `privacy`) may be absent in the Web build; callers
+ * must normalize unavailable categories via `resolveLegacyCategory`.
  */
 export type SettingsTabRegistry = Partial<Record<SettingsCategory, TabRegistryEntry>>;
 
@@ -47,6 +48,7 @@ export function buildSettingsTabRegistry(options: { isElectron: boolean }): Sett
   if (options.isElectron) {
     base.terminal = { component: TerminalSettingsTab };
     base.power = { component: PowerSettingsTab };
+    base.privacy = { component: PrivacySettingsTab };
   }
   return base;
 }

--- a/contexts/EditorSettingsContext.tsx
+++ b/contexts/EditorSettingsContext.tsx
@@ -171,6 +171,18 @@ export function usePowerSettings() {
   );
 }
 
+/** Usage analytics consent (Aptabase) */
+export function useAnalyticsSettings() {
+  const { settings, handlers } = useEditorSettingsContext();
+  return useMemo(
+    () => ({
+      usageAnalyticsConsent: settings.usageAnalyticsConsent,
+      onUsageAnalyticsConsentChange: handlers.handleUsageAnalyticsConsentChange,
+    }),
+    [settings, handlers],
+  );
+}
+
 /** UI settings (compact mode, auto-save, settings modal) */
 export function useUISettings() {
   const { settings, handlers } = useEditorSettingsContext();

--- a/electron/ipc/__tests__/analytics-ipc.test.ts
+++ b/electron/ipc/__tests__/analytics-ipc.test.ts
@@ -28,7 +28,7 @@ async function createHandler(hasAppKey = true): Promise<TrackEventHandler> {
 describe("registerAnalyticsHandlers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.APTABASE_APP_KEY = "A-US-test";
+    process.env.APTABASE_APP_KEY = "test-app-key";
     loadAppStateMock.mockResolvedValue({});
     trackEventMock.mockResolvedValue(undefined);
   });

--- a/electron/ipc/__tests__/analytics-ipc.test.ts
+++ b/electron/ipc/__tests__/analytics-ipc.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { loadAppStateMock, trackEventMock } = vi.hoisted(() => ({
+  loadAppStateMock: vi.fn(),
+  trackEventMock: vi.fn(),
+}));
+
+vi.mock("@aptabase/electron/main", () => ({
+  trackEvent: trackEventMock,
+}));
+
+type TrackEventHandler = (_event: unknown, eventName: unknown, props?: unknown) => Promise<void>;
+
+async function loadAnalyticsIpc(): Promise<typeof import("../analytics-ipc.js")> {
+  vi.resetModules();
+  return import("../analytics-ipc.js");
+}
+
+async function createHandler(hasAppKey = true): Promise<TrackEventHandler> {
+  const mod = await loadAnalyticsIpc();
+  return mod.createAnalyticsTrackEventHandler({
+    getStorageManager: () => ({ loadAppState: loadAppStateMock }),
+    trackEvent: trackEventMock,
+    hasAppKey: () => hasAppKey,
+  });
+}
+
+describe("registerAnalyticsHandlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.APTABASE_APP_KEY = "A-US-test";
+    loadAppStateMock.mockResolvedValue({});
+    trackEventMock.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.APTABASE_APP_KEY;
+  });
+
+  it("tracks whitelisted events when analytics consent is enabled", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "feature_used", { feature: "export", count: 1 });
+
+    expect(loadAppStateMock).toHaveBeenCalledOnce();
+    expect(trackEventMock).toHaveBeenCalledWith("feature_used", { feature: "export", count: 1 });
+  });
+
+  it("does not track events when analytics consent is disabled", async () => {
+    loadAppStateMock.mockResolvedValue({ usageAnalyticsConsent: false });
+    const handler = await createHandler();
+
+    await handler({}, "feature_used", { feature: "export" });
+
+    expect(loadAppStateMock).toHaveBeenCalledOnce();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("does not load app state or track when the app key is unavailable", async () => {
+    const handler = await createHandler(false);
+
+    await handler({}, "feature_used", { feature: "export" });
+
+    expect(loadAppStateMock).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-whitelisted props before reading consent", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "feature_used", { feature: "export", nested: { path: "/tmp/file.mdi" } });
+
+    expect(loadAppStateMock).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty event names before reading consent", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "", { feature: "export" });
+
+    expect(loadAppStateMock).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/analytics-ipc.js
+++ b/electron/ipc/analytics-ipc.js
@@ -1,0 +1,58 @@
+// Usage analytics (Aptabase) IPC handlers
+// renderer はイベント名 + ホワイトリスト化した引数のみを渡し、送信可否（同意フラグ）の
+// 判断と実際の送信は必ず main process 側で行う。
+
+const { ipcMain } = require("electron");
+const { ANALYTICS_CHANNELS } = require("../lib/ipc-channels");
+
+function isWhitelistedProps(props) {
+  if (props === undefined) return true;
+  if (typeof props !== "object" || props === null) return false;
+  return Object.values(props).every(
+    (value) => typeof value === "string" || typeof value === "number",
+  );
+}
+
+/**
+ * @typedef {Object} AnalyticsHandlerDependencies
+ * @property {() => { loadAppState: () => Promise<Record<string, unknown>> }} [getStorageManager]
+ * @property {(eventName: string, props?: Record<string, string | number>) => Promise<void>} [trackEvent]
+ * @property {() => boolean} [hasAppKey]
+ */
+
+/**
+ * @param {AnalyticsHandlerDependencies} [dependencies]
+ */
+function createAnalyticsTrackEventHandler(
+  {
+    getStorageManager = () => require("./storage-ipc").getStorageManager(),
+    trackEvent = (eventName, props) =>
+      require("@aptabase/electron/main").trackEvent(eventName, props),
+    hasAppKey = () => Boolean(false),
+  } = /** @type {AnalyticsHandlerDependencies} */ ({}),
+) {
+  return async (_event, eventName, props) => {
+    if (typeof eventName !== "string" || !eventName) return;
+    if (!isWhitelistedProps(props)) return;
+    if (!hasAppKey()) return;
+
+    try {
+      const appState = await getStorageManager().loadAppState();
+      if (appState?.usageAnalyticsConsent === false) return;
+
+      await trackEvent(eventName, props);
+    } catch (error) {
+      console.warn("[Analytics IPC] trackEvent failed:", error);
+    }
+  };
+}
+
+function registerAnalyticsHandlers(options) {
+  ipcMain.handle(ANALYTICS_CHANNELS.invoke.trackEvent, createAnalyticsTrackEventHandler(options));
+}
+
+module.exports = {
+  registerAnalyticsHandlers,
+  createAnalyticsTrackEventHandler,
+  isWhitelistedProps,
+};

--- a/electron/lib/ipc-channels.js
+++ b/electron/lib/ipc-channels.js
@@ -200,6 +200,14 @@ const SAFE_STORAGE_CHANNELS = Object.freeze({
   event: Object.freeze({}),
 });
 
+// Usage analytics / Aptabase (electron/ipc/analytics-ipc.js)
+const ANALYTICS_CHANNELS = Object.freeze({
+  invoke: Object.freeze({
+    trackEvent: "analytics:track-event",
+  }),
+  event: Object.freeze({}),
+});
+
 // Power monitoring (invoke in electron/ipc/system-ipc.js; event pushed from
 // electron/window-manager.js)
 const POWER_CHANNELS = Object.freeze({
@@ -295,6 +303,7 @@ module.exports = {
   VFS_CHANNELS,
   AUTH_CHANNELS,
   SAFE_STORAGE_CHANNELS,
+  ANALYTICS_CHANNELS,
   POWER_CHANNELS,
   EDITOR_CHANNELS,
   NLP_CHANNELS,

--- a/electron/main.js
+++ b/electron/main.js
@@ -44,7 +44,18 @@ const { registerDictHandlers } = require("./ipc/dict-ipc");
 const { getDictManager } = require("./dict-manager");
 const { registerRulesetsHandlers } = require("./ipc/rulesets-ipc");
 const { getRulesetsManager } = require("./rulesets-manager");
+const { registerAnalyticsHandlers } = require("./ipc/analytics-ipc");
 const { DICT_CHANNELS, POWER_CHANNELS, RULESETS_CHANNELS } = require("./lib/ipc-channels");
+
+// --- Aptabase（匿名使用統計）初期化 ---
+// initialize() は app.whenReady() より前に呼ぶ必要がある（内部でカスタムプロトコルを
+// privileged scheme として登録するため）。App Key はビルド時に esbuild の define で
+// 埋め込まれる（scripts/bundle-electron.mjs）。未設定（OSSビルド等）の場合は計測を無効化する。
+const APTABASE_APP_KEY = process.env.APTABASE_APP_KEY || "";
+if (APTABASE_APP_KEY) {
+  const { initialize: initializeAnalytics } = require("@aptabase/electron/main");
+  initializeAnalytics(APTABASE_APP_KEY);
+}
 
 process.on("uncaughtException", (err) => {
   console.error("[FATAL] Uncaught exception:", err);
@@ -208,6 +219,22 @@ app.whenReady().then(async () => {
   registerEditorHandlers();
   registerDictHandlers();
   registerRulesetsHandlers();
+  registerAnalyticsHandlers({ hasAppKey: () => Boolean(APTABASE_APP_KEY) });
+
+  // 匿名使用統計：起動イベント（同意フラグ未設定時はデフォルト ON）
+  if (APTABASE_APP_KEY) {
+    try {
+      const appState = await getStorageManager().loadAppState();
+      if (appState?.usageAnalyticsConsent !== false) {
+        const { trackEvent } = require("@aptabase/electron/main");
+        void trackEvent("app_launched", { platform: process.platform }).catch((trackError) => {
+          console.warn("[Analytics] Failed to send app_launched event:", trackError);
+        });
+      }
+    } catch (err) {
+      console.warn("[Analytics] Failed to send app_launched event:", err);
+    }
+  }
 
   // Power state monitoring
   powerMonitor.on("on-ac", () => broadcastPowerState("ac"));

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -20,6 +20,7 @@ const {
   VFS_CHANNELS,
   AUTH_CHANNELS,
   SAFE_STORAGE_CHANNELS,
+  ANALYTICS_CHANNELS,
   POWER_CHANNELS,
   EDITOR_CHANNELS,
   NLP_CHANNELS,
@@ -164,6 +165,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
     encrypt: invokeChannel(SAFE_STORAGE_CHANNELS.invoke.encrypt, { arity: 1 }),
     decrypt: invokeChannel(SAFE_STORAGE_CHANNELS.invoke.decrypt, { arity: 1 }),
     isAvailable: invokeChannel(SAFE_STORAGE_CHANNELS.invoke.isAvailable, { arity: 0 }),
+  },
+  analytics: {
+    // イベント名 + ホワイトリスト化した引数のみを渡す。同意フラグの判定と実送信は
+    // main process（electron/ipc/analytics-ipc.js）で行う。
+    trackEvent: invokeChannel(ANALYTICS_CHANNELS.invoke.trackEvent, { arity: 2 }),
   },
   power: {
     // Returns an unsubscribe function that removes ONLY this wrapper.

--- a/lib/editor-page/use-analytics-settings.ts
+++ b/lib/editor-page/use-analytics-settings.ts
@@ -1,0 +1,43 @@
+/**
+ * Usage analytics (Aptabase) settings hook — manages the consent AppState field.
+ * Follows the same pattern as use-dict-settings.ts.
+ */
+import { useCallback, useState } from "react";
+import { persistAppState } from "@/lib/storage/app-state-manager";
+
+export interface AnalyticsSettings {
+  usageAnalyticsConsent: boolean;
+}
+
+export interface AnalyticsSettingsHandlers {
+  handleUsageAnalyticsConsentChange: (value: boolean) => void;
+}
+
+export interface UseAnalyticsSettingsResult {
+  analyticsSettings: AnalyticsSettings;
+  analyticsHandlers: AnalyticsSettingsHandlers;
+  applyPersistedAnalyticsSettings: (appState: Record<string, unknown>) => void;
+}
+
+export function useAnalyticsSettings(): UseAnalyticsSettingsResult {
+  const [usageAnalyticsConsent, setUsageAnalyticsConsent] = useState(true);
+
+  const applyPersistedAnalyticsSettings = useCallback((appState: Record<string, unknown>) => {
+    if (typeof appState.usageAnalyticsConsent === "boolean") {
+      setUsageAnalyticsConsent(appState.usageAnalyticsConsent);
+    }
+  }, []);
+
+  const handleUsageAnalyticsConsentChange = useCallback((value: boolean) => {
+    setUsageAnalyticsConsent(value);
+    void persistAppState({ usageAnalyticsConsent: value }).catch((e: unknown) =>
+      console.error("プライバシー設定の保存に失敗しました", e),
+    );
+  }, []);
+
+  return {
+    analyticsSettings: { usageAnalyticsConsent },
+    analyticsHandlers: { handleUsageAnalyticsConsentChange },
+    applyPersistedAnalyticsSettings,
+  };
+}

--- a/lib/editor-page/use-editor-settings.ts
+++ b/lib/editor-page/use-editor-settings.ts
@@ -14,20 +14,28 @@ import { useDictSettings } from "./use-dict-settings";
 import type { DictSettings, DictSettingsHandlers } from "./use-dict-settings";
 import { useUpdateSettings } from "./use-update-settings";
 import type { UpdateSettings, UpdateSettingsHandlers } from "./use-update-settings";
+import { useAnalyticsSettings } from "./use-analytics-settings";
+import type { AnalyticsSettings, AnalyticsSettingsHandlers } from "./use-analytics-settings";
 
 export type { DisplaySettings, DisplaySettingsHandlers } from "./use-display-settings";
 export type { AiSettings, AiSettingsHandlers } from "./use-ai-settings";
 export type { DictSettings, DictSettingsHandlers } from "./use-dict-settings";
 export type { UpdateSettings, UpdateSettingsHandlers } from "./use-update-settings";
+export type { AnalyticsSettings, AnalyticsSettingsHandlers } from "./use-analytics-settings";
 
-/** Combined editor settings from display, AI, dictionary, and update sub-hooks */
-export type EditorSettings = DisplaySettings & AiSettings & DictSettings & UpdateSettings;
+/** Combined editor settings from display, AI, dictionary, update, and analytics sub-hooks */
+export type EditorSettings = DisplaySettings &
+  AiSettings &
+  DictSettings &
+  UpdateSettings &
+  AnalyticsSettings;
 
-/** Combined handlers from display, AI, dictionary, and update sub-hooks */
+/** Combined handlers from display, AI, dictionary, update, and analytics sub-hooks */
 export type EditorSettingsHandlers = Omit<DisplaySettingsHandlers, "setShowSettingsModal"> &
   Omit<AiSettingsHandlers, "setLintingEnabled" | "setLintingRuleConfigs"> &
   DictSettingsHandlers &
-  UpdateSettingsHandlers & {
+  UpdateSettingsHandlers &
+  AnalyticsSettingsHandlers & {
     setShowSettingsModal: (value: boolean) => void;
     handleLintingEnabledChange: (value: boolean) => void;
     handleLintingRuleConfigChange: (
@@ -72,6 +80,8 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
   const { aiSettings, aiHandlers, applyPersistedAiSettings } = useAiSettings();
   const { dictSettings, dictHandlers, applyPersistedDictSettings } = useDictSettings();
   const { updateSettings, updateHandlers, applyPersistedUpdateSettings } = useUpdateSettings();
+  const { analyticsSettings, analyticsHandlers, applyPersistedAnalyticsSettings } =
+    useAnalyticsSettings();
 
   // Flips true once persisted state has been applied, so downstream effects
   // (e.g. the mode-config migration) can wait for the real values instead of
@@ -93,6 +103,7 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
           applyPersistedAiSettings(appState as Record<string, unknown>);
           applyPersistedDictSettings(appState as Record<string, unknown>);
           applyPersistedUpdateSettings(appState as Record<string, unknown>);
+          applyPersistedAnalyticsSettings(appState as Record<string, unknown>);
 
           // Force editor rebuild to apply restored settings (e.g. custom font)
           incrementEditorKey();
@@ -116,6 +127,7 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
     ...aiSettings,
     ...dictSettings,
     ...updateSettings,
+    ...analyticsSettings,
   };
 
   const handlers: EditorSettingsHandlers = {
@@ -139,6 +151,7 @@ export function useEditorSettings(incrementEditorKey: () => void): UseEditorSett
     handleAiApiKeyChange: aiHandlers.handleAiApiKeyChange,
     handleAiBaseUrlChange: aiHandlers.handleAiBaseUrlChange,
     handleAiModelIdChange: aiHandlers.handleAiModelIdChange,
+    handleUsageAnalyticsConsentChange: analyticsHandlers.handleUsageAnalyticsConsentChange,
   };
 
   return {

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -195,6 +195,13 @@ export interface AppState {
   allowBetaUpdates?: boolean;
   /** 起動時に校正ルールセットの更新を自動で適用する（デフォルト: true） */
   rulesetAutoUpdate?: boolean;
+
+  // プライバシー設定
+  /**
+   * 匿名使用統計（Aptabase）の送信に同意する（デフォルト: true）。
+   * 本文・ファイル名・パス・検索語など内容に関わる情報は送信対象に含まれない。
+   */
+  usageAnalyticsConsent?: boolean;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@aptabase/electron": "^0.3.1",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -109,6 +110,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@aptabase/electron": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@aptabase/electron/-/electron-0.3.1.tgz",
+      "integrity": "sha512-FECaGsjuoQu70F+M6V1evdgLP7yaq/sne9fC60AZZ6B9RsCDlxFBnJzdq3+xevHlUx6AB5o9ygUhQ+ONT9EqiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "electron": ">= 3.x"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1159,7 +1169,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
       "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
@@ -1181,7 +1190,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -1196,7 +1204,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -1206,7 +1213,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -4524,9 +4530,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4544,9 +4547,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4564,9 +4564,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4584,9 +4581,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4604,9 +4598,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4624,9 +4615,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4987,7 +4975,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5016,7 +5003,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
@@ -5050,7 +5036,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
@@ -5136,7 +5121,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -5164,7 +5148,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5250,7 +5233,6 @@
       "version": "26.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
       "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -5297,7 +5279,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5320,7 +5301,6 @@
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7367,7 +7347,6 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -7471,7 +7450,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -7537,7 +7515,6 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
@@ -7547,7 +7524,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
@@ -7845,7 +7821,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
@@ -8606,7 +8581,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8679,7 +8653,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
       "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9019,7 +8992,6 @@
       "version": "41.4.0",
       "resolved": "https://registry.npmjs.org/electron/-/electron-41.4.0.tgz",
       "integrity": "sha512-1afmxJGyrZ4bve+PDCs8YtNjjVu4cPwUtSjx36o6gyJWI0NvhebMKtIzzKNOScRyXntH2hX0i350Xgm3BKiEYQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -9229,7 +9201,6 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -9239,7 +9210,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -9274,7 +9244,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9485,7 +9454,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9544,7 +9512,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -10107,7 +10075,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -10210,7 +10177,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -10594,7 +10560,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
@@ -10695,7 +10660,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
       "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -10714,7 +10678,6 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -10741,7 +10704,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
       "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -10770,7 +10733,6 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
@@ -10984,7 +10946,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
@@ -11005,7 +10966,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -11994,7 +11954,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -12028,7 +11987,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -12158,7 +12116,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -12583,9 +12540,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12607,9 +12561,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12631,9 +12582,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12655,9 +12603,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -13155,7 +13100,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13289,7 +13233,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
       "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14284,7 +14227,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -14757,7 +14699,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -15053,7 +14994,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15259,7 +15199,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -15685,7 +15624,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -16031,7 +15969,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -16523,7 +16460,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -16550,7 +16486,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
@@ -16636,7 +16571,6 @@
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
       "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -16842,7 +16776,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -16852,7 +16785,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
       "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -16860,7 +16792,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
       "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17320,7 +17251,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
     },
@@ -17693,7 +17623,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
       "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.1.0"
@@ -18256,7 +18185,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
       "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "optional": true,
       "engines": {
@@ -18433,7 +18361,6 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -19348,7 +19275,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "postinstall": "node -e \"if(!process.env.VERCEL){require('child_process').execSync('electron-builder install-app-deps',{stdio:'inherit'})}\""
   },
   "dependencies": {
+    "@aptabase/electron": "^0.3.1",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -25,6 +25,24 @@ if (!fs.existsSync(outDir)) {
   fs.mkdirSync(outDir, { recursive: true });
 }
 
+// Load APTABASE_APP_KEY from .env.local for local dev builds (CI sets it directly
+// via job env / secrets). Not a real secret (it's a public app identifier, like a
+// Sentry DSN), but CLAUDE.md forbids hardcoding it in source, so it's baked into
+// the bundle at build time via esbuild `define` instead of read from process.env
+// at runtime (the packaged app has no .env file or shell env to read from).
+if (!process.env.APTABASE_APP_KEY) {
+  const envLocalPath = join(projectRoot, ".env.local");
+  if (fs.existsSync(envLocalPath)) {
+    const match = fs
+      .readFileSync(envLocalPath, "utf8")
+      .split("\n")
+      .find((line) => line.startsWith("APTABASE_APP_KEY="));
+    if (match) {
+      process.env.APTABASE_APP_KEY = match.slice("APTABASE_APP_KEY=".length).trim();
+    }
+  }
+}
+
 console.log("📦 Bundling Electron main process...");
 
 // Bundle main process
@@ -44,6 +62,9 @@ await esbuild.build({
     // node-pty is a native module for terminal support
     "node-pty",
   ],
+  define: {
+    "process.env.APTABASE_APP_KEY": JSON.stringify(process.env.APTABASE_APP_KEY || ""),
+  },
   format: "cjs",
   minify: false, // Keep readable for debugging
   sourcemap: true,

--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -25,24 +25,6 @@ if (!fs.existsSync(outDir)) {
   fs.mkdirSync(outDir, { recursive: true });
 }
 
-// Load APTABASE_APP_KEY from .env.local for local dev builds (CI sets it directly
-// via job env / secrets). Not a real secret (it's a public app identifier, like a
-// Sentry DSN), but CLAUDE.md forbids hardcoding it in source, so it's baked into
-// the bundle at build time via esbuild `define` instead of read from process.env
-// at runtime (the packaged app has no .env file or shell env to read from).
-if (!process.env.APTABASE_APP_KEY) {
-  const envLocalPath = join(projectRoot, ".env.local");
-  if (fs.existsSync(envLocalPath)) {
-    const match = fs
-      .readFileSync(envLocalPath, "utf8")
-      .split("\n")
-      .find((line) => line.startsWith("APTABASE_APP_KEY="));
-    if (match) {
-      process.env.APTABASE_APP_KEY = match.slice("APTABASE_APP_KEY=".length).trim();
-    }
-  }
-}
-
 console.log("📦 Bundling Electron main process...");
 
 // Bundle main process

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -267,6 +267,14 @@ declare global {
       /** Check if OS-level encryption is available */
       isAvailable: () => Promise<boolean>;
     };
+    analytics?: {
+      /**
+       * Track an anonymous usage analytics event (Aptabase). Event name and
+       * props are whitelisted on the renderer side; consent enforcement and
+       * the actual send happen in main process.
+       */
+      trackEvent: (eventName: string, props?: Record<string, string | number>) => Promise<void>;
+    };
     power?: {
       /**
        * Listen for debounced power state changes from main process.


### PR DESCRIPTION
## Summary

- デスクトップ版に Aptabase ベースの匿名使用統計を導入しました。
- 設定画面から送信同意を切り替えられるようにしました。
- 起動イベント app_launched を同意時のみ送信するようにしました。

## Changes

- Electron main / preload / IPC: analytics:track-event を追加し、起動時の送信と同意判定を main process に集約しました。
- Settings UI: 「プライバシー」タブと匿名使用統計トグルを追加しました。
- Build / CI: Aptabase App Key を local build と GitHub Actions へ流すようにしました。
- Tests: settings tab registry と analytics IPC のテストを追加しました。

## Test plan

- [x] npm run type-check
- [x] npx vitest run
- [x] node scripts/check-import-boundaries.mjs
- [x] npm run bundle:electron

Closes #1816

🤖 Generated with [Codex](https://Codex.com/Codex)
