### PR TITLE
ci: include prerelease version in MSIX asset names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -658,6 +658,33 @@ jobs:
         if: github.event_name != 'pull_request'
         run: npx electron-builder --win appx --${{ matrix.arch }} --publish never
 
+      - name: Normalize MSIX artifact names
+        if: github.event_name != 'pull_request'
+        shell: pwsh
+        run: |
+          $fullVersion = "${{ needs.compute-version.outputs.full }}"
+          $arch = "${{ matrix.arch }}"
+          $targetName = "illusions-$fullVersion-$arch.appx"
+          $targetPath = Join-Path "dist-electron" $targetName
+
+          $appxFiles = Get-ChildItem "dist-electron\*.appx"
+          if ($appxFiles.Count -ne 1) {
+            Write-Error "Expected exactly one .appx for $arch, found $($appxFiles.Count)"
+            $appxFiles | ForEach-Object { Write-Host "  - $($_.FullName)" }
+            exit 1
+          }
+
+          $appx = $appxFiles[0]
+          $blockmapPath = "$($appx.FullName).blockmap"
+
+          Rename-Item -Path $appx.FullName -NewName $targetName -Force
+
+          if (Test-Path $blockmapPath) {
+            Rename-Item -Path $blockmapPath -NewName "$targetName.blockmap" -Force
+          }
+
+          Write-Host "Renamed MSIX artifact to $targetPath"
+
       - name: Upload MSIX artifacts
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v7

--- a/docs/release/store-flights.md
+++ b/docs/release/store-flights.md
@@ -37,6 +37,11 @@ Center and upload the beta `.appx` artifacts from the GitHub prerelease for the
 `beta` branch. Package flight listing text is shared with the non-flighted Store
 submission; only packages differ.
 
+MSIX package identity versions are four-part numeric versions and cannot contain
+SemVer prerelease labels such as `-beta`. GitHub release asset filenames include
+the full Illusions prerelease version for operator clarity, but Partner Center
+will still show the numeric MSIX package version from the package manifest.
+
 Automation note: do not add a package-flight upload workflow until we have a
 verified Partner Center API endpoint or supported CLI path for package flight
 submissions. The existing submission API script only targets normal app


### PR DESCRIPTION
## Summary
- Rename Windows Store .appx release assets after electron-builder so beta releases carry the full prerelease version in the asset filename.
- Keep the MSIX package identity version numeric-only, as required by MSIX/Partner Center.
- Document the distinction between GitHub asset filenames and Partner Center package manifest versions.

## Verification
- npx prettier --write .github/workflows/build.yml docs/release/store-flights.md
- git diff --check