### PR TITLE
ci: mark MSIX channel in package revision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,14 +124,21 @@ jobs:
           case "$BRANCH_NAME" in
             main)
               FULL_VERSION="${BASE_VERSION}"
+              MSIX_REVISION=0
               ;;
             beta)
               BETA_DATE=$(date -u +%Y%m%d)
               BETA_TIME=$(date -u +%H%M%S)
               FULL_VERSION="${BASE_VERSION}-beta.${BETA_DATE}.$((10#$BETA_TIME))"
+              MSIX_REVISION=1
               ;;
-            alpha|dev)
+            alpha)
               FULL_VERSION="${BASE_VERSION}-${BRANCH_NAME}"
+              MSIX_REVISION=2
+              ;;
+            dev)
+              FULL_VERSION="${BASE_VERSION}-${BRANCH_NAME}"
+              MSIX_REVISION=3
               ;;
             *)
               echo "::error::Unexpected branch '${BRANCH_NAME}' — only main/alpha/beta/dev are allowed"
@@ -139,15 +146,16 @@ jobs:
               ;;
           esac
 
-          # MSIX requires exactly four numeric parts; electron-builder handles this
-          # but we compute it here for logging
-          MSIX_VERSION="${BASE_VERSION}.0"
+          # MSIX requires exactly four numeric parts and cannot contain semver
+          # prerelease labels. Use revision as a channel marker:
+          # stable=0, beta=1, alpha=2, dev=3. Lower means closer to stable.
+          MSIX_VERSION="${BASE_VERSION}.${MSIX_REVISION}"
 
           echo "base=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "full=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
           echo "msix=${MSIX_VERSION}" >> "$GITHUB_OUTPUT"
           echo "branch=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
-          echo "Version: base=${BASE_VERSION} | full=${FULL_VERSION} | MSIX=${MSIX_VERSION} | Branch=${BRANCH_NAME} | Latest tag patch=${LATEST_PATCH:-none}"
+          echo "Version: base=${BASE_VERSION} | full=${FULL_VERSION} | MSIX=${MSIX_VERSION} | Branch=${BRANCH_NAME} | MSIX revision=${MSIX_REVISION} | Latest tag patch=${LATEST_PATCH:-none}"
 
       - name: Validate version format
         run: |
@@ -608,7 +616,7 @@ jobs:
 
       - name: Update package.json version for MSIX build
         if: github.event_name != 'pull_request'
-        run: node -e "const p=require('./package.json');p.version='${{ needs.compute-version.outputs.base }}';require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+        run: node -e "const p=require('./package.json');p.version='${{ needs.compute-version.outputs.base }}';p.build={...(p.build||{}),buildVersion:'${{ needs.compute-version.outputs.msix }}'};require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
 
       - name: Download build output
         if: github.event_name != 'pull_request'

--- a/docs/release/store-flights.md
+++ b/docs/release/store-flights.md
@@ -41,6 +41,17 @@ MSIX package identity versions are four-part numeric versions and cannot contain
 SemVer prerelease labels such as `-beta`. GitHub release asset filenames include
 the full Illusions prerelease version for operator clarity, but Partner Center
 will still show the numeric MSIX package version from the package manifest.
+The fourth MSIX version part is reserved as a channel marker:
+
+- `0`: stable
+- `1`: beta
+- `2`: alpha
+- `3`: dev
+
+Lower revision numbers are closer to the stable release channel.
+The workflow keeps `package.json.version` at the stable three-part base version
+for SemVer compatibility and writes the four-part MSIX version to
+`build.buildVersion` before invoking the AppX target.
 
 Automation note: do not add a package-flight upload workflow until we have a
 verified Partner Center API endpoint or supported CLI path for package flight


### PR DESCRIPTION
## Summary
- Use the fourth MSIX version part as a channel marker: stable=0, beta=1, alpha=2, dev=3.
- Keep package.json.version as a valid three-part SemVer and set electron-builder build.buildVersion for AppX/MSIX.
- Document the MSIX revision mapping for Store flights.

## Verification
- npx prettier --write .github/workflows/build.yml docs/release/store-flights.md
- git diff --check

Note: the AppX packaging step runs on push builds, not PR builds, so the first beta release after this merge will validate the generated package manifest version end-to-end.