### PR TITLE
chore(build): bundle ID を app.illusions.editor / app.illusions.mdi に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     ]
   },
   "build": {
-    "appId": "com.iktahana.illusions",
+    "appId": "app.illusions.editor",
     "productName": "illusions",
     "directories": {
       "app": ".",
@@ -176,7 +176,7 @@
       "extendInfo": {
         "UTExportedTypeDeclarations": [
           {
-            "UTTypeIdentifier": "com.iktahana.illusions.mdi",
+            "UTTypeIdentifier": "app.illusions.mdi",
             "UTTypeDescription": "illusions MDI Document",
             "UTTypeConformsTo": [
               "public.plain-text"

--- a/quicklook/MDIQuickLook/Info.plist
+++ b/quicklook/MDIQuickLook/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleExecutable</key>
   <string>MDIQuickLook</string>
   <key>CFBundleIdentifier</key>
-  <string>com.iktahana.illusions.quicklook</string>
+  <string>app.illusions.editor.quicklook</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>
@@ -30,7 +30,7 @@
     <dict>
       <key>QLSupportedContentTypes</key>
       <array>
-        <string>com.iktahana.illusions.mdi</string>
+        <string>app.illusions.mdi</string>
       </array>
       <key>QLSupportsSearchableItems</key>
       <false/>

--- a/quicklook/README.md
+++ b/quicklook/README.md
@@ -21,12 +21,12 @@ principal class を持つ Quick Look Preview Extension を `<App>.app/Contents/P
    - `Source/MarkdownRenderer.swift` — Markdown → HTML（macOS 12+ は `AttributedString`、
      以前は escaped plain text）
    - `Info.plist` — `NSExtension`（`com.apple.quicklook.preview`）+
-     `QLSupportedContentTypes = com.iktahana.illusions.mdi`
+     `QLSupportedContentTypes = app.illusions.mdi`
    - エントリポイントは Foundation の `NSExtensionMain`（`scripts/build-quicklook.sh` が
      `-e _NSExtensionMain` でリンク、universal binary を `lipo` で生成）
 
 2. **UTI の export**（`package.json` の `mac.extendInfo.UTExportedTypeDeclarations`）
-   - ホストアプリが `com.iktahana.illusions.mdi`（`public.plain-text` 準拠、拡張子 `mdi`）を
+   - ホストアプリが `app.illusions.mdi`（`public.plain-text` 準拠、拡張子 `mdi`）を
      export しないと、`.mdi` は動的 UTI (`dyn... = public.data`) に解決され、
      拡張の `QLSupportedContentTypes` に**永遠にマッチしません**。これが旧構成で
      プレビューが出なかったもう一つの根本原因です。


### PR DESCRIPTION
## 概要

- Mac App Store 上架準備の一環として、Electron ビルドの appId を `com.iktahana.illusions` から `app.illusions.editor` に変更
- `.mdi` ファイル形式の UTI は app のバンドルIDから独立させ `app.illusions.mdi` とした（`.mdi` は `mdi.illusions.app` に公式仕様を持つ独立したフォーマットであり、将来 illusions 以外のツールが対応する可能性を考慮）
- App Store Connect への登録はこれから（新規提出）のため、既存の MAS インストールベースは存在せず、リネームによる既存ユーザーへの影響はゼロ

## Changes

| ファイル | 変更内容 |
| --- | --- |
| `package.json` | `build.appId`: `com.iktahana.illusions` → `app.illusions.editor`／`mac.extendInfo.UTExportedTypeDeclarations[0].UTTypeIdentifier`: `com.iktahana.illusions.mdi` → `app.illusions.mdi` |
| `quicklook/MDIQuickLook/Info.plist` | `CFBundleIdentifier`: `com.iktahana.illusions.quicklook` → `app.illusions.editor.quicklook`／`QLSupportedContentTypes`: `com.iktahana.illusions.mdi` → `app.illusions.mdi`（package.json の UTTypeIdentifier と一致させる必要あり） |
| `quicklook/README.md` | 上記変更に合わせてドキュメント内の識別子表記を更新 |

## 影響範囲外（意図的に変更していないもの）

- Windows Store 側の `appx.identityName` / `publisher` / `applicationId`（Microsoft Partner Center 登録済みの既存Store提出に紐づくため）
- `illusions://` カスタムURLスキーム、`OAUTH_CLIENT_ID`（バンドルIDとは無関係の別概念）
- GitHub org/repo owner (`Iktahana`)、`author.url: iktahana.com`（開発者個人情報）

## Test plan

- [x] `package.json` の JSON 構文検証（`node -e "JSON.parse(...)"`）
- [x] `quicklook/MDIQuickLook/Info.plist` の plist 構文検証（`plutil -lint`）
- [x] リポジトリ全体で旧識別子 `com.iktahana` の残存がないことを grep で確認
- [ ] ローカル `electron:build` でビルドし `.app` の `Info.plist` に新IDが反映されることを確認（macOS実機）
- [ ] Quick Look 拡張が新UTIで `.mdi` プレビューに正しくマッチすることを確認（署名済みビルドが必要）

関連 issue なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)