### PR TITLE
fix(auto-updater): adjust macOS sunset notice wording

### DIFF
--- a/electron/auto-updater.js
+++ b/electron/auto-updater.js
@@ -100,7 +100,7 @@ function setupAutoUpdater() {
         .showMessageBox(mainWindow, {
           type: "warning",
           title: "サポート終了のお知らせ",
-          message: "illusions 1.2 はサポートを終了しました",
+          message: "illusions 1.2 はSunset（サポート終了）となりました",
           detail: `最新バージョン ${info.version} が公開されています。公式サイトから最新版をダウンロードしてください。\n${DOWNLOAD_PAGE_URL}`,
           buttons: ["公式サイトを開く", "後で"],
           defaultId: 0,


### PR DESCRIPTION
## Summary
- Tweak the macOS 1.2→1.3 sunset dialog message text (#2039 follow-up wording adjustment).

## Test plan
- [ ] Visual check of the sunset dialog message

🤖 Generated with [Claude Code](https://claude.com/claude-code)