### PR TITLE
feat: アプリ内バグ・フィードバック報告フォーム

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,8 @@ import { useElectronMenuHandlers } from "@/lib/menu/use-electron-menu-handlers";
 import { useExport } from "@/lib/export/use-export";
 import { openWebPrintPreview } from "@/lib/export/web-print-preview";
 import TxtExportDialog from "@/components/TxtExportDialog";
+import BugReportDialog from "@/components/BugReportDialog";
+import type { BugReportCategory } from "@/lib/bug-report/bug-report-types";
 import type { TxtIndentOptions } from "@/lib/export/txt-exporter";
 import type { ExportMetadata } from "@/lib/export/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
@@ -797,6 +799,9 @@ export default function EditorPage() {
   const [exportDialogState, setExportDialogState] = useState<ExportDialogState | null>(null);
   const exportDialogStateRef = useRef<ExportDialogState | null>(null);
 
+  // Bug/feedback report dialog state (null = closed; category = open with preset)
+  const [bugReportCategory, setBugReportCategory] = useState<BugReportCategory | null>(null);
+
   // Print dialog state
   interface PrintDialogState {
     content: string;
@@ -1172,6 +1177,7 @@ export default function EditorPage() {
     fontScale,
     onFontScaleChange: (scale: number) => fontScaleChangeRef.current(scale),
     isEditorTabActive: !!activeEditorTab,
+    onReportBug: (category) => setBugReportCategory(category),
   });
 
   // Global shortcuts for Web (only when not in Electron)
@@ -1221,6 +1227,7 @@ export default function EditorPage() {
     handleOpenRecentProject,
     handleOpenAsProject,
     confirmBeforeAction: unsavedWarning.confirmBeforeAction,
+    onReportBug: (category) => setBugReportCategory(category),
   });
 
   contentRef.current = content;
@@ -1804,6 +1811,11 @@ export default function EditorPage() {
           void pending?.execute();
         }}
         onCancel={() => setRenameCollision(null)}
+      />
+      <BugReportDialog
+        isOpen={bugReportCategory != null}
+        initialCategory={bugReportCategory ?? "bug"}
+        onClose={() => setBugReportCategory(null)}
       />
     </>
   );

--- a/components/BugReportDialog.tsx
+++ b/components/BugReportDialog.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import GlassDialog from "@/shared/ui/GlassDialog";
+import { notificationManager } from "@/lib/services/notification-manager";
+import {
+  BUG_REPORT_CATEGORY_LABELS,
+  BUG_REPORT_CATEGORY_ORDER,
+  type BugReportCategory,
+} from "@/lib/bug-report/bug-report-types";
+import { collectDiagnostics, submitBugReport } from "@/lib/bug-report/submit-bug-report";
+
+interface BugReportDialogProps {
+  isOpen: boolean;
+  initialCategory: BugReportCategory;
+  onClose: () => void;
+}
+
+const OS_LABELS: Record<string, string> = {
+  mac: "macOS",
+  windows: "Windows",
+  linux: "Linux",
+  unknown: "不明",
+};
+
+export default function BugReportDialog({
+  isOpen,
+  initialCategory,
+  onClose,
+}: BugReportDialogProps) {
+  const [category, setCategory] = useState<BugReportCategory>(initialCategory);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [reproSteps, setReproSteps] = useState("");
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 両入口 (バグ報告 / AI報告) で同一インスタンスを再利用するため、
+  // 開くたびにカテゴリを initialCategory へ再同期し、入力もリセットする。
+  useEffect(() => {
+    if (isOpen) {
+      setCategory(initialCategory);
+      setTitle("");
+      setDescription("");
+      setReproSteps("");
+      setEmail("");
+      setIsSubmitting(false);
+    }
+  }, [isOpen, initialCategory]);
+
+  const diagnostics = collectDiagnostics();
+  const canSubmit = title.trim().length > 0 && description.trim().length > 0 && !isSubmitting;
+
+  async function handleSubmit(): Promise<void> {
+    if (!canSubmit) return;
+    setIsSubmitting(true);
+    const result = await submitBugReport({
+      category,
+      title,
+      description,
+      reproductionSteps: reproSteps,
+      email,
+    });
+    setIsSubmitting(false);
+
+    if (result.ok) {
+      notificationManager.showMessage("報告を送信しました。ご協力ありがとうございます。", {
+        type: "success",
+      });
+      onClose();
+    } else {
+      notificationManager.showMessage("送信に失敗しました。時間をおいて再度お試しください。", {
+        type: "error",
+      });
+    }
+  }
+
+  return (
+    <GlassDialog
+      isOpen={isOpen}
+      onBackdropClick={isSubmitting ? undefined : onClose}
+      ariaLabel="バグ・ご要望を報告"
+      panelClassName="mx-4 w-full max-w-lg p-6"
+    >
+      <div className="space-y-4">
+        <h3 className="text-lg font-semibold text-foreground">バグ・ご要望を報告</h3>
+
+        <div className="space-y-3">
+          {/* カテゴリ */}
+          <div>
+            <label className="text-xs font-medium text-foreground-secondary mb-1 block">種別</label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value as BugReportCategory)}
+              className="w-full px-3 py-2 bg-background border border-border rounded text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
+            >
+              {BUG_REPORT_CATEGORY_ORDER.map((key) => (
+                <option key={key} value={key}>
+                  {BUG_REPORT_CATEGORY_LABELS[key]}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* タイトル (必須) */}
+          <div>
+            <label className="text-xs font-medium text-foreground-secondary mb-1 block">
+              タイトル *
+            </label>
+            <input
+              type="text"
+              placeholder="例: 起動時にクラッシュする"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="w-full px-3 py-2 bg-background border border-border rounded text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
+              autoFocus
+            />
+          </div>
+
+          {/* 詳細 (必須) */}
+          <div>
+            <label className="text-xs font-medium text-foreground-secondary mb-1 block">
+              詳細 *
+            </label>
+            <textarea
+              placeholder="発生した問題やご要望の内容を具体的にご記入ください"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full px-3 py-2 bg-background border border-border rounded text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent resize-none"
+              rows={4}
+            />
+          </div>
+
+          {/* 再現手順 (任意) */}
+          <div>
+            <label className="text-xs font-medium text-foreground-secondary mb-1 block">
+              再現手順
+            </label>
+            <textarea
+              placeholder="1. ○○を開く&#10;2. ○○をクリック&#10;3. ……"
+              value={reproSteps}
+              onChange={(e) => setReproSteps(e.target.value)}
+              className="w-full px-3 py-2 bg-background border border-border rounded text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent resize-none"
+              rows={3}
+            />
+          </div>
+
+          {/* メール (任意) */}
+          <div>
+            <label className="text-xs font-medium text-foreground-secondary mb-1 block">
+              メールアドレス
+            </label>
+            <input
+              type="email"
+              placeholder="例: you@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 bg-background border border-border rounded text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-accent"
+            />
+            <p className="text-xs text-foreground-secondary mt-1">
+              任意です。ご記入いただくと、フォローアップをこのメールアドレスでご連絡する場合があります。
+            </p>
+          </div>
+
+          {/* 診断情報の明示 */}
+          <p className="text-xs text-foreground-secondary border-t border-border pt-3">
+            診断情報を添付します: アプリバージョン {diagnostics.appVersion} / OS{" "}
+            {OS_LABELS[diagnostics.os] ?? diagnostics.os}
+            （原稿の内容やファイルパスは送信されません）
+          </p>
+        </div>
+
+        {/* アクション */}
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="px-4 py-2 text-sm text-foreground-secondary hover:text-foreground transition-colors rounded hover:bg-hover disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="px-4 py-2 text-sm bg-accent text-accent-foreground rounded hover:bg-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? "送信中…" : "送信"}
+          </button>
+        </div>
+      </div>
+    </GlassDialog>
+  );
+}

--- a/components/__tests__/BugReportDialog.test.tsx
+++ b/components/__tests__/BugReportDialog.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import BugReportDialog from "../BugReportDialog";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const submitBugReportMock = vi.fn();
+const showMessageMock = vi.fn();
+
+vi.mock("@/lib/bug-report/submit-bug-report", () => ({
+  submitBugReport: (...args: unknown[]) => submitBugReportMock(...args),
+  collectDiagnostics: () => ({ appVersion: "1.4.2", os: "mac" }),
+}));
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { showMessage: (...args: unknown[]) => showMessageMock(...args) },
+}));
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  submitBugReportMock.mockReset();
+  showMessageMock.mockReset();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function getSubmitButton(): HTMLButtonElement {
+  const buttons = Array.from(container.querySelectorAll("button"));
+  const submit = buttons.find((b) => b.textContent?.includes("送信"));
+  if (!submit) throw new Error("送信ボタンが見つかりません");
+  return submit as HTMLButtonElement;
+}
+
+describe("BugReportDialog", () => {
+  it("診断情報 (バージョン/OS) を明示し、原稿を送らない旨を表示する", async () => {
+    await act(async () => {
+      root.render(<BugReportDialog isOpen initialCategory="bug" onClose={vi.fn()} />);
+    });
+
+    expect(container.textContent).toContain("アプリバージョン 1.4.2");
+    expect(container.textContent).toContain("macOS");
+    expect(container.textContent).toContain("原稿の内容やファイルパスは送信されません");
+  });
+
+  it("initialCategory を select の初期値に反映する", async () => {
+    await act(async () => {
+      root.render(<BugReportDialog isOpen initialCategory="ai-inappropriate" onClose={vi.fn()} />);
+    });
+
+    const select = container.querySelector("select") as HTMLSelectElement;
+    expect(select.value).toBe("ai-inappropriate");
+  });
+
+  it("タイトル・詳細が未入力なら送信ボタンが無効", async () => {
+    await act(async () => {
+      root.render(<BugReportDialog isOpen initialCategory="bug" onClose={vi.fn()} />);
+    });
+
+    expect(getSubmitButton().disabled).toBe(true);
+  });
+
+  it("送信成功で submitBugReport を呼び、成功トーストを出して閉じる", async () => {
+    submitBugReportMock.mockResolvedValue({ ok: true, status: 200 });
+    const onClose = vi.fn();
+
+    await act(async () => {
+      root.render(<BugReportDialog isOpen initialCategory="bug" onClose={onClose} />);
+    });
+
+    const title = container.querySelector('input[type="text"]') as HTMLInputElement;
+    const description = container.querySelector("textarea") as HTMLTextAreaElement;
+
+    await act(async () => {
+      setInputValue(title, "クラッシュ");
+      setTextareaValue(description, "起動でクラッシュ");
+    });
+
+    expect(getSubmitButton().disabled).toBe(false);
+
+    await act(async () => {
+      getSubmitButton().click();
+    });
+
+    expect(submitBugReportMock).toHaveBeenCalledTimes(1);
+    expect(submitBugReportMock.mock.calls[0][0]).toMatchObject({
+      category: "bug",
+      title: "クラッシュ",
+      description: "起動でクラッシュ",
+    });
+    expect(showMessageMock).toHaveBeenCalledWith(expect.any(String), { type: "success" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("送信失敗ではエラートーストを出し、閉じない", async () => {
+    submitBugReportMock.mockResolvedValue({ ok: false });
+    const onClose = vi.fn();
+
+    await act(async () => {
+      root.render(<BugReportDialog isOpen initialCategory="bug" onClose={onClose} />);
+    });
+
+    const title = container.querySelector('input[type="text"]') as HTMLInputElement;
+    const description = container.querySelector("textarea") as HTMLTextAreaElement;
+
+    await act(async () => {
+      setInputValue(title, "t");
+      setTextareaValue(description, "d");
+    });
+
+    await act(async () => {
+      getSubmitButton().click();
+    });
+
+    expect(showMessageMock).toHaveBeenCalledWith(expect.any(String), { type: "error" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+// React が管理する input/textarea の値を native setter 経由で更新する
+function setInputValue(el: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function setTextareaValue(el: HTMLTextAreaElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}

--- a/electron/lib/__tests__/ipc-bridge.test.ts
+++ b/electron/lib/__tests__/ipc-bridge.test.ts
@@ -194,6 +194,8 @@ describe("ipc-channels: pinned channel names (public IPC contract)", () => {
       exportPdf: "menu-export-pdf",
       exportEpub: "menu-export-epub",
       exportDocx: "menu-export-docx",
+      reportBug: "menu-report-bug",
+      reportAiInappropriate: "menu-report-ai-inappropriate",
     });
   });
 

--- a/electron/lib/ipc-channels.js
+++ b/electron/lib/ipc-channels.js
@@ -153,6 +153,8 @@ const MENU_CHANNELS = Object.freeze({
     exportPdf: "menu-export-pdf",
     exportEpub: "menu-export-epub",
     exportDocx: "menu-export-docx",
+    reportBug: "menu-report-bug",
+    reportAiInappropriate: "menu-report-ai-inappropriate",
   }),
 });
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -87,6 +87,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onMenuExportPDF: eventChannel(MENU_CHANNELS.event.exportPdf, { arity: 0 }),
   onMenuExportEPUB: eventChannel(MENU_CHANNELS.event.exportEpub, { arity: 0 }),
   onMenuExportDOCX: eventChannel(MENU_CHANNELS.event.exportDocx, { arity: 0 }),
+  onMenuReportBug: eventChannel(MENU_CHANNELS.event.reportBug, { arity: 0 }),
+  onMenuReportAiInappropriate: eventChannel(MENU_CHANNELS.event.reportAiInappropriate, {
+    arity: 0,
+  }),
   nlp: {
     init: invokeChannel(NLP_CHANNELS.invoke.init, { arity: 1 }),
     tokenizeParagraph: invokeChannel(NLP_CHANNELS.invoke.tokenizeParagraph, { arity: 1 }),

--- a/lib/bug-report/__tests__/submit-bug-report.test.ts
+++ b/lib/bug-report/__tests__/submit-bug-report.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { BUG_REPORT_ENDPOINT, collectDiagnostics, submitBugReport } from "../submit-bug-report";
+
+// detectOSPlatform を制御するためモック
+vi.mock("@/lib/utils/runtime-env", () => ({
+  detectOSPlatform: () => "mac",
+}));
+
+const originalFetch = globalThis.fetch;
+
+describe("collectDiagnostics", () => {
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+  });
+
+  it("アプリバージョンと OS のみを返す", () => {
+    process.env.NEXT_PUBLIC_APP_VERSION = "1.4.2";
+    const diag = collectDiagnostics();
+    expect(diag).toEqual({ appVersion: "1.4.2", os: "mac" });
+  });
+
+  it("バージョン未設定時は 0.0.0 にフォールバックする", () => {
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+    expect(collectDiagnostics().appVersion).toBe("0.0.0");
+  });
+});
+
+describe("submitBugReport", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_VERSION = "1.4.2";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.NEXT_PUBLIC_APP_VERSION;
+  });
+
+  it("エンドポイントへ JSON を POST し、診断情報と source を含める", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    globalThis.fetch = fetchMock;
+
+    const result = await submitBugReport({
+      category: "bug",
+      title: "  クラッシュ  ",
+      description: "  詳細  ",
+      reproductionSteps: "1. 起動",
+      email: "user@example.com",
+    });
+
+    expect(result).toEqual({ ok: true, status: 200 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe(BUG_REPORT_ENDPOINT);
+    expect(options.method).toBe("POST");
+    expect(options.credentials).toBe("omit");
+    expect(options.headers).toMatchObject({ "Content-Type": "application/json" });
+
+    const body = JSON.parse(options.body as string);
+    expect(body.category).toBe("bug");
+    // title / description は trim される
+    expect(body.title).toBe("クラッシュ");
+    expect(body.description).toBe("詳細");
+    expect(body.reproductionSteps).toBe("1. 起動");
+    expect(body.email).toBe("user@example.com");
+    expect(body.source).toBe("illusions-app");
+    expect(body.diagnostics).toEqual({ appVersion: "1.4.2", os: "mac" });
+    expect(typeof body.submittedAt).toBe("string");
+  });
+
+  it("空の再現手順・メールは payload から省かれる", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    globalThis.fetch = fetchMock;
+
+    await submitBugReport({
+      category: "feature",
+      title: "要望",
+      description: "内容",
+      reproductionSteps: "   ",
+      email: "",
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).not.toHaveProperty("reproductionSteps");
+    expect(body).not.toHaveProperty("email");
+  });
+
+  it("原稿内容やファイルパスに相当するフィールドを送らない", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    globalThis.fetch = fetchMock;
+
+    await submitBugReport({ category: "other", title: "t", description: "d" });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    // diagnostics は appVersion / os の 2 キーのみ
+    expect(Object.keys(body.diagnostics).sort()).toEqual(["appVersion", "os"]);
+  });
+
+  it("ネットワークエラー時は ok:false を返す", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    const result = await submitBugReport({ category: "bug", title: "t", description: "d" });
+    expect(result).toEqual({ ok: false });
+  });
+
+  it("HTTP エラー応答時は ok:false + status を返す", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    const result = await submitBugReport({ category: "bug", title: "t", description: "d" });
+    expect(result).toEqual({ ok: false, status: 500 });
+  });
+});

--- a/lib/bug-report/bug-report-types.ts
+++ b/lib/bug-report/bug-report-types.ts
@@ -1,0 +1,61 @@
+import type { OSPlatform } from "@/lib/utils/runtime-env";
+
+/**
+ * バグ・フィードバック報告のカテゴリ。
+ * メニューのアクション ID / フォームの select 値として使う。
+ */
+export type BugReportCategory = "bug" | "feature" | "ai-inappropriate" | "other";
+
+/**
+ * カテゴリ → フォームに表示する日本語ラベル。
+ */
+export const BUG_REPORT_CATEGORY_LABELS: Record<BugReportCategory, string> = {
+  bug: "BUG・不具合のフィードバック",
+  feature: "ご要望・機能のリクエスト",
+  "ai-inappropriate": "AI回答の不適切を報告",
+  other: "その他・お問い合わせ",
+};
+
+/**
+ * select の並び順（表示順を固定するため配列でも保持）。
+ */
+export const BUG_REPORT_CATEGORY_ORDER: BugReportCategory[] = [
+  "bug",
+  "feature",
+  "ai-inappropriate",
+  "other",
+];
+
+/**
+ * 自動添付する診断情報。原稿の内容やファイルパスは一切含めない。
+ */
+export interface BugReportDiagnostics {
+  appVersion: string;
+  os: OSPlatform | "unknown";
+}
+
+/**
+ * バックエンド (bug-report.api.illusions.app) へ POST する本体。
+ * フィールド名はバックエンド実装と突合済みであること。
+ */
+export interface BugReportPayload {
+  category: BugReportCategory;
+  title: string;
+  description: string;
+  reproductionSteps?: string;
+  email?: string;
+  diagnostics: BugReportDiagnostics;
+  source: "illusions-app";
+  submittedAt: string;
+}
+
+/**
+ * フォームからの送信入力（診断情報・メタは submit 側で付与）。
+ */
+export interface BugReportInput {
+  category: BugReportCategory;
+  title: string;
+  description: string;
+  reproductionSteps?: string;
+  email?: string;
+}

--- a/lib/bug-report/submit-bug-report.ts
+++ b/lib/bug-report/submit-bug-report.ts
@@ -1,0 +1,79 @@
+import { detectOSPlatform } from "@/lib/utils/runtime-env";
+import type { BugReportDiagnostics, BugReportInput, BugReportPayload } from "./bug-report-types";
+
+/**
+ * バグ報告バックエンドのエンドポイント。
+ */
+export const BUG_REPORT_ENDPOINT = "https://bug-report.api.illusions.app";
+
+/**
+ * リクエストのタイムアウト (ms)。
+ */
+const REQUEST_TIMEOUT_MS = 15000;
+
+/**
+ * アプリバージョン + OS のみの最小限の診断情報を収集する。
+ * 原稿の内容やファイルパスなど、機微な情報は一切含めない。
+ */
+export function collectDiagnostics(): BugReportDiagnostics {
+  const appVersion = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
+  const os = detectOSPlatform() ?? "unknown";
+  return { appVersion, os };
+}
+
+/**
+ * 空文字・空白のみのフィールドを省いた payload を構築する。
+ */
+function buildPayload(input: BugReportInput, submittedAt: string): BugReportPayload {
+  const payload: BugReportPayload = {
+    category: input.category,
+    title: input.title.trim(),
+    description: input.description.trim(),
+    diagnostics: collectDiagnostics(),
+    source: "illusions-app",
+    submittedAt,
+  };
+
+  const reproductionSteps = input.reproductionSteps?.trim();
+  if (reproductionSteps) {
+    payload.reproductionSteps = reproductionSteps;
+  }
+
+  const email = input.email?.trim();
+  if (email) {
+    payload.email = email;
+  }
+
+  return payload;
+}
+
+export interface SubmitBugReportResult {
+  ok: boolean;
+  status?: number;
+}
+
+/**
+ * バグ報告をバックエンドへ POST する。
+ * レンダラー (web / Electron 両対応) から直接 fetch する。
+ */
+export async function submitBugReport(input: BugReportInput): Promise<SubmitBugReportResult> {
+  const payload = buildPayload(input, new Date().toISOString());
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(BUG_REPORT_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "omit",
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    return { ok: res.ok, status: res.status };
+  } catch {
+    return { ok: false };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/lib/editor-page/use-electron-events.ts
+++ b/lib/editor-page/use-electron-events.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { persistAppState } from "@/lib/storage/app-state-manager";
 import { getProjectFileService } from "@/lib/services/project-file-service";
+import type { BugReportCategory } from "@/lib/bug-report/bug-report-types";
 
 interface UseElectronEventsParams {
   isElectron: boolean;
@@ -40,6 +41,9 @@ interface UseElectronEventsParams {
   // Open as project (double-clicked .mdi in project dir)
   handleOpenAsProject: (projectPath: string, initialFile: string) => Promise<void>;
   confirmBeforeAction: (action: () => void | Promise<void>) => void;
+
+  // Open the bug/feedback report dialog with a preset category
+  onReportBug: (category: BugReportCategory) => void;
 }
 
 /**
@@ -67,6 +71,7 @@ export function useElectronEvents(params: UseElectronEventsParams): void {
     handleOpenRecentProject,
     handleOpenAsProject,
     confirmBeforeAction,
+    onReportBug,
   } = params;
 
   // Paste as plaintext IPC listener
@@ -212,6 +217,28 @@ export function useElectronEvents(params: UseElectronEventsParams): void {
       cleanup?.();
     };
   }, [isElectron]);
+
+  // Bug/feedback report from menu IPC listener
+  useEffect(() => {
+    if (!isElectron || typeof window === "undefined") return;
+    const cleanup = window.electronAPI?.onMenuReportBug?.(() => {
+      onReportBug("bug");
+    });
+    return () => {
+      cleanup?.();
+    };
+  }, [isElectron, onReportBug]);
+
+  // AI-inappropriate report from menu IPC listener (opens the same dialog)
+  useEffect(() => {
+    if (!isElectron || typeof window === "undefined") return;
+    const cleanup = window.electronAPI?.onMenuReportAiInappropriate?.(() => {
+      onReportBug("ai-inappropriate");
+    });
+    return () => {
+      cleanup?.();
+    };
+  }, [isElectron, onReportBug]);
 
   // Open project from menu IPC listener
   useEffect(() => {

--- a/lib/menu/__tests__/menu-template-drift.test.ts
+++ b/lib/menu/__tests__/menu-template-drift.test.ts
@@ -460,6 +460,7 @@ describe("WEB_MENU_STRUCTURE preserves the pre-#1433 structure", () => {
           { label: `バージョン ${APP_VERSION}`, enabled: false },
           { type: "separator" },
           { label: "公式サイトへ", action: "open-website" },
+          { label: "バグ・ご要望を報告", action: "report-bug" },
           { label: "AI回答の不適切を報告", action: "report-ai-inappropriate" },
         ],
       },

--- a/lib/menu/menu-template.js
+++ b/lib/menu/menu-template.js
@@ -373,9 +373,14 @@ const MENU_TEMPLATE = [
         electronOpenExternal: "https://www.illusions.app/",
       },
       {
+        id: "report-bug",
+        label: "バグ・ご要望を報告",
+        electronChannel: "menu-report-bug",
+      },
+      {
         id: "report-ai-inappropriate",
         label: "AI回答の不適切を報告",
-        electronOpenExternal: "https://github.com/Iktahana/illusions/issues/new",
+        electronChannel: "menu-report-ai-inappropriate",
       },
     ],
   },

--- a/lib/menu/use-web-menu-handlers.ts
+++ b/lib/menu/use-web-menu-handlers.ts
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react";
 import type { EditorView } from "@milkdown/prose/view";
+import type { BugReportCategory } from "@/lib/bug-report/bug-report-types";
 
 interface UseWebMenuHandlersProps {
   onNew: () => void;
@@ -28,6 +29,8 @@ interface UseWebMenuHandlersProps {
   onNewTab?: () => void;
   /** Handler for closing the active tab */
   onCloseTab?: () => void;
+  /** Handler for opening the bug/feedback report dialog with a preset category */
+  onReportBug?: (category: BugReportCategory) => void;
 }
 
 export function useWebMenuHandlers({
@@ -49,6 +52,7 @@ export function useWebMenuHandlers({
   onThemeChange,
   onNewTab,
   onCloseTab,
+  onReportBug,
 }: UseWebMenuHandlersProps) {
   const handleMenuAction = useCallback(
     (action: string) => {
@@ -238,8 +242,11 @@ export function useWebMenuHandlers({
         case "open-website":
           window.open("https://www.illusions.app/", "_blank");
           break;
+        case "report-bug":
+          onReportBug?.("bug");
+          break;
         case "report-ai-inappropriate":
-          window.open("https://github.com/Iktahana/illusions/issues/new", "_blank");
+          onReportBug?.("ai-inappropriate");
           break;
 
         default:
@@ -270,6 +277,7 @@ export function useWebMenuHandlers({
       onThemeChange,
       onNewTab,
       onCloseTab,
+      onReportBug,
     ],
   );
 

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -132,6 +132,8 @@ declare global {
     onMenuExportPDF?: (callback: () => void) => (() => void) | void;
     onMenuExportEPUB?: (callback: () => void) => (() => void) | void;
     onMenuExportDOCX?: (callback: () => void) => (() => void) | void;
+    onMenuReportBug?: (callback: () => void) => (() => void) | void;
+    onMenuReportAiInappropriate?: (callback: () => void) => (() => void) | void;
     /** Virtual File System IPC bridge */
     vfs?: {
       /** Open a native directory picker dialog */


### PR DESCRIPTION
## 概要
ヘルプメニューから開く**カテゴリ選択式のバグ・フィードバック報告フォーム**を追加。`https://bug-report.api.illusions.app` へ直接 POST します（バックエンドは別リポで実装済み）。

従来「AI回答の不適切を報告」は GitHub Issues を外部ブラウザで開くだけでしたが、アプリを離れずに構造化された報告を送れるようにしました。

## 変更内容
- ヘルプメニューに新項目「バグ・ご要望を報告」を追加
- 既存「AI回答の不適切を報告」も同フォーム（AIカテゴリ初期選択）に置き換え
- カテゴリ: `BUG・不具合のフィードバック` / `ご要望・機能のリクエスト` / `AI回答の不適切を報告` / `その他・お問い合わせ`
- 項目: タイトル（必須）・詳細（必須）・再現手順（任意）・メール（任意、フォローアップ用のヘルパーテキスト付き）
- **診断情報はアプリバージョン + OS のみ**を自動添付し、フォーム上で明示（原稿本文・ファイルパスは送らない）
- 送信はレンダラー直 `fetch`（web / Electron 両対応）

### 新規ファイル
- `lib/bug-report/bug-report-types.ts` — カテゴリ型・ラベル・payload 型
- `lib/bug-report/submit-bug-report.ts` — POST クライアント + 診断情報収集（15s タイムアウト）
- `components/BugReportDialog.tsx` — `GlassDialog` ベースのフォーム

### IPC 配線
- `MENU_CHANNELS.event` に `menu-report-bug` / `menu-report-ai-inappropriate` を追加
- `menu-template.js` を `electronChannel` 化、preload / `electron.d.ts` / web・electron ハンドラを配線

## テスト
- ✅ `type-check` パス
- ✅ 全 **2589 テスト**パス（drift・ipc-bridge・submit ユニット7件・dialog コンポーネント5件を含む）
- ✅ 変更ファイルの eslint エラー0

## 未検証（別 issue で追跡予定）
実機 Electron ネイティブメニューのクリック→フォーム表示→送信の**ライブ UI 検証は環境制約で自動駆動できず未実施**（claude-in-chrome 未接続 / Docker Playwright がホスト dev サーバーに到達不可）。renderer 経路・payload・バリデーションはユニット/コンポーネントテストで担保済み、Electron 固有の IPC 経路は型チェック済みで既存リスナーと同型。

## 確認事項
- バックエンドが web / Electron オリジンからの CORS を許可しているか（未許可時は main プロセス fetch フォールバックが必要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)