### PR TITLE
fix(build): rebuild Windows arm64 native modules for Electron 43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14868,10 +14868,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
-      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
-      "dev": true,
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.6.3"
@@ -14884,7 +14883,6 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
       "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -15928,30 +15926,6 @@
       },
       "bin": {
         "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/node-abi": {
-      "version": "3.87.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
-      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -122,6 +122,9 @@
     "vitest": "^4.0.18",
     "wait-on": "^9.0.10"
   },
+  "overrides": {
+    "node-abi": "^4.31.0"
+  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "prettier --write",

--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -9,6 +9,7 @@ import * as esbuild from "esbuild";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import fs from "fs";
+import { execSync } from "child_process";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -179,19 +180,26 @@ function resolvePackageDir(dep) {
 async function prepareNativeModulesForArch(arch) {
   if (arch === process.arch) return;
 
-  const { execSync } = await import("child_process");
-
   // --- better-sqlite3: download correct prebuild for target arch ---
   const bsqlDir = resolvePackageDir("better-sqlite3");
   if (bsqlDir) {
     const electronPkgPath = join(projectRoot, "node_modules", "electron", "package.json");
     const electronPkg = JSON.parse(fs.readFileSync(electronPkgPath, "utf-8"));
     console.log(`  📥 Downloading better-sqlite3 prebuild for win32-${arch}...`);
-    execSync(
-      `npx prebuild-install --arch ${arch} --platform win32 --runtime electron --target ${electronPkg.version}`,
-      { cwd: bsqlDir, stdio: "inherit" },
-    );
-    console.log(`  ✅ better-sqlite3 prebuild ready for ${arch}`);
+    try {
+      execSync(
+        `npx prebuild-install --arch ${arch} --platform win32 --runtime electron --target ${electronPkg.version}`,
+        { cwd: bsqlDir, stdio: "inherit" },
+      );
+      console.log(`  ✅ better-sqlite3 prebuild ready for ${arch}`);
+    } catch {
+      console.log(`  ⚙️  No better-sqlite3 prebuild for ${arch}; rebuilding from source...`);
+      execSync(
+        `npx electron-rebuild --force --only better-sqlite3 --arch ${arch} --version ${electronPkg.version} --module-dir ${projectRoot} --build-from-source`,
+        { cwd: projectRoot, stdio: "inherit" },
+      );
+      console.log(`  ✅ better-sqlite3 rebuilt from source for ${arch}`);
+    }
   }
 
   // --- node-pty: remove build/Release so runtime uses prebuilds/win32-<arch> ---


### PR DESCRIPTION
## Summary
- force node-abi resolution to a version that recognizes Electron 43
- fall back to electron-rebuild when better-sqlite3 has no Windows arm64 Electron prebuild

## Verification
- npm install
- npm run bundle:electron
- npm run type-check
- git diff --check
- npm ls node-abi prebuild-install --all