### PR TITLE
feat(auto-updater): macOS sunset notice for 1.3.0+ stable releases

### DIFF
--- a/electron/__tests__/auto-updater-sunset.test.ts
+++ b/electron/__tests__/auto-updater-sunset.test.ts
@@ -1,0 +1,226 @@
+/**
+ * macOS sunset 通知の実行時挙動テスト。
+ *
+ * `vi.mock("electron-updater", ...)` は効かない — electron-updater 内部の遅延 getter が
+ * 実クラス (MacUpdater 等) を construct し、そこで再度 `require("electron")` した際に
+ * Vitest の SSR モックが伝播せず実パッケージ (Node 上では単なる文字列) を掴んでクラッシュする。
+ * そのため window-manager.test.ts の "saveAllBeforeQuitAndInstall — functional" と同じ手法で
+ * `Module._load` を直接差し替えて `electron/auto-updater.js` を読み込む。
+ *
+ * 1.3.0 を実際にリリースして動作確認することはできないため、可能な限りここで実挙動を固定する。
+ */
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const Module = require("module") as {
+  _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+};
+const originalLoad = Module._load;
+const autoUpdaterPath = require.resolve("../auto-updater.js");
+
+class FakeAutoUpdater extends EventEmitter {
+  logger: unknown;
+  autoDownload = true;
+  allowPrerelease = false;
+  allowDowngrade = false;
+  checkForUpdates = vi.fn();
+  downloadUpdate = vi.fn();
+  quitAndInstall = vi.fn();
+}
+
+interface Harness {
+  fakeAutoUpdater: FakeAutoUpdater;
+  showMessageBoxMock: ReturnType<typeof vi.fn>;
+  openExternalMock: ReturnType<typeof vi.fn>;
+  mod: { setupAutoUpdater: () => void };
+}
+
+function loadAutoUpdaterWithMocks(params: {
+  platform: string;
+  currentVersion: string;
+  showMessageBoxResult: unknown;
+}): Harness {
+  const { platform, currentVersion, showMessageBoxResult } = params;
+
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+
+  const fakeAutoUpdater = new FakeAutoUpdater();
+  const showMessageBoxMock = vi.fn().mockResolvedValue(showMessageBoxResult);
+  const openExternalMock = vi.fn();
+  const mockWindow = {};
+
+  const mockElectron = {
+    app: { getVersion: () => currentVersion },
+    dialog: { showMessageBox: showMessageBoxMock },
+    shell: { openExternal: openExternalMock },
+  };
+
+  // require キャッシュから対象を除去してから、Module._load を差し替えて再読込する。
+  // auto-updater.js は循環依存回避のため window-manager を「イベント発火時」に遅延 require
+  // する。そのためこの差し替えはここでは restore せず、テスト側の afterEach まで維持する
+  // 必要がある（先に restore すると遅延 require が実モジュールを掴んで無反応になる）。
+  delete require.cache[autoUpdaterPath];
+  const windowManagerPath = require.resolve("../window-manager.js");
+  delete require.cache[windowManagerPath];
+
+  Module._load = (request: string, parent: unknown, isMain: boolean) => {
+    if (request === "electron") return mockElectron;
+    if (request === "electron-updater") return { autoUpdater: fakeAutoUpdater };
+    if (request === "electron-log") {
+      return {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        transports: { file: { level: "" } },
+      };
+    }
+    if (request === "./app-constants") return { isDev: false, isMicrosoftStoreApp: false };
+    if (request === "./window-manager") {
+      return { getMainWindow: () => mockWindow, saveAllBeforeQuitAndInstall: async () => true };
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  const mod: { setupAutoUpdater: () => void } = require(autoUpdaterPath);
+
+  return { fakeAutoUpdater, showMessageBoxMock, openExternalMock, mod };
+}
+
+const originalPlatform = process.platform;
+
+describe("auto-updater.js — update-available 実行時挙動 (sunset)", () => {
+  afterEach(() => {
+    Module._load = originalLoad;
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    delete require.cache[autoUpdaterPath];
+    delete require.cache[require.resolve("../window-manager.js")];
+  });
+
+  it("macOS + 1.2.x 実行中 + 1.3.0 正式版検出 → sunset ダイアログを表示し downloadUpdate は呼ばない", async () => {
+    const { fakeAutoUpdater, showMessageBoxMock, mod } = loadAutoUpdaterWithMocks({
+      platform: "darwin",
+      currentVersion: "1.2.22",
+      showMessageBoxResult: { response: 1 },
+    });
+
+    mod.setupAutoUpdater();
+    fakeAutoUpdater.emit("update-available", { version: "1.3.0" });
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+
+    const [, options] = showMessageBoxMock.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(options.title).toBe("サポート終了のお知らせ");
+    expect(options.detail).toContain("https://www.illusions.app/downloads/");
+    expect(fakeAutoUpdater.downloadUpdate).not.toHaveBeenCalled();
+  });
+
+  it("sunset ダイアログで「公式サイトを開く」(response 0) を選ぶと shell.openExternal が呼ばれる", async () => {
+    const { fakeAutoUpdater, showMessageBoxMock, openExternalMock, mod } = loadAutoUpdaterWithMocks(
+      {
+        platform: "darwin",
+        currentVersion: "1.2.22",
+        showMessageBoxResult: { response: 0 },
+      },
+    );
+
+    mod.setupAutoUpdater();
+    fakeAutoUpdater.emit("update-available", { version: "1.3.0" });
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() =>
+      expect(openExternalMock).toHaveBeenCalledWith("https://www.illusions.app/downloads/"),
+    );
+    expect(fakeAutoUpdater.downloadUpdate).not.toHaveBeenCalled();
+  });
+
+  it("sunset ダイアログで「後で」(response 1) を選ぶと shell.openExternal は呼ばれない", async () => {
+    const { fakeAutoUpdater, showMessageBoxMock, openExternalMock, mod } = loadAutoUpdaterWithMocks(
+      {
+        platform: "darwin",
+        currentVersion: "1.2.22",
+        showMessageBoxResult: { response: 1 },
+      },
+    );
+
+    mod.setupAutoUpdater();
+    fakeAutoUpdater.emit("update-available", { version: "1.3.0" });
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+
+  it("Windows では 1.3.0 検出でも sunset にならず、通常の update-available フローで downloadUpdate される", async () => {
+    const { fakeAutoUpdater, showMessageBoxMock, mod } = loadAutoUpdaterWithMocks({
+      platform: "win32",
+      currentVersion: "1.2.22",
+      showMessageBoxResult: {},
+    });
+
+    mod.setupAutoUpdater();
+    fakeAutoUpdater.emit("update-available", { version: "1.3.0" });
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+
+    const [, options] = showMessageBoxMock.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(options.title).toBe("アップデート可能");
+    await vi.waitFor(() => expect(fakeAutoUpdater.downloadUpdate).toHaveBeenCalledTimes(1));
+  });
+
+  it("Linux でも同様に sunset にならない", async () => {
+    const { fakeAutoUpdater, showMessageBoxMock, mod } = loadAutoUpdaterWithMocks({
+      platform: "linux",
+      currentVersion: "1.2.22",
+      showMessageBoxResult: {},
+    });
+
+    mod.setupAutoUpdater();
+    fakeAutoUpdater.emit("update-available", { version: "1.3.0" });
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+
+    const [, options] = showMessageBoxMock.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(options.title).toBe("アップデート可能");
+  });
+
+  it("macOS でも 1.3.0 未満への通常アップデートは sunset にならない", async () => {
+    const { fakeAutoUpdater, showMessageBoxMock, mod } = loadAutoUpdaterWithMocks({
+      platform: "darwin",
+      currentVersion: "1.2.20",
+      showMessageBoxResult: {},
+    });
+
+    mod.setupAutoUpdater();
+    fakeAutoUpdater.emit("update-available", { version: "1.2.22" });
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+
+    const [, options] = showMessageBoxMock.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(options.title).toBe("アップデート可能");
+    await vi.waitFor(() => expect(fakeAutoUpdater.downloadUpdate).toHaveBeenCalledTimes(1));
+  });
+
+  it("既に 1.3.0 を実行中の macOS では、さらなる新版 (1.3.1) も sunset にならない", async () => {
+    const { fakeAutoUpdater, showMessageBoxMock, mod } = loadAutoUpdaterWithMocks({
+      platform: "darwin",
+      currentVersion: "1.3.0",
+      showMessageBoxResult: {},
+    });
+
+    mod.setupAutoUpdater();
+    fakeAutoUpdater.emit("update-available", { version: "1.3.1" });
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+
+    const [, options] = showMessageBoxMock.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(options.title).toBe("アップデート可能");
+  });
+
+  it("macOS + 1.3.0 の beta プレリリース検出は sunset にならない（正式版のみ対象）", async () => {
+    const { fakeAutoUpdater, showMessageBoxMock, mod } = loadAutoUpdaterWithMocks({
+      platform: "darwin",
+      currentVersion: "1.2.22",
+      showMessageBoxResult: {},
+    });
+
+    mod.setupAutoUpdater();
+    fakeAutoUpdater.emit("update-available", { version: "1.3.0-beta.20260706.120000" });
+    await vi.waitFor(() => expect(showMessageBoxMock).toHaveBeenCalledTimes(1));
+
+    const [, options] = showMessageBoxMock.mock.calls[0] as [unknown, Record<string, unknown>];
+    expect(options.title).toBe("アップデート可能");
+  });
+});

--- a/electron/__tests__/auto-updater.test.ts
+++ b/electron/__tests__/auto-updater.test.ts
@@ -270,3 +270,42 @@ describe("saveAllBeforeQuitAndInstall — functional (mocked electron)", () => {
     expect(windowManagerSrc).toMatch(/return true/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// macOS 1.2.x sunset 通知 (1.3.0 正式版検出時、auto-update ダイアログを置き換える)
+// ---------------------------------------------------------------------------
+
+describe("auto-updater.js — macOS sunset 通知の結線 (drift guard)", () => {
+  it("純粋ポリシー isSunsetDetected を update-policy から import している", () => {
+    expect(autoUpdaterSrc).toContain('require("./lib/update-policy")');
+    expect(autoUpdaterSrc).toMatch(/isSunsetDetected/);
+  });
+
+  it("update-available ハンドラ内で isSunsetDetected を呼び、platform/currentVersion/availableVersion を渡す", () => {
+    const handlerIdx = autoUpdaterSrc.indexOf('autoUpdater.on("update-available"');
+    const sunsetCallIdx = autoUpdaterSrc.indexOf("isSunsetDetected({", handlerIdx);
+    expect(handlerIdx).toBeGreaterThan(-1);
+    expect(sunsetCallIdx).toBeGreaterThan(handlerIdx);
+    expect(autoUpdaterSrc).toMatch(/platform:\s*process\.platform/);
+    expect(autoUpdaterSrc).toMatch(/currentVersion:\s*app\.getVersion\(\)/);
+    expect(autoUpdaterSrc).toMatch(/availableVersion:\s*info\.version/);
+  });
+
+  it("sunset 判定が true のときは autoUpdater.downloadUpdate() を呼ばない（早期 return する）", () => {
+    const sunsetCallIdx = autoUpdaterSrc.indexOf("isSunsetDetected({");
+    const nextReturnIdx = autoUpdaterSrc.indexOf("return;", sunsetCallIdx);
+    const downloadCallIdx = autoUpdaterSrc.indexOf("autoUpdater.downloadUpdate()");
+    expect(nextReturnIdx).toBeGreaterThan(sunsetCallIdx);
+    expect(nextReturnIdx).toBeLessThan(downloadCallIdx);
+  });
+
+  it("sunset ダイアログは公式ダウンロードページを開く導線を持つ", () => {
+    expect(autoUpdaterSrc).toContain("https://www.illusions.app/downloads/");
+    expect(autoUpdaterSrc).toMatch(/shell\.openExternal\(DOWNLOAD_PAGE_URL\)/);
+  });
+
+  it("electron の shell モジュールを import している", () => {
+    expect(autoUpdaterSrc).toMatch(/require\("electron"\)/);
+    expect(autoUpdaterSrc).toMatch(/const\s*\{[^}]*shell[^}]*\}\s*=\s*require\("electron"\)/);
+  });
+});

--- a/electron/auto-updater.js
+++ b/electron/auto-updater.js
@@ -1,10 +1,16 @@
 // Auto-updater setup and manual/automatic update checks
 
-const { app, dialog } = require("electron");
+const { app, dialog, shell } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const log = require("electron-log");
 const { isDev, isMicrosoftStoreApp } = require("./app-constants");
-const { resolveUpdaterFlags, isUnpublishedChannelVersion } = require("./lib/update-policy");
+const {
+  resolveUpdaterFlags,
+  isUnpublishedChannelVersion,
+  isSunsetDetected,
+} = require("./lib/update-policy");
+
+const DOWNLOAD_PAGE_URL = "https://www.illusions.app/downloads/";
 
 // dev/alpha ブランチのビルドは GitHub Release を持たない CI 専用成果物のため、
 // auto-updater を走らせると安定版/beta への誤ダウングレードを招く。バージョン文字列で
@@ -79,20 +85,47 @@ function setupAutoUpdater() {
     // Defer require to avoid circular dependency with window-manager.js
     const { getMainWindow } = require("./window-manager");
     const mainWindow = getMainWindow();
-    if (mainWindow) {
+    if (!mainWindow) return;
+
+    // macOS の 1.2.x は 1.3.0 正式版検出時に auto-update を提案せず、公式サイトへの
+    // 手動ダウンロード誘導に置き換える（notarization/bundle ID 変更で追従できない事例があるため）。
+    if (
+      isSunsetDetected({
+        platform: process.platform,
+        currentVersion: app.getVersion(),
+        availableVersion: info.version,
+      })
+    ) {
       dialog
         .showMessageBox(mainWindow, {
-          type: "info",
-          title: "アップデート可能",
-          message: `新しいバージョン ${info.version} が見つかりました`,
-          detail: "バックグラウンドでアップデートをダウンロードしています...",
-          buttons: ["OK"],
+          type: "warning",
+          title: "サポート終了のお知らせ",
+          message: "illusions 1.2 はサポートを終了しました",
+          detail: `最新バージョン ${info.version} が公開されています。公式サイトから最新版をダウンロードしてください。\n${DOWNLOAD_PAGE_URL}`,
+          buttons: ["公式サイトを開く", "後で"],
+          defaultId: 0,
+          cancelId: 1,
         })
-        .then(() => {
-          // ダウンロード開始
-          autoUpdater.downloadUpdate();
+        .then((result) => {
+          if (result.response === 0) {
+            void shell.openExternal(DOWNLOAD_PAGE_URL);
+          }
         });
+      return;
     }
+
+    dialog
+      .showMessageBox(mainWindow, {
+        type: "info",
+        title: "アップデート可能",
+        message: `新しいバージョン ${info.version} が見つかりました`,
+        detail: "バックグラウンドでアップデートをダウンロードしています...",
+        buttons: ["OK"],
+      })
+      .then(() => {
+        // ダウンロード開始
+        autoUpdater.downloadUpdate();
+      });
   });
 
   // イベント: ダウンロード完了

--- a/electron/lib/__tests__/update-policy.test.ts
+++ b/electron/lib/__tests__/update-policy.test.ts
@@ -8,10 +8,16 @@ import { describe, expect, it } from "vitest";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
-const { resolveUpdaterFlags, isUnpublishedChannelVersion } = require("../update-policy") as {
-  resolveUpdaterFlags: (v: unknown) => { allowPrerelease: boolean; allowDowngrade: boolean };
-  isUnpublishedChannelVersion: (v: unknown) => boolean;
-};
+const { resolveUpdaterFlags, isUnpublishedChannelVersion, isSunsetDetected } =
+  require("../update-policy") as {
+    resolveUpdaterFlags: (v: unknown) => { allowPrerelease: boolean; allowDowngrade: boolean };
+    isUnpublishedChannelVersion: (v: unknown) => boolean;
+    isSunsetDetected: (params: {
+      platform: unknown;
+      currentVersion: unknown;
+      availableVersion: unknown;
+    }) => boolean;
+  };
 
 describe("resolveUpdaterFlags", () => {
   it("beta ON → プレリリース受信、ダウングレード不可", () => {
@@ -72,5 +78,63 @@ describe("isUnpublishedChannelVersion", () => {
   it("'develop' のような部分一致では誤検出しない（ハイフン区切りのチャンネル接尾辞のみ）", () => {
     expect(isUnpublishedChannelVersion("1.2.20-developer")).toBe(false);
     expect(isUnpublishedChannelVersion("1.2.20-alphabet")).toBe(false);
+  });
+});
+
+describe("isSunsetDetected", () => {
+  it("macOS で 1.2.x 実行中に 1.3.0 正式版を検出したら true", () => {
+    expect(
+      isSunsetDetected({ platform: "darwin", currentVersion: "1.2.22", availableVersion: "1.3.0" }),
+    ).toBe(true);
+  });
+
+  it("1.3.0 より新しい正式版でも true（1.3.x 系はすべて sunset 対象）", () => {
+    expect(
+      isSunsetDetected({ platform: "darwin", currentVersion: "1.2.22", availableVersion: "1.4.5" }),
+    ).toBe(true);
+  });
+
+  it.each(["win32", "linux"])(
+    "macOS 以外 (%s) は常に false（通常の auto-update を継続）",
+    (platform) => {
+      expect(
+        isSunsetDetected({ platform, currentVersion: "1.2.22", availableVersion: "1.3.0" }),
+      ).toBe(false);
+    },
+  );
+
+  it("1.3.0 の beta プレリリースはまだ正式版ではないので false", () => {
+    expect(
+      isSunsetDetected({
+        platform: "darwin",
+        currentVersion: "1.2.22",
+        availableVersion: "1.3.0-beta.20260706.120000",
+      }),
+    ).toBe(false);
+  });
+
+  it("現在バージョンが既に 1.3.0 以降なら false（自身の通常アップデートを sunset 扱いしない）", () => {
+    expect(
+      isSunsetDetected({ platform: "darwin", currentVersion: "1.3.0", availableVersion: "1.3.1" }),
+    ).toBe(false);
+  });
+
+  it("1.3.0 未満の通常アップデート（1.2.x → 1.2.y）は false", () => {
+    expect(
+      isSunsetDetected({
+        platform: "darwin",
+        currentVersion: "1.2.20",
+        availableVersion: "1.2.22",
+      }),
+    ).toBe(false);
+  });
+
+  it.each([undefined, null, 0, {}, "not-a-version"])("不正な値 (%s) は安全側 = false", (value) => {
+    expect(
+      isSunsetDetected({ platform: "darwin", currentVersion: "1.2.22", availableVersion: value }),
+    ).toBe(false);
+    expect(
+      isSunsetDetected({ platform: "darwin", currentVersion: value, availableVersion: "1.3.0" }),
+    ).toBe(false);
   });
 });

--- a/electron/lib/update-policy.js
+++ b/electron/lib/update-policy.js
@@ -50,4 +50,52 @@ function isUnpublishedChannelVersion(version) {
   return /-(?:dev|alpha)(?:\.|$)/.test(version);
 }
 
-module.exports = { resolveUpdaterFlags, isUnpublishedChannelVersion };
+/**
+ * illusions 1.2 系列の sunset 判定に使う下限バージョン（1.3.0 正式版以降）。
+ */
+const SUNSET_MIN_VERSION = { major: 1, minor: 3 };
+
+/**
+ * "X.Y.Z..." から major/minor だけを取り出す。パース不能なら null。
+ * @param {unknown} version
+ * @returns {{ major: number, minor: number } | null}
+ */
+function parseMajorMinor(version) {
+  if (typeof version !== "string") return null;
+  const match = version.match(/^(\d+)\.(\d+)\.\d+/);
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+/** major/minor のみで比較する（patch は無視）。a<b なら負、a>b なら正、等しければ 0。 */
+function compareMajorMinor(a, b) {
+  return a.major !== b.major ? a.major - b.major : a.minor - b.minor;
+}
+
+/**
+ * macOS 限定の sunset 検出。
+ *
+ * 1.2.x を実行中のユーザーが 1.3.0 以降の「正式版」(プレリリースではない) を検出したら、
+ * 通常の auto-update フロー（ダウンロード提案）ではなく sunset 通知に置き換える。
+ * macOS は過去に notarization/bundle ID 変更で auto-updater が追従できなかったことがあり
+ * (#2019 revert)、確実に手動ダウンロードへ誘導する必要があるため他プラットフォームとは
+ * 扱いを分ける。beta プレリリース (`1.3.0-beta.*`) はまだ「正式版」ではないので対象外。
+ *
+ * @param {{ platform: unknown, currentVersion: unknown, availableVersion: unknown }} params
+ * @returns {boolean}
+ */
+function isSunsetDetected({ platform, currentVersion, availableVersion }) {
+  if (platform !== "darwin") return false;
+  if (typeof availableVersion !== "string" || availableVersion.includes("-")) return false;
+
+  const current = parseMajorMinor(currentVersion);
+  const available = parseMajorMinor(availableVersion);
+  if (!current || !available) return false;
+
+  return (
+    compareMajorMinor(current, SUNSET_MIN_VERSION) < 0 &&
+    compareMajorMinor(available, SUNSET_MIN_VERSION) >= 0
+  );
+}
+
+module.exports = { resolveUpdaterFlags, isUnpublishedChannelVersion, isSunsetDetected };


### PR DESCRIPTION
## Summary

- macOS の illusions 1.2.x が 1.3.0 以降の正式版リリースを検出したら、通常の自動更新ダイアログの代わりに「サポート終了」通知を表示し、公式サイト (https://www.illusions.app/downloads/) へ手動ダウンロード誘導する
- Windows / Linux は対象外。既存の自動更新フローをそのまま維持する

## Changes

| 領域 | 内容 |
| --- | --- |
| `electron/lib/update-policy.js` | 純粋関数 `isSunsetDetected({ platform, currentVersion, availableVersion })` を追加。macOS かつ現在バージョン < 1.3.0 かつ検出バージョン ≥ 1.3.0 かつ正式版（プレリリースでない）のときのみ true |
| `electron/auto-updater.js` | `update-available` ハンドラで `isSunsetDetected` を判定し、true なら「サポート終了のお知らせ」ダイアログ（「公式サイトを開く」ボタンで `shell.openExternal`）に差し替え、`downloadUpdate()` は呼ばない |
| `electron/lib/__tests__/update-policy.test.ts` | `isSunsetDetected` の純粋関数テスト（プラットフォーム、バージョン境界、beta プレリリース除外、不正値） |
| `electron/__tests__/auto-updater.test.ts` | 既存の drift-guard 方式（ソーステキスト検証）で sunset 分岐の結線を固定 |
| `electron/__tests__/auto-updater-sunset.test.ts`（新規） | `Module._load` を差し替えて `electron/auto-updater.js` を実際に読み込み、`update-available` イベントを発火させて挙動を検証する実行時テスト（ダイアログ内容・ボタン応答・downloadUpdate 呼び出し有無・プラットフォーム/バージョン境界） |

### なぜ macOS だけか

過去に notarization / bundle ID 変更で macOS の auto-updater が正しく追従できなかった事例 (#2019 revert) があり、1.3.0 のような大きめのバージョン境界で自動更新に頼るとユーザーが古いバージョンに取り残される可能性がある。確実に手動ダウンロードへ誘導する安全弁として追加した。

### 1.3.0 を実際にリリースせずにどう検証したか

- 純粋関数 `isSunsetDetected` の単体テストで判定ロジックを網羅
- `electron/auto-updater.js` は electron-updater を最上位で require するため通常は vitest でロードできない（既存コメント参照）。`vi.mock("electron-updater", ...)` を試したが、ライブラリ内部の遅延 getter が実クラスを construct して失敗したため、既存の `saveAllBeforeQuitAndInstall` テストと同じ `Module._load` 差し替え手法で実際に `electron/auto-updater.js` を読み込み、`update-available` イベントを発火させてダイアログの実引数・ボタン応答・`downloadUpdate()` 呼び出し有無まで検証する実行時テストを追加した

## Follow-up

- #2037: 1.3.0 リリース後にこの sunset 通知機構（今回追加した全コード）を削除する

## Test plan

- [x] `npm run type-check` — pass
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 2621/2638 pass（残り 17 件は `dev` 上で元から失敗している既存不具合、本 PR と無関係）
- [x] `electron/__tests__/auto-updater-sunset.test.ts` の 8 ケース（macOS sunset 表示、ボタン応答、Windows/Linux 非対象、バージョン境界、beta プレリリース除外）すべて実行時テストで通過
- [x] `electron` 配下 25 ファイル・392 テストをまとめて実行し、モックの相互汚染がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)