### PR TITLE
fix(build): revert bundle ID back to com.iktahana.illusions

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     ]
   },
   "build": {
-    "appId": "app.illusions.editor",
+    "appId": "com.iktahana.illusions",
     "productName": "illusions",
     "directories": {
       "app": ".",

--- a/quicklook/MDIQuickLook/Info.plist
+++ b/quicklook/MDIQuickLook/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleExecutable</key>
   <string>MDIQuickLook</string>
   <key>CFBundleIdentifier</key>
-  <string>app.illusions.editor.quicklook</string>
+  <string>com.iktahana.illusions.quicklook</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>


### PR DESCRIPTION
## Summary

- #2007 でバンドル ID を `app.illusions.editor` にリネームしたところ、macOS の notarization が `401 Unable to authenticate. The account does not exist.` で失敗するようになった（beta ブランチの Desktop Build and Release が red）
- Developer ID 証明書 / App Store Connect の登録が旧識別子 `com.iktahana.illusions` に紐づいているため、appId を元に戻す
- `.mdi` の UTI (`app.illusions.mdi`) は `mdi.illusions.app` ドメインに紐づく独立した識別子のため据え置き（#2007 の設計判断どおり）

## Changes

| File | Change |
| --- | --- |
| `package.json` | `build.appId`: `app.illusions.editor` → `com.iktahana.illusions` |
| `quicklook/MDIQuickLook/Info.plist` | `CFBundleIdentifier`: `app.illusions.editor.quicklook` → `com.iktahana.illusions.quicklook` |

main にはこのリネームはまだ昇格されていないため影響なし。dev/beta のみが対象。

## Test plan

- [ ] dev → beta マージ後、`Desktop Build and Release` の macOS ジョブが notarize を通過することを確認
- [ ] beta 版を実機インストールし、QuickLook プレビュー（`.mdi`）が引き続き機能することを確認

関連 issue なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)