### PR TITLE
fix(bug-report): CSP ブロック解除 + CSP 違反の GlitchTip 自動上報

### DIFF
--- a/components/ErrorReportingRuntime.tsx
+++ b/components/ErrorReportingRuntime.tsx
@@ -25,11 +25,21 @@ export function ErrorReportingRuntime(): null {
       });
     };
 
+    const onCspViolation = (event: SecurityPolicyViolationEvent): void => {
+      void window.electronAPI?.errorReporting?.captureRendererError({
+        source: "csp-violation",
+        name: "SecurityPolicyViolation",
+        message: `CSP violation: ${event.violatedDirective} blocked ${event.blockedURI}`,
+      });
+    };
+
     window.addEventListener("error", onError);
     window.addEventListener("unhandledrejection", onUnhandledRejection);
+    document.addEventListener("securitypolicyviolation", onCspViolation);
     return () => {
       window.removeEventListener("error", onError);
       window.removeEventListener("unhandledrejection", onUnhandledRejection);
+      document.removeEventListener("securitypolicyviolation", onCspViolation);
     };
   }, []);
 

--- a/components/__tests__/ErrorReportingRuntime.test.tsx
+++ b/components/__tests__/ErrorReportingRuntime.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ErrorReportingRuntime } from "../ErrorReportingRuntime";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const captureRendererErrorMock = vi.fn().mockResolvedValue(undefined);
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  captureRendererErrorMock.mockClear();
+  (window as unknown as { electronAPI?: unknown }).electronAPI = {
+    errorReporting: {
+      captureRendererError: captureRendererErrorMock,
+    },
+  };
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+describe("ErrorReportingRuntime", () => {
+  it("captures document CSP violations as renderer errors", async () => {
+    await act(async () => {
+      root.render(<ErrorReportingRuntime />);
+    });
+
+    const event = Object.assign(new Event("securitypolicyviolation"), {
+      violatedDirective: "connect-src",
+      blockedURI: "https://blocked.example.test/report",
+    });
+
+    document.dispatchEvent(event);
+
+    expect(captureRendererErrorMock).toHaveBeenCalledWith({
+      source: "csp-violation",
+      name: "SecurityPolicyViolation",
+      message: "CSP violation: connect-src blocked https://blocked.example.test/report",
+    });
+  });
+});

--- a/electron/__tests__/csp.test.ts
+++ b/electron/__tests__/csp.test.ts
@@ -1,0 +1,13 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const mainSrc = fs.readFileSync(path.resolve(__dirname, "../main.js"), "utf8");
+
+describe("main.js CSP (drift guard)", () => {
+  it("allows the bug report API in connect-src", () => {
+    const connectSrcLine = mainSrc.split("\n").find((line) => line.includes("connect-src"));
+
+    expect(connectSrcLine).toContain("https://bug-report.api.illusions.app");
+  });
+});

--- a/electron/ipc/__tests__/error-reporting-ipc.test.ts
+++ b/electron/ipc/__tests__/error-reporting-ipc.test.ts
@@ -31,6 +31,20 @@ describe("createCaptureRendererErrorHandler", () => {
     expect(captureRendererError).toHaveBeenCalledWith({ source: "window-error", message: "boom" });
   });
 
+  it("forwards csp-violation payloads", async () => {
+    const { handler, captureRendererError } = await createHandler();
+
+    await handler(
+      {},
+      { source: "csp-violation", message: "CSP violation: connect-src blocked https://x" },
+    );
+
+    expect(captureRendererError).toHaveBeenCalledWith({
+      source: "csp-violation",
+      message: "CSP violation: connect-src blocked https://x",
+    });
+  });
+
   it("ignores non-object payloads", async () => {
     const { handler, captureRendererError } = await createHandler();
 

--- a/electron/ipc/error-reporting-ipc.js
+++ b/electron/ipc/error-reporting-ipc.js
@@ -1,7 +1,12 @@
 const { ipcMain } = require("electron");
 const { ERROR_REPORTING_CHANNELS } = require("../lib/ipc-channels");
 
-const VALID_SOURCES = new Set(["error-boundary", "window-error", "unhandledrejection"]);
+const VALID_SOURCES = new Set([
+  "error-boundary",
+  "window-error",
+  "unhandledrejection",
+  "csp-violation",
+]);
 
 function isValidPayload(payload) {
   return (

--- a/electron/main.js
+++ b/electron/main.js
@@ -216,7 +216,7 @@ app.whenReady().then(async () => {
             "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
             "img-src 'self' data: blob: https:",
             "font-src 'self' data: https://fonts.gstatic.com",
-            `connect-src 'self' https://my.illusions.app https://api.dict.illusions.app https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com${extraAiConnectSrc} ws://localhost:*`,
+            `connect-src 'self' https://my.illusions.app https://api.dict.illusions.app https://bug-report.api.illusions.app https://api.openai.com https://api.anthropic.com https://generativelanguage.googleapis.com${extraAiConnectSrc} ws://localhost:*`,
             "worker-src 'self' blob:",
             "object-src blob:",
             "frame-src blob:",

--- a/lib/error-reporting/error-reporting-types.ts
+++ b/lib/error-reporting/error-reporting-types.ts
@@ -1,4 +1,5 @@
-export type RendererErrorSource = "error-boundary" | "window-error" | "unhandledrejection";
+export type RendererErrorSource =
+  "error-boundary" | "window-error" | "unhandledrejection" | "csp-violation";
 
 export interface RendererErrorPayload {
   source: RendererErrorSource;

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -279,7 +279,7 @@ declare global {
     };
     errorReporting?: {
       captureRendererError: (payload: {
-        source: "error-boundary" | "window-error" | "unhandledrejection";
+        source: "error-boundary" | "window-error" | "unhandledrejection" | "csp-violation";
         name?: string;
         message?: string;
         stack?: string;


### PR DESCRIPTION
## Summary

- bug 回報表單の送信は Electron 自体の CSP `connect-src` に `bug-report.api.illusions.app` が含まれておらず、DSN ベースの送信ロジック自体は正しいにもかかわらずブロックされていた。
- CSP 違反は `securitypolicyviolation` という独立した DOM イベントで発生し、既存の `error` / `unhandledrejection` リスナーでは捕捉できず、GlitchTip に一切上報されていなかった。

## Changes

| File | Change |
| --- | --- |
| `electron/main.js` | CSP `connect-src` に `https://bug-report.api.illusions.app` を追加 |
| `components/ErrorReportingRuntime.tsx` | `securitypolicyviolation` リスナーを追加し `captureRendererError` に `source: "csp-violation"` で送信 |
| `lib/error-reporting/error-reporting-types.ts`, `types/electron.d.ts` | `RendererErrorSource` に `"csp-violation"` を追加 |
| `electron/ipc/error-reporting-ipc.js` | IPC ペイロードの `VALID_SOURCES` allowlist に `"csp-violation"` を追加（未対応のままだと新イベントが黙って破棄されるため必須の追加修正） |
| `electron/__tests__/csp.test.ts` | CSP `connect-src` の drift guard を新規追加 |
| `components/__tests__/ErrorReportingRuntime.test.tsx`, `electron/ipc/__tests__/error-reporting-ipc.test.ts` | 新規/追加の振る舞いテスト |

## Test plan

- [x] `npx vitest run electron components/__tests__ lib/error-reporting` — 新規/既存 528 件中 522 件成功（残り6件は dev で既知の localStorage 関連の既存失敗で本修正と無関係）
- [x] `npm run type-check` — エラーなし
- [x] `npx eslint` 変更ファイル一式 — エラーなし
- [x] `npm run electron:dev` を実データで実行し、Chrome DevTools Protocol 経由で実機検証:
  - `bug-report.api.illusions.app` への fetch が CSP でブロックされなくなったことを確認
  - allowlist 外ドメインへの fetch で実際に `securitypolicyviolation` が発火し、`ErrorReportingRuntime` → IPC → メインプロセスまで `source: "csp-violation"` のペイロードが正しく到達することを確認

Closes #2041

🤖 Generated with [Claude Code](https://claude.com/claude-code)