### PR TITLE
fix(ci): publish GitHub releases from draft to survive immutable-release enforcement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -811,7 +811,7 @@ jobs:
       # release is published, so assets must be attached while the release is
       # still a draft. Publish only after every asset above has landed.
       - name: Publish GitHub Release
-        run: gh release edit "v${{ needs.compute-version.outputs.full }}" --draft=false
+        run: gh release edit "v${{ needs.compute-version.outputs.full }}" --draft=false --repo "${{ github.repository }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -795,15 +795,23 @@ jobs:
           find dist-electron -type f \( -name "*.yml" -o -name "*.exe" -o -name "*.exe.blockmap" -o -name "*.dmg" -o -name "*.dmg.blockmap" -o -name "*-mac.zip" -o -name "*-mac.zip.blockmap" -o -name "*.appx" -o -name "*.appx.blockmap" -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \) -exec cp {} release-assets/ \;
           ls -lh release-assets/
 
-      - name: Create GitHub Release and upload assets
+      - name: Create draft GitHub Release and upload assets
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.compute-version.outputs.full }}
           name: Illusions v${{ needs.compute-version.outputs.full }}
           files: release-assets/*
-          draft: false
+          draft: true
           prerelease: ${{ needs.compute-version.outputs.branch != 'main' }}
           generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # GitHub's immutable-releases enforcement rejects asset uploads once a
+      # release is published, so assets must be attached while the release is
+      # still a draft. Publish only after every asset above has landed.
+      - name: Publish GitHub Release
+        run: gh release edit "v${{ needs.compute-version.outputs.full }}" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- The first beta release from this session (v1.2.22-beta.20260706.41208) shipped with **zero assets** — GitHub's immutable-release enforcement rejects asset uploads after `softprops/action-gh-release@v3` publishes the release with `draft: false`.
- Manually verified with `gh release upload` against the broken release: `HTTP 422: Cannot upload assets to an immutable release.`
- Fix: create the release as `draft: true`, let assets attach while mutable, then publish with a follow-up `gh release edit --draft=false` step.

## Test plan
- [ ] Next beta/main build.yml run creates a release with all installer assets attached
- [ ] Verify `gh release view <tag> --json assets` is non-empty after the run

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>