### PR TITLE
chore: post-1.2.0-archive cleanup — bump to 1.3.0 + bundle ID rename

### DIFF
--- a/docs/release/mac-app-store.md
+++ b/docs/release/mac-app-store.md
@@ -32,7 +32,7 @@ illusions は現在 Developer ID 署名 + notarization で DMG/ZIP を GitHub Re
 
 ### Phase A — Apple 側セットアップ（手動）
 
-1. App ID `com.iktahana.illusions` 登録、App Sandbox 有効化
+1. App ID `app.illusions.editor` 登録、App Sandbox 有効化
 2. 証明書 2 種発行: Apple Distribution / Mac Installer Distribution
 3. Mac App Store distribution プロビジョニングプロファイル発行 → `build/illusions.provisionprofile`（コミットしない / CI secret 化）
 4. App Store Connect アプリレコード作成（名称・Bundle ID・SKU）

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "illusions",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "illusions",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aptabase/electron": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     ]
   },
   "build": {
-    "appId": "com.iktahana.illusions",
+    "appId": "app.illusions.editor",
     "productName": "illusions",
     "directories": {
       "app": ".",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "illusions",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "engines": {
     "node": ">=22.12.0"
@@ -8,7 +8,7 @@
   "author": {
     "name": "幾田花",
     "url": "https://iktahana.com",
-    "email": "illusions@iktahana.com"
+    "email": "support@illusions.app"
   },
   "main": "dist-main/main.js",
   "scripts": {

--- a/quicklook/MDIQuickLook/Info.plist
+++ b/quicklook/MDIQuickLook/Info.plist
@@ -7,7 +7,7 @@
   <key>CFBundleExecutable</key>
   <string>MDIQuickLook</string>
   <key>CFBundleIdentifier</key>
-  <string>com.iktahana.illusions.quicklook</string>
+  <string>app.illusions.editor.quicklook</string>
   <key>CFBundleInfoDictionaryVersion</key>
   <string>6.0</string>
   <key>CFBundleName</key>


### PR DESCRIPTION
## Summary
- Bump version to 1.3.0 following the `archived/1.2.0` snapshot cut from `dev`, plus update author email to `support@illusions.app`.
- Re-apply the bundle ID rename `com.iktahana.illusions` → `app.illusions.editor` (originally #2007, reverted in 5873918 due to a macOS notarization 401). Apple-side Developer ID/App Store Connect registration has been migrated for the new identity.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Confirm CI's macOS build/notarization job succeeds (no 401) before merging — this is the exact failure mode from the previous attempt
- [ ] Spot check no other file still references `com.iktahana.illusions` as a live identifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)