### PR TITLE
ci: enable AppX build number for MSIX packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -616,7 +616,7 @@ jobs:
 
       - name: Update package.json version for MSIX build
         if: github.event_name != 'pull_request'
-        run: node -e "const p=require('./package.json');const msix='${{ needs.compute-version.outputs.msix }}';const revision=msix.split('.').at(-1);p.version='${{ needs.compute-version.outputs.base }}';p.build={...(p.build||{}),buildVersion:msix,buildNumber:revision};require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+        run: node -e "const p=require('./package.json');const msix='${{ needs.compute-version.outputs.msix }}';const revision=msix.split('.').at(-1);p.version='${{ needs.compute-version.outputs.base }}';p.build={...(p.build||{}),buildVersion:msix,buildNumber:revision,appx:{...((p.build||{}).appx||{}),setBuildNumber:true}};require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
 
       - name: Download build output
         if: github.event_name != 'pull_request'

--- a/docs/release/store-flights.md
+++ b/docs/release/store-flights.md
@@ -53,7 +53,7 @@ The workflow keeps `package.json.version` at the stable three-part base version
 for SemVer compatibility and writes the four-part MSIX version to
 `build.buildVersion` plus the channel marker to `build.buildNumber` before
 invoking the AppX target. Electron Builder uses `buildNumber` as the fourth
-AppX manifest version part.
+AppX manifest version part only when `appx.setBuildNumber=true`.
 
 Automation note: do not add a package-flight upload workflow until we have a
 verified Partner Center API endpoint or supported CLI path for package flight


### PR DESCRIPTION
## Summary
- enable appx.setBuildNumber during MSIX packaging so AppX manifest uses buildNumber as the fourth version part
- document the AppX-specific switch

## Validation
- verified prior beta artifacts still showed Version=1.3.1.0 without appx.setBuildNumber