### PR TITLE
chore: default dev script to electron, drop unused next start

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,22 +2,16 @@
   "version": "0.0.1",
   "configurations": [
     {
-      "name": "next-dev",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
-      "port": 3010
-    },
-    {
       "name": "electron-dev",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "electron:dev"],
+      "runtimeArgs": ["run", "dev"],
       "port": 3020
     },
     {
-      "name": "next-start",
+      "name": "next-dev-web",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "start"],
-      "port": 3000
+      "runtimeArgs": ["run", "dev:web"],
+      "port": 3010
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "main": "dist-main/main.js",
   "scripts": {
     "type-check": "tsc --noEmit",
-    "dev": "npm run type-check && node scripts/ensure-credits-stub.mjs && next dev -p 3010",
+    "dev": "npm run electron:dev",
+    "dev:web": "npm run type-check && node scripts/ensure-credits-stub.mjs && next dev -p 3010",
     "build": "npm run type-check && npm run generate:credits && next build",
-    "start": "next start",
     "lint": "eslint .",
     "check:boundaries": "node scripts/check-import-boundaries.mjs",
     "format": "prettier --write \"**/*.{ts,tsx,js,mjs,json,css,md}\"",


### PR DESCRIPTION
## Summary

- Web は現在セカンダリ扱いのため、`npm run dev` は Electron アプリを直接起動するように変更（`electron:dev` を呼び出す）
- 元の web dev server は `npm run dev:web` として維持（web 側を個別に触りたいときのため）
- CI（quality.yml / build.yml）にも Vercel の `main` デプロイにも参照されていなかった `start`（`next start`）スクリプトを削除
- `.claude/launch.json` のデバッグ構成を新しいスクリプト名に合わせて更新（`electron-dev` → `dev`、`next-dev` → `next-dev-web` → `dev:web`、未使用の `next-start` 構成は削除）

## Changes

| File | Change |
| --- | --- |
| `package.json` | `dev` を Electron 起動に変更、`dev:web` を新設、`start` を削除 |
| `.claude/launch.json` | 上記スクリプト名変更に追従、`next-start` 構成を削除 |

## Test plan

- [x] `node -e` で `package.json` / `.claude/launch.json` の JSON 妥当性を確認
- [x] CI ワークフロー（`quality.yml` / `build.yml`）が参照するスクリプト名が変更されていないことを確認
- [ ] `npm run dev` で Electron アプリが起動することをローカルで確認
- [ ] `npm run dev:web` で web dev server (port 3010) が起動することをローカルで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)