### PR TITLE
fix(bug-report): send reports via GlitchTip ingest API, fix dev-server 500 loop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 # illusions Environment Variables Example
 # Copy this file to .env.local and fill in your values
+
+# GlitchTip (Sentry-compatible) DSN. Used for both automatic crash reporting
+# (Electron main process) and the manual bug-report form. The public key in
+# a DSN is not a secret — it's safe to bake into client-side bundles.
+ERROR_REPORT_DSN=

--- a/lib/bug-report/__tests__/submit-bug-report.test.ts
+++ b/lib/bug-report/__tests__/submit-bug-report.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { BUG_REPORT_ENDPOINT, collectDiagnostics, submitBugReport } from "../submit-bug-report";
+import { collectDiagnostics, submitBugReport } from "../submit-bug-report";
 
 // detectOSPlatform を制御するためモック
 vi.mock("@/lib/utils/runtime-env", () => ({
@@ -8,6 +8,7 @@ vi.mock("@/lib/utils/runtime-env", () => ({
 }));
 
 const originalFetch = globalThis.fetch;
+const TEST_DSN = "https://testkey123@bug-report.api.illusions.app/1";
 
 describe("collectDiagnostics", () => {
   afterEach(() => {
@@ -29,14 +30,16 @@ describe("collectDiagnostics", () => {
 describe("submitBugReport", () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_APP_VERSION = "1.4.2";
+    process.env.NEXT_PUBLIC_ERROR_REPORT_DSN = TEST_DSN;
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
     delete process.env.NEXT_PUBLIC_APP_VERSION;
+    delete process.env.NEXT_PUBLIC_ERROR_REPORT_DSN;
   });
 
-  it("エンドポイントへ JSON を POST し、診断情報と source を含める", async () => {
+  it("DSN の ingest エンドポイントへ X-Sentry-Auth 付きで POST する", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
     globalThis.fetch = fetchMock;
 
@@ -52,21 +55,23 @@ describe("submitBugReport", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     const [url, options] = fetchMock.mock.calls[0];
-    expect(url).toBe(BUG_REPORT_ENDPOINT);
+    expect(url).toBe("https://bug-report.api.illusions.app/api/1/store/");
     expect(options.method).toBe("POST");
     expect(options.credentials).toBe("omit");
     expect(options.headers).toMatchObject({ "Content-Type": "application/json" });
+    expect(options.headers["X-Sentry-Auth"]).toContain("sentry_key=testkey123");
 
     const body = JSON.parse(options.body as string);
-    expect(body.category).toBe("bug");
+    expect(body.tags.category).toBe("bug");
+    expect(body.level).toBe("error");
     // title / description は trim される
-    expect(body.title).toBe("クラッシュ");
-    expect(body.description).toBe("詳細");
-    expect(body.reproductionSteps).toBe("1. 起動");
-    expect(body.email).toBe("user@example.com");
-    expect(body.source).toBe("illusions-app");
-    expect(body.diagnostics).toEqual({ appVersion: "1.4.2", os: "mac" });
-    expect(typeof body.submittedAt).toBe("string");
+    expect(body.message).toBe("クラッシュ");
+    expect(body.extra.description).toBe("詳細");
+    expect(body.extra.reproductionSteps).toBe("1. 起動");
+    expect(body.user).toEqual({ email: "user@example.com" });
+    expect(body.tags.source).toBe("bug-report-form");
+    expect(body.release).toBe("1.4.2");
+    expect(body.tags.os).toBe("mac");
   });
 
   it("空の再現手順・メールは payload から省かれる", async () => {
@@ -82,8 +87,9 @@ describe("submitBugReport", () => {
     });
 
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
-    expect(body).not.toHaveProperty("reproductionSteps");
-    expect(body).not.toHaveProperty("email");
+    expect(body).not.toHaveProperty("user");
+    expect(body.extra).not.toHaveProperty("reproductionSteps");
+    expect(body.level).toBe("info");
   });
 
   it("原稿内容やファイルパスに相当するフィールドを送らない", async () => {
@@ -93,8 +99,18 @@ describe("submitBugReport", () => {
     await submitBugReport({ category: "other", title: "t", description: "d" });
 
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
-    // diagnostics は appVersion / os の 2 キーのみ
-    expect(Object.keys(body.diagnostics).sort()).toEqual(["appVersion", "os"]);
+    // tags は source / category / os の 3 キーのみ
+    expect(Object.keys(body.tags).sort()).toEqual(["category", "os", "source"]);
+  });
+
+  it("DSN 未設定時は ok:false を返し fetch しない", async () => {
+    delete process.env.NEXT_PUBLIC_ERROR_REPORT_DSN;
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+
+    const result = await submitBugReport({ category: "bug", title: "t", description: "d" });
+    expect(result).toEqual({ ok: false });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("ネットワークエラー時は ok:false を返す", async () => {

--- a/lib/bug-report/bug-report-types.ts
+++ b/lib/bug-report/bug-report-types.ts
@@ -35,21 +35,6 @@ export interface BugReportDiagnostics {
 }
 
 /**
- * バックエンド (bug-report.api.illusions.app) へ POST する本体。
- * フィールド名はバックエンド実装と突合済みであること。
- */
-export interface BugReportPayload {
-  category: BugReportCategory;
-  title: string;
-  description: string;
-  reproductionSteps?: string;
-  email?: string;
-  diagnostics: BugReportDiagnostics;
-  source: "illusions-app";
-  submittedAt: string;
-}
-
-/**
  * フォームからの送信入力（診断情報・メタは submit 側で付与）。
  */
 export interface BugReportInput {

--- a/lib/bug-report/submit-bug-report.ts
+++ b/lib/bug-report/submit-bug-report.ts
@@ -1,15 +1,20 @@
 import { detectOSPlatform } from "@/lib/utils/runtime-env";
-import type { BugReportDiagnostics, BugReportInput, BugReportPayload } from "./bug-report-types";
-
-/**
- * バグ報告バックエンドのエンドポイント。
- */
-export const BUG_REPORT_ENDPOINT = "https://bug-report.api.illusions.app";
+import type { BugReportCategory, BugReportDiagnostics, BugReportInput } from "./bug-report-types";
 
 /**
  * リクエストのタイムアウト (ms)。
  */
 const REQUEST_TIMEOUT_MS = 15000;
+
+/**
+ * カテゴリ → GlitchTip 上での重要度。トリアージしやすいよう分ける。
+ */
+const CATEGORY_LEVEL: Record<BugReportCategory, string> = {
+  bug: "error",
+  "ai-inappropriate": "warning",
+  feature: "info",
+  other: "info",
+};
 
 /**
  * アプリバージョン + OS のみの最小限の診断情報を収集する。
@@ -21,30 +26,29 @@ export function collectDiagnostics(): BugReportDiagnostics {
   return { appVersion, os };
 }
 
+interface ParsedDsn {
+  ingestUrl: string;
+  publicKey: string;
+}
+
 /**
- * 空文字・空白のみのフィールドを省いた payload を構築する。
+ * GlitchTip/Sentry の DSN を ingest エンドポイント + public key に分解する。
+ * 専用のバグ報告バックエンドは存在しないため、クラッシュ報告と同じ
+ * GlitchTip プロジェクトへ通常の error イベントとして送信する。
  */
-function buildPayload(input: BugReportInput, submittedAt: string): BugReportPayload {
-  const payload: BugReportPayload = {
-    category: input.category,
-    title: input.title.trim(),
-    description: input.description.trim(),
-    diagnostics: collectDiagnostics(),
-    source: "illusions-app",
-    submittedAt,
-  };
-
-  const reproductionSteps = input.reproductionSteps?.trim();
-  if (reproductionSteps) {
-    payload.reproductionSteps = reproductionSteps;
+function parseDsn(dsn: string): ParsedDsn | null {
+  try {
+    const url = new URL(dsn);
+    const publicKey = url.username;
+    const projectId = url.pathname.replace(/^\//, "");
+    if (!publicKey || !projectId) return null;
+    return {
+      ingestUrl: `${url.protocol}//${url.host}/api/${projectId}/store/`,
+      publicKey,
+    };
+  } catch {
+    return null;
   }
-
-  const email = input.email?.trim();
-  if (email) {
-    payload.email = email;
-  }
-
-  return payload;
 }
 
 export interface SubmitBugReportResult {
@@ -53,21 +57,53 @@ export interface SubmitBugReportResult {
 }
 
 /**
- * バグ報告をバックエンドへ POST する。
- * レンダラー (web / Electron 両対応) から直接 fetch する。
+ * ユーザーからのバグ・要望報告を GlitchTip へ通常の error イベントとして送信する。
+ * DSN の public key は秘匿情報ではないため、レンダラー (web / Electron 両対応) から
+ * 直接 fetch してよい。CSRF 保護のかかった Web UI ではなく ingest API を叩く。
  */
 export async function submitBugReport(input: BugReportInput): Promise<SubmitBugReportResult> {
-  const payload = buildPayload(input, new Date().toISOString());
+  const dsn = process.env.NEXT_PUBLIC_ERROR_REPORT_DSN || "";
+  const parsed = parseDsn(dsn);
+  if (!parsed) return { ok: false };
+
+  const diagnostics = collectDiagnostics();
+  const title = input.title.trim();
+  const description = input.description.trim();
+  const reproductionSteps = input.reproductionSteps?.trim();
+  const email = input.email?.trim();
+
+  const event = {
+    event_id: crypto.randomUUID().replace(/-/g, ""),
+    timestamp: new Date().toISOString(),
+    platform: "javascript",
+    logger: "bug-report-form",
+    level: CATEGORY_LEVEL[input.category],
+    message: title,
+    release: diagnostics.appVersion,
+    tags: {
+      source: "bug-report-form",
+      category: input.category,
+      os: diagnostics.os,
+    },
+    extra: {
+      description,
+      ...(reproductionSteps ? { reproductionSteps } : {}),
+    },
+    ...(email ? { user: { email } } : {}),
+  };
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
   try {
-    const res = await fetch(BUG_REPORT_ENDPOINT, {
+    const res = await fetch(parsed.ingestUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Sentry-Auth": `Sentry sentry_version=7, sentry_client=illusions-bug-report/1.0, sentry_key=${parsed.publicKey}`,
+      },
       credentials: "omit",
-      body: JSON.stringify(payload),
+      body: JSON.stringify(event),
       signal: controller.signal,
     });
     return { ok: res.ok, status: res.status };

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,8 @@ const nextConfig: NextConfig = {
     NEXT_PUBLIC_APP_VERSION: packageJson.version,
     NEXT_PUBLIC_LICENSE_TEXT: readFileSync(resolve(__dirname, "LICENSE"), "utf8"),
     NEXT_PUBLIC_TERMS_TEXT: readFileSync(resolve(__dirname, "TERMS.md"), "utf8"),
+    // DSN の public key は秘匿情報ではない (Sentry/GlitchTip の設計上、クライアント埋め込み前提)
+    NEXT_PUBLIC_ERROR_REPORT_DSN: process.env.ERROR_REPORT_DSN || "",
   },
   images: { unoptimized: true },
   trailingSlash: true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "dist-main/main.js",
   "scripts": {
     "type-check": "tsc --noEmit",
-    "dev": "npm run type-check && next dev -p 3010",
+    "dev": "npm run type-check && node scripts/ensure-credits-stub.mjs && next dev -p 3010",
     "build": "npm run type-check && npm run generate:credits && next build",
     "start": "next start",
     "lint": "eslint .",
@@ -23,7 +23,7 @@
     "prepare": "husky",
     "download:fonts": "node scripts/download-local-fonts.mjs",
     "bundle:electron": "node scripts/bundle-electron.mjs",
-    "electron:dev": "npm run bundle:electron && concurrently \"next dev -p 3020\" \"wait-on http://localhost:3020 && cross-env ELECTRON_DEV=1 electron .\"",
+    "electron:dev": "node scripts/ensure-credits-stub.mjs && npm run bundle:electron && concurrently \"next dev -p 3020\" \"wait-on http://localhost:3020 && cross-env ELECTRON_DEV=1 electron .\"",
     "electron:build": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 next build && npm run bundle:electron && electron-builder",
     "build:quicklook": "node -e \"if(process.platform==='darwin'){const {execSync}=require('child_process');execSync('bash scripts/build-quicklook.sh',{stdio:'inherit'});}else{console.log('build:quicklook skipped (macOS only)');}\" ",
     "test": "vitest run",

--- a/scripts/ensure-credits-stub.mjs
+++ b/scripts/ensure-credits-stub.mjs
@@ -1,0 +1,21 @@
+/**
+ * Dev-only safeguard: `generated/credits.json` is only produced by
+ * `generate:credits` (run as part of `build`). Turbopack statically resolves
+ * the dynamic import in AboutSection.tsx and hard-fails every request with a
+ * 500 if the file is missing, instead of letting the runtime .catch() handle
+ * it. Write an empty stub so dev servers can boot; `npm run generate:credits`
+ * still produces the real list for production builds.
+ */
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { resolve } from "path";
+
+const outDir = resolve(import.meta.dirname, "..", "generated");
+const outPath = resolve(outDir, "credits.json");
+
+if (!existsSync(outPath)) {
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(outPath, "[]\n");
+  console.log(
+    "Created empty generated/credits.json stub for dev (run `npm run generate:credits` for real data)",
+  );
+}


### PR DESCRIPTION
## Summary

- バグ・ご要望報告フォームの送信が常に失敗していた問題を修正
- `npm run dev` / `npm run electron:dev` が新規 clone 直後に無限 500 ループでフリーズする問題を修正

## Changes

| 領域 | 内容 |
| --- | --- |
| `lib/bug-report/submit-bug-report.ts` | `bug-report.api.illusions.app` の bare domain へ直接 POST していたのをやめ、DSN 認証の GlitchTip ingest API (`/api/<project>/store/`) へ通常の error イベントとして送信するよう変更。`tags.source=bug-report-form` / `tags.category` でクラッシュ報告と区別可能 |
| `lib/bug-report/bug-report-types.ts` | 不要になった `BugReportPayload` 型を削除 |
| `next.config.ts` | 既存の `ERROR_REPORT_DSN`（Electron クラッシュ報告で使用中）を `NEXT_PUBLIC_ERROR_REPORT_DSN` としてレンダラーにも公開。DSN の public key は秘匿情報ではないため安全 |
| `scripts/ensure-credits-stub.mjs`（新規） | `generated/credits.json` が存在しない場合に空配列のスタブを生成。`dev` / `electron:dev` スクリプトに追加 |
| `.env.example` | `ERROR_REPORT_DSN` の説明を追加 |

### 根本原因

1. **バグ報告 403**: `bug-report.api.illusions.app` は実は GlitchTip (Sentry 互換) サーバーで、カスタム REST バックエンドではなかった。root へのカスタム JSON POST は CSRF 保護のかかった Django Web UI に当たっており、常に 403 で失敗していた。
2. **dev 500 ループ**: `AboutSection.tsx` の `import("@/generated/credits.json")` は本来 dev では存在しなくても catch されるはずだったが、Turbopack が静的解決に失敗すると `app/page.tsx` の SSR が毎リクエスト 500 を返し、`wait-on` が never 200 を検出できず Electron が起動しないまま無限にエラーを吐き続けていた。

## Test plan

- [x] `npm run type-check` — pass
- [x] `npm run lint` — 0 errors (既存 warning のみ)
- [x] `npm run test` — 2596/2613 pass（残り 17 件は `dev` ブランチで元から失敗している `localStorage` 関連の既存不具合で、本 PR とは無関係と確認済み）
- [x] `generated/` / `dist-main/` を削除したクリーン状態から `npm run electron:dev` を実行し、500 ループなしで正常に起動・ウィンドウ表示されることを確認
- [x] 実際に GlitchTip ingest API (`/api/1/store/`) へテストイベントを送信し `HTTP 200` を確認（`tags.source=bug-report-form` で識別可能、削除可能な verification イベント）

🤖 Generated with [Claude Code](https://claude.com/claude-code)