### PR TITLE
feat(analytics): activity-gated heartbeat + app_closed duration

### DIFF
--- a/electron/ipc/__tests__/analytics-ipc.test.ts
+++ b/electron/ipc/__tests__/analytics-ipc.test.ts
@@ -54,6 +54,33 @@ describe("registerAnalyticsHandlers", () => {
     });
   });
 
+  it("tracks app_heartbeat without props", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "app_heartbeat");
+
+    expect(loadAppStateMock).toHaveBeenCalledOnce();
+    expect(trackEventMock).toHaveBeenCalledWith("app_heartbeat", undefined);
+  });
+
+  it("tracks app_closed with a valid duration bucket", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "app_closed", { duration_bucket: "15_60m" });
+
+    expect(loadAppStateMock).toHaveBeenCalledOnce();
+    expect(trackEventMock).toHaveBeenCalledWith("app_closed", { duration_bucket: "15_60m" });
+  });
+
+  it("rejects app_closed with a non-contract duration bucket before reading consent", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "app_closed", { duration_bucket: "42m" });
+
+    expect(loadAppStateMock).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
   it("does not track events when analytics consent is disabled", async () => {
     loadAppStateMock.mockResolvedValue({ usageAnalyticsConsent: false });
     const handler = await createHandler();
@@ -85,6 +112,14 @@ describe("registerAnalyticsHandlers", () => {
 
     expect(loadAppStateMock).not.toHaveBeenCalled();
     expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("validates app lifecycle analytics props against the contract", async () => {
+    const { isWhitelistedProps } = await loadAnalyticsIpc();
+
+    expect(isWhitelistedProps("app_heartbeat", undefined)).toBe(true);
+    expect(isWhitelistedProps("app_closed", { duration_bucket: "15_60m" })).toBe(true);
+    expect(isWhitelistedProps("app_closed", { duration_bucket: "42m" })).toBe(false);
   });
 
   it("rejects unknown event names before reading consent", async () => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -63,6 +63,22 @@ if (APTABASE_APP_KEY) {
   initializeAnalytics(APTABASE_APP_KEY);
 }
 
+const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000;
+let sessionStartedAt = null;
+let heartbeatTimer = null;
+let hadFocusEventSinceLastHeartbeat = false;
+let hasHandledAppClosed = false;
+
+// Keep these boundaries in sync with lib/analytics/usage-events.ts bucketSessionDuration.
+function bucketSessionDuration(ms) {
+  const minutes = ms / 60000;
+  if (minutes < 1) return "lt_1m";
+  if (minutes < 5) return "1_5m";
+  if (minutes < 15) return "5_15m";
+  if (minutes < 60) return "15_60m";
+  return "gte_60m";
+}
+
 initializeErrorReporting({
   dsn: process.env.ERROR_REPORT_DSN || "",
   getStorageManager,
@@ -243,9 +259,35 @@ app.whenReady().then(async () => {
       const appState = await getStorageManager().loadAppState();
       if (appState?.usageAnalyticsConsent !== false) {
         const { trackEvent } = require("@aptabase/electron/main");
+        // Fire-and-forget: a failed/offline beacon must not stop sessionStartedAt
+        // and the heartbeat timer from being set up below (they're purely local
+        // clock/state and don't depend on this network call succeeding).
         void trackEvent("app_launched", { platform: process.platform }).catch((trackError) => {
           console.warn("[Analytics] Failed to send app_launched event:", trackError);
         });
+        sessionStartedAt = Date.now();
+
+        heartbeatTimer = setInterval(() => {
+          const isFocusedNow = BrowserWindow.getAllWindows().some((w) => w.isFocused());
+          const shouldSend = hadFocusEventSinceLastHeartbeat || isFocusedNow;
+          hadFocusEventSinceLastHeartbeat = false;
+          if (!shouldSend) return;
+
+          // Re-check consent on every tick: the user can toggle it off mid-session
+          // from Settings, and unlike the one-shot app_launched event, this timer
+          // keeps firing for the rest of the session unless we recheck.
+          void (async () => {
+            try {
+              const currentState = await getStorageManager().loadAppState();
+              if (currentState?.usageAnalyticsConsent === false) return;
+            } catch {
+              // Unreadable — fail open, same default-on convention as above.
+            }
+            trackEvent("app_heartbeat").catch((err) => {
+              console.warn("[Analytics] Failed to send app_heartbeat event:", err);
+            });
+          })();
+        }, HEARTBEAT_INTERVAL_MS);
       }
     } catch (err) {
       console.warn("[Analytics] Failed to send app_launched event:", err);
@@ -340,6 +382,35 @@ app.whenReady().then(async () => {
 app.on("before-quit", () => {
   // Kill all active PTY sessions before the process exits
   killAllSessions();
+
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+
+  if (!APTABASE_APP_KEY || sessionStartedAt === null || hasHandledAppClosed) return;
+  hasHandledAppClosed = true;
+
+  // Deliberately does NOT preventDefault()/delay quit: window-manager.js's
+  // per-window `close` handler owns the unsaved-changes save dialog and state
+  // flush (see the quitAndInstall backstop at #1839), and this must never race
+  // or get skipped for an analytics beacon. Fire-and-forget, same as
+  // app_launched — losing an occasional app_closed event on a fast quit is a
+  // fine trade-off; losing a user's unsaved manuscript is not.
+  const duration_bucket = bucketSessionDuration(Date.now() - sessionStartedAt);
+  void (async () => {
+    try {
+      // Re-check consent: it may have been toggled off after app_launched.
+      const appState = await getStorageManager().loadAppState();
+      if (appState?.usageAnalyticsConsent === false) return;
+    } catch {
+      // Unreadable — fail open, same default-on convention as elsewhere.
+    }
+    const { trackEvent } = require("@aptabase/electron/main");
+    trackEvent("app_closed", { duration_bucket }).catch((err) => {
+      console.warn("[Analytics] Failed to send app_closed event:", err);
+    });
+  })();
 });
 
 // Per-window menu state lifecycle: focus → swap active state; closed → cleanup
@@ -353,6 +424,13 @@ app.on("browser-window-focus", (_event, win) => {
 app.on("browser-window-created", (_event, win) => {
   const wcId = win.webContents.id;
   const winId = win.id;
+
+  if (APTABASE_APP_KEY) {
+    win.on("focus", () => {
+      hadFocusEventSinceLastHeartbeat = true;
+    });
+    if (win.isFocused()) hadFocusEventSinceLastHeartbeat = true;
+  }
 
   win.on("closed", () => {
     killSessionsForWindow(wcId);

--- a/lib/analytics/__tests__/usage-events.test.ts
+++ b/lib/analytics/__tests__/usage-events.test.ts
@@ -76,6 +76,20 @@ describe("usage analytics facade", () => {
     expect(bucketTelemetryCount(12)).toBe("11_plus");
   });
 
+  it("buckets session duration instead of sending exact elapsed time", async () => {
+    const { bucketSessionDuration } = await import("../usage-events");
+
+    expect(bucketSessionDuration(0)).toBe("lt_1m");
+    expect(bucketSessionDuration(59_999)).toBe("lt_1m");
+    expect(bucketSessionDuration(60_000)).toBe("1_5m");
+    expect(bucketSessionDuration(5 * 60_000 - 1)).toBe("1_5m");
+    expect(bucketSessionDuration(5 * 60_000)).toBe("5_15m");
+    expect(bucketSessionDuration(15 * 60_000 - 1)).toBe("5_15m");
+    expect(bucketSessionDuration(15 * 60_000)).toBe("15_60m");
+    expect(bucketSessionDuration(60 * 60_000 - 1)).toBe("15_60m");
+    expect(bucketSessionDuration(60 * 60_000)).toBe("gte_60m");
+  });
+
   it("normalizes file extensions without preserving filenames", async () => {
     const { normalizeTelemetryFileType } = await import("../usage-events");
 

--- a/lib/analytics/usage-event-contract.json
+++ b/lib/analytics/usage-event-contract.json
@@ -3,6 +3,10 @@
     "app_launched": {
       "platform": ["aix", "darwin", "freebsd", "linux", "openbsd", "sunos", "win32"]
     },
+    "app_heartbeat": {},
+    "app_closed": {
+      "duration_bucket": ["lt_1m", "1_5m", "5_15m", "15_60m", "gte_60m"]
+    },
     "auth_login_started": {
       "surface": ["settings", "welcome", "menu", "startup", "callback", "unknown"]
     },

--- a/lib/analytics/usage-events.ts
+++ b/lib/analytics/usage-events.ts
@@ -4,6 +4,8 @@ import contract from "./usage-event-contract.json";
 
 export type UsageEventName =
   | "app_launched"
+  | "app_heartbeat"
+  | "app_closed"
   | "auth_login_started"
   | "auth_login_completed"
   | "auth_login_failed"
@@ -53,6 +55,7 @@ export type TelemetryReason =
   | "unknown";
 
 export type TelemetryCountBucket = "0" | "1" | "2_5" | "6_10" | "11_plus";
+export type SessionDurationBucket = "lt_1m" | "1_5m" | "5_15m" | "15_60m" | "gte_60m";
 export type TelemetryTargetKind = "file" | "untitled" | "handle" | "unknown";
 
 export type UsageEventProps = Record<string, string | number | undefined>;
@@ -90,6 +93,15 @@ export function bucketTelemetryCount(count: number): TelemetryCountBucket {
   if (count <= 5) return "2_5";
   if (count <= 10) return "6_10";
   return "11_plus";
+}
+
+export function bucketSessionDuration(ms: number): SessionDurationBucket {
+  const minutes = ms / 60_000;
+  if (minutes < 1) return "lt_1m";
+  if (minutes < 5) return "1_5m";
+  if (minutes < 15) return "5_15m";
+  if (minutes < 60) return "15_60m";
+  return "gte_60m";
 }
 
 export function normalizeTelemetryFileType(


### PR DESCRIPTION
## Summary
Aptabase's dashboard "Avg. Duration" always showed 0s because the app only ever sends one event per launch (`app_launched`), and Aptabase infers session duration server-side from the gap between a session's first and last event.

- `app_heartbeat` fires every 10 minutes, but only if a window was focused at some point during that window (combines a `focus`-event flag with a point-in-time `isFocused()` check at tick time, so a window that stays continuously focused for hours — the common case for this writing app — still heartbeats every tick; a naive event-only approach would have stopped after the first tick).
- `app_closed` fires once on quit with a bucketed `duration_bucket` (`lt_1m | 1_5m | 5_15m | 15_60m | gte_60m`).
- Both re-check the `usageAnalyticsConsent` AppState flag live (it can be toggled off mid-session from Settings), not just once at launch.
- Both gated behind `APTABASE_APP_KEY` (no-op on OSS builds) and fail-open if storage is unreadable, matching the existing `app_launched` convention.

Implemented via `codex exec`, reviewed by Claude, and independently re-reviewed by an Opus-model pass before merge.

**Caught in review before merge:** an earlier draft called `event.preventDefault()` + `app.exit()` in `before-quit` to race the `app_closed` beacon against a timeout. That bypassed `window-manager.js`'s per-window unsaved-changes save dialog and state flush entirely (`app.exit()` force-terminates without emitting window `close` events), which would have silently discarded unsaved work on every normal quit once analytics is enabled. Fixed to be plain fire-and-forget on `before-quit`, same as `app_launched` — no `preventDefault`, no blocking, no risk to the save flow.

## Test plan
- [x] Manual review of full diff (twice — once by Claude, once by an independent Opus-model pass)
- [x] Added `bucketSessionDuration` boundary tests (`lib/analytics/__tests__/usage-events.test.ts`)
- [x] Added contract-whitelist tests for `app_heartbeat`/`app_closed` (`electron/ipc/__tests__/analytics-ipc.test.ts`)
- [ ] No unit coverage for the `main.js` heartbeat-timer/before-quit wiring itself — no existing test harness for that file's lifecycle code (same as the pre-existing `app_launched` logic)
- [ ] CI (lint / type-check / test:coverage) — pending on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)