### PR TITLE
ci: keep MSIX revision compatible with Microsoft Store

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,15 +130,15 @@ jobs:
               BETA_DATE=$(date -u +%Y%m%d)
               BETA_TIME=$(date -u +%H%M%S)
               FULL_VERSION="${BASE_VERSION}-beta.${BETA_DATE}.$((10#$BETA_TIME))"
-              MSIX_REVISION=1
+              MSIX_REVISION=0
               ;;
             alpha)
               FULL_VERSION="${BASE_VERSION}-${BRANCH_NAME}"
-              MSIX_REVISION=2
+              MSIX_REVISION=0
               ;;
             dev)
               FULL_VERSION="${BASE_VERSION}-${BRANCH_NAME}"
-              MSIX_REVISION=3
+              MSIX_REVISION=0
               ;;
             *)
               echo "::error::Unexpected branch '${BRANCH_NAME}' — only main/alpha/beta/dev are allowed"
@@ -146,9 +146,9 @@ jobs:
               ;;
           esac
 
-          # MSIX requires exactly four numeric parts and cannot contain semver
-          # prerelease labels. Use revision as a channel marker:
-          # stable=0, beta=1, alpha=2, dev=3. Lower means closer to stable.
+          # Microsoft Store package acceptance requires an AppX manifest
+          # revision of 0. Flight/channel identity must come from Partner
+          # Center flights and artifact names, not the package version.
           MSIX_VERSION="${BASE_VERSION}.${MSIX_REVISION}"
 
           echo "base=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
@@ -616,7 +616,7 @@ jobs:
 
       - name: Update package.json version for MSIX build
         if: github.event_name != 'pull_request'
-        run: node -e "const p=require('./package.json');const msix='${{ needs.compute-version.outputs.msix }}';const revision=msix.split('.').at(-1);p.version='${{ needs.compute-version.outputs.base }}';p.build={...(p.build||{}),buildVersion:msix,buildNumber:revision,appx:{...((p.build||{}).appx||{}),setBuildNumber:true}};require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
+        run: node -e "const p=require('./package.json');p.version='${{ needs.compute-version.outputs.base }}';p.build={...(p.build||{}),buildVersion:'${{ needs.compute-version.outputs.msix }}'};require('fs').writeFileSync('package.json',JSON.stringify(p,null,2)+'\n')"
 
       - name: Download build output
         if: github.event_name != 'pull_request'

--- a/docs/release/store-flights.md
+++ b/docs/release/store-flights.md
@@ -41,19 +41,11 @@ MSIX package identity versions are four-part numeric versions and cannot contain
 SemVer prerelease labels such as `-beta`. GitHub release asset filenames include
 the full Illusions prerelease version for operator clarity, but Partner Center
 will still show the numeric MSIX package version from the package manifest.
-The fourth MSIX version part is reserved as a channel marker:
-
-- `0`: stable
-- `1`: beta
-- `2`: alpha
-- `3`: dev
-
-Lower revision numbers are closer to the stable release channel.
+Microsoft Store package acceptance requires the fourth MSIX version part
+(`revision`) to be `0`; do not use it as a channel marker.
 The workflow keeps `package.json.version` at the stable three-part base version
-for SemVer compatibility and writes the four-part MSIX version to
-`build.buildVersion` plus the channel marker to `build.buildNumber` before
-invoking the AppX target. Electron Builder uses `buildNumber` as the fourth
-AppX manifest version part only when `appx.setBuildNumber=true`.
+for SemVer compatibility and writes the four-part Store-compatible MSIX version
+to `build.buildVersion` before invoking the AppX target.
 
 Automation note: do not add a package-flight upload workflow until we have a
 verified Partner Center API endpoint or supported CLI path for package flight


### PR DESCRIPTION
## Summary
- keep AppX/MSIX manifest revision at 0 for Store acceptance
- remove the incorrect channel-marker revision behavior
- document that beta identity comes from Partner Center flights and artifact names

## Validation
- Partner Center rejected Version=1.3.1.1 with: Apps are not allowed to have a Version with a revision number other than zero