### PR TITLE
feat(settings): genji-out-of-dict の includeVerbsAdjectives を設定 UI から上書き可能にする

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1623,7 +1623,11 @@ export default function EditorPage() {
     onCorrectionModeChange: (modeId: CorrectionModeId) => {
       const mode = CORRECTION_MODES[modeId];
       handleCorrectionConfigChange({ mode: modeId, guidelines: [...mode.defaultGuidelines] });
-      handleLintingRuleConfigsBatchChange(buildModeRuleConfigsFromRules(modeId, loadedRules));
+      // Pass the current configs so user rule-option overrides (#2048)
+      // survive the whole-map replace a mode switch performs.
+      handleLintingRuleConfigsBatchChange(
+        buildModeRuleConfigsFromRules(modeId, loadedRules, lintingRuleConfigs),
+      );
     },
     switchToCorrectionsTrigger,
     previousDayStats,

--- a/components/inspector/CorrectionsPanel.tsx
+++ b/components/inspector/CorrectionsPanel.tsx
@@ -252,7 +252,9 @@ export default function CorrectionsPanel({
       for (const ruleId of group.ruleIds) {
         const current = lintingRuleConfigs[ruleId];
         const severity = current?.severity ?? "warning";
-        onLintingRuleConfigChange(ruleId, { enabled: false, severity });
+        // Spread `current` so per-rule extras (skipDialogue / options, #2048)
+        // survive; the replace-style persistence would otherwise drop them.
+        onLintingRuleConfigChange(ruleId, { ...current, enabled: false, severity });
       }
     },
     [onLintingRuleConfigChange, lintingRuleConfigs],

--- a/components/settings/LintingSettings.tsx
+++ b/components/settings/LintingSettings.tsx
@@ -17,20 +17,19 @@ import RulesetAutoUpdateToggle from "./linting/RulesetAutoUpdateToggle";
 import ClearIgnoredCorrectionsButton from "./linting/ClearIgnoredCorrectionsButton";
 import { useRulesetStatus } from "./linting/useRulesetStatus";
 
+type RuleConfig = {
+  enabled: boolean;
+  severity: Severity;
+  skipDialogue?: boolean;
+  options?: Record<string, unknown>;
+};
+
 export interface LintingSettingsProps {
   lintingEnabled: boolean;
   onLintingEnabledChange: (value: boolean) => void;
-  lintingRuleConfigs: Record<
-    string,
-    { enabled: boolean; severity: Severity; skipDialogue?: boolean }
-  >;
-  onLintingRuleConfigChange: (
-    ruleId: string,
-    config: { enabled: boolean; severity: Severity; skipDialogue?: boolean },
-  ) => void;
-  onLintingRuleConfigsBatchChange: (
-    configs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>,
-  ) => void;
+  lintingRuleConfigs: Record<string, RuleConfig>;
+  onLintingRuleConfigChange: (ruleId: string, config: RuleConfig) => void;
+  onLintingRuleConfigsBatchChange: (configs: Record<string, RuleConfig>) => void;
   characterExtractionBatchSize?: number;
   onCharacterExtractionBatchSizeChange?: (value: number) => void;
   characterExtractionConcurrency?: number;
@@ -110,6 +109,7 @@ function LintingSettingsInner({
             correctionConfig={correctionConfig}
             disabled={!lintingEnabled}
             loadedRules={loadedRules}
+            lintingRuleConfigs={lintingRuleConfigs}
             onCorrectionConfigChange={onCorrectionConfigChange}
             onLintingRuleConfigsBatchChange={onLintingRuleConfigsBatchChange}
           />

--- a/components/settings/linting/ModeSelector.tsx
+++ b/components/settings/linting/ModeSelector.tsx
@@ -24,9 +24,32 @@ interface ModeSelectorProps {
    * regression this prop exists to fix).
    */
   loadedRules: readonly ModeRuleMetaInput[];
+  /**
+   * Current per-rule configs. Mode switching replaces the whole config map,
+   * so user rule-option overrides (`options`, #2048) must be read from here
+   * and carried into the rebuilt map — enabled/severity are intentionally
+   * mode-derived and NOT carried over.
+   */
+  lintingRuleConfigs: Record<
+    string,
+    {
+      enabled: boolean;
+      severity: Severity;
+      skipDialogue?: boolean;
+      options?: Record<string, unknown>;
+    }
+  >;
   onCorrectionConfigChange: (config: Partial<CorrectionConfig>) => void;
   onLintingRuleConfigsBatchChange: (
-    configs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>,
+    configs: Record<
+      string,
+      {
+        enabled: boolean;
+        severity: Severity;
+        skipDialogue?: boolean;
+        options?: Record<string, unknown>;
+      }
+    >,
   ) => void;
 }
 
@@ -34,6 +57,7 @@ export default function ModeSelector({
   correctionConfig,
   disabled,
   loadedRules,
+  lintingRuleConfigs,
   onCorrectionConfigChange,
   onLintingRuleConfigsBatchChange,
 }: ModeSelectorProps): React.ReactElement {
@@ -48,10 +72,12 @@ export default function ModeSelector({
       // Build a complete config map (every loaded rule) from the rules'
       // applicableModes so the batch handler's replace semantics is correct:
       // rules opting into this mode are enabled, all others disabled.
-      const configs = buildModeRuleConfigsFromRules(mode.id, loadedRules);
+      // Passing the current configs preserves user rule-option overrides
+      // across the replace (#2048).
+      const configs = buildModeRuleConfigsFromRules(mode.id, loadedRules, lintingRuleConfigs);
       onLintingRuleConfigsBatchChange(configs);
     },
-    [loadedRules, onCorrectionConfigChange, onLintingRuleConfigsBatchChange],
+    [loadedRules, lintingRuleConfigs, onCorrectionConfigChange, onLintingRuleConfigsBatchChange],
   );
 
   return (

--- a/components/settings/linting/RuleRow.tsx
+++ b/components/settings/linting/RuleRow.tsx
@@ -17,6 +17,8 @@ export interface RuleConfig {
   enabled: boolean;
   severity: Severity;
   skipDialogue?: boolean;
+  /** Rule-specific option overrides (merged over the manifest defaults). */
+  options?: Record<string, unknown>;
 }
 
 export interface RuleRowProps {
@@ -24,6 +26,13 @@ export interface RuleRowProps {
   nameJa: string;
   level?: RuleLevel;
   supportsSkipDialogue?: boolean;
+  /**
+   * Manifest default of the rule's `includeVerbsAdjectives` option.
+   * `undefined` = the rule does not declare the option (sub-toggle hidden).
+   * Defined = show the 「動詞・形容詞も照合する」 sub-toggle, using this value
+   * until the user sets an explicit override in `config.options` (#2048).
+   */
+  includeVerbsAdjectivesDefault?: boolean;
   config: RuleConfig;
   disabled?: boolean;
   onChange: (ruleId: string, config: RuleConfig) => void;
@@ -34,67 +43,98 @@ export default function RuleRow({
   nameJa,
   level,
   supportsSkipDialogue,
+  includeVerbsAdjectivesDefault,
   config,
   disabled,
   onChange,
 }: RuleRowProps): React.ReactElement {
+  const supportsIncludeVerbsAdjectives = includeVerbsAdjectivesDefault !== undefined;
+  const userIncludeVerbsAdjectives = config.options?.includeVerbsAdjectives;
+  const includeVerbsAdjectives =
+    typeof userIncludeVerbsAdjectives === "boolean"
+      ? userIncludeVerbsAdjectives
+      : (includeVerbsAdjectivesDefault ?? false);
+
   return (
     <div
-      className={clsx(
-        "flex items-center gap-2 px-3 py-2 transition-opacity",
-        disabled && "opacity-50 pointer-events-none",
-      )}
+      className={clsx("px-3 py-2 transition-opacity", disabled && "opacity-50 pointer-events-none")}
     >
-      {/* Rule name + level tag */}
-      <div className="flex-1 min-w-0 flex items-center gap-1.5">
-        {level && (
-          <span
-            className="flex-shrink-0 text-[10px] font-medium leading-none px-1 py-0.5 rounded border border-border-secondary text-foreground-tertiary bg-background-tertiary/50"
-            title={RULE_LEVEL_LABELS[level]}
+      <div className="flex items-center gap-2">
+        {/* Rule name + level tag */}
+        <div className="flex-1 min-w-0 flex items-center gap-1.5">
+          {level && (
+            <span
+              className="flex-shrink-0 text-[10px] font-medium leading-none px-1 py-0.5 rounded border border-border-secondary text-foreground-tertiary bg-background-tertiary/50"
+              title={RULE_LEVEL_LABELS[level]}
+            >
+              {level}
+            </span>
+          )}
+          <span className="text-sm text-foreground truncate">{nameJa}</span>
+        </div>
+
+        {/* Skip dialogue toggle */}
+        {supportsSkipDialogue && (
+          <button
+            onClick={() => onChange(ruleId, { ...config, skipDialogue: !config.skipDialogue })}
+            className={clsx(
+              "p-1 rounded transition-colors flex-shrink-0",
+              config.skipDialogue
+                ? "text-accent hover:text-accent-hover"
+                : "text-foreground-muted hover:text-foreground-secondary",
+            )}
+            title={config.skipDialogue ? "対話文を無視中" : "対話文も検査中"}
           >
-            {level}
-          </span>
+            {config.skipDialogue ? (
+              <MessageSquareOff className="w-3.5 h-3.5" />
+            ) : (
+              <MessageSquare className="w-3.5 h-3.5" />
+            )}
+          </button>
         )}
-        <span className="text-sm text-foreground truncate">{nameJa}</span>
+
+        {/* Severity dropdown */}
+        <select
+          value={config.severity}
+          onChange={(e) => onChange(ruleId, { ...config, severity: e.target.value as Severity })}
+          className="text-xs px-1.5 py-0.5 border border-border-secondary rounded bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-accent w-16"
+        >
+          <option value="error">エラー</option>
+          <option value="warning">警告</option>
+          <option value="info">情報</option>
+        </select>
+
+        {/* Enable toggle */}
+        <ToggleSwitch
+          checked={config.enabled}
+          onChange={() => onChange(ruleId, { ...config, enabled: !config.enabled })}
+          ariaLabel={config.enabled ? "ルールを無効にする" : "ルールを有効にする"}
+        />
       </div>
 
-      {/* Skip dialogue toggle */}
-      {supportsSkipDialogue && (
-        <button
-          onClick={() => onChange(ruleId, { ...config, skipDialogue: !config.skipDialogue })}
-          className={clsx(
-            "p-1 rounded transition-colors flex-shrink-0",
-            config.skipDialogue
-              ? "text-accent hover:text-accent-hover"
-              : "text-foreground-muted hover:text-foreground-secondary",
-          )}
-          title={config.skipDialogue ? "対話文を無視中" : "対話文も検査中"}
-        >
-          {config.skipDialogue ? (
-            <MessageSquareOff className="w-3.5 h-3.5" />
-          ) : (
-            <MessageSquare className="w-3.5 h-3.5" />
-          )}
-        </button>
+      {/* Per-rule option: 動詞・形容詞も照合する（genji-out-of-dict など、#2048） */}
+      {supportsIncludeVerbsAdjectives && (
+        <div className="mt-1.5 flex items-center gap-2 pl-1">
+          <span className="flex-1 min-w-0 text-xs text-foreground-secondary truncate">
+            動詞・形容詞も照合する
+          </span>
+          <ToggleSwitch
+            checked={includeVerbsAdjectives}
+            onChange={() =>
+              onChange(ruleId, {
+                ...config,
+                options: { ...config.options, includeVerbsAdjectives: !includeVerbsAdjectives },
+              })
+            }
+            ariaLabel={
+              includeVerbsAdjectives
+                ? "動詞・形容詞の照合を無効にする"
+                : "動詞・形容詞の照合を有効にする"
+            }
+            title="有効にすると名詞に加えて動詞・形容詞（基本形）も辞書と照合します"
+          />
+        </div>
       )}
-
-      {/* Severity dropdown */}
-      <select
-        value={config.severity}
-        onChange={(e) => onChange(ruleId, { ...config, severity: e.target.value as Severity })}
-        className="text-xs px-1.5 py-0.5 border border-border-secondary rounded bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-accent w-16"
-      >
-        <option value="error">エラー</option>
-        <option value="warning">警告</option>
-        <option value="info">情報</option>
-      </select>
-
-      {/* Enable toggle */}
-      <ToggleSwitch
-        checked={config.enabled}
-        onChange={() => onChange(ruleId, { ...config, enabled: !config.enabled })}
-        ariaLabel={config.enabled ? "ルールを無効にする" : "ルールを有効にする"}
-      />
     </div>
   );
 }

--- a/components/settings/linting/RulesetCard.tsx
+++ b/components/settings/linting/RulesetCard.tsx
@@ -27,6 +27,11 @@ export interface RulesetCardRule {
   nameJa: string;
   level?: RuleLevel;
   supportsSkipDialogue?: boolean;
+  /**
+   * Manifest default of the rule's `includeVerbsAdjectives` option;
+   * `undefined` = the rule does not declare it (no sub-toggle). See RuleRow.
+   */
+  includeVerbsAdjectivesDefault?: boolean;
 }
 
 export interface RulesetCardProps {
@@ -50,13 +55,10 @@ export interface RulesetCardProps {
   /** If true, delete button is disabled (built-in and official packs) */
   deletable?: boolean;
   /** Config keyed by ruleId */
-  ruleConfigs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>;
+  ruleConfigs: Record<string, RuleConfig>;
   defaultConfigs?: Record<string, { enabled: boolean; severity: Severity }>;
   disabled?: boolean;
-  onRuleConfigChange: (
-    ruleId: string,
-    config: { enabled: boolean; severity: Severity; skipDialogue?: boolean },
-  ) => void;
+  onRuleConfigChange: (ruleId: string, config: RuleConfig) => void;
   onPackToggle: (ruleIds: string[], enabled: boolean) => void;
   onCheckUpdate?: () => Promise<void>;
   onRedownload?: () => Promise<void>;
@@ -73,7 +75,7 @@ const LEGACY_LEVEL_MAP: ReadonlyMap<string, RuleLevel> | null = (() => {
 
 function getEffectiveConfig(
   ruleId: string,
-  configs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>,
+  configs: Record<string, RuleConfig>,
   defaults?: Record<string, { enabled: boolean; severity: Severity }>,
 ): RuleConfig {
   return (
@@ -294,6 +296,7 @@ export default function RulesetCard({
                     nameJa={rule.nameJa}
                     level={level}
                     supportsSkipDialogue={rule.supportsSkipDialogue}
+                    includeVerbsAdjectivesDefault={rule.includeVerbsAdjectivesDefault}
                     config={config}
                     onChange={onRuleConfigChange}
                   />

--- a/components/settings/linting/RulesetList.tsx
+++ b/components/settings/linting/RulesetList.tsx
@@ -17,28 +17,37 @@ import type { RulesetCardRule } from "./RulesetCard";
 import type { UseRulesetStatusReturn } from "./useRulesetStatus";
 import { buildBulkConfig, collectAllRuleIds } from "./bulk-toggle";
 
+type RuleConfig = {
+  enabled: boolean;
+  severity: Severity;
+  skipDialogue?: boolean;
+  options?: Record<string, unknown>;
+};
+
 interface RulesetListProps {
-  lintingRuleConfigs: Record<
-    string,
-    { enabled: boolean; severity: Severity; skipDialogue?: boolean }
-  >;
-  onLintingRuleConfigChange: (
-    ruleId: string,
-    config: { enabled: boolean; severity: Severity; skipDialogue?: boolean },
-  ) => void;
-  onLintingRuleConfigsBatchChange: (
-    configs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>,
-  ) => void;
+  lintingRuleConfigs: Record<string, RuleConfig>;
+  onLintingRuleConfigChange: (ruleId: string, config: RuleConfig) => void;
+  onLintingRuleConfigsBatchChange: (configs: Record<string, RuleConfig>) => void;
   disabled?: boolean;
   /** Undefined on Web (no-op; only Electron provides this) */
   rulesetStatus?: UseRulesetStatusReturn;
 }
 
-function getConfig(
-  ruleId: string,
-  configs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>,
-): { enabled: boolean; severity: Severity; skipDialogue?: boolean } {
+function getConfig(ruleId: string, configs: Record<string, RuleConfig>): RuleConfig {
   return configs[ruleId] ?? LINT_DEFAULT_CONFIGS[ruleId] ?? { enabled: true, severity: "warning" };
+}
+
+/**
+ * Manifest default of a rule's boolean `includeVerbsAdjectives` option, or
+ * `undefined` when the rule does not declare it. Presence gates the per-rule
+ * 「動詞・形容詞も照合する」 sub-toggle (#2048) — data-driven, so any rule that
+ * declares the option (currently genji-out-of-dict) gets the toggle.
+ */
+function includeVerbsAdjectivesDefault(defaultConfig?: {
+  options?: Record<string, unknown>;
+}): boolean | undefined {
+  const value = defaultConfig?.options?.includeVerbsAdjectives;
+  return typeof value === "boolean" ? value : undefined;
 }
 
 export default function RulesetList({
@@ -210,6 +219,7 @@ export default function RulesetList({
               nameJa: r.nameJa,
               level: r.level as RulesetCardRule["level"],
               supportsSkipDialogue: r.supportsSkipDialogue,
+              includeVerbsAdjectivesDefault: includeVerbsAdjectivesDefault(r.defaultConfig),
             }))}
             updateAvailable={rs.updateAvailable}
             syncing={rs.syncing}

--- a/components/settings/linting/__tests__/ModeSelector-mode-switch.test.tsx
+++ b/components/settings/linting/__tests__/ModeSelector-mode-switch.test.tsx
@@ -77,6 +77,7 @@ describe("ModeSelector — mode switch actually toggles rules (regression #1809/
         <ModeSelector
           correctionConfig={BASE_CONFIG}
           loadedRules={LOADED_RULES}
+          lintingRuleConfigs={{}}
           onCorrectionConfigChange={() => {}}
           onLintingRuleConfigsBatchChange={onBatch}
         />,
@@ -104,6 +105,7 @@ describe("ModeSelector — mode switch actually toggles rules (regression #1809/
         <ModeSelector
           correctionConfig={{ ...BASE_CONFIG, mode: "official" }}
           loadedRules={LOADED_RULES}
+          lintingRuleConfigs={{}}
           onCorrectionConfigChange={() => {}}
           onLintingRuleConfigsBatchChange={onBatch}
         />,
@@ -115,5 +117,55 @@ describe("ModeSelector — mode switch actually toggles rules (regression #1809/
     const configs = onBatch.mock.calls[0][0];
     expect(configs["me2-17-repetition-symbols"].enabled).toBe(true);
     expect(configs["jtf-1-2-1"].enabled).toBe(false);
+  });
+
+  it("carries user rule-option overrides through a mode switch (#2048)", () => {
+    const onBatch =
+      vi.fn<
+        (
+          configs: Record<
+            string,
+            { enabled: boolean; severity: Severity; options?: Record<string, unknown> }
+          >,
+        ) => void
+      >();
+
+    const rules: ModeRuleMetaInput[] = [
+      ...LOADED_RULES,
+      {
+        ruleId: "genji-out-of-dict",
+        applicableModes: ["novel"],
+        defaultConfig: {
+          enabled: true,
+          severity: "info",
+          options: { includeVerbsAdjectives: false },
+        },
+      },
+    ];
+
+    act(() => {
+      root.render(
+        <ModeSelector
+          correctionConfig={{ ...BASE_CONFIG, mode: "official" }}
+          loadedRules={rules}
+          lintingRuleConfigs={{
+            "genji-out-of-dict": {
+              enabled: true,
+              severity: "info",
+              options: { includeVerbsAdjectives: true },
+            },
+          }}
+          onCorrectionConfigChange={() => {}}
+          onLintingRuleConfigsBatchChange={onBatch}
+        />,
+      );
+    });
+
+    clickModeButton("小説");
+
+    const configs = onBatch.mock.calls[0][0];
+    // The whole-map replace must NOT drop the user's option override.
+    expect(configs["genji-out-of-dict"].options).toEqual({ includeVerbsAdjectives: true });
+    expect(configs["genji-out-of-dict"].enabled).toBe(true);
   });
 });

--- a/components/settings/linting/__tests__/RuleRow-options-toggle.test.tsx
+++ b/components/settings/linting/__tests__/RuleRow-options-toggle.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * #2048 — per-rule 「動詞・形容詞も照合する」 sub-toggle.
+ *
+ * Rendered only for rules whose manifest declares a boolean
+ * `includeVerbsAdjectives` in defaultConfig.options (genji-out-of-dict).
+ * Toggling must emit a config whose `options.includeVerbsAdjectives` flips,
+ * without touching other option keys.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import RuleRow, { type RuleConfig } from "../RuleRow";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const LABEL = "動詞・形容詞も照合する";
+
+let container: HTMLElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function renderRow(props: Partial<React.ComponentProps<typeof RuleRow>> = {}): void {
+  const base: React.ComponentProps<typeof RuleRow> = {
+    ruleId: "genji-out-of-dict",
+    nameJa: "未知語の検出",
+    config: { enabled: true, severity: "info" },
+    onChange: () => {},
+    ...props,
+  };
+  act(() => {
+    root.render(<RuleRow {...base} />);
+  });
+}
+
+function findOptionSwitch(): HTMLButtonElement {
+  // Innermost div containing the label = the sub-toggle row (the root row div
+  // also contains the label text, so take the LAST match in document order).
+  const row = [...container.querySelectorAll("div")]
+    .filter((d) => d.textContent?.includes(LABEL))
+    .at(-1);
+  const button = row?.querySelector<HTMLButtonElement>('button[role="switch"]');
+  if (!button) throw new Error("option toggle not found");
+  return button;
+}
+
+describe("RuleRow — includeVerbsAdjectives sub-toggle (#2048)", () => {
+  it("is hidden for rules that do not declare the option", () => {
+    renderRow({ includeVerbsAdjectivesDefault: undefined });
+    expect(container.textContent).not.toContain(LABEL);
+  });
+
+  it("renders for rules declaring the option, defaulting to the manifest value", () => {
+    renderRow({ includeVerbsAdjectivesDefault: false });
+    const toggle = findOptionSwitch();
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("reflects the user override over the manifest default", () => {
+    renderRow({
+      includeVerbsAdjectivesDefault: false,
+      config: {
+        enabled: true,
+        severity: "info",
+        options: { includeVerbsAdjectives: true },
+      },
+    });
+    expect(findOptionSwitch().getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("clicking emits a config with the flipped option, preserving other keys", () => {
+    const onChange = vi.fn<(ruleId: string, config: RuleConfig) => void>();
+    renderRow({
+      includeVerbsAdjectivesDefault: false,
+      config: {
+        enabled: true,
+        severity: "info",
+        skipDialogue: true,
+        options: { minLength: 2 },
+      },
+      onChange,
+    });
+
+    act(() => {
+      findOptionSwitch().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [ruleId, config] = onChange.mock.calls[0];
+    expect(ruleId).toBe("genji-out-of-dict");
+    expect(config).toEqual({
+      enabled: true,
+      severity: "info",
+      skipDialogue: true,
+      options: { minLength: 2, includeVerbsAdjectives: true },
+    });
+  });
+
+  it("clicking again turns the override off (explicit false, not deletion)", () => {
+    const onChange = vi.fn<(ruleId: string, config: RuleConfig) => void>();
+    renderRow({
+      includeVerbsAdjectivesDefault: false,
+      config: {
+        enabled: true,
+        severity: "info",
+        options: { includeVerbsAdjectives: true },
+      },
+      onChange,
+    });
+
+    act(() => {
+      findOptionSwitch().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const [, config] = onChange.mock.calls[0];
+    expect(config.options).toEqual({ includeVerbsAdjectives: false });
+  });
+});

--- a/components/settings/linting/useRulesetStatus.ts
+++ b/components/settings/linting/useRulesetStatus.ts
@@ -17,7 +17,12 @@ export interface RulesetRuleMeta {
   descriptionJa?: string;
   guidelineId?: string;
   level?: string;
-  defaultConfig?: { enabled?: boolean; severity?: string };
+  defaultConfig?: {
+    enabled?: boolean;
+    severity?: string;
+    skipDialogue?: boolean;
+    options?: Record<string, unknown>;
+  };
   applicableModes?: string[];
   supportsSkipDialogue?: boolean;
 }

--- a/lib/editor-page/__tests__/use-ai-settings-options.test.tsx
+++ b/lib/editor-page/__tests__/use-ai-settings-options.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * #2048 — persistence round-trip for per-rule `options` overrides
+ * (e.g. genji-out-of-dict's `includeVerbsAdjectives`).
+ *
+ * The settings UI writes `options` through `handleLintingRuleConfigChange`;
+ * on the next launch `applyPersistedAiSettings` must read them back so the
+ * override actually reaches the RuleRunner (via useLinting's setConfig sync).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { useEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import { useAiSettings } from "../use-ai-settings";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const persistAppState = vi.fn((_updates: unknown) => Promise.resolve({}));
+const fetchAppState = vi.fn(() => Promise.resolve(null));
+
+vi.mock("@/lib/storage/app-state-manager", () => ({
+  persistAppState: (updates: unknown) => persistAppState(updates),
+  fetchAppState: () => fetchAppState(),
+}));
+
+vi.mock("@/lib/ai/ai-client", () => ({
+  configureAiClient: vi.fn(),
+  resetAiClient: vi.fn(),
+}));
+
+type HookValue = ReturnType<typeof useAiSettings>;
+
+let latestValue: HookValue | null = null;
+
+function HookHost({ onValue }: { onValue: (value: HookValue) => void }): null {
+  const value = useAiSettings();
+
+  useEffect(() => {
+    onValue(value);
+  }, [onValue, value]);
+
+  return null;
+}
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  latestValue = null;
+  persistAppState.mockClear();
+  fetchAppState.mockClear();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function renderHook(): Promise<void> {
+  await act(async () => {
+    root.render(<HookHost onValue={(value) => (latestValue = value)} />);
+  });
+}
+
+describe("useAiSettings — per-rule options round-trip (#2048)", () => {
+  it("reads back persisted rule options (load path)", async () => {
+    await renderHook();
+
+    await act(async () => {
+      latestValue!.applyPersistedAiSettings({
+        lintingRuleConfigs: {
+          "genji-out-of-dict": {
+            enabled: true,
+            severity: "info",
+            options: { includeVerbsAdjectives: true },
+          },
+        },
+      });
+    });
+
+    expect(latestValue!.aiSettings.lintingRuleConfigs["genji-out-of-dict"]).toEqual({
+      enabled: true,
+      severity: "info",
+      options: { includeVerbsAdjectives: true },
+    });
+  });
+
+  it("drops malformed options on load but keeps the rest of the entry", async () => {
+    await renderHook();
+
+    await act(async () => {
+      latestValue!.applyPersistedAiSettings({
+        lintingRuleConfigs: {
+          "genji-out-of-dict": { enabled: true, severity: "info", options: "not-an-object" },
+          "other-rule": { enabled: false, severity: "warning", options: [1, 2] },
+        },
+      });
+    });
+
+    expect(latestValue!.aiSettings.lintingRuleConfigs["genji-out-of-dict"]).toEqual({
+      enabled: true,
+      severity: "info",
+    });
+    expect(latestValue!.aiSettings.lintingRuleConfigs["other-rule"]).toEqual({
+      enabled: false,
+      severity: "warning",
+    });
+  });
+
+  it("persists options through handleLintingRuleConfigChange (save path)", async () => {
+    await renderHook();
+
+    await act(async () => {
+      latestValue!.aiHandlers.handleLintingRuleConfigChange("genji-out-of-dict", {
+        enabled: true,
+        severity: "info",
+        options: { includeVerbsAdjectives: true },
+      });
+    });
+
+    expect(latestValue!.aiSettings.lintingRuleConfigs["genji-out-of-dict"].options).toEqual({
+      includeVerbsAdjectives: true,
+    });
+    expect(persistAppState).toHaveBeenCalledWith({
+      lintingRuleConfigs: {
+        "genji-out-of-dict": {
+          enabled: true,
+          severity: "info",
+          options: { includeVerbsAdjectives: true },
+        },
+      },
+    });
+  });
+
+  it("full round-trip: save → reload sees the same options", async () => {
+    await renderHook();
+
+    await act(async () => {
+      latestValue!.aiHandlers.handleLintingRuleConfigChange("genji-out-of-dict", {
+        enabled: true,
+        severity: "info",
+        options: { includeVerbsAdjectives: true },
+      });
+    });
+
+    // What was handed to persistAppState is what the next launch loads.
+    const persisted = persistAppState.mock.calls.at(-1)![0] as Record<string, unknown>;
+
+    await act(async () => {
+      latestValue!.applyPersistedAiSettings(persisted);
+    });
+
+    expect(latestValue!.aiSettings.lintingRuleConfigs["genji-out-of-dict"].options).toEqual({
+      includeVerbsAdjectives: true,
+    });
+  });
+});

--- a/lib/editor-page/use-ai-settings.ts
+++ b/lib/editor-page/use-ai-settings.ts
@@ -11,9 +11,22 @@ import type {
 import { DEFAULT_CORRECTION_CONFIG } from "@/lib/linting/correction-config";
 import { CORRECTION_MODES } from "@/lib/linting/correction-modes";
 
+/**
+ * Per-rule proofreading config as persisted in app state and edited from the
+ * settings UI. `options` carries rule-specific overrides (e.g.
+ * genji-out-of-dict's `includeVerbsAdjectives`, #2048) that are merged over the
+ * rule manifest's defaultConfig.options at lint time.
+ */
+export interface PersistedRuleConfig {
+  enabled: boolean;
+  severity: Severity;
+  skipDialogue?: boolean;
+  options?: Record<string, unknown>;
+}
+
 export interface AiSettings {
   lintingEnabled: boolean;
-  lintingRuleConfigs: Record<string, { enabled: boolean; severity: Severity }>;
+  lintingRuleConfigs: Record<string, PersistedRuleConfig>;
   /** One-time mode-config migration marker (see use-mode-config-migration.ts). */
   lintingModeConfigVersion: number;
   characterExtractionBatchSize: number;
@@ -31,13 +44,8 @@ export interface AiSettings {
 
 export interface AiSettingsHandlers {
   handleLintingEnabledChange: (value: boolean) => void;
-  handleLintingRuleConfigChange: (
-    ruleId: string,
-    config: { enabled: boolean; severity: Severity },
-  ) => void;
-  handleLintingRuleConfigsBatchChange: (
-    configs: Record<string, { enabled: boolean; severity: Severity }>,
-  ) => void;
+  handleLintingRuleConfigChange: (ruleId: string, config: PersistedRuleConfig) => void;
+  handleLintingRuleConfigsBatchChange: (configs: Record<string, PersistedRuleConfig>) => void;
   /** Persist the one-time mode-config migration version. */
   handleLintingModeConfigVersionChange: (version: number) => void;
   handleCharacterExtractionBatchSizeChange: (value: number) => void;
@@ -52,9 +60,7 @@ export interface AiSettingsHandlers {
   handleAiModelIdChange: (modelId: string) => void;
   /** Expose setters so power-save restore can update linting state */
   setLintingEnabled: (value: boolean) => void;
-  setLintingRuleConfigs: (
-    configs: Record<string, { enabled: boolean; severity: Severity }>,
-  ) => void;
+  setLintingRuleConfigs: (configs: Record<string, PersistedRuleConfig>) => void;
 }
 
 export interface UseAiSettingsResult {
@@ -70,9 +76,9 @@ export interface UseAiSettingsResult {
  */
 export function useAiSettings(): UseAiSettingsResult {
   const [lintingEnabled, setLintingEnabled] = useState(true);
-  const [lintingRuleConfigs, setLintingRuleConfigs] = useState<
-    Record<string, { enabled: boolean; severity: Severity }>
-  >({});
+  const [lintingRuleConfigs, setLintingRuleConfigs] = useState<Record<string, PersistedRuleConfig>>(
+    {},
+  );
   const [lintingModeConfigVersion, setLintingModeConfigVersion] = useState(0);
   const [characterExtractionBatchSize, setCharacterExtractionBatchSize] = useState(3);
   const [characterExtractionConcurrency, setCharacterExtractionConcurrency] = useState(4);
@@ -106,21 +112,28 @@ export function useAiSettings(): UseAiSettingsResult {
     if (appState.lintingRuleConfigs && typeof appState.lintingRuleConfigs === "object") {
       const isSeverity = (v: unknown): v is Severity =>
         v === "error" || v === "warning" || v === "info";
-      const sanitized: Record<
-        string,
-        { enabled: boolean; severity: Severity; skipDialogue?: boolean }
-      > = {};
+      const isPlainOptions = (v: unknown): v is Record<string, unknown> =>
+        typeof v === "object" && v !== null && !Array.isArray(v);
+      const sanitized: Record<string, PersistedRuleConfig> = {};
       for (const [ruleId, config] of Object.entries(
         appState.lintingRuleConfigs as Record<string, unknown>,
       )) {
-        const cfg = config as { enabled?: unknown; severity?: unknown; skipDialogue?: unknown };
+        const cfg = config as {
+          enabled?: unknown;
+          severity?: unknown;
+          skipDialogue?: unknown;
+          options?: unknown;
+        };
         if (typeof cfg.enabled === "boolean" && isSeverity(cfg.severity)) {
-          const entry: { enabled: boolean; severity: Severity; skipDialogue?: boolean } = {
+          const entry: PersistedRuleConfig = {
             enabled: cfg.enabled,
             severity: cfg.severity,
           };
           if (typeof cfg.skipDialogue === "boolean") {
             entry.skipDialogue = cfg.skipDialogue;
+          }
+          if (isPlainOptions(cfg.options)) {
+            entry.options = cfg.options;
           }
           sanitized[ruleId] = entry;
         }
@@ -230,7 +243,7 @@ export function useAiSettings(): UseAiSettingsResult {
   }, [aiApiKey, aiBaseUrl, aiModelId]);
 
   const handleLintingRuleConfigChange = useCallback(
-    (ruleId: string, config: { enabled: boolean; severity: Severity }) => {
+    (ruleId: string, config: PersistedRuleConfig) => {
       setLintingRuleConfigs((prev) => {
         const next = { ...prev, [ruleId]: config };
         void persistAppState({ lintingRuleConfigs: next }).catch((e) =>
@@ -243,7 +256,7 @@ export function useAiSettings(): UseAiSettingsResult {
   );
 
   const handleLintingRuleConfigsBatchChange = useCallback(
-    (configs: Record<string, { enabled: boolean; severity: Severity; skipDialogue?: boolean }>) => {
+    (configs: Record<string, PersistedRuleConfig>) => {
       // Replace (not merge): callers pass a COMPLETE map covering every loaded
       // rule (see buildModeRuleConfigsFromRules), so replacement correctly
       // enables the new mode's rules and disables the rest. A partial map here

--- a/lib/editor-page/use-installed-rule-metas.ts
+++ b/lib/editor-page/use-installed-rule-metas.ts
@@ -24,7 +24,12 @@ import { isElectronRenderer } from "@/lib/utils/runtime-env";
 interface ManifestRule {
   ruleId: string;
   applicableModes?: string[];
-  defaultConfig?: { enabled?: boolean; severity?: string; skipDialogue?: boolean };
+  defaultConfig?: {
+    enabled?: boolean;
+    severity?: string;
+    skipDialogue?: boolean;
+    options?: Record<string, unknown>;
+  };
   suggestsDictionaryEntry?: boolean;
 }
 

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -32,7 +32,12 @@ export function useLinting(
   lintingEnabled: boolean,
   lintingRuleConfigs: Record<
     string,
-    { enabled: boolean; severity: Severity; skipDialogue?: boolean }
+    {
+      enabled: boolean;
+      severity: Severity;
+      skipDialogue?: boolean;
+      options?: Record<string, unknown>;
+    }
   >,
   editorViewInstance: EditorView | null,
   // Reserved for future throttling / mode-aware logic; kept in the
@@ -153,12 +158,16 @@ export function useLinting(
   useEffect(() => {
     if (!ruleRunner) return;
 
-    // Apply user overrides from settings
+    // Apply user overrides from settings. `options` must be forwarded so
+    // rule-specific overrides (e.g. genji-out-of-dict's
+    // includeVerbsAdjectives, #2048) actually reach the rule at lint time;
+    // when omitted (undefined) the runner preserves the manifest defaults.
     for (const [ruleId, config] of Object.entries(lintingRuleConfigs)) {
       ruleRunner.setConfig(ruleId, {
         enabled: config.enabled,
         severity: config.severity,
         skipDialogue: config.skipDialogue,
+        options: config.options,
       });
     }
 

--- a/lib/linting/__tests__/mode-rule-configs-runtime.test.ts
+++ b/lib/linting/__tests__/mode-rule-configs-runtime.test.ts
@@ -109,6 +109,84 @@ describe("buildModeRuleConfigsFromRules — runtime applicableModes wiring", () 
     expect(configs["x-skip"].skipDialogue).toBe(true);
   });
 
+  it("carries manifest defaultConfig.options into the mode config (#1975 non-regression)", () => {
+    const configs = buildModeRuleConfigsFromRules("novel", [
+      {
+        ruleId: "genji-out-of-dict",
+        applicableModes: ["novel"],
+        defaultConfig: {
+          enabled: true,
+          severity: "info",
+          options: { includeVerbsAdjectives: false },
+        },
+      },
+    ]);
+    expect(configs["genji-out-of-dict"].options).toEqual({ includeVerbsAdjectives: false });
+  });
+
+  it("merges user option overrides from prevConfigs over manifest defaults (#2048)", () => {
+    const rules: ModeRuleMetaInput[] = [
+      {
+        ruleId: "genji-out-of-dict",
+        applicableModes: ["novel"],
+        defaultConfig: {
+          enabled: true,
+          severity: "info",
+          options: { includeVerbsAdjectives: false, minLength: 2 },
+        },
+      },
+    ];
+    const prev = {
+      "genji-out-of-dict": {
+        enabled: true,
+        severity: "info",
+        options: { includeVerbsAdjectives: true },
+      },
+    };
+    const configs = buildModeRuleConfigsFromRules("novel", rules, prev);
+    // User's true wins over the manifest false; untouched keys keep defaults.
+    expect(configs["genji-out-of-dict"].options).toEqual({
+      includeVerbsAdjectives: true,
+      minLength: 2,
+    });
+  });
+
+  it("user option overrides survive a mode switch even for rules leaving the mode (#2048)", () => {
+    const rules: ModeRuleMetaInput[] = [
+      {
+        ruleId: "genji-out-of-dict",
+        applicableModes: ["novel"],
+        defaultConfig: {
+          enabled: true,
+          severity: "info",
+          options: { includeVerbsAdjectives: false },
+        },
+      },
+    ];
+    const prev = {
+      "genji-out-of-dict": {
+        enabled: true,
+        severity: "info" as const,
+        options: { includeVerbsAdjectives: true },
+      },
+    };
+    // Switch to a mode the rule does NOT opt into: enabled flips off (strict
+    // membership), but the user's option override must be retained so it is
+    // still there when the user switches back.
+    const official = buildModeRuleConfigsFromRules("official", rules, prev);
+    expect(official["genji-out-of-dict"].enabled).toBe(false);
+    expect(official["genji-out-of-dict"].options).toEqual({ includeVerbsAdjectives: true });
+  });
+
+  it("emits no options key when neither manifest nor prevConfigs define one", () => {
+    const configs = buildModeRuleConfigsFromRules(
+      "novel",
+      [{ ruleId: "plain", applicableModes: ["novel"], defaultConfig: { severity: "warning" } }],
+      { plain: { options: undefined } },
+    );
+    expect("options" in configs["plain"]).toBe(false);
+  });
+
   it("an empty rule list yields an empty map (Web has no rulesets)", () => {
     for (const mode of CORRECTION_MODE_IDS) {
       expect(buildModeRuleConfigsFromRules(mode, [])).toEqual({});

--- a/lib/linting/__tests__/rule-runner.test.ts
+++ b/lib/linting/__tests__/rule-runner.test.ts
@@ -138,11 +138,57 @@ describe("RuleRunner", () => {
       expect(runner.getConfig("opt-rule")?.options).toEqual({ includeVerbsAdjectives: false });
     });
 
-    it("lets an explicit options object override the preserved one (#1962)", () => {
+    it("merges explicit options over the preserved ones per key (#2048)", () => {
       const runner = new RuleRunner();
       runner.setConfig("r", { enabled: true, severity: "info", options: { a: 1 } });
       runner.setConfig("r", { enabled: true, severity: "info", options: { b: 2 } });
-      expect(runner.getConfig("r")?.options).toEqual({ b: 2 });
+      // Per-key merge: setting `b` must not wipe the previously-set `a`.
+      expect(runner.getConfig("r")?.options).toEqual({ a: 1, b: 2 });
+
+      // Same-key override: the newest explicit value wins.
+      runner.setConfig("r", { enabled: true, severity: "info", options: { a: 9 } });
+      expect(runner.getConfig("r")?.options).toEqual({ a: 9, b: 2 });
+    });
+
+    it("a user override of one key keeps the other manifest-default keys (#2048)", () => {
+      class OptionRule extends AbstractLintRule {
+        readonly id = "opt-rule";
+        readonly name = "Opt";
+        readonly nameJa = "Opt";
+        readonly description = "";
+        readonly descriptionJa = "";
+        readonly level = "L2" as const;
+        readonly defaultConfig: LintRuleConfig = {
+          enabled: true,
+          severity: "info",
+          options: { includeVerbsAdjectives: false, minLength: 2 },
+        };
+        lint(): LintIssue[] {
+          return [];
+        }
+      }
+      const runner = new RuleRunner();
+      runner.registerRule(new OptionRule());
+
+      // The settings UI writes ONLY the toggled key (#2048).
+      runner.setConfig("opt-rule", {
+        enabled: true,
+        severity: "info",
+        options: { includeVerbsAdjectives: true },
+      });
+
+      expect(runner.getConfig("opt-rule")?.options).toEqual({
+        includeVerbsAdjectives: true,
+        minLength: 2,
+      });
+
+      // A later mode-switch replay that omits options (the #1962/#1975 path)
+      // must not clobber the user's override.
+      runner.setConfig("opt-rule", { enabled: true, severity: "warning" });
+      expect(runner.getConfig("opt-rule")?.options).toEqual({
+        includeVerbsAdjectives: true,
+        minLength: 2,
+      });
     });
   });
 

--- a/lib/linting/mode-rule-configs.ts
+++ b/lib/linting/mode-rule-configs.ts
@@ -25,6 +25,8 @@ export interface ModeRuleConfig {
   enabled: boolean;
   severity: Severity;
   skipDialogue?: boolean;
+  /** Rule-specific options: manifest defaults overlaid with user overrides. */
+  options?: Record<string, unknown>;
 }
 
 /**
@@ -36,7 +38,12 @@ export interface ModeRuleMetaInput {
   ruleId: string;
   /** Modes this rule opts into. Missing/empty = never auto-enabled by a mode. */
   applicableModes?: readonly string[];
-  defaultConfig?: { enabled?: boolean; severity?: string; skipDialogue?: boolean };
+  defaultConfig?: {
+    enabled?: boolean;
+    severity?: string;
+    skipDialogue?: boolean;
+    options?: Record<string, unknown>;
+  };
   /** Declares that the rule's issues can be resolved by adding the word to the user dictionary. */
   suggestsDictionaryEntry?: boolean;
 }
@@ -56,17 +63,23 @@ function normalizeSeverity(value: string | undefined): Severity {
  * - `enabled = applicableModes.includes(modeId)` (strict membership)
  * - `severity = defaultConfig.severity ?? "warning"`
  * - `skipDialogue` is carried over from `defaultConfig` when present
+ * - `options = { ...defaultConfig.options, ...prevConfigs[ruleId].options }` —
+ *   rule options have no per-mode semantics, so user overrides (e.g.
+ *   genji-out-of-dict's `includeVerbsAdjectives`, #2048) must survive the
+ *   whole-map replace a mode switch performs, layered over manifest defaults.
  *
  * The result intentionally covers every rule in `rules` so callers may replace
  * the whole `lintingRuleConfigs` object. Duplicate ruleIds keep the first entry.
  *
  * @param modeId Selected correction mode.
  * @param rules Flattened metadata of every loaded rule (across all rulesets).
+ * @param prevConfigs Current per-rule configs; only user `options` are carried over.
  * @returns ruleId → config map covering every supplied rule.
  */
 export function buildModeRuleConfigsFromRules(
   modeId: CorrectionModeId,
   rules: readonly ModeRuleMetaInput[],
+  prevConfigs?: Record<string, { options?: Record<string, unknown> }>,
 ): Record<string, ModeRuleConfig> {
   const out: Record<string, ModeRuleConfig> = {};
   for (const rule of rules) {
@@ -78,6 +91,11 @@ export function buildModeRuleConfigsFromRules(
     };
     if (rule.defaultConfig?.skipDialogue !== undefined) {
       config.skipDialogue = rule.defaultConfig.skipDialogue;
+    }
+    const defaultOptions = rule.defaultConfig?.options;
+    const userOptions = prevConfigs?.[rule.ruleId]?.options;
+    if (defaultOptions !== undefined || userOptions !== undefined) {
+      config.options = { ...defaultOptions, ...userOptions };
     }
     out[rule.ruleId] = config;
   }

--- a/lib/linting/rule-runner.ts
+++ b/lib/linting/rule-runner.ts
@@ -26,6 +26,7 @@ export class RuleRunner {
 
   /** Update the config for a specific rule. */
   setConfig(ruleId: string, config: LintRuleConfig): void {
+    const prev = this.configs.get(ruleId);
     // Preserve rule-specific `options` from the registered manifest defaultConfig
     // when the caller omits them. The renderer's config pipeline only carries
     // enabled/severity/skipDialogue (mode switching rebuilds the whole config
@@ -33,13 +34,21 @@ export class RuleRunner {
     // noun-only `includeVerbsAdjectives:false` — would revert to its internal
     // default and over-detect verbs/adjectives after every mode switch (#1962).
     if (config.options === undefined) {
-      const prev = this.configs.get(ruleId);
       if (prev?.options !== undefined) {
         this.configs.set(ruleId, { ...config, options: prev.options });
         return;
       }
+      this.configs.set(ruleId, config);
+      return;
     }
-    this.configs.set(ruleId, config);
+    // Explicit options are a per-key override MERGED over the existing
+    // (manifest-default) options: a user toggling one key (e.g.
+    // genji-out-of-dict's `includeVerbsAdjectives`) must not wipe the rule's
+    // other default option keys (#2048).
+    this.configs.set(ruleId, {
+      ...config,
+      options: { ...prev?.options, ...config.options },
+    });
   }
 
   /** Get the current config for a specific rule. */

--- a/lib/storage/storage-types.ts
+++ b/lib/storage/storage-types.ts
@@ -80,7 +80,13 @@ export interface AppState {
   lintingEnabled?: boolean;
   lintingRuleConfigs?: Record<
     string,
-    { enabled: boolean; severity: Severity; skipDialogue?: boolean }
+    {
+      enabled: boolean;
+      severity: Severity;
+      skipDialogue?: boolean;
+      /** Rule-specific option overrides (e.g. genji-out-of-dict's includeVerbsAdjectives, #2048). */
+      options?: Record<string, unknown>;
+    }
   >;
   /**
    * One-time migration marker for mode-derived rule config recovery.
@@ -133,7 +139,15 @@ export interface AppState {
   autoPowerSaveOnBattery?: boolean;
   prePowerSaveState?: {
     lintingEnabled: boolean;
-    lintingRuleConfigs: Record<string, { enabled: boolean; severity: Severity }>;
+    lintingRuleConfigs: Record<
+      string,
+      {
+        enabled: boolean;
+        severity: Severity;
+        skipDialogue?: boolean;
+        options?: Record<string, unknown>;
+      }
+    >;
   } | null;
 
   // 読み上げ（TTS）設定


### PR DESCRIPTION
## Summary

- `genji-out-of-dict`（未知語の検出）の `includeVerbsAdjectives` オプションを、実機の設定 UI（設定 → 校正と文体 → 校正ルールセット）から切り替えられるようにする
- これまで runner 側にはオプション保持の仕組み（#1962/#1975）があったものの、ユーザーが値を設定する経路（UI → 永続化 → lint 時のルールへの配信）が丸ごと欠落していた
- 有効にすると、名詞に加えて動詞・形容詞（青い / 観る / 測る / 澄みきる など、基本形照合）も幻辞辞書と照合される（#1962 C-3 で確認された挙動）

Closes #2048

## Changes

| 領域 | 内容 |
| --- | --- |
| `components/settings/linting/RuleRow.tsx` | ルール行に「動詞・形容詞も照合する」サブトグルを追加。`includeVerbsAdjectivesDefault` prop（マニフェスト既定値）の有無で表示をゲートし、ユーザー上書きがなければ既定値を表示 |
| `components/settings/linting/RulesetList.tsx` | マニフェスト `defaultConfig.options.includeVerbsAdjectives`（boolean）を宣言するルールに対してのみトグルを供給（データ駆動。現状は genji-out-of-dict のみ該当） |
| `components/settings/linting/RulesetCard.tsx` / `useRulesetStatus.ts` | `options` / 既定値のパススルーと型の拡張 |
| `lib/storage/storage-types.ts` | `lintingRuleConfigs` の各エントリと `prePowerSaveState` に `options?: Record<string, unknown>` を追加 |
| `lib/editor-page/use-ai-settings.ts` | 永続化スキーマを `PersistedRuleConfig` として型定義し、load 時の sanitize で `options`（プレーンオブジェクトのみ）を読み戻し、save 時にそのまま永続化 |
| `lib/editor-page/use-linting.ts` | 設定 → runner の同期で `options` を `setConfig` に転送（欠落していた最後のリンク） |
| `lib/linting/rule-runner.ts` | `setConfig` で明示 `options` を既存（マニフェスト既定）へ**キー単位でマージ**。1 キーの上書きが他の既定キーを消さない。省略時の既定保持（#1962/#1975 の修正）は従来どおり。worker / main-thread フォールバックも同一クラスを共有するため両経路に効く |
| `lib/linting/mode-rule-configs.ts` | `buildModeRuleConfigsFromRules` に `prevConfigs` を追加。モード切替の全置換でも `options = { ...マニフェスト既定, ...ユーザー上書き }` として存続（enabled/severity は従来どおりモード導出） |
| `components/settings/linting/ModeSelector.tsx` / `app/page.tsx` | モード切替（設定・インスペクタ両方）で現行 `lintingRuleConfigs` を `prevConfigs` として渡す |
| `components/inspector/CorrectionsPanel.tsx` | グループ一括無効化（EyeOff）が `options` / `skipDialogue` を落とさないよう現行設定をスプレッド |
| `lib/editor-page/use-installed-rule-metas.ts` | マニフェスト `defaultConfig.options` の型を明示（ランタイムは従来から素通し） |

### 設計判断: 汎用 `options` パススルー + 単一トグル

- 永続化・配信は特定キーではなく `options?: Record<string, unknown>` の汎用パススルーとして実装（`LintRuleConfig.options` / `skipDialogue` の既存モデルに整合）。将来ほかのルールオプションを追加しても配管の再工事が不要
- UI は汎用オプションフォームは作らず、`includeVerbsAdjectives` の 1 トグルのみ。表示ゲートはルール ID のハードコードではなく「マニフェストが boolean `includeVerbsAdjectives` を宣言しているか」で判定
- マージ順は常に「マニフェスト既定 < ユーザー上書き」。runner の `setConfig` もキー単位マージにし、モード切替リプレイ（#1975 の回帰領域）でユーザー上書きが消えないことをテストで固定

## Test plan

- [x] `npm run type-check` — pass
- [x] `npm run lint` — 0 errors（警告は既存のもののみ、変更ファイルに新規指摘なし）
- [x] `npx vitest run lib/linting packages/milkdown-plugin-japanese-novel lib/editor-page components/settings` — 649/652 pass（失敗 3 件は `dev` 上で元から失敗する `search-history.test.ts` のみ。stash して確認済み、本 PR と無関係）
- [x] 新規: `RuleRow-options-toggle.test.tsx` — トグルの表示ゲート / 既定値表示 / 上書き反映 / onChange のペイロード（他キー保持）
- [x] 新規: `use-ai-settings-options.test.tsx` — options の load / sanitize / persist / 完全ラウンドトリップ
- [x] 追加: `rule-runner.test.ts` — 明示 options のキー単位マージ、1 キー上書きで他のマニフェスト既定キーが残ること、省略時の既定保持（#1962/#1975 非回帰）
- [x] 追加: `mode-rule-configs-runtime.test.ts` — マニフェスト options の導出（#1975 非回帰）、prevConfigs マージ、モード離脱→復帰でも上書き存続
- [x] 追加: `ModeSelector-mode-switch.test.tsx` — モード切替の全置換でユーザー上書きが消えないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)