### PR TITLE
fix: restrict shell path IPC to approved VFS roots

### DIFF
--- a/electron/ipc/__tests__/shell-ipc-path-validation.test.ts
+++ b/electron/ipc/__tests__/shell-ipc-path-validation.test.ts
@@ -1,0 +1,119 @@
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+async function loadShellPathPolicy(): Promise<typeof import("../../lib/shell-path-policy.js")> {
+  vi.resetModules();
+  return import("../../lib/shell-path-policy.js");
+}
+
+describe("shell-ipc path validation", () => {
+  const senderId = 42;
+  const home = os.homedir();
+  const root = path.join(home, "illusions-shell-test-project");
+  const rootReal = path.join(home, "illusions-shell-test-project-real");
+  const allowedFile = path.join(root, "assets", "cover.pdf");
+  const allowedFileReal = path.join(rootReal, "assets", "cover.pdf");
+  const outsideFile = path.join(home, "outside.pdf");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function deps(overrides: Record<string, unknown> = {}) {
+    return {
+      getVfsRoot: vi.fn(() => ({ path: root, realPath: rootReal })),
+      resolveRealPath: vi.fn(async (p: string) =>
+        p === allowedFile ? allowedFileReal : p.replace(root, rootReal),
+      ),
+      stat: vi.fn(async () => ({ isFile: () => true })),
+      ...overrides,
+    };
+  }
+
+  it("rejects renderer-provided absolute paths when the window has no approved VFS root", async () => {
+    const { validateShellPathForSender } = await loadShellPathPolicy();
+
+    const result = await validateShellPathForSender(allowedFile, senderId, {
+      ...deps(),
+      getVfsRoot: vi.fn(() => null),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("allows a non-executable path inside the approved VFS root", async () => {
+    const { validateShellPathForSender } = await loadShellPathPolicy();
+
+    const result = await validateShellPathForSender(allowedFile, senderId, deps());
+
+    expect(result).toBe(path.resolve(allowedFile));
+  });
+
+  it("allows the approved VFS root itself so Show in File Manager still works", async () => {
+    const { validateShellPathForSender } = await loadShellPathPolicy();
+
+    const result = await validateShellPathForSender(root, senderId, {
+      ...deps(),
+      resolveRealPath: vi.fn(async () => rootReal),
+    });
+
+    expect(result).toBe(path.resolve(root));
+  });
+
+  it("rejects paths outside the approved VFS root", async () => {
+    const { validateShellPathForSender } = await loadShellPathPolicy();
+
+    const result = await validateShellPathForSender(outsideFile, senderId, deps());
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects symlink-resolved paths that escape the approved real root", async () => {
+    const { validateShellPathForSender } = await loadShellPathPolicy();
+
+    const result = await validateShellPathForSender(allowedFile, senderId, {
+      ...deps(),
+      resolveRealPath: vi.fn(async () => outsideFile),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("rejects executable targets even when they are under the approved root", async () => {
+    const { validateShellPathForSender } = await loadShellPathPolicy();
+    const appPath = path.join(root, "Tools", "Helper.app");
+
+    const result = await validateShellPathForSender(appPath, senderId, {
+      ...deps(),
+      resolveRealPath: vi.fn(async () => path.join(rootReal, "Tools", "Helper.app")),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("openWithDefaultApp handler does not call shell.openPath for rejected paths", async () => {
+    const { createOpenPathHandler } = await loadShellPathPolicy();
+    const openPath = vi.fn(async () => "");
+    const handler = createOpenPathHandler(openPath, {
+      ...deps(),
+      getVfsRoot: vi.fn(() => null),
+    });
+
+    const result = await handler({ sender: { id: senderId } }, allowedFile);
+
+    expect(result).toBe(false);
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it("openWithDefaultApp handler opens validated paths", async () => {
+    const { createOpenPathHandler } = await loadShellPathPolicy();
+    const openPath = vi.fn(async () => "");
+    const handler = createOpenPathHandler(openPath, deps());
+
+    const result = await handler({ sender: { id: senderId } }, allowedFile);
+
+    expect(result).toBe(true);
+    expect(openPath).toHaveBeenCalledWith(path.resolve(allowedFile));
+  });
+});

--- a/electron/ipc/shell-ipc.js
+++ b/electron/ipc/shell-ipc.js
@@ -1,43 +1,18 @@
 // Shell and OS integration IPC handlers
 
 const { ipcMain, BrowserWindow, Menu, shell, app } = require("electron");
-const path = require("path");
 const { SHELL_CHANNELS } = require("../lib/ipc-channels");
+const { createOpenPathHandler, createRevealPathHandler } = require("../lib/shell-path-policy");
 
 function registerShellHandlers() {
-  ipcMain.handle(SHELL_CHANNELS.invoke.showInFileManager, async (_event, dirPath) => {
-    if (!dirPath || typeof dirPath !== "string") return false;
-    // Reject relative paths and paths containing traversal sequences
-    if (!path.isAbsolute(dirPath) || dirPath.includes("..")) {
-      console.warn("[Security] Invalid path in show-in-file-manager:", dirPath);
-      return false;
-    }
-    const normalizedPath = path.normalize(dirPath);
-    const result = await shell.openPath(normalizedPath);
-    return result === ""; // empty string = success
-  });
+  ipcMain.handle(SHELL_CHANNELS.invoke.showInFileManager, createOpenPathHandler(shell.openPath));
 
-  ipcMain.handle(SHELL_CHANNELS.invoke.revealInFileManager, async (_event, filePath) => {
-    if (!filePath || typeof filePath !== "string") return false;
-    // Reject relative paths and paths containing traversal sequences
-    if (!path.isAbsolute(filePath) || filePath.includes("..")) {
-      console.warn("[Security] Invalid path in reveal-in-file-manager:", filePath);
-      return false;
-    }
-    const normalizedPath = path.normalize(filePath);
-    shell.showItemInFolder(normalizedPath);
-    return true;
-  });
+  ipcMain.handle(
+    SHELL_CHANNELS.invoke.revealInFileManager,
+    createRevealPathHandler(shell.showItemInFolder),
+  );
 
-  ipcMain.handle(SHELL_CHANNELS.invoke.openWithDefaultApp, async (_event, filePath) => {
-    if (!filePath || typeof filePath !== "string") return false;
-    if (!path.isAbsolute(filePath) || filePath.includes("..")) {
-      console.warn("[Security] Invalid path in open-with-default-app:", filePath);
-      return false;
-    }
-    const result = await shell.openPath(path.normalize(filePath));
-    return result === ""; // empty string = success on macOS/Windows
-  });
+  ipcMain.handle(SHELL_CHANNELS.invoke.openWithDefaultApp, createOpenPathHandler(shell.openPath));
 
   ipcMain.handle(SHELL_CHANNELS.invoke.openExternal, async (_event, url) => {
     if (typeof url !== "string") return false;
@@ -143,4 +118,8 @@ function registerShellHandlers() {
   });
 }
 
-module.exports = { registerShellHandlers };
+module.exports = {
+  registerShellHandlers,
+  createOpenPathHandler,
+  createRevealPathHandler,
+};

--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -19,6 +19,7 @@ const { readFileStrictUtf8 } = require("../lib/text-decode");
 // #1476: rehydration — begin
 const { loadApprovals, saveApprovals } = require("../lib/vfs-approvals");
 const { createIndexLockManager } = require("../lib/index-lock");
+const { setVfsRoot, clearVfsRoot } = require("../lib/vfs-root-registry");
 // #1476: rehydration — end
 
 function registerVFSHandlers() {
@@ -163,6 +164,7 @@ function registerVFSHandlers() {
       path: dirPath,
       realPath: await resolveRootRealPath(dirPath),
     });
+    setVfsRoot(event.sender.id, allowedRoots.get(event.sender.id));
     approveDialogPath(event.sender.id, dirPath);
 
     return {
@@ -468,7 +470,9 @@ function registerVFSHandlers() {
 
     // #1559: store the realpath alongside the lexical root so per-I/O
     // symlink-collapsed containment checks have a trusted physical root
-    allowedRoots.set(event.sender.id, { path: resolved, realPath: resolvedReal });
+    const rootEntry = { path: resolved, realPath: resolvedReal };
+    allowedRoots.set(event.sender.id, rootEntry);
+    setVfsRoot(event.sender.id, rootEntry);
     return { path: resolved, name: path.basename(resolved) };
   });
 
@@ -476,6 +480,7 @@ function registerVFSHandlers() {
   app.on("web-contents-created", (_, contents) => {
     contents.on("destroyed", () => {
       allowedRoots.delete(contents.id);
+      clearVfsRoot(contents.id);
       dialogApprovedPaths.revokeWindow(contents.id);
       // #1476: rehydration — clean up projectId association
       senderProjectId.delete(contents.id);

--- a/electron/lib/shell-path-policy.js
+++ b/electron/lib/shell-path-policy.js
@@ -1,0 +1,101 @@
+"use strict";
+
+const fs = require("fs/promises");
+const path = require("path");
+const {
+  assertPathInsideRoot,
+  normalizeForCompare,
+  resolveRealPath,
+  toForwardSlash,
+} = require("./path-utils");
+const { isSensitiveSystemPath } = require("./path-policy");
+const { getVfsRoot } = require("./vfs-root-registry");
+
+const EXECUTABLE_OPEN_EXTENSIONS = new Set([
+  ".app",
+  ".bat",
+  ".cmd",
+  ".com",
+  ".exe",
+  ".msi",
+  ".ps1",
+  ".scr",
+  ".sh",
+]);
+
+function hasTraversalSegment(rawPath) {
+  return rawPath.split(/[\\/]+/).includes("..");
+}
+
+function isExecutableOpenTarget(resolvedPath) {
+  const ext = path.extname(resolvedPath).toLowerCase();
+  if (EXECUTABLE_OPEN_EXTENSIONS.has(ext)) return true;
+  return resolvedPath
+    .split(/[\\/]+/)
+    .some((part) => process.platform === "darwin" && part.toLowerCase().endsWith(".app"));
+}
+
+async function validateShellPathForSender(filePath, senderId, deps = {}) {
+  const getRoot = deps.getVfsRoot ?? getVfsRoot;
+  const realPath = deps.resolveRealPath ?? resolveRealPath;
+  const stat = deps.stat ?? fs.stat;
+
+  if (!filePath || typeof filePath !== "string") return null;
+  if (!path.isAbsolute(filePath) || hasTraversalSegment(filePath)) {
+    console.warn("[Security] Invalid shell path:", filePath);
+    return null;
+  }
+
+  const resolved = path.resolve(filePath);
+  const normalizedResolved = normalizeForCompare(toForwardSlash(resolved));
+  if (isSensitiveSystemPath(normalizedResolved)) {
+    console.warn("[Security] Denied shell path:", filePath);
+    return null;
+  }
+  if (isExecutableOpenTarget(resolved)) {
+    console.warn("[Security] Blocked executable shell path:", filePath);
+    return null;
+  }
+
+  const root = getRoot(senderId);
+  if (!root) {
+    console.warn("[Security] Shell path rejected without approved VFS root:", filePath);
+    return null;
+  }
+
+  try {
+    assertPathInsideRoot(normalizedResolved, normalizeForCompare(root.path));
+    const realResolved = normalizeForCompare(toForwardSlash(await realPath(resolved)));
+    assertPathInsideRoot(realResolved, normalizeForCompare(root.realPath));
+    await stat(resolved);
+    return resolved;
+  } catch (error) {
+    console.warn("[Security] Shell path rejected outside approved VFS root:", filePath, error);
+    return null;
+  }
+}
+
+function createOpenPathHandler(openPath, deps = {}) {
+  return async (event, filePath) => {
+    const normalizedPath = await validateShellPathForSender(filePath, event?.sender?.id, deps);
+    if (!normalizedPath) return false;
+    const result = await openPath(normalizedPath);
+    return result === "";
+  };
+}
+
+function createRevealPathHandler(showItemInFolder, deps = {}) {
+  return async (event, filePath) => {
+    const normalizedPath = await validateShellPathForSender(filePath, event?.sender?.id, deps);
+    if (!normalizedPath) return false;
+    showItemInFolder(normalizedPath);
+    return true;
+  };
+}
+
+module.exports = {
+  validateShellPathForSender,
+  createOpenPathHandler,
+  createRevealPathHandler,
+  EXECUTABLE_OPEN_EXTENSIONS,
+};

--- a/electron/lib/vfs-root-registry.js
+++ b/electron/lib/vfs-root-registry.js
@@ -1,0 +1,36 @@
+"use strict";
+
+/**
+ * Shared VFS root registry for main-process IPC boundaries.
+ *
+ * vfs-ipc owns root selection/approval, but other IPC modules that operate on
+ * native paths (for example shell.openPath) must be able to enforce the same
+ * per-window root boundary. Keeping the registry here avoids duplicating state
+ * or trusting renderer-supplied absolute paths.
+ */
+
+/** @type {Map<number, { path: string, realPath: string }>} */
+const rootsBySender = new Map();
+
+function setVfsRoot(senderId, root) {
+  rootsBySender.set(senderId, root);
+}
+
+function getVfsRoot(senderId) {
+  return rootsBySender.get(senderId) ?? null;
+}
+
+function clearVfsRoot(senderId) {
+  rootsBySender.delete(senderId);
+}
+
+function clearAllVfsRootsForTests() {
+  rootsBySender.clear();
+}
+
+module.exports = {
+  setVfsRoot,
+  getVfsRoot,
+  clearVfsRoot,
+  clearAllVfsRootsForTests,
+};


### PR DESCRIPTION
## Summary
- share the approved VFS root with shell IPC handlers
- validate shell-open/reveal/show paths against lexical and realpath VFS containment
- block sensitive and executable targets before calling shell.openPath
- add regression coverage for rejected and allowed shell path opens

## Verification
- npx vitest run electron/ipc/__tests__/shell-ipc-path-validation.test.ts electron/ipc/__tests__/vfs-path-validation.test.ts electron/lib/__tests__/path-policy.test.ts
- npm run check:boundaries
- npx eslint electron/ipc/shell-ipc.js electron/lib/shell-path-policy.js electron/lib/vfs-root-registry.js electron/ipc/vfs-ipc.js electron/ipc/__tests__/shell-ipc-path-validation.test.ts

Note: npm run type-check currently fails on dev at lib/dockview/use-dockview-adapter.ts:479 with TS2339 (unrelated to this JS/IPC change).