### PR TITLE
fix(lint): 校正カードの「ユーザー辞書に追加」が位置ズレした文字列を登録する問題を修正

### DIFF
--- a/lib/editor-page/__tests__/use-lint-handlers.test.ts
+++ b/lib/editor-page/__tests__/use-lint-handlers.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for useLintHandlers — issue-text extraction for the lint UI actions.
+ *
+ * #2047: issue positions held in React state are frozen at lint-dispatch time
+ * and are NOT remapped when the document changes. Re-slicing the current
+ * document with those stale positions returned drifted garbage (e.g.
+ * 「。 フガピ」 instead of 「フガピヨ」) from the correction card's
+ * 「この語をユーザー辞書に追加」action. The handlers must prefer the
+ * detection-time `originalText` recorded by the lint pipeline and only fall
+ * back to document extraction when it is absent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import type { EditorView } from "@milkdown/prose/view";
+import type { LintIssue } from "@/lib/linting/types";
+
+vi.mock("@/lib/services/notification-manager", () => ({
+  notificationManager: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
+import { useLintHandlers } from "../use-lint-handlers";
+
+/**
+ * Minimal EditorView stand-in: the document is a flat string and textBetween
+ * is a plain slice. Tests emulate #2047's position drift by giving issues
+ * from/to values that no longer point at the flagged word in this string.
+ */
+function makeView(docText: string): EditorView {
+  return {
+    state: {
+      doc: {
+        content: { size: docText.length },
+        textBetween: (from: number, to: number) => docText.slice(from, to),
+        descendants: () => {},
+      },
+      selection: { from: 0 },
+    },
+    dom: document.createElement("div"),
+  } as unknown as EditorView;
+}
+
+function makeIssue(overrides: Partial<LintIssue>): LintIssue {
+  return {
+    ruleId: "genji-out-of-dict",
+    severity: "info",
+    message: "Out-of-dictionary word",
+    messageJa: "辞書外語",
+    from: 0,
+    to: 0,
+    ...overrides,
+  };
+}
+
+// Repro from #2047: a sentence, a newline, then the flagged word used again.
+// The word フガピヨ currently sits at [6, 10), but the issue carries stale
+// positions [4, 8) — two characters back — spanning the preceding 。 + newline.
+const DOC_TEXT = "フガピヨ。\nフガピヨを使う。";
+const STALE_FROM = 4;
+const STALE_TO = 8;
+const DRIFTED_SLICE = DOC_TEXT.slice(STALE_FROM, STALE_TO); // 「。\nフガ」
+
+let root: Root | null = null;
+
+function setup(view: EditorView | null, lintIssues: LintIssue[]) {
+  const ignoreCorrection = vi.fn();
+  const addWordToUserDictionary = vi.fn(async () => {});
+  const triggerSwitchToCorrections = vi.fn();
+  const capturedRef: { current: ReturnType<typeof useLintHandlers> | null } = { current: null };
+
+  function Probe() {
+    // Capture the hook return into an outer ref so the test can drive it.
+    // Not a production render pattern.
+    // eslint-disable-next-line react-hooks/immutability
+    capturedRef.current = useLintHandlers({
+      editorViewInstance: view,
+      lintIssues,
+      ignoreCorrection,
+      addWordToUserDictionary,
+      triggerSwitchToCorrections,
+    });
+    return null;
+  }
+  root = createRoot(document.createElement("div"));
+  act(() => {
+    root!.render(React.createElement(Probe));
+  });
+  return {
+    handlers: capturedRef.current!,
+    ignoreCorrection,
+    addWordToUserDictionary,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = null;
+});
+
+describe("useLintHandlers — issue text extraction (#2047)", () => {
+  it("adds the detection-time originalText to the user dictionary, not a stale-position slice", () => {
+    const issue = makeIssue({ from: STALE_FROM, to: STALE_TO, originalText: "フガピヨ" });
+    const { handlers, addWordToUserDictionary } = setup(makeView(DOC_TEXT), [issue]);
+
+    handlers.handleAddToUserDictionary(issue);
+
+    expect(addWordToUserDictionary).toHaveBeenCalledTimes(1);
+    expect(addWordToUserDictionary).toHaveBeenCalledWith("フガピヨ");
+    expect(addWordToUserDictionary).not.toHaveBeenCalledWith(DRIFTED_SLICE);
+  });
+
+  it("falls back to extracting from the document when originalText is absent", () => {
+    const issue = makeIssue({ from: 6, to: 10 }); // current position of フガピヨ
+    const { handlers, addWordToUserDictionary } = setup(makeView(DOC_TEXT), [issue]);
+
+    handlers.handleAddToUserDictionary(issue);
+
+    expect(addWordToUserDictionary).toHaveBeenCalledWith("フガピヨ");
+  });
+
+  it("ignores a correction by its detection-time originalText, not a stale-position slice", () => {
+    const issue = makeIssue({ from: STALE_FROM, to: STALE_TO, originalText: "フガピヨ" });
+    const { handlers, ignoreCorrection } = setup(makeView(DOC_TEXT), [issue]);
+
+    handlers.handleIgnoreCorrection(issue, true);
+
+    expect(ignoreCorrection).toHaveBeenCalledWith("genji-out-of-dict", "フガピヨ");
+  });
+
+  it("enrichedLintIssues preserves a pre-existing originalText instead of clobbering it", () => {
+    const issue = makeIssue({ from: STALE_FROM, to: STALE_TO, originalText: "フガピヨ" });
+    const { handlers } = setup(makeView(DOC_TEXT), [issue]);
+
+    expect(handlers.enrichedLintIssues[0].originalText).toBe("フガピヨ");
+    expect(handlers.enrichedLintIssues[0].originalText).not.toBe(DRIFTED_SLICE);
+  });
+
+  it("enrichedLintIssues fills originalText from the document when absent", () => {
+    const issue = makeIssue({ from: 6, to: 10 });
+    const { handlers } = setup(makeView(DOC_TEXT), [issue]);
+
+    expect(handlers.enrichedLintIssues[0].originalText).toBe("フガピヨ");
+  });
+});

--- a/lib/editor-page/use-lint-handlers.ts
+++ b/lib/editor-page/use-lint-handlers.ts
@@ -4,6 +4,24 @@ import type { EditorView } from "@milkdown/prose/view";
 import type { LintIssue } from "@/lib/linting/types";
 import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
 
+/**
+ * Get the exact text a lint issue flagged.
+ *
+ * Prefers `issue.originalText`, captured by the lint pipeline at detection
+ * time: issue positions held in React state are frozen at lint-dispatch time
+ * and are not remapped when the document changes, so slicing the current
+ * document with them can return a drifted, wrong string (#2047). Falls back
+ * to extracting from the document only when `originalText` is absent.
+ */
+function getIssueText(issue: LintIssue, view: EditorView): string | null {
+  if (issue.originalText) return issue.originalText;
+  try {
+    return view.state.doc.textBetween(issue.from, Math.min(issue.to, view.state.doc.content.size));
+  } catch {
+    return null;
+  }
+}
+
 interface UseLintHandlersOptions {
   editorViewInstance: EditorView | null;
   lintIssues: LintIssue[];
@@ -19,11 +37,18 @@ export function useLintHandlers({
   addWordToUserDictionary,
   triggerSwitchToCorrections,
 }: UseLintHandlersOptions) {
-  // Enrich lint issues with original text from the document
+  // Enrich lint issues with original text from the document.
+  // The lint pipeline already records `originalText` at detection time (the
+  // exact string the rule flagged, extracted in the linter's own coordinate
+  // space). Positions in React state are frozen at lint-dispatch time and are
+  // NOT remapped when the document changes, so re-extracting via textBetween
+  // can yield drifted garbage (#2047). Never clobber an existing originalText;
+  // only fill it in for issues that lack one.
   const enrichedLintIssues = useMemo(() => {
     if (!editorViewInstance || lintIssues.length === 0) return lintIssues;
     const doc = editorViewInstance.state.doc;
     return lintIssues.map((issue: LintIssue) => {
+      if (issue.originalText != null) return issue;
       try {
         const originalText = doc.textBetween(issue.from, Math.min(issue.to, doc.content.size));
         return { ...issue, originalText };
@@ -86,16 +111,7 @@ export function useLintHandlers({
   const handleIgnoreCorrection = useCallback(
     (issue: LintIssue, ignoreAll: boolean) => {
       if (!editorViewInstance) return;
-      // Extract original text from the document
-      let issueText: string;
-      try {
-        issueText = editorViewInstance.state.doc.textBetween(
-          issue.from,
-          Math.min(issue.to, editorViewInstance.state.doc.content.size),
-        );
-      } catch {
-        return;
-      }
+      const issueText = getIssueText(issue, editorViewInstance);
       if (!issueText) return;
 
       if (ignoreAll) {
@@ -126,15 +142,7 @@ export function useLintHandlers({
   const handleAddToUserDictionary = useCallback(
     (issue: LintIssue) => {
       if (!editorViewInstance) return;
-      let issueText: string;
-      try {
-        issueText = editorViewInstance.state.doc.textBetween(
-          issue.from,
-          Math.min(issue.to, editorViewInstance.state.doc.content.size),
-        );
-      } catch {
-        return;
-      }
+      const issueText = getIssueText(issue, editorViewInstance);
       if (!issueText) return;
       void addWordToUserDictionary(issueText);
     },


### PR DESCRIPTION
## Summary

- 校正カード（辞書外語 `genji-out-of-dict`）の「この語をユーザー辞書に追加」が、検出語ではなく数文字ズレた文字列（例: `フガピヨ` に対して「。 フガピ」）を登録していた問題を修正。
- 根本原因: React state に保持される lint issue の `from`/`to` は lint 実行時点の ProseMirror ドキュメント位置のまま固定され、その後の文書変更で再マップされない。装飾（Decoration）は ProseMirror が自動で位置を追従させるが、issue オブジェクト側は追従しないため、古い位置で `doc.textBetween(from, to)` を再抽出すると前方の句読点・改行を含むズレた文字列が返っていた。
- 修正方針: lint パイプラインが検出時に記録している `originalText`（decoration-plugin が段落座標系で切り出した正確な語）を優先し、`textBetween` による再抽出は `originalText` が無い場合のフォールバックに限定。文字列のトリム等の対症療法は行わない。
- 付随修正: `enrichedLintIssues` が正しい `originalText` を現在文書の `textBetween` で上書きしていた問題も解消（`handleApplyFix` の「テキストが変更されたため修正を適用できません」ガードが textBetween 同士の常時一致で無効化されていた潜在バグも復旧）。

## Changes

| File | Change |
| --- | --- |
| `lib/editor-page/use-lint-handlers.ts` | 検出時 `originalText` 優先・`textBetween` フォールバックの `getIssueText` ヘルパーを追加し、`handleAddToUserDictionary` / `handleIgnoreCorrection` を移行。`enrichedLintIssues` は既存 `originalText` を上書きせず欠落時のみ補完 |
| `lib/editor-page/__tests__/use-lint-handlers.test.ts` | 新規。Issue の再現ケース（前文 + 改行の後に検出語、位置ズレ状態）で、登録される文字列が検出語 `フガピヨ` に一致すること、`originalText` 欠落時のフォールバック、enrichment が検出時 `originalText` を保持することを検証（5 件） |

## Test plan

- [x] `npx vitest run lib/editor-page/__tests__/use-lint-handlers.test.ts lib/editor-page/__tests__/use-user-dictionary-actions.test.ts` — 11 件全て成功
- [x] `npm run test` — 2629 passed / 17 failed（17 件は clean な dev でも失敗する既知の localStorage 関連の既存失敗で本修正と無関係。本 PR による新規失敗なし）
- [x] `npm run type-check` — エラーなし
- [x] `npm run lint` — エラーなし（変更ファイルに警告なし）

Closes #2047

🤖 Generated with [Claude Code](https://claude.com/claude-code)
