### PR TITLE
ci: set AppX build number for store channel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -616,7 +616,7 @@ jobs:
 
       - name: Update package.json version for MSIX build
         if: github.event_name != 'pull_request'
-        run: node -e "const p=require('./package.json');p.version='${{ needs.compute-version.outputs.base }}';p.build={...(p.build||{}),buildVersion:'${{ needs.compute-version.outputs.msix }}'};require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+        run: node -e "const p=require('./package.json');const msix='${{ needs.compute-version.outputs.msix }}';const revision=msix.split('.').at(-1);p.version='${{ needs.compute-version.outputs.base }}';p.build={...(p.build||{}),buildVersion:msix,buildNumber:revision};require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
 
       - name: Download build output
         if: github.event_name != 'pull_request'

--- a/docs/release/store-flights.md
+++ b/docs/release/store-flights.md
@@ -51,7 +51,9 @@ The fourth MSIX version part is reserved as a channel marker:
 Lower revision numbers are closer to the stable release channel.
 The workflow keeps `package.json.version` at the stable three-part base version
 for SemVer compatibility and writes the four-part MSIX version to
-`build.buildVersion` before invoking the AppX target.
+`build.buildVersion` plus the channel marker to `build.buildNumber` before
+invoking the AppX target. Electron Builder uses `buildNumber` as the fourth
+AppX manifest version part.
 
 Automation note: do not add a package-flight upload workflow until we have a
 verified Partner Center API endpoint or supported CLI path for package flight


### PR DESCRIPTION
## Summary
- set electron-builder buildNumber during MSIX packaging so AppX manifest uses the store channel revision
- document that AppX manifest version comes from buildNumber

## Validation
- inspected generated AppX manifest from the previous beta run and confirmed buildVersion alone was not used