### PR TITLE
Add privacy-safe Aptabase usage events

### DIFF
--- a/components/CreateProjectWizard.tsx
+++ b/components/CreateProjectWizard.tsx
@@ -3,6 +3,11 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { FolderPlus, Check, Loader2, AlertCircle, ChevronDown } from "lucide-react";
 import { getProjectService, validateProjectName } from "@/lib/project/project-service";
+import {
+  classifyTelemetryError,
+  normalizeTelemetryFileType,
+  trackUsageEvent,
+} from "@/lib/analytics/usage-events";
 import GlassDialog from "@/shared/ui/GlassDialog";
 
 import type { ProjectMode, SupportedFileExtension } from "@/lib/project/project-types";
@@ -92,6 +97,7 @@ export default function CreateProjectWizard({
     setIsCreating(true);
     setErrorMessage(null);
     setCreationSuccess(false);
+    trackUsageEvent("project_create_started", { surface: "wizard", mode: "project" });
 
     try {
       const projectService = getProjectService();
@@ -101,6 +107,11 @@ export default function CreateProjectWizard({
 
       setCreationSuccess(true);
       setIsCreating(false);
+      trackUsageEvent("project_create_completed", {
+        surface: "wizard",
+        mode: "project",
+        initial_file_type: normalizeTelemetryFileType(selectedExtension),
+      });
 
       // Brief delay to show success message before closing
       setTimeout(() => {
@@ -112,6 +123,11 @@ export default function CreateProjectWizard({
       if (!mountedRef.current) return;
 
       setIsCreating(false);
+      trackUsageEvent("project_create_failed", {
+        surface: "wizard",
+        mode: "project",
+        reason: classifyTelemetryError(error),
+      });
 
       // Handle user cancellation of directory picker
       if (error instanceof DOMException && error.name === "AbortError") {

--- a/components/explorer/FilesPanel.tsx
+++ b/components/explorer/FilesPanel.tsx
@@ -10,6 +10,11 @@ import { isElectronRenderer, detectOSPlatform } from "@/lib/utils/runtime-env";
 import { isTextDroppable } from "@/lib/utils/file-type-guard";
 import { notificationManager } from "@/lib/services/notification-manager";
 import {
+  bucketTelemetryCount,
+  normalizeTelemetryFileType,
+  trackUsageEvent,
+} from "@/lib/analytics/usage-events";
+import {
   flattenVisibleRows,
   nextRowPath,
   prevRowPath,
@@ -291,7 +296,7 @@ export function FilesPanel({
   );
 
   const executeDelete = useCallback(
-    async (fullPath: string, kind: "file" | "directory") => {
+    async (fullPath: string, kind: "file" | "directory", affectedTabs: AffectedTab[] = []) => {
       try {
         const { getProjectFileService } = await import("@/lib/services/project-file-service");
         const vfs = getProjectFileService();
@@ -313,6 +318,13 @@ export function FilesPanel({
         // #1868: detach any open tabs at/under the deleted path so the next
         // save cannot recreate the now-deleted file at its old location.
         onFileDeleted?.(toVFSPath(fullPath));
+        trackUsageEvent("project_file_deleted", {
+          surface: "explorer",
+          target_kind: kind === "directory" ? "folder" : "file",
+          dirty_open_tabs_bucket: bucketTelemetryCount(
+            affectedTabs.filter((tab) => tab.isDirty).length,
+          ),
+        });
         refresh();
       } catch (error) {
         console.error("Failed to delete:", error);
@@ -347,6 +359,11 @@ export function FilesPanel({
               await vfs.rename(toVFSPath(fullPath), toVFSPath(newFullPath));
               // #1868: keep open tabs in sync with the new path before refresh.
               onFileRenamed?.(toVFSPath(fullPath), toVFSPath(newFullPath));
+              trackUsageEvent("project_file_renamed", {
+                surface: "explorer",
+                target_kind: "file",
+                result: "completed",
+              });
               refresh();
             },
           });
@@ -356,6 +373,11 @@ export function FilesPanel({
         await vfs.rename(toVFSPath(fullPath), toVFSPath(newFullPath));
         // #1868: keep open tabs in sync with the new path before refresh.
         onFileRenamed?.(toVFSPath(fullPath), toVFSPath(newFullPath));
+        trackUsageEvent("project_file_renamed", {
+          surface: "explorer",
+          target_kind: "file",
+          result: "completed",
+        });
         setEditing(null);
         refresh();
       } catch (error) {
@@ -387,6 +409,11 @@ export function FilesPanel({
             name: copyName,
             execute: async () => {
               await vfs.writeFile(toVFSPath(copyPath), content);
+              trackUsageEvent("project_file_duplicated", {
+                surface: "explorer",
+                file_type: normalizeTelemetryFileType(ext),
+                collision: "confirmed",
+              });
               refresh();
             },
           });
@@ -394,6 +421,11 @@ export function FilesPanel({
         }
 
         await vfs.writeFile(toVFSPath(copyPath), content);
+        trackUsageEvent("project_file_duplicated", {
+          surface: "explorer",
+          file_type: normalizeTelemetryFileType(ext),
+          collision: "none",
+        });
         refresh();
       } catch (error) {
         console.error("Failed to duplicate:", error);
@@ -445,6 +477,11 @@ export function FilesPanel({
             name: finalName,
             execute: async () => {
               await vfs.writeFile(toVFSPath(filePath), "");
+              trackUsageEvent("project_file_created", {
+                surface: "explorer",
+                file_type: normalizeTelemetryFileType(finalName.slice(finalName.lastIndexOf("."))),
+                collision: "confirmed",
+              });
               refresh();
             },
           });
@@ -452,6 +489,11 @@ export function FilesPanel({
         }
 
         await vfs.writeFile(toVFSPath(filePath), "");
+        trackUsageEvent("project_file_created", {
+          surface: "explorer",
+          file_type: normalizeTelemetryFileType(finalName.slice(finalName.lastIndexOf("."))),
+          collision: "none",
+        });
         setEditing(null);
         refresh();
       } catch (error) {
@@ -473,6 +515,7 @@ export function FilesPanel({
         const vfs = getProjectFileService();
         const parentHandle = await vfs.getDirectoryHandle(toVFSPath(parentPath));
         await parentHandle.getDirectoryHandle(name, { create: true });
+        trackUsageEvent("project_folder_created", { surface: "explorer" });
         setEditing(null);
         // Expand the parent so new folder is visible
         setExpandedDirs((prev) => {
@@ -613,6 +656,11 @@ export function FilesPanel({
                 name: file.name,
                 execute: async () => {
                   await vfs.writeFile(toVFSPath(capturedFilePath), capturedContent);
+                  trackUsageEvent("project_file_created", {
+                    surface: "explorer",
+                    file_type: normalizeTelemetryFileType(file.name.split(".").pop() ?? ""),
+                    collision: "confirmed",
+                  });
                   refresh();
                 },
               });
@@ -621,6 +669,11 @@ export function FilesPanel({
             }
 
             await vfs.writeFile(toVFSPath(filePath), content);
+            trackUsageEvent("project_file_created", {
+              surface: "explorer",
+              file_type: normalizeTelemetryFileType(file.name.split(".").pop() ?? ""),
+              collision: "none",
+            });
           } catch (err) {
             console.warn("Failed to read external file:", file.name, err);
           }
@@ -1378,7 +1431,7 @@ export function FilesPanel({
         dangerous={true}
         onConfirm={() => {
           if (deleteConfirm) {
-            void executeDelete(deleteConfirm.path, deleteConfirm.kind);
+            void executeDelete(deleteConfirm.path, deleteConfirm.kind, deleteConfirm.affectedTabs);
           }
           setDeleteConfirm(null);
         }}

--- a/electron/ipc/__tests__/analytics-ipc.test.ts
+++ b/electron/ipc/__tests__/analytics-ipc.test.ts
@@ -37,20 +37,28 @@ describe("registerAnalyticsHandlers", () => {
     delete process.env.APTABASE_APP_KEY;
   });
 
-  it("tracks whitelisted events when analytics consent is enabled", async () => {
+  it("tracks contract-approved events when analytics consent is enabled", async () => {
     const handler = await createHandler();
 
-    await handler({}, "feature_used", { feature: "export", count: 1 });
+    await handler({}, "save_completed", {
+      trigger: "manual",
+      mode: "standalone",
+      target_kind: "file",
+    });
 
     expect(loadAppStateMock).toHaveBeenCalledOnce();
-    expect(trackEventMock).toHaveBeenCalledWith("feature_used", { feature: "export", count: 1 });
+    expect(trackEventMock).toHaveBeenCalledWith("save_completed", {
+      trigger: "manual",
+      mode: "standalone",
+      target_kind: "file",
+    });
   });
 
   it("does not track events when analytics consent is disabled", async () => {
     loadAppStateMock.mockResolvedValue({ usageAnalyticsConsent: false });
     const handler = await createHandler();
 
-    await handler({}, "feature_used", { feature: "export" });
+    await handler({}, "auth_login_started", { surface: "settings" });
 
     expect(loadAppStateMock).toHaveBeenCalledOnce();
     expect(trackEventMock).not.toHaveBeenCalled();
@@ -59,7 +67,7 @@ describe("registerAnalyticsHandlers", () => {
   it("does not load app state or track when the app key is unavailable", async () => {
     const handler = await createHandler(false);
 
-    await handler({}, "feature_used", { feature: "export" });
+    await handler({}, "auth_login_started", { surface: "settings" });
 
     expect(loadAppStateMock).not.toHaveBeenCalled();
     expect(trackEventMock).not.toHaveBeenCalled();
@@ -68,7 +76,43 @@ describe("registerAnalyticsHandlers", () => {
   it("rejects non-whitelisted props before reading consent", async () => {
     const handler = await createHandler();
 
-    await handler({}, "feature_used", { feature: "export", nested: { path: "/tmp/file.mdi" } });
+    await handler({}, "file_open_completed", {
+      surface: "menu",
+      source: "dialog",
+      file_type: "mdi",
+      nested: { path: "/tmp/file.mdi" },
+    });
+
+    expect(loadAppStateMock).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown event names before reading consent", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "feature_used", { feature: "export" });
+
+    expect(loadAppStateMock).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-contract props that could carry account data before reading consent", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "auth_login_completed", { surface: "settings", email: "user@example.com" });
+
+    expect(loadAppStateMock).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-contract prop values before reading consent", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "project_file_created", {
+      surface: "explorer",
+      file_type: "chapter-name.mdi",
+      collision: "none",
+    });
 
     expect(loadAppStateMock).not.toHaveBeenCalled();
     expect(trackEventMock).not.toHaveBeenCalled();

--- a/electron/ipc/analytics-ipc.js
+++ b/electron/ipc/analytics-ipc.js
@@ -4,13 +4,21 @@
 
 const { ipcMain } = require("electron");
 const { ANALYTICS_CHANNELS } = require("../lib/ipc-channels");
+const usageEventContract = require("../../lib/analytics/usage-event-contract.json");
 
-function isWhitelistedProps(props) {
+function isWhitelistedProps(eventName, props) {
+  const eventContract = usageEventContract.events[eventName];
+  if (!eventContract) return false;
   if (props === undefined) return true;
   if (typeof props !== "object" || props === null) return false;
-  return Object.values(props).every(
-    (value) => typeof value === "string" || typeof value === "number",
-  );
+  return Object.entries(props).every(([key, value]) => {
+    const allowedValues = eventContract[key];
+    if (!Array.isArray(allowedValues)) return false;
+    if (typeof value === "number")
+      return Number.isFinite(value) && allowedValues.includes("__number");
+    if (typeof value !== "string") return false;
+    return allowedValues.includes(value);
+  });
 }
 
 /**
@@ -33,7 +41,7 @@ function createAnalyticsTrackEventHandler(
 ) {
   return async (_event, eventName, props) => {
     if (typeof eventName !== "string" || !eventName) return;
-    if (!isWhitelistedProps(props)) return;
+    if (!isWhitelistedProps(eventName, props)) return;
     if (!hasAppKey()) return;
 
     try {

--- a/lib/analytics/__tests__/usage-events.test.ts
+++ b/lib/analytics/__tests__/usage-events.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("usage analytics facade", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    Reflect.deleteProperty(window, "electronAPI");
+  });
+
+  it("forwards approved anonymous events to the Electron analytics bridge", async () => {
+    const trackEvent = vi.fn(async () => undefined);
+    Object.defineProperty(window, "electronAPI", {
+      value: { analytics: { trackEvent } },
+      configurable: true,
+    });
+    const { trackUsageEvent } = await import("../usage-events");
+
+    trackUsageEvent("project_create_completed", {
+      surface: "wizard",
+      mode: "project",
+      initial_file_type: "mdi",
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith("project_create_completed", {
+      surface: "wizard",
+      mode: "project",
+      initial_file_type: "mdi",
+    });
+  });
+
+  it("drops undefined props before sending", async () => {
+    const trackEvent = vi.fn(async () => undefined);
+    Object.defineProperty(window, "electronAPI", {
+      value: { analytics: { trackEvent } },
+      configurable: true,
+    });
+    const { trackUsageEvent } = await import("../usage-events");
+
+    trackUsageEvent("save_failed", {
+      trigger: "manual",
+      mode: "standalone",
+      target_kind: "file",
+      reason: undefined,
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith("save_failed", {
+      trigger: "manual",
+      mode: "standalone",
+      target_kind: "file",
+    });
+  });
+
+  it("does not throw when analytics bridge is unavailable", async () => {
+    const { trackUsageEvent } = await import("../usage-events");
+
+    expect(() => {
+      trackUsageEvent("auth_login_started", { surface: "settings" });
+    }).not.toThrow();
+  });
+
+  it("maps raw errors to safe reason enums without exposing messages", async () => {
+    const { classifyTelemetryError } = await import("../usage-events");
+
+    expect(
+      classifyTelemetryError(Object.assign(new Error("user@example.com"), { code: "ENOENT" })),
+    ).toBe("not_found");
+    expect(classifyTelemetryError(new Error("/Users/alice/private/chapter.mdi"))).toBe("unknown");
+  });
+
+  it("buckets counts instead of sending exact project/file counts", async () => {
+    const { bucketTelemetryCount } = await import("../usage-events");
+
+    expect(bucketTelemetryCount(0)).toBe("0");
+    expect(bucketTelemetryCount(1)).toBe("1");
+    expect(bucketTelemetryCount(4)).toBe("2_5");
+    expect(bucketTelemetryCount(8)).toBe("6_10");
+    expect(bucketTelemetryCount(12)).toBe("11_plus");
+  });
+
+  it("normalizes file extensions without preserving filenames", async () => {
+    const { normalizeTelemetryFileType } = await import("../usage-events");
+
+    expect(normalizeTelemetryFileType(".mdi")).toBe("mdi");
+    expect(normalizeTelemetryFileType("chapter.mdi")).toBe("unknown");
+    expect(normalizeTelemetryFileType(".markdown")).toBe("unknown");
+  });
+
+  it("maps save outcomes to safe reason enums", async () => {
+    const { classifySaveOutcome } = await import("../usage-events");
+
+    expect(classifySaveOutcome({ status: "cancelled" })).toBe("cancelled");
+    expect(classifySaveOutcome({ status: "conflicted" })).toBe("conflict");
+    expect(classifySaveOutcome({ status: "locked" })).toBe("locked");
+    expect(classifySaveOutcome({ status: "failed", error: new Error("/tmp/private.mdi") })).toBe(
+      "unknown",
+    );
+  });
+
+  it("derives target kind from anonymous file descriptor shape only", async () => {
+    const { getTelemetryTargetKind } = await import("../usage-events");
+
+    expect(getTelemetryTargetKind(null)).toBe("untitled");
+    expect(getTelemetryTargetKind({ path: "/Users/alice/private.mdi", handle: null })).toBe("file");
+    expect(getTelemetryTargetKind({ path: null, handle: {} })).toBe("handle");
+  });
+});

--- a/lib/analytics/usage-event-contract.json
+++ b/lib/analytics/usage-event-contract.json
@@ -1,0 +1,470 @@
+{
+  "events": {
+    "app_launched": {
+      "platform": ["aix", "darwin", "freebsd", "linux", "openbsd", "sunos", "win32"]
+    },
+    "auth_login_started": {
+      "surface": ["settings", "welcome", "menu", "startup", "callback", "unknown"]
+    },
+    "auth_login_completed": {
+      "surface": ["settings", "welcome", "menu", "startup", "callback", "unknown"]
+    },
+    "auth_login_failed": {
+      "surface": ["settings", "welcome", "menu", "startup", "callback", "unknown"],
+      "stage": ["start", "callback", "exchange", "restore", "refresh", "logout", "unknown"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "auth_session_restored": {
+      "surface": ["startup"],
+      "strategy": ["electron_tokens", "web_cookie"]
+    },
+    "auth_session_restore_failed": {
+      "surface": ["startup"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "auth_refresh_completed": {
+      "surface": ["startup"]
+    },
+    "auth_refresh_failed": {
+      "surface": ["startup"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "auth_logout_completed": {
+      "surface": ["settings", "menu", "unknown"]
+    },
+    "auth_logout_failed": {
+      "surface": ["settings", "menu", "unknown"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "save_attempted": {
+      "trigger": ["manual", "save_as", "auto", "close_tab", "window_close", "save_all"],
+      "mode": ["project", "standalone"],
+      "target_kind": ["file", "untitled", "handle", "unknown"]
+    },
+    "save_completed": {
+      "trigger": ["manual", "save_as", "auto", "close_tab", "window_close", "save_all"],
+      "mode": ["project", "standalone"],
+      "target_kind": ["file", "untitled", "handle", "unknown"]
+    },
+    "save_failed": {
+      "trigger": ["manual", "save_as", "auto", "close_tab", "window_close", "save_all"],
+      "mode": ["project", "standalone"],
+      "target_kind": ["file", "untitled", "handle", "unknown"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "save_blocked": {
+      "trigger": ["manual", "save_as", "auto", "close_tab", "window_close", "save_all"],
+      "mode": ["project", "standalone"],
+      "target_kind": ["file", "untitled", "handle", "unknown"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "save_all_completed": {
+      "dirty_count_bucket": ["0", "1", "2_5", "6_10", "11_plus"],
+      "result": ["all_saved", "blocked", "partial"]
+    },
+    "autosave_attempted": {
+      "target_kind": ["file", "untitled", "handle", "unknown"],
+      "activity": ["foreground", "background", "unknown"]
+    },
+    "autosave_failed": {
+      "target_kind": ["file", "untitled", "handle", "unknown"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "save_conflict_blocked": {
+      "trigger": ["manual", "save_as", "auto", "close_tab", "window_close", "save_all"],
+      "mode": ["project", "standalone"]
+    },
+    "project_create_started": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "mode": ["project", "standalone"]
+    },
+    "project_create_completed": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "mode": ["project", "standalone"],
+      "initial_file_type": ["mdi", "md", "txt", "unknown"]
+    },
+    "project_create_failed": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "mode": ["project", "standalone"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "project_open_started": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "source": ["dialog", "recent", "system_open", "auto_restore", "open_as_project"]
+    },
+    "project_open_completed": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "source": ["dialog", "recent", "system_open", "auto_restore", "open_as_project"],
+      "restore_strategy": ["fresh", "recent", "stored_handle", "none"]
+    },
+    "project_open_failed": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "source": ["dialog", "recent", "system_open", "auto_restore", "open_as_project"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "project_recent_open_failed": {
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "project_auto_restore_completed": {
+      "restore_strategy": ["fresh", "recent", "stored_handle", "none"]
+    },
+    "project_auto_restore_failed": {
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "file_new_created": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "file_type": ["mdi", "md", "txt", "unknown"],
+      "context": ["standalone", "project"]
+    },
+    "file_open_started": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "source": ["dialog", "recent", "system_open", "auto_restore", "open_as_project"]
+    },
+    "file_open_completed": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "source": ["dialog", "recent", "system_open", "auto_restore", "open_as_project"],
+      "file_type": ["mdi", "md", "txt", "unknown"]
+    },
+    "file_open_failed": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "source": ["dialog", "recent", "system_open", "auto_restore", "open_as_project"],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "project_file_open_completed": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "file_type": ["mdi", "md", "txt", "unknown"],
+      "preview": ["true", "false"]
+    },
+    "project_file_open_failed": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "reason": [
+        "cancelled",
+        "conflict",
+        "invalid_project",
+        "io_error",
+        "locked",
+        "not_found",
+        "permission_denied",
+        "unknown"
+      ]
+    },
+    "project_file_created": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "file_type": ["mdi", "md", "txt", "unknown"],
+      "collision": ["none", "confirmed", "blocked"]
+    },
+    "project_folder_created": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ]
+    },
+    "project_file_renamed": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "target_kind": ["file", "folder"],
+      "result": ["completed", "blocked", "failed"]
+    },
+    "project_file_deleted": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "target_kind": ["file", "folder"],
+      "dirty_open_tabs_bucket": ["0", "1", "2_5", "6_10", "11_plus"]
+    },
+    "project_file_duplicated": {
+      "surface": [
+        "wizard",
+        "welcome",
+        "menu",
+        "settings",
+        "sidebar",
+        "explorer",
+        "system",
+        "startup",
+        "shortcut",
+        "unknown"
+      ],
+      "file_type": ["mdi", "md", "txt", "unknown"],
+      "collision": ["none", "confirmed", "blocked"]
+    }
+  }
+}

--- a/lib/analytics/usage-events.ts
+++ b/lib/analytics/usage-events.ts
@@ -1,0 +1,149 @@
+"use client";
+
+import contract from "./usage-event-contract.json";
+
+export type UsageEventName =
+  | "app_launched"
+  | "auth_login_started"
+  | "auth_login_completed"
+  | "auth_login_failed"
+  | "auth_session_restored"
+  | "auth_session_restore_failed"
+  | "auth_refresh_completed"
+  | "auth_refresh_failed"
+  | "auth_logout_completed"
+  | "auth_logout_failed"
+  | "save_attempted"
+  | "save_completed"
+  | "save_failed"
+  | "save_blocked"
+  | "save_all_completed"
+  | "autosave_attempted"
+  | "autosave_failed"
+  | "save_conflict_blocked"
+  | "project_create_started"
+  | "project_create_completed"
+  | "project_create_failed"
+  | "project_open_started"
+  | "project_open_completed"
+  | "project_open_failed"
+  | "project_recent_open_failed"
+  | "project_auto_restore_completed"
+  | "project_auto_restore_failed"
+  | "file_new_created"
+  | "file_open_started"
+  | "file_open_completed"
+  | "file_open_failed"
+  | "project_file_open_completed"
+  | "project_file_open_failed"
+  | "project_file_created"
+  | "project_folder_created"
+  | "project_file_renamed"
+  | "project_file_deleted"
+  | "project_file_duplicated";
+
+export type TelemetryReason =
+  | "cancelled"
+  | "conflict"
+  | "invalid_project"
+  | "io_error"
+  | "locked"
+  | "not_found"
+  | "permission_denied"
+  | "unknown";
+
+export type TelemetryCountBucket = "0" | "1" | "2_5" | "6_10" | "11_plus";
+export type TelemetryTargetKind = "file" | "untitled" | "handle" | "unknown";
+
+export type UsageEventProps = Record<string, string | number | undefined>;
+
+type UsageEventContract = {
+  events: Record<string, Record<string, string[]>>;
+};
+
+const usageEventContract = contract as UsageEventContract;
+
+export function isUsageEventName(eventName: string): eventName is UsageEventName {
+  return Object.hasOwn(usageEventContract.events, eventName);
+}
+
+export function trackUsageEvent(eventName: UsageEventName, props: UsageEventProps = {}): void {
+  if (typeof window === "undefined") return;
+  const analytics = window.electronAPI?.analytics;
+  if (!analytics) return;
+
+  const sanitizedProps: Record<string, string | number> = {};
+  for (const [key, value] of Object.entries(props)) {
+    if (value !== undefined) sanitizedProps[key] = value;
+  }
+
+  try {
+    void analytics.trackEvent(eventName, sanitizedProps).catch(() => undefined);
+  } catch {
+    // Analytics must never affect product behavior.
+  }
+}
+
+export function bucketTelemetryCount(count: number): TelemetryCountBucket {
+  if (count <= 0) return "0";
+  if (count === 1) return "1";
+  if (count <= 5) return "2_5";
+  if (count <= 10) return "6_10";
+  return "11_plus";
+}
+
+export function normalizeTelemetryFileType(
+  fileType: string | null | undefined,
+): "mdi" | "md" | "txt" | "unknown" {
+  const normalized = fileType?.replace(/^\./, "").toLowerCase();
+  if (normalized === "mdi" || normalized === "md" || normalized === "txt") return normalized;
+  return "unknown";
+}
+
+export function classifyTelemetryError(error: unknown): TelemetryReason {
+  if (!error || typeof error !== "object") return "unknown";
+
+  const record = error as { code?: unknown; name?: unknown; status?: unknown };
+  const code = typeof record.code === "string" ? record.code : "";
+  const name = typeof record.name === "string" ? record.name : "";
+  const status = typeof record.status === "number" ? record.status : undefined;
+
+  if (code === "ENOENT" || status === 404) return "not_found";
+  if (
+    code === "EACCES" ||
+    code === "EPERM" ||
+    name === "NotAllowedError" ||
+    status === 401 ||
+    status === 403
+  ) {
+    return "permission_denied";
+  }
+  if (name === "AbortError") return "cancelled";
+  if (code === "INVALID_PROJECT") return "invalid_project";
+  if (code === "EIO") return "io_error";
+  return "unknown";
+}
+
+export function classifySaveOutcome(outcome: { status: string; error?: unknown }): TelemetryReason {
+  switch (outcome.status) {
+    case "cancelled":
+      return "cancelled";
+    case "conflicted":
+      return "conflict";
+    case "locked":
+      return "locked";
+    case "failed":
+      return classifyTelemetryError(outcome.error);
+    default:
+      return "unknown";
+  }
+}
+
+export function getTelemetryTargetKind(
+  descriptor: { path?: string | null; handle?: unknown } | null | undefined,
+): TelemetryTargetKind {
+  if (!descriptor) return "untitled";
+  if (descriptor.path) return "file";
+  if (descriptor.handle) return "handle";
+  return "unknown";
+}

--- a/lib/auth/__tests__/use-auth-session-unmount.test.tsx
+++ b/lib/auth/__tests__/use-auth-session-unmount.test.tsx
@@ -29,6 +29,10 @@ const { loadTokensMock, saveTokensMock, clearTokensMock } = vi.hoisted(() => ({
   clearTokensMock: vi.fn(async () => undefined),
 }));
 
+const { trackUsageEventMock } = vi.hoisted(() => ({
+  trackUsageEventMock: vi.fn(),
+}));
+
 vi.mock("../token-storage", () => ({
   loadTokens: loadTokensMock,
   saveTokens: saveTokensMock,
@@ -38,6 +42,14 @@ vi.mock("../token-storage", () => ({
 vi.mock("@/lib/utils/runtime-env", () => ({
   isElectronRenderer: () => true,
 }));
+
+vi.mock("@/lib/analytics/usage-events", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/analytics/usage-events")>();
+  return {
+    ...actual,
+    trackUsageEvent: trackUsageEventMock,
+  };
+});
 
 const USER_INFO = {
   sub: "user-1",
@@ -154,6 +166,10 @@ describe("#1567 — refresh timer lifecycle in useAuthSession", () => {
     });
 
     expect(sessionRef.current?.user?.id).toBe("user-1");
+    expect(trackUsageEventMock).toHaveBeenCalledWith("auth_session_restored", {
+      surface: "startup",
+      strategy: "electron_tokens",
+    });
     expect(vi.getTimerCount()).toBe(1);
 
     await act(async () => {
@@ -177,6 +193,9 @@ describe("#1567 — refresh timer lifecycle in useAuthSession", () => {
       await sessionRef.current?.logout();
     });
 
+    expect(trackUsageEventMock).toHaveBeenCalledWith("auth_logout_completed", {
+      surface: "settings",
+    });
     expect(vi.getTimerCount()).toBe(0);
     expect(sessionRef.current?.user).toBeNull();
     expect(clearTokensMock).toHaveBeenCalled();

--- a/lib/auth/use-auth-session.ts
+++ b/lib/auth/use-auth-session.ts
@@ -20,6 +20,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { isElectronRenderer } from "@/lib/utils/runtime-env";
+import { classifyTelemetryError, trackUsageEvent } from "@/lib/analytics/usage-events";
 import {
   completeElectronOAuthCallback,
   getElectronAuthApi,
@@ -64,10 +65,15 @@ export function useAuthSession(): AuthSessionState {
         // Unmounted or logged out while refreshing — discard the result.
         if (!schedulerRef.current || getSessionEpoch() !== epochAtStart) return;
         setUser(session.user);
+        trackUsageEvent("auth_refresh_completed", { surface: "startup" });
         scheduleElectronRefresh(session.expiresAt, session.refreshToken);
       } catch (err) {
         // Logout fenced this refresh — tokens already handled, never retry.
         if (isSessionInvalidatedError(err) || getSessionEpoch() !== epochAtStart) return;
+        trackUsageEvent("auth_refresh_failed", {
+          surface: "startup",
+          reason: classifyTelemetryError(err),
+        });
         if (isElectronAuthErrorPermanent(err)) {
           // Permanent failure (4xx / invalid_grant): token is invalid — log out
           if (schedulerRef.current) setUser(null);
@@ -89,6 +95,7 @@ export function useAuthSession(): AuthSessionState {
       if (!schedulerRef.current || getSessionEpoch() !== epochAtStart) return;
       if (me.authenticated && me.user) {
         setUser(me.user);
+        trackUsageEvent("auth_refresh_completed", { surface: "startup" });
         if (me.expiresAt) scheduleWebRefresh(me.expiresAt);
       } else if (me.permanent) {
         // Permanent failure (401/403): token is invalid — log out
@@ -118,6 +125,10 @@ export function useAuthSession(): AuthSessionState {
           if (cancelled || getSessionEpoch() !== epochAtStart) return;
           if (session) {
             setUser(session.user);
+            trackUsageEvent("auth_session_restored", {
+              surface: "startup",
+              strategy: "electron_tokens",
+            });
             scheduleElectronRefresh(session.expiresAt, session.refreshToken);
           }
         } else {
@@ -126,11 +137,21 @@ export function useAuthSession(): AuthSessionState {
           if (cancelled || getSessionEpoch() !== epochAtStart) return;
           if (me.authenticated && me.user) {
             setUser(me.user);
+            trackUsageEvent("auth_session_restored", {
+              surface: "startup",
+              strategy: "web_cookie",
+            });
             if (me.expiresAt) scheduleWebRefresh(me.expiresAt);
           }
         }
-      } catch {
+      } catch (err) {
         // Silently fail — startup restore must never crash the provider
+        if (!cancelled) {
+          trackUsageEvent("auth_session_restore_failed", {
+            surface: "startup",
+            reason: classifyTelemetryError(err),
+          });
+        }
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -159,6 +180,11 @@ export function useAuthSession(): AuthSessionState {
     const unsubscribe = authApi.onCallback(async (data) => {
       if (data.error) {
         console.error("[auth] OAuth error:", data.error);
+        trackUsageEvent("auth_login_failed", {
+          surface: "callback",
+          stage: "callback",
+          reason: "unknown",
+        });
         return;
       }
 
@@ -174,10 +200,16 @@ export function useAuthSession(): AuthSessionState {
         // Unmounted or logged out during the exchange — discard the result.
         if (!schedulerRef.current || getSessionEpoch() !== epochAtStart) return;
         setUser(session.user);
+        trackUsageEvent("auth_login_completed", { surface: "callback" });
         scheduleElectronRefresh(session.expiresAt, session.refreshToken);
       } catch (err) {
         if (isSessionInvalidatedError(err)) return;
         console.error("[auth] Token exchange failed:", err);
+        trackUsageEvent("auth_login_failed", {
+          surface: "callback",
+          stage: "exchange",
+          reason: classifyTelemetryError(err),
+        });
       }
     });
 
@@ -186,14 +218,33 @@ export function useAuthSession(): AuthSessionState {
 
   // --- Login ---
   const login = useCallback(async (): Promise<void> => {
+    trackUsageEvent("auth_login_started", { surface: "settings" });
     if (isElectron.current) {
       const authApi = getElectronAuthApi();
       if (!authApi) return;
-      await authApi.startLogin();
+      try {
+        await authApi.startLogin();
+      } catch (err) {
+        trackUsageEvent("auth_login_failed", {
+          surface: "settings",
+          stage: "start",
+          reason: classifyTelemetryError(err),
+        });
+        throw err;
+      }
     } else {
       // Dynamic import to avoid bundling web-auth in Electron builds
       const { startWebLogin } = await import("./web-auth");
-      await startWebLogin();
+      try {
+        await startWebLogin();
+      } catch (err) {
+        trackUsageEvent("auth_login_failed", {
+          surface: "settings",
+          stage: "start",
+          reason: classifyTelemetryError(err),
+        });
+        throw err;
+      }
     }
   }, []);
 
@@ -208,16 +259,25 @@ export function useAuthSession(): AuthSessionState {
     // Reset single-flight/permanent-failure state so a subsequent login starts clean.
     resetRefreshState();
 
-    if (isElectron.current) {
-      const authApi = getElectronAuthApi();
-      if (!authApi) return;
-      await authApi.logout();
-      await clearTokens();
-    } else {
-      await webLogout();
+    try {
+      if (isElectron.current) {
+        const authApi = getElectronAuthApi();
+        if (!authApi) return;
+        await authApi.logout();
+        await clearTokens();
+      } else {
+        await webLogout();
+      }
+    } catch (err) {
+      trackUsageEvent("auth_logout_failed", {
+        surface: "settings",
+        reason: classifyTelemetryError(err),
+      });
+      throw err;
     }
 
     setUser(null);
+    trackUsageEvent("auth_logout_completed", { surface: "settings" });
   }, []);
 
   return { user, isLoading, login, logout };

--- a/lib/editor-page/use-auto-restore.ts
+++ b/lib/editor-page/use-auto-restore.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { trackUsageEvent } from "@/lib/analytics/usage-events";
 
 interface UseAutoRestoreParams {
   autoRestoreProjectId: string | null;
@@ -39,6 +40,9 @@ export function useAutoRestore({
       } catch {
         // handleOpenRecentProject catches its own errors internally
       }
+      trackUsageEvent(success ? "project_auto_restore_completed" : "project_auto_restore_failed", {
+        ...(success ? { restore_strategy: "recent" } : { reason: "unknown" }),
+      });
       isAutoRestoringRef.current = false;
       signalVfsReady();
       timerId = setTimeout(() => {

--- a/lib/editor-page/use-file-opening.ts
+++ b/lib/editor-page/use-file-opening.ts
@@ -5,6 +5,11 @@ import { getProjectService } from "@/lib/project/project-service";
 import { getDefaultWorkspaceState } from "@/lib/project/project-types";
 import { getProjectFileService as getVFS } from "@/lib/services/project-file-service";
 import { notificationManager } from "@/lib/services/notification-manager";
+import {
+  classifyTelemetryError,
+  normalizeTelemetryFileType,
+  trackUsageEvent,
+} from "@/lib/analytics/usage-events";
 
 import type { ProjectMode, StandaloneMode, WorkspaceTab } from "@/lib/project/project-types";
 import { ensureProjectFiles, readFileHandle } from "./project-file-utils";
@@ -68,6 +73,7 @@ export function useFileOpening({
   restoreProjectTabs,
 }: UseFileOpeningParams): UseFileOpeningResult {
   const handleOpenProject = useCallback(async () => {
+    trackUsageEvent("project_open_started", { surface: "menu", source: "dialog" });
     try {
       const projectService = getProjectService();
       const project = await projectService.openProject();
@@ -81,6 +87,11 @@ export function useFileOpening({
       if (!restored) {
         await loadProjectContent(project);
       }
+      trackUsageEvent("project_open_completed", {
+        surface: "menu",
+        source: "dialog",
+        restore_strategy: restored ? "stored_handle" : "fresh",
+      });
 
       if (isElectron && project.rootPath) {
         const storage = getStorageService();
@@ -94,11 +105,17 @@ export function useFileOpening({
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;
       if (error instanceof Error && error.message.includes("cancelled")) return;
+      trackUsageEvent("project_open_failed", {
+        surface: "menu",
+        source: "dialog",
+        reason: classifyTelemetryError(error),
+      });
       console.error("Failed to open project:", error);
     }
   }, [setProjectMode, isElectron, loadProjectContent, restoreProjectTabs]);
 
   const handleOpenStandaloneFile = useCallback(async () => {
+    trackUsageEvent("file_open_started", { surface: "menu", source: "dialog" });
     try {
       const projectService = getProjectService();
       const standalone = await projectService.openStandaloneFile();
@@ -109,9 +126,19 @@ export function useFileOpening({
       const tabPath = standalone.filePath ?? standalone.fileName;
       tabLoadSystemFile(tabPath, content);
       incrementEditorKey();
+      trackUsageEvent("file_open_completed", {
+        surface: "menu",
+        source: "dialog",
+        file_type: normalizeTelemetryFileType(standalone.fileExtension),
+      });
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;
       if (error instanceof Error && error.message.includes("キャンセル")) return;
+      trackUsageEvent("file_open_failed", {
+        surface: "menu",
+        source: "dialog",
+        reason: classifyTelemetryError(error),
+      });
       console.error("Failed to open file:", error);
       // #1888: non-UTF-8 manuscript — refuse to open (no editable tab) and tell
       // the user to convert it first, instead of silently loading lossy U+FFFD
@@ -128,12 +155,17 @@ export function useFileOpening({
 
   const handleOpenRecentProject = useCallback(
     async (projectId: string): Promise<boolean> => {
+      trackUsageEvent("project_open_started", {
+        surface: isAutoRestoringRef.current ? "startup" : "menu",
+        source: isAutoRestoringRef.current ? "auto_restore" : "recent",
+      });
       try {
         if (isElectron) {
           const storage = getStorageService();
           const projects = await storage.getRecentProjects();
           const project = projects.find((p) => p.id === projectId);
           if (!project) {
+            trackUsageEvent("project_recent_open_failed", { reason: "not_found" });
             if (!isAutoRestoringRef.current) {
               notificationManager.error("このプロジェクトが見つかりませんでした。");
             }
@@ -202,6 +234,11 @@ export function useFileOpening({
             if (!restored) {
               await loadProjectContent(restoredProject);
             }
+            trackUsageEvent("project_open_completed", {
+              surface: isAutoRestoringRef.current ? "startup" : "menu",
+              source: isAutoRestoringRef.current ? "auto_restore" : "recent",
+              restore_strategy: restored ? "recent" : "fresh",
+            });
 
             // Signal VFS ready AFTER tab restore — this ensures the standalone
             // mount-time restore sees projectTabsRestoredRef=true and skips.
@@ -226,8 +263,14 @@ export function useFileOpening({
             // otherwise the stale recent entry re-triggers the same failure on
             // every launch and the app appears unable to open any project (#1965).
             if (isFileNotFound) {
+              trackUsageEvent("project_recent_open_failed", { reason: "not_found" });
               setConfirmRemoveRecent({ projectId, message });
             } else if (!isAutoRestoringRef.current) {
+              trackUsageEvent("project_open_failed", {
+                surface: "menu",
+                source: "recent",
+                reason: classifyTelemetryError(error),
+              });
               notificationManager.error(message);
             }
             return false;
@@ -255,6 +298,11 @@ export function useFileOpening({
         }
 
         if (!restoreResult.success || !restoreResult.handle) {
+          trackUsageEvent("project_open_failed", {
+            surface: isAutoRestoringRef.current ? "startup" : "menu",
+            source: isAutoRestoringRef.current ? "auto_restore" : "recent",
+            reason: "unknown",
+          });
           console.error("Failed to restore project handle:", restoreResult.error);
           if (!isAutoRestoringRef.current) {
             notificationManager.error(
@@ -265,8 +313,18 @@ export function useFileOpening({
         }
 
         await openRestoredProject(restoreResult.handle);
+        trackUsageEvent("project_open_completed", {
+          surface: isAutoRestoringRef.current ? "startup" : "menu",
+          source: isAutoRestoringRef.current ? "auto_restore" : "recent",
+          restore_strategy: "stored_handle",
+        });
         return true;
       } catch (error) {
+        trackUsageEvent("project_open_failed", {
+          surface: isAutoRestoringRef.current ? "startup" : "menu",
+          source: isAutoRestoringRef.current ? "auto_restore" : "recent",
+          reason: classifyTelemetryError(error),
+        });
         console.error("Failed to open recent project:", error);
         return false;
       }
@@ -287,6 +345,7 @@ export function useFileOpening({
 
   const handleOpenAsProject = useCallback(
     async (projectPath: string, initialFile: string) => {
+      trackUsageEvent("project_open_started", { surface: "system", source: "open_as_project" });
       try {
         const vfs = getVFS();
         if ("setRootPath" in vfs) {
@@ -335,6 +394,11 @@ export function useFileOpening({
         if (!restored) {
           await loadProjectContent(project);
         }
+        trackUsageEvent("project_open_completed", {
+          surface: "system",
+          source: "open_as_project",
+          restore_strategy: restored ? "recent" : "fresh",
+        });
 
         const storage = getStorageService();
         await storage.addRecentProject({
@@ -344,6 +408,11 @@ export function useFileOpening({
         });
         void window.electronAPI?.rebuildMenu?.();
       } catch (error) {
+        trackUsageEvent("project_open_failed", {
+          surface: "system",
+          source: "open_as_project",
+          reason: classifyTelemetryError(error),
+        });
         console.error("[Open as Project] Failed to open project:", error);
         notificationManager.error(
           "プロジェクトを開けませんでした。.illusionsフォルダが正しく設定されているか確認してください。",

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -1,6 +1,11 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import {
+  classifySaveOutcome,
+  getTelemetryTargetKind,
+  trackUsageEvent,
+} from "@/lib/analytics/usage-events";
 import { getAutoSaveIntervalMs } from "../editor-page/power-policy";
 import { getWindowActivitySnapshot, subscribeWindowActivity } from "../editor-page/window-activity";
 import { notificationManager } from "../services/notification-manager";
@@ -117,6 +122,12 @@ export function useAutoSave(params: UseAutoSaveParams): void {
         // acquires the unified per-target lock synchronously (#1562 a /
         // #1579) and re-checks the conflicted transition right before
         // writing (#1562 b).
+        const activity = getWindowActivitySnapshot();
+        trackUsageEvent("autosave_attempted", {
+          target_kind: getTelemetryTargetKind(tab.file),
+          activity:
+            activity.isWindowFocused && activity.isDocumentVisible ? "foreground" : "background",
+        });
         void (async () => {
           const outcome = await executeTabSave({
             tab,
@@ -130,6 +141,10 @@ export function useAutoSave(params: UseAutoSaveParams): void {
             isMounted: () => mountedRef.current,
           });
           if (outcome.status === "failed") {
+            trackUsageEvent("autosave_failed", {
+              target_kind: getTelemetryTargetKind(tab.file),
+              reason: classifySaveOutcome(outcome),
+            });
             console.error(`自動保存に失敗しました (${tab.file?.name}):`, outcome.error);
             notificationManager.warning(
               `自動保存に失敗しました: ${tab.file?.name ?? "不明なファイル"}`,

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -4,6 +4,14 @@
 const PERSIST_FAILURE_WARNING = "ファイル参照の保存に失敗しました";
 
 import { useCallback, useRef } from "react";
+import {
+  bucketTelemetryCount,
+  classifySaveOutcome,
+  classifyTelemetryError,
+  getTelemetryTargetKind,
+  normalizeTelemetryFileType,
+  trackUsageEvent,
+} from "@/lib/analytics/usage-events";
 import { openMdiFile } from "../project/mdi-file";
 import type { MdiFileDescriptor } from "../project/mdi-file";
 import { notificationManager } from "../services/notification-manager";
@@ -245,7 +253,18 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
   /** Open a file via system dialog → new tab (or reuse untitled clean tab) */
   const openFile = useCallback(async () => {
-    const result = await openMdiFile();
+    trackUsageEvent("file_open_started", { surface: "menu", source: "dialog" });
+    let result: Awaited<ReturnType<typeof openMdiFile>>;
+    try {
+      result = await openMdiFile();
+    } catch (error) {
+      trackUsageEvent("file_open_failed", {
+        surface: "menu",
+        source: "dialog",
+        reason: classifyTelemetryError(error),
+      });
+      throw error;
+    }
     if (!result) return;
 
     const { descriptor, content: fileContent } = result;
@@ -264,6 +283,11 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
     }
 
     const detectedFileType = inferFileType(descriptor.name);
+    trackUsageEvent("file_open_completed", {
+      surface: "menu",
+      source: "dialog",
+      file_type: normalizeTelemetryFileType(detectedFileType),
+    });
 
     // Reuse current tab if untitled and clean
     const cur = tabsRef.current.find((t) => t.id === activeTabIdRef.current);
@@ -323,6 +347,10 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
       // Block save if tab has unresolved external conflict
       if (tab.fileSyncStatus === "conflicted") {
+        trackUsageEvent("save_conflict_blocked", {
+          trigger: isAutoSave ? "auto" : "manual",
+          mode: isProjectRef.current ? "project" : "standalone",
+        });
         notificationManager.warning(
           "ファイルが外部で変更されています。保存する前にコンフリクトを解決してください。",
         );
@@ -334,6 +362,15 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         // #1840: serialize the live editor doc before saving so we never write
         // debounce-lagged content (and applySavedTabState compares correctly).
         const tabToSave = flushActiveTabContent(tab);
+        trackUsageEvent(isAutoSave ? "autosave_attempted" : "save_attempted", {
+          ...(isAutoSave
+            ? { target_kind: getTelemetryTargetKind(tabToSave.file), activity: "unknown" }
+            : {
+                trigger: "manual",
+                mode: isProjectRef.current ? "project" : "standalone",
+                target_kind: getTelemetryTargetKind(tabToSave.file),
+              }),
+        });
         const outcome = await executeTabSave({
           tab: tabToSave,
           isProject: isProjectRef.current,
@@ -348,14 +385,49 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         });
 
         if (outcome.status === "saved" && outcome.persistFailed) {
+          trackUsageEvent("save_completed", {
+            trigger: isAutoSave ? "auto" : "manual",
+            mode: isProjectRef.current ? "project" : "standalone",
+            target_kind: getTelemetryTargetKind(outcome.descriptor),
+          });
           notificationManager.warning(PERSIST_FAILURE_WARNING);
+        } else if (outcome.status === "saved") {
+          trackUsageEvent("save_completed", {
+            trigger: isAutoSave ? "auto" : "manual",
+            mode: isProjectRef.current ? "project" : "standalone",
+            target_kind: getTelemetryTargetKind(outcome.descriptor),
+          });
         } else if (outcome.status === "conflicted") {
+          trackUsageEvent("save_conflict_blocked", {
+            trigger: isAutoSave ? "auto" : "manual",
+            mode: isProjectRef.current ? "project" : "standalone",
+          });
           notificationManager.warning(
             "ファイルが外部で変更されています。保存する前にコンフリクトを解決してください。",
           );
         } else if (outcome.status === "failed") {
+          trackUsageEvent(isAutoSave ? "autosave_failed" : "save_failed", {
+            ...(isAutoSave
+              ? {
+                  target_kind: getTelemetryTargetKind(tabToSave.file),
+                  reason: classifySaveOutcome(outcome),
+                }
+              : {
+                  trigger: "manual",
+                  mode: isProjectRef.current ? "project" : "standalone",
+                  target_kind: getTelemetryTargetKind(tabToSave.file),
+                  reason: classifySaveOutcome(outcome),
+                }),
+          });
           console.error("保存に失敗しました:", outcome.error);
           notificationManager.error(`保存に失敗しました: ${getErrorMessage(outcome.error)}`);
+        } else {
+          trackUsageEvent("save_blocked", {
+            trigger: isAutoSave ? "auto" : "manual",
+            mode: isProjectRef.current ? "project" : "standalone",
+            target_kind: getTelemetryTargetKind(tabToSave.file),
+            reason: classifySaveOutcome(outcome),
+          });
         }
         // "cancelled" / "locked" / "skipped": nothing to do
       } finally {
@@ -390,6 +462,12 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
   const saveAllDirtyTabs = useCallback(async (): Promise<SaveAllDirtyResult> => {
     if (isSavingRef.current) {
       // A save is already in flight; report locked so the caller blocks.
+      trackUsageEvent("save_blocked", {
+        trigger: "save_all",
+        mode: isProjectRef.current ? "project" : "standalone",
+        target_kind: "unknown",
+        reason: "locked",
+      });
       return { allSaved: false, outcomes: [{ status: "locked" }] };
     }
 
@@ -397,6 +475,10 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
       (t): t is EditorTabState => isEditorTab(t) && t.isDirty,
     );
     if (dirtyTabs.length === 0) {
+      trackUsageEvent("save_all_completed", {
+        dirty_count_bucket: "0",
+        result: "all_saved",
+      });
       return { allSaved: true, outcomes: [] };
     }
 
@@ -406,6 +488,10 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
       for (const tab of dirtyTabs) {
         // Block conflicted tabs up front (mirrors saveFile's guard).
         if (tab.fileSyncStatus === "conflicted") {
+          trackUsageEvent("save_conflict_blocked", {
+            trigger: "save_all",
+            mode: isProjectRef.current ? "project" : "standalone",
+          });
           notificationManager.warning(
             "ファイルが外部で変更されています。保存する前にコンフリクトを解決してください。",
           );
@@ -415,6 +501,11 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
         // #1840: flush live editor content for the active tab before saving.
         const tabToSave = flushActiveTabContent(tab);
+        trackUsageEvent("save_attempted", {
+          trigger: "save_all",
+          mode: isProjectRef.current ? "project" : "standalone",
+          target_kind: getTelemetryTargetKind(tabToSave.file),
+        });
         const outcome = await executeTabSave({
           tab: tabToSave,
           isProject: isProjectRef.current,
@@ -428,6 +519,11 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         outcomes.push(outcome);
 
         if (outcome.status === "saved") {
+          trackUsageEvent("save_completed", {
+            trigger: "save_all",
+            mode: isProjectRef.current ? "project" : "standalone",
+            target_kind: getTelemetryTargetKind(outcome.descriptor),
+          });
           if (outcome.persistFailed) {
             notificationManager.warning(PERSIST_FAILURE_WARNING);
           }
@@ -436,12 +532,29 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
         // Non-saved: surface the right notification and stop saving the rest.
         if (outcome.status === "conflicted") {
+          trackUsageEvent("save_conflict_blocked", {
+            trigger: "save_all",
+            mode: isProjectRef.current ? "project" : "standalone",
+          });
           notificationManager.warning(
             "ファイルが外部で変更されています。保存する前にコンフリクトを解決してください。",
           );
         } else if (outcome.status === "failed") {
+          trackUsageEvent("save_failed", {
+            trigger: "save_all",
+            mode: isProjectRef.current ? "project" : "standalone",
+            target_kind: getTelemetryTargetKind(tabToSave.file),
+            reason: classifySaveOutcome(outcome),
+          });
           console.error("保存に失敗しました:", outcome.error);
           notificationManager.error(`保存に失敗しました: ${getErrorMessage(outcome.error)}`);
+        } else {
+          trackUsageEvent("save_blocked", {
+            trigger: "save_all",
+            mode: isProjectRef.current ? "project" : "standalone",
+            target_kind: getTelemetryTargetKind(tabToSave.file),
+            reason: classifySaveOutcome(outcome),
+          });
         }
         // "cancelled" (user dismissed Save As) / "locked" / "skipped":
         // no notification, but still blocks the pending action.
@@ -453,6 +566,14 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
     const allSaved =
       outcomes.length === dirtyTabs.length && outcomes.every((o) => o.status === "saved");
+    trackUsageEvent("save_all_completed", {
+      dirty_count_bucket: bucketTelemetryCount(dirtyTabs.length),
+      result: allSaved
+        ? "all_saved"
+        : outcomes.some((o) => o.status === "saved")
+          ? "partial"
+          : "blocked",
+    });
     return { allSaved, outcomes };
   }, [
     persistFileReference,
@@ -477,6 +598,11 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
     try {
       // #1840: flush live editor content before Save As as well.
       const tabToSave = flushActiveTabContent(tab);
+      trackUsageEvent("save_attempted", {
+        trigger: "save_as",
+        mode: isProjectRef.current ? "project" : "standalone",
+        target_kind: getTelemetryTargetKind(tabToSave.file),
+      });
       const outcome = await executeTabSave({
         tab: tabToSave,
         isProject: isProjectRef.current,
@@ -492,6 +618,11 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
       });
 
       if (outcome.status === "saved") {
+        trackUsageEvent("save_completed", {
+          trigger: "save_as",
+          mode: isProjectRef.current ? "project" : "standalone",
+          target_kind: getTelemetryTargetKind(outcome.descriptor),
+        });
         if (outcome.persistFailed) {
           notificationManager.warning(PERSIST_FAILURE_WARNING);
         }
@@ -531,10 +662,23 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           }
         }
       } else if (outcome.status === "failed") {
+        trackUsageEvent("save_failed", {
+          trigger: "save_as",
+          mode: isProjectRef.current ? "project" : "standalone",
+          target_kind: getTelemetryTargetKind(tabToSave.file),
+          reason: classifySaveOutcome(outcome),
+        });
         console.error("名前を付けて保存に失敗しました:", outcome.error);
         notificationManager.error(
           `名前を付けて保存に失敗しました: ${getErrorMessage(outcome.error)}`,
         );
+      } else {
+        trackUsageEvent("save_blocked", {
+          trigger: "save_as",
+          mode: isProjectRef.current ? "project" : "standalone",
+          target_kind: getTelemetryTargetKind(tabToSave.file),
+          reason: classifySaveOutcome(outcome),
+        });
       }
       // "cancelled" / "locked": nothing to do
     } finally {
@@ -567,6 +711,11 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
 
       const sysFileName = path.split("/").pop() || "無題";
       const sysFileType = inferFileType(sysFileName);
+      trackUsageEvent("file_open_completed", {
+        surface: "system",
+        source: "system_open",
+        file_type: normalizeTelemetryFileType(sysFileType),
+      });
 
       // Reuse current tab if untitled and clean
       const cur = tabsRef.current.find((t) => t.id === activeTabIdRef.current);
@@ -677,6 +826,10 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
           notificationManager.error(
             `ファイルを開けませんでした: ${vfsPath.split("/").pop() || vfsPath}`,
           );
+          trackUsageEvent("project_file_open_failed", {
+            surface: "explorer",
+            reason: classifyTelemetryError(error),
+          });
           return;
         }
 
@@ -691,6 +844,11 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         const fileName = vfsPath.split("/").pop() || "無題";
         const vfsFileType = inferFileType(fileName);
         const effectivePreview = openingPathsRef.current.get(vfsPath) ?? preview;
+        trackUsageEvent("project_file_open_completed", {
+          surface: "explorer",
+          file_type: normalizeTelemetryFileType(vfsFileType),
+          preview: effectivePreview ? "true" : "false",
+        });
 
         if (effectivePreview) {
           // Replace existing preview tab, or create new preview tab


### PR DESCRIPTION
## Summary
- add a central Aptabase usage event contract and main-process allowlist validation
- add a renderer analytics facade with safe enum/count-bucket helpers
- instrument auth, save/autosave, project, and file lifecycle events without sending user content, paths, filenames, account identifiers, tokens, or raw errors

## Terms / Privacy
- custom event names and props are allowlisted before consent lookup or send
- props are enums/count buckets only
- account data, OAuth data, paths, filenames, content, hashes, raw errors, stacks, URLs, and request bodies are not sent

## Verification
- npm run type-check
- npm run lint (passes with existing warnings)
- npm test
- npm run bundle:electron