### PR TITLE
feat: model store-managed flight updates

### DIFF
--- a/components/settings/AboutSection.tsx
+++ b/components/settings/AboutSection.tsx
@@ -8,6 +8,7 @@ import clsx from "clsx";
 import SettingsField from "@/components/settings/primitives/SettingsField";
 import SettingsToggle from "@/components/settings/primitives/SettingsToggle";
 import { useUpdateSettingsContext } from "@/contexts/EditorSettingsContext";
+import { getAppRuntimeInfo, type AppRuntimeInfo } from "@/lib/utils/runtime-env";
 
 const LICENSE_TEXT = process.env.NEXT_PUBLIC_LICENSE_TEXT || "";
 const TERMS_TEXT = process.env.NEXT_PUBLIC_TERMS_TEXT || "";
@@ -37,7 +38,10 @@ export default function AboutSection(): React.ReactElement {
   const [activeTab, setActiveTab] = useState<AboutTab>("terms");
   const [expandedCredits, setExpandedCredits] = useState<Set<string>>(new Set());
   const [creditsData, setCreditsData] = useState<CreditEntry[]>([]);
-  const [isElectron, setIsElectron] = useState(false);
+  const [runtimeInfo, setRuntimeInfo] = useState<AppRuntimeInfo>({
+    distributionProvider: "unknown",
+    releaseChannel: "unknown",
+  });
 
   const { allowBetaUpdates, onAllowBetaUpdatesChange } = useUpdateSettingsContext();
 
@@ -49,10 +53,17 @@ export default function AboutSection(): React.ReactElement {
       });
   }, []);
 
-  // beta opt-in トグルは auto-updater を持つデスクトップ版でのみ表示する
+  // beta opt-in トグルは直售版の auto-updater でのみ表示する。
+  // Store / App Store 系の flight は配信プラットフォーム側の tester group で管理する。
   useEffect(() => {
-    setIsElectron(Boolean(window.electronAPI?.isElectron));
+    setRuntimeInfo(getAppRuntimeInfo());
   }, []);
+
+  const showDirectBetaToggle = runtimeInfo.distributionProvider === "direct";
+  const showStoreManagedUpdates =
+    runtimeInfo.distributionProvider === "microsoft-store" ||
+    runtimeInfo.distributionProvider === "app-store";
+  const isFlightBuild = runtimeInfo.releaseChannel === "beta";
 
   // Group credits by license type
   const creditsByLicense = creditsData.reduce<Record<string, CreditEntry[]>>((acc, entry) => {
@@ -94,8 +105,8 @@ export default function AboutSection(): React.ReactElement {
         </p>
       </div>
 
-      {/* Beta update opt-in (desktop only) */}
-      {isElectron && (
+      {/* Beta update opt-in (direct desktop only) */}
+      {showDirectBetaToggle && (
         <div className="rounded-lg border border-border bg-background-secondary p-4">
           <SettingsField
             label="ベータ版アップデートを受け取る"
@@ -109,6 +120,17 @@ export default function AboutSection(): React.ReactElement {
               onChange={onAllowBetaUpdatesChange}
             />
           </SettingsField>
+        </div>
+      )}
+
+      {showStoreManagedUpdates && (
+        <div className="rounded-lg border border-border bg-background-secondary p-4">
+          <p className="text-sm font-medium text-foreground">
+            {isFlightBuild ? "ベータ版（Flight）" : "ストア版"}
+          </p>
+          <p className="mt-1 text-xs text-foreground-tertiary">
+            このストア版は配信プラットフォーム経由で更新されます。ベータ版は招待されたテスターにのみ配信されます。
+          </p>
         </div>
       )}
 

--- a/components/settings/__tests__/AboutSection.test.tsx
+++ b/components/settings/__tests__/AboutSection.test.tsx
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import AboutSection from "../AboutSection";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const updateSettingsMock = vi.fn();
+
+vi.mock("@/contexts/EditorSettingsContext", () => ({
+  useUpdateSettingsContext: () => updateSettingsMock(),
+}));
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  updateSettingsMock.mockReset();
+  updateSettingsMock.mockReturnValue({
+    allowBetaUpdates: false,
+    onAllowBetaUpdatesChange: vi.fn(),
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.unstubAllEnvs();
+  delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+});
+
+describe("AboutSection update channel UI", () => {
+  it("shows the beta update toggle for direct desktop builds", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.3.0");
+    (window as unknown as { electronAPI: { isElectron: boolean } }).electronAPI = {
+      isElectron: true,
+    };
+
+    await act(async () => {
+      root.render(<AboutSection />);
+    });
+
+    expect(container.textContent).toContain("ベータ版アップデートを受け取る");
+    expect(container.textContent).not.toContain("配信プラットフォーム経由で更新されます");
+    expect(container.querySelector("#allow-beta-updates")).not.toBeNull();
+  });
+
+  it("hides the direct beta toggle for Microsoft Store flight builds", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.3.0-beta.20260708.1");
+    (
+      window as unknown as {
+        electronAPI: {
+          isElectron: boolean;
+          appRuntime: {
+            distributionProvider: "microsoft-store";
+            releaseChannel: "beta";
+          };
+        };
+      }
+    ).electronAPI = {
+      isElectron: true,
+      appRuntime: {
+        distributionProvider: "microsoft-store",
+        releaseChannel: "beta",
+      },
+    };
+
+    await act(async () => {
+      root.render(<AboutSection />);
+    });
+
+    expect(container.textContent).not.toContain("ベータ版アップデートを受け取る");
+    expect(container.textContent).toContain("ベータ版（Flight）");
+    expect(container.textContent).toContain("配信プラットフォーム経由で更新されます");
+    expect(container.querySelector("#allow-beta-updates")).toBeNull();
+  });
+
+  it("shows store-managed copy for App Store builds", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.3.0");
+    (
+      window as unknown as {
+        electronAPI: {
+          isElectron: boolean;
+          appRuntime: {
+            distributionProvider: "app-store";
+            releaseChannel: "stable";
+          };
+        };
+      }
+    ).electronAPI = {
+      isElectron: true,
+      appRuntime: {
+        distributionProvider: "app-store",
+        releaseChannel: "stable",
+      },
+    };
+
+    await act(async () => {
+      root.render(<AboutSection />);
+    });
+
+    expect(container.textContent).not.toContain("ベータ版アップデートを受け取る");
+    expect(container.textContent).toContain("ストア版");
+    expect(container.textContent).toContain("ベータ版は招待されたテスターにのみ配信されます");
+  });
+});

--- a/docs/release/store-flights.md
+++ b/docs/release/store-flights.md
@@ -1,0 +1,61 @@
+# Store flights
+
+This document defines how Illusions treats beta/flight delivery across direct
+sales and store platforms.
+
+## Distribution model
+
+The app distinguishes two independent concepts:
+
+- `distributionProvider`: `direct`, `microsoft-store`, `app-store`, or `unknown`
+- `releaseChannel`: `stable`, `beta`, `dev`, `alpha`, or `unknown`
+
+The in-app beta update toggle is only valid for `distributionProvider=direct`.
+Direct builds use GitHub Releases and `electron-updater`, so the app can opt in
+or out of prerelease updates.
+
+Store builds do not use the in-app beta toggle. Their eligibility is controlled
+by the platform account and tester group:
+
+- Microsoft Store: Package flights + known user groups in Partner Center
+- Apple: TestFlight tester groups / App Store phased or normal release controls
+
+## Microsoft Store
+
+Stable Microsoft Store submission remains handled by:
+
+- `.github/workflows/store-submit.yml`
+- `.github/workflows/sync-ms-store-listing.yml`
+- `scripts/submit-store.mjs`
+
+These workflows submit a normal application submission. They must not be reused
+for beta packages, because that would publish a beta `.appx` to the regular
+Store audience instead of a limited flight group.
+
+For Microsoft Store beta delivery, create or update a Package flight in Partner
+Center and upload the beta `.appx` artifacts from the GitHub prerelease for the
+`beta` branch. Package flight listing text is shared with the non-flighted Store
+submission; only packages differ.
+
+Automation note: do not add a package-flight upload workflow until we have a
+verified Partner Center API endpoint or supported CLI path for package flight
+submissions. The existing submission API script only targets normal app
+submissions.
+
+## Apple
+
+Apple flight delivery will use TestFlight after the Mac App Store build pipeline
+exists. The MAS work is tracked separately in `docs/release/mac-app-store.md`.
+
+Until that pipeline is implemented, the shared runtime model already supports
+`distributionProvider=app-store`, but there is no App Store Connect upload job
+to wire to it.
+
+## UI policy
+
+About settings should follow this behavior:
+
+- `direct`: show the beta update opt-in toggle.
+- `microsoft-store` / `app-store`: show platform-managed update copy.
+- `releaseChannel=beta` on a store provider: label the build as a flight/beta
+  build, but still do not show an opt-in toggle.

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -30,8 +30,25 @@ const {
   RULESETS_CHANNELS,
 } = require("./lib/ipc-channels");
 
+function detectDistributionProvider() {
+  if (process.windowsStore === true) return "microsoft-store";
+  if (process.mas === true) return "app-store";
+  return "direct";
+}
+
+function detectReleaseChannel(version) {
+  if (/-beta(?:\.|$)/.test(version)) return "beta";
+  if (/-dev(?:\.|$)/.test(version)) return "dev";
+  if (/-alpha(?:\.|$)/.test(version)) return "alpha";
+  return "stable";
+}
+
 contextBridge.exposeInMainWorld("electronAPI", {
   isElectron: true,
+  appRuntime: {
+    distributionProvider: detectDistributionProvider(),
+    releaseChannel: detectReleaseChannel(process.env.npm_package_version || "0.0.0"),
+  },
   openFile: invokeChannel(FILE_CHANNELS.invoke.openFile, { arity: 0 }),
   saveFile: invokeChannel(FILE_CHANNELS.invoke.saveFile, { arity: 3 }),
   getChromeVersion: invokeChannel(SYSTEM_CHANNELS.invoke.getChromeVersion, { arity: 0 }),

--- a/lib/utils/__tests__/runtime-env-distribution.test.ts
+++ b/lib/utils/__tests__/runtime-env-distribution.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("runtime distribution helpers", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  });
+
+  it.each([
+    ["1.3.0", "stable"],
+    ["1.3.0-beta.20260708.1", "beta"],
+    ["1.3.0-dev", "dev"],
+    ["1.3.0-alpha.1", "alpha"],
+    [undefined, "unknown"],
+  ] as const)("detects release channel for %s", async (version, expected) => {
+    const { detectReleaseChannel } = await import("../runtime-env");
+    expect(detectReleaseChannel(version)).toBe(expected);
+  });
+
+  it("returns direct provider for Electron renderer without store metadata", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.3.0-beta.20260708.1");
+    (window as unknown as { electronAPI: { isElectron: boolean } }).electronAPI = {
+      isElectron: true,
+    };
+
+    const { getAppRuntimeInfo } = await import("../runtime-env");
+
+    expect(getAppRuntimeInfo()).toEqual({
+      distributionProvider: "direct",
+      releaseChannel: "beta",
+    });
+  });
+
+  it("uses platform distribution provider from preload metadata", async () => {
+    vi.stubEnv("NEXT_PUBLIC_APP_VERSION", "1.3.0");
+    (
+      window as unknown as { electronAPI: { isElectron: boolean; appRuntime: unknown } }
+    ).electronAPI = {
+      isElectron: true,
+      appRuntime: {
+        distributionProvider: "microsoft-store",
+        releaseChannel: "beta",
+      },
+    };
+
+    const { getAppRuntimeInfo } = await import("../runtime-env");
+
+    expect(getAppRuntimeInfo()).toEqual({
+      distributionProvider: "microsoft-store",
+      releaseChannel: "stable",
+    });
+  });
+});

--- a/lib/utils/runtime-env.ts
+++ b/lib/utils/runtime-env.ts
@@ -4,6 +4,15 @@ export type RuntimeEnvironment = "browser" | "electron-renderer" | "unknown";
 
 export type OSPlatform = "mac" | "windows" | "linux";
 
+export type DistributionProvider = "direct" | "microsoft-store" | "app-store" | "unknown";
+
+export type ReleaseChannel = "stable" | "beta" | "dev" | "alpha" | "unknown";
+
+export interface AppRuntimeInfo {
+  distributionProvider: DistributionProvider;
+  releaseChannel: ReleaseChannel;
+}
+
 /**
  * ブラウザ相当の環境で動いているか判定する
  */
@@ -34,6 +43,36 @@ export function getRuntimeEnvironment(): RuntimeEnvironment {
     return "browser";
   }
   return "unknown";
+}
+
+export function detectReleaseChannel(version: string | undefined): ReleaseChannel {
+  if (!version) return "unknown";
+  if (/-beta(?:\.|$)/.test(version)) return "beta";
+  if (/-dev(?:\.|$)/.test(version)) return "dev";
+  if (/-alpha(?:\.|$)/.test(version)) return "alpha";
+  return "stable";
+}
+
+export function getAppRuntimeInfo(): AppRuntimeInfo {
+  const version = process.env.NEXT_PUBLIC_APP_VERSION;
+  const releaseChannel = detectReleaseChannel(version);
+
+  if (!isElectronRenderer()) {
+    return {
+      distributionProvider: "unknown",
+      releaseChannel,
+    };
+  }
+
+  const electronAPI = window.electronAPI;
+
+  return {
+    distributionProvider: electronAPI?.appRuntime?.distributionProvider ?? "direct",
+    releaseChannel:
+      releaseChannel !== "unknown"
+        ? releaseChannel
+        : (electronAPI?.appRuntime?.releaseChannel ?? "unknown"),
+  };
 }
 
 /**

--- a/test/setup-vitest.ts
+++ b/test/setup-vitest.ts
@@ -1,0 +1,59 @@
+import { beforeEach } from "vitest";
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(values.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
+function installBrowserStorageGlobals(): void {
+  const local = createMemoryStorage();
+  const session = createMemoryStorage();
+
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: local,
+  });
+
+  Object.defineProperty(globalThis, "sessionStorage", {
+    configurable: true,
+    value: session,
+  });
+
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: local,
+    });
+
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: session,
+    });
+  }
+}
+
+installBrowserStorageGlobals();
+
+beforeEach(() => {
+  installBrowserStorageGlobals();
+});

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -11,12 +11,14 @@ import type { VFSWatchEvent } from "@/lib/vfs/types";
 import type { KeymapOverrides } from "@/lib/keymap/keymap-types";
 import type { DictEntry, DictDownloadStatus, DictLookup } from "@/lib/dict/dict-types";
 import type { PdfGenerationOptions } from "@/lib/export/types";
+import type { AppRuntimeInfo } from "@/lib/utils/runtime-env";
 
 export {};
 
 declare global {
   interface ElectronAPI {
     isElectron: boolean;
+    appRuntime?: AppRuntimeInfo;
     openFile: () => Promise<{ path: string; content: string } | null>;
     saveFile: (
       filePath: string | null,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    environmentOptions: {
+      jsdom: {
+        url: "http://localhost/",
+      },
+    },
+    setupFiles: ["./test/setup-vitest.ts"],
     include: ["**/__tests__/**/*.test.ts", "**/__tests__/**/*.test.tsx"],
     // stale worktree コピー（.claude/worktrees/agent-*）配下の __tests__ が
     // テスト探索に混入して false-RED を起こすのを防ぐ


### PR DESCRIPTION
## Summary
- Add a shared distribution provider / release channel runtime model for direct, Microsoft Store, and App Store builds.
- Show the beta update opt-in only for direct desktop builds; show platform-managed flight copy for Store/App Store builds.
- Document store flight ownership and keep existing Microsoft Store stable submission flow from being reused for beta packages.
- Add Vitest storage setup so the full jsdom suite has deterministic localStorage/sessionStorage.

## Verification
- npm run type-check
- npm test
- npx eslint lib/utils/runtime-env.ts types/electron.d.ts components/settings/AboutSection.tsx lib/utils/__tests__/runtime-env-distribution.test.ts components/settings/__tests__/AboutSection.test.tsx vitest.config.ts test/setup-vitest.ts