### PR TITLE
fix(auto-updater): polish sunset notice wording

### DIFF
--- a/electron/auto-updater.js
+++ b/electron/auto-updater.js
@@ -100,7 +100,7 @@ function setupAutoUpdater() {
         .showMessageBox(mainWindow, {
           type: "warning",
           title: "サポート終了のお知らせ",
-          message: "illusions 1.2 はSunset（サポート終了）となりました",
+          message: "illusions 1.2 は Sunset（サポート終了）となりました",
           detail: `最新バージョン ${info.version} が公開されています。公式サイトから最新版をダウンロードしてください。\n${DOWNLOAD_PAGE_URL}`,
           buttons: ["公式サイトを開く", "後で"],
           defaultId: 0,


### PR DESCRIPTION
## Summary
- Adds the missing space in the macOS 1.2 sunset notice message.

## Verification
- \
 RUN  v4.1.9 /Users/iktahana/Repos/illusions


 Test Files  2 passed (2)
      Tests  33 passed (33)
   Start at  22:36:46
   Duration  313ms (transform 40ms, setup 0ms, import 50ms, tests 8ms, environment 438ms)