### PR TITLE
ci: automate Microsoft Store beta flights

### DIFF
--- a/.github/workflows/ms-store-flight-submit.yml
+++ b/.github/workflows/ms-store-flight-submit.yml
@@ -1,0 +1,53 @@
+name: Microsoft Store Flight Auto Submit
+
+on:
+  workflow_run:
+    workflows: ["Desktop Build and Release"]
+    types: [completed]
+    branches: [beta]
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: "ms-store-flight-dispatch"
+  cancel-in-progress: false
+
+jobs:
+  submit-flight:
+    name: Submit Beta to Microsoft Store Flight
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get latest beta release tag
+        id: get-tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG=$(gh api repos/${{ github.repository }}/releases \
+            --jq '[.[] | select(.draft == false and .prerelease == true and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.")))] | sort_by(.created_at) | last | .tag_name')
+          if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
+            echo "::error::No beta prerelease found"
+            exit 1
+          fi
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Found beta release tag: ${RELEASE_TAG}"
+
+      - name: Dispatch package flight submission
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'sync-ms-store-listing.yml',
+              ref: 'beta',
+              inputs: {
+                mode: 'flight-submission',
+                release_tag: '${{ steps.get-tag.outputs.tag }}',
+                dry_run: 'false',
+              },
+            });
+            core.info(`Dispatched Microsoft Store flight submission for ${{ steps.get-tag.outputs.tag }}`);

--- a/.github/workflows/sync-ms-store-listing.yml
+++ b/.github/workflows/sync-ms-store-listing.yml
@@ -11,6 +11,7 @@ on:
           - listing-only
           - full-submission
           - flight-submission
+          - inspect-flights
         default: listing-only
       release_tag:
         description: "GitHub Release tag to download .appx from (required for full-submission/flight-submission, e.g. v0.2.0)"
@@ -29,7 +30,7 @@ on:
   workflow_call:
     inputs:
       mode:
-        description: "Submission mode (listing-only | full-submission | flight-submission)"
+        description: "Submission mode (listing-only | full-submission | flight-submission | inspect-flights)"
         required: true
         type: string
       release_tag:
@@ -75,9 +76,9 @@ jobs:
         shell: bash
         run: |
           case "${{ inputs.mode }}" in
-            flight-submission)
+            flight-submission | inspect-flights)
               if [ "${{ github.ref }}" != "refs/heads/beta" ] && [[ "${{ github.ref }}" != refs/tags/*-beta.* ]]; then
-                echo "::error::flight-submission may only be run from beta or a beta tag. Current ref: ${{ github.ref }}"
+                echo "::error::${{ inputs.mode }} may only be run from beta or a beta tag. Current ref: ${{ github.ref }}"
                 exit 1
               fi
               ;;
@@ -92,7 +93,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.mode == 'flight-submission' && 'refs/heads/beta' || 'refs/heads/main' }}
+          ref: ${{ (inputs.mode == 'flight-submission' || inputs.mode == 'inspect-flights') && 'refs/heads/beta' || 'refs/heads/main' }}
           fetch-depth: 0
 
       - name: Set up Node.js
@@ -103,11 +104,11 @@ jobs:
       - name: Validate inputs
         shell: bash
         run: |
-          if [ "${{ inputs.mode }}" != "listing-only" ] && [ "${{ inputs.mode }}" != "full-submission" ] && [ "${{ inputs.mode }}" != "flight-submission" ]; then
-            echo "::error::mode must be 'listing-only', 'full-submission', or 'flight-submission', got: ${{ inputs.mode }}"
+          if [ "${{ inputs.mode }}" != "listing-only" ] && [ "${{ inputs.mode }}" != "full-submission" ] && [ "${{ inputs.mode }}" != "flight-submission" ] && [ "${{ inputs.mode }}" != "inspect-flights" ]; then
+            echo "::error::mode must be 'listing-only', 'full-submission', 'flight-submission', or 'inspect-flights', got: ${{ inputs.mode }}"
             exit 1
           fi
-          if [ "${{ inputs.mode }}" != "listing-only" ] && [ -z "${{ inputs.release_tag }}" ]; then
+          if [ "${{ inputs.mode }}" != "listing-only" ] && [ "${{ inputs.mode }}" != "inspect-flights" ] && [ -z "${{ inputs.release_tag }}" ]; then
             echo "::error::release_tag is required for ${{ inputs.mode }} mode"
             exit 1
           fi
@@ -135,7 +136,7 @@ jobs:
         run: echo "" > store/microsoft/ja-JP/release-notes.md
 
       - name: Download MSIX packages from GitHub Release
-        if: inputs.mode != 'listing-only'
+        if: inputs.mode != 'listing-only' && inputs.mode != 'inspect-flights'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-ms-store-listing.yml
+++ b/.github/workflows/sync-ms-store-listing.yml
@@ -10,9 +10,14 @@ on:
         options:
           - listing-only
           - full-submission
+          - flight-submission
         default: listing-only
       release_tag:
-        description: "GitHub Release tag to download .appx from (required for full-submission, e.g. v0.2.0)"
+        description: "GitHub Release tag to download .appx from (required for full-submission/flight-submission, e.g. v0.2.0)"
+        required: false
+        type: string
+      flight_id:
+        description: "Microsoft Store package flight ID/name (required for flight-submission)"
         required: false
         type: string
       dry_run:
@@ -24,11 +29,15 @@ on:
   workflow_call:
     inputs:
       mode:
-        description: "Submission mode (listing-only | full-submission)"
+        description: "Submission mode (listing-only | full-submission | flight-submission)"
         required: true
         type: string
       release_tag:
-        description: "GitHub Release tag to download .appx from (required for full-submission)"
+        description: "GitHub Release tag to download .appx from (required for full-submission/flight-submission)"
+        required: false
+        type: string
+      flight_id:
+        description: "Microsoft Store package flight ID/name (required for flight-submission)"
         required: false
         type: string
       dry_run:
@@ -58,21 +67,32 @@ jobs:
       MSSTORE_CLIENT_SECRET: ${{ secrets.MSSTORE_CLIENT_SECRET }}
       STORE_PRODUCT_ID: ${{ vars.STORE_PRODUCT_ID }}
       SUBMISSION_MODE: ${{ inputs.mode }}
+      PACKAGE_FLIGHT_ID: ${{ inputs.flight_id || vars.MSSTORE_BETA_FLIGHT_ID }}
       DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
 
     steps:
       - name: Verify running from main branch or version tag
         shell: bash
         run: |
-          if [ "${{ github.ref }}" != "refs/heads/main" ] && [[ "${{ github.ref }}" != refs/tags/v* ]]; then
-            echo "::error::This workflow may only be run from main or a version tag (refs/tags/v*). Current ref: ${{ github.ref }}"
-            exit 1
-          fi
+          case "${{ inputs.mode }}" in
+            flight-submission)
+              if [ "${{ github.ref }}" != "refs/heads/beta" ] && [[ "${{ github.ref }}" != refs/tags/*-beta.* ]]; then
+                echo "::error::flight-submission may only be run from beta or a beta tag. Current ref: ${{ github.ref }}"
+                exit 1
+              fi
+              ;;
+            *)
+              if [ "${{ github.ref }}" != "refs/heads/main" ] && [[ "${{ github.ref }}" != refs/tags/v* ]]; then
+                echo "::error::This workflow may only be run from main or a version tag (refs/tags/v*). Current ref: ${{ github.ref }}"
+                exit 1
+              fi
+              ;;
+          esac
 
-      - name: Checkout repository (main)
+      - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: refs/heads/main
+          ref: ${{ inputs.mode == 'flight-submission' && 'refs/heads/beta' || 'refs/heads/main' }}
           fetch-depth: 0
 
       - name: Set up Node.js
@@ -83,12 +103,16 @@ jobs:
       - name: Validate inputs
         shell: bash
         run: |
-          if [ "${{ inputs.mode }}" != "listing-only" ] && [ "${{ inputs.mode }}" != "full-submission" ]; then
-            echo "::error::mode must be 'listing-only' or 'full-submission', got: ${{ inputs.mode }}"
+          if [ "${{ inputs.mode }}" != "listing-only" ] && [ "${{ inputs.mode }}" != "full-submission" ] && [ "${{ inputs.mode }}" != "flight-submission" ]; then
+            echo "::error::mode must be 'listing-only', 'full-submission', or 'flight-submission', got: ${{ inputs.mode }}"
             exit 1
           fi
-          if [ "${{ inputs.mode }}" = "full-submission" ] && [ -z "${{ inputs.release_tag }}" ]; then
-            echo "::error::release_tag is required for full-submission mode"
+          if [ "${{ inputs.mode }}" != "listing-only" ] && [ -z "${{ inputs.release_tag }}" ]; then
+            echo "::error::release_tag is required for ${{ inputs.mode }} mode"
+            exit 1
+          fi
+          if [ "${{ inputs.mode }}" = "flight-submission" ] && [ -z "$PACKAGE_FLIGHT_ID" ]; then
+            echo "::error::flight_id input or MSSTORE_BETA_FLIGHT_ID environment variable is required for flight-submission mode"
             exit 1
           fi
 
@@ -106,12 +130,12 @@ jobs:
           cat store/microsoft/ja-JP/release-notes.md
 
       - name: Write empty release notes stub (listing-only)
-        if: inputs.mode == 'listing-only'
+        if: inputs.mode != 'full-submission'
         shell: bash
         run: echo "" > store/microsoft/ja-JP/release-notes.md
 
       - name: Download MSIX packages from GitHub Release
-        if: inputs.mode == 'full-submission'
+        if: inputs.mode != 'listing-only'
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/submit-store.mjs
+++ b/scripts/submit-store.mjs
@@ -17,7 +17,7 @@
  *   MSIX_DIR              - Directory containing .appx packages (default: "msix-packages")
  *
  * Optional:
- *   SUBMISSION_MODE   - "listing-only", "full-submission", or "flight-submission" (default: "full-submission")
+ *   SUBMISSION_MODE   - "listing-only", "full-submission", "flight-submission", or "inspect-flights" (default: "full-submission")
  *   PACKAGE_FLIGHT_ID - Microsoft Store package flight ID/name (required for flight-submission)
  *   DRY_RUN=true     - Log API calls without mutating state (credentials not required)
  *   POLL_TIMEOUT_MS  - Polling timeout in ms (default: 600000 = 10 min)
@@ -41,6 +41,7 @@ const DRY_RUN = process.env.DRY_RUN === "true";
 const SUBMISSION_MODE = process.env.SUBMISSION_MODE ?? "full-submission";
 const LISTING_ONLY = SUBMISSION_MODE === "listing-only";
 const FLIGHT_SUBMISSION = SUBMISSION_MODE === "flight-submission";
+const INSPECT_FLIGHTS = SUBMISSION_MODE === "inspect-flights";
 const PACKAGE_SUBMISSION = SUBMISSION_MODE === "full-submission" || FLIGHT_SUBMISSION;
 const TENANT_ID = process.env.MSSTORE_TENANT_ID;
 const CLIENT_ID = process.env.MSSTORE_CLIENT_ID;
@@ -189,6 +190,70 @@ function getSubmissionCollectionPath() {
 
 function getSubmissionPath(submissionId) {
   return `${getSubmissionCollectionPath()}/${submissionId}`;
+}
+
+function collectFlightLikeFields(value, path = "$", output = []) {
+  if (!value || typeof value !== "object") return output;
+  if (output.length >= 80) return output;
+
+  if (Array.isArray(value)) {
+    value.slice(0, 20).forEach((item, index) => {
+      collectFlightLikeFields(item, `${path}[${index}]`, output);
+    });
+    return output;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    const childPath = `${path}.${key}`;
+    if (/flight|rank|group|audience|id|name/i.test(key)) {
+      if (child == null || typeof child !== "object") {
+        output.push({ path: childPath, value: child });
+      } else if (Array.isArray(child)) {
+        output.push({ path: childPath, type: "array", length: child.length });
+        collectFlightLikeFields(child, childPath, output);
+      } else {
+        output.push({ path: childPath, type: "object", keys: Object.keys(child).slice(0, 20) });
+        collectFlightLikeFields(child, childPath, output);
+      }
+    } else if (child && typeof child === "object") {
+      collectFlightLikeFields(child, childPath, output);
+    }
+    if (output.length >= 80) break;
+  }
+
+  return output;
+}
+
+async function inspectPackageFlights(token, app) {
+  console.log("\nInspecting package flight metadata...");
+  console.log(`  App top-level keys: ${Object.keys(app).sort().join(", ")}`);
+
+  const fields = collectFlightLikeFields(app);
+  if (fields.length === 0) {
+    console.log("  No flight-like fields found in application object.");
+  } else {
+    console.log("  Flight-like fields from application object:");
+    for (const field of fields) {
+      console.log(`    ${JSON.stringify(field)}`);
+    }
+  }
+
+  const candidatePaths = [
+    `/applications/${APP_ID}/flights`,
+    `/applications/${APP_ID}/packageFlights`,
+    `/applications/${APP_ID}/listflights`,
+    `/applications/${APP_ID}/listFlights`,
+  ];
+
+  for (const path of candidatePaths) {
+    try {
+      console.log(`\nTrying GET ${path}...`);
+      const response = await apiGet(token, path);
+      console.log(JSON.stringify(response, null, 2));
+    } catch (err) {
+      console.log(`  ${err.message}`);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -402,9 +467,13 @@ async function main() {
     );
   }
 
-  if (!["listing-only", "full-submission", "flight-submission"].includes(SUBMISSION_MODE)) {
+  if (
+    !["listing-only", "full-submission", "flight-submission", "inspect-flights"].includes(
+      SUBMISSION_MODE,
+    )
+  ) {
     throw new Error(
-      `Invalid SUBMISSION_MODE '${SUBMISSION_MODE}' (expected listing-only, full-submission, or flight-submission)`,
+      `Invalid SUBMISSION_MODE '${SUBMISSION_MODE}' (expected listing-only, full-submission, flight-submission, or inspect-flights)`,
     );
   }
 
@@ -448,6 +517,12 @@ async function main() {
 
   console.log(`\nFetching app info for ${APP_ID}...`);
   const app = await apiGet(token, `/applications/${APP_ID}`);
+
+  if (INSPECT_FLIGHTS) {
+    await inspectPackageFlights(token, app);
+    console.log("\nFlight inspection completed.");
+    return;
+  }
 
   if (!FLIGHT_SUBMISSION && app.pendingApplicationSubmission?.id) {
     const pendingId = app.pendingApplicationSubmission.id;

--- a/scripts/submit-store.mjs
+++ b/scripts/submit-store.mjs
@@ -17,7 +17,8 @@
  *   MSIX_DIR              - Directory containing .appx packages (default: "msix-packages")
  *
  * Optional:
- *   SUBMISSION_MODE   - "listing-only" or "full-submission" (default: "full-submission")
+ *   SUBMISSION_MODE   - "listing-only", "full-submission", or "flight-submission" (default: "full-submission")
+ *   PACKAGE_FLIGHT_ID - Microsoft Store package flight ID/name (required for flight-submission)
  *   DRY_RUN=true     - Log API calls without mutating state (credentials not required)
  *   POLL_TIMEOUT_MS  - Polling timeout in ms (default: 600000 = 10 min)
  */
@@ -39,10 +40,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const DRY_RUN = process.env.DRY_RUN === "true";
 const SUBMISSION_MODE = process.env.SUBMISSION_MODE ?? "full-submission";
 const LISTING_ONLY = SUBMISSION_MODE === "listing-only";
+const FLIGHT_SUBMISSION = SUBMISSION_MODE === "flight-submission";
+const PACKAGE_SUBMISSION = SUBMISSION_MODE === "full-submission" || FLIGHT_SUBMISSION;
 const TENANT_ID = process.env.MSSTORE_TENANT_ID;
 const CLIENT_ID = process.env.MSSTORE_CLIENT_ID;
 const CLIENT_SECRET = process.env.MSSTORE_CLIENT_SECRET;
 const APP_ID = process.env.STORE_PRODUCT_ID;
+const PACKAGE_FLIGHT_ID = process.env.PACKAGE_FLIGHT_ID ?? process.env.MSSTORE_PACKAGE_FLIGHT_ID;
 const MSIX_DIR = resolve(process.env.MSIX_DIR ?? "msix-packages");
 const POLL_TIMEOUT_MS = Number(process.env.POLL_TIMEOUT_MS ?? 1_200_000);
 
@@ -169,6 +173,22 @@ async function apiDelete(token, path) {
     err.status = res.status;
     throw err;
   }
+}
+
+function getSubmissionCollectionPath() {
+  if (FLIGHT_SUBMISSION) {
+    if (!PACKAGE_FLIGHT_ID) {
+      throw new Error(
+        "PACKAGE_FLIGHT_ID or MSSTORE_PACKAGE_FLIGHT_ID is required for flight-submission mode",
+      );
+    }
+    return `/applications/${APP_ID}/flights/${encodeURIComponent(PACKAGE_FLIGHT_ID)}/submissions`;
+  }
+  return `/applications/${APP_ID}/submissions`;
+}
+
+function getSubmissionPath(submissionId) {
+  return `${getSubmissionCollectionPath()}/${submissionId}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -341,7 +361,7 @@ async function pollSubmissionStatus(token, submissionId) {
   const intervalMs = 30_000;
 
   while (Date.now() - start < POLL_TIMEOUT_MS) {
-    const sub = await apiGet(token, `/applications/${APP_ID}/submissions/${submissionId}`);
+    const sub = await apiGet(token, getSubmissionPath(submissionId));
     // The Store API uses "status" for newer endpoints and "commitStatus" for legacy
     const status = sub.commitStatus ?? sub.status;
     console.log(`  commitStatus: ${sub.commitStatus}, status: ${sub.status}`);
@@ -369,6 +389,9 @@ async function main() {
   console.log(
     `Mode: ${SUBMISSION_MODE}${LISTING_ONLY ? " (listing metadata only, no package upload)" : ""}`,
   );
+  if (FLIGHT_SUBMISSION) {
+    console.log(`Package flight: ${PACKAGE_FLIGHT_ID ?? "(not set)"}`);
+  }
 
   if (DRY_RUN) {
     console.log("=== DRY RUN MODE — no mutations will be made ===\n");
@@ -379,20 +402,36 @@ async function main() {
     );
   }
 
-  // --- Step 1: Read listing content ---
-  console.log("Reading store listing content...");
-  const description = readListingFile("description.md");
-  const shortDescription = readListingFile("short-description.md");
-  const featuresMarkdown = readListingFile("features.md");
-  const releaseNotes = readListingFile("release-notes.md", { required: false });
-  const licenseTerms = readLicenseTerms();
-  const features = parseBulletList(featuresMarkdown);
+  if (!["listing-only", "full-submission", "flight-submission"].includes(SUBMISSION_MODE)) {
+    throw new Error(
+      `Invalid SUBMISSION_MODE '${SUBMISSION_MODE}' (expected listing-only, full-submission, or flight-submission)`,
+    );
+  }
 
-  console.log(`  description:      ${description.length} chars`);
-  console.log(`  shortDescription: ${shortDescription.length} chars`);
-  console.log(`  features:         ${features.length} items`);
-  console.log(`  releaseNotes:     ${releaseNotes.length} chars`);
-  console.log(`  licenseTerms:     ${licenseTerms.length} chars`);
+  // --- Step 1: Read listing content ---
+  let description = "";
+  let shortDescription = "";
+  let releaseNotes = "";
+  let licenseTerms = "";
+  let features = [];
+
+  if (!FLIGHT_SUBMISSION) {
+    console.log("Reading store listing content...");
+    description = readListingFile("description.md");
+    shortDescription = readListingFile("short-description.md");
+    const featuresMarkdown = readListingFile("features.md");
+    releaseNotes = readListingFile("release-notes.md", { required: false });
+    licenseTerms = readLicenseTerms();
+    features = parseBulletList(featuresMarkdown);
+
+    console.log(`  description:      ${description.length} chars`);
+    console.log(`  shortDescription: ${shortDescription.length} chars`);
+    console.log(`  features:         ${features.length} items`);
+    console.log(`  releaseNotes:     ${releaseNotes.length} chars`);
+    console.log(`  licenseTerms:     ${licenseTerms.length} chars`);
+  } else {
+    console.log("Skipping listing metadata for package flight submission.");
+  }
 
   // --- Step 2: Authenticate ---
   let token = "dry-run-token";
@@ -405,11 +444,12 @@ async function main() {
   // --- Step 3: Get app info + resolve pending submission ---
   let submissionId;
   let fileUploadUrl;
+  const submissionCollectionPath = getSubmissionCollectionPath();
 
   console.log(`\nFetching app info for ${APP_ID}...`);
   const app = await apiGet(token, `/applications/${APP_ID}`);
 
-  if (app.pendingApplicationSubmission?.id) {
+  if (!FLIGHT_SUBMISSION && app.pendingApplicationSubmission?.id) {
     const pendingId = app.pendingApplicationSubmission.id;
 
     if (LISTING_ONLY) {
@@ -466,8 +506,8 @@ async function main() {
 
   // --- Step 4: Create new submission (if no pending submission to reuse) ---
   if (!submissionId) {
-    console.log("\nCreating new submission...");
-    const newSub = await apiPost(token, `/applications/${APP_ID}/submissions`, null);
+    console.log(`\nCreating new ${FLIGHT_SUBMISSION ? "package flight " : ""}submission...`);
+    const newSub = await apiPost(token, submissionCollectionPath, null);
     submissionId = newSub.id;
     fileUploadUrl = newSub.fileUploadUrl;
     console.log(`  Submission ID: ${submissionId}`);
@@ -475,24 +515,28 @@ async function main() {
 
   // --- Step 5: Get full submission details ---
   console.log("\nGetting submission details...");
-  const submission = await apiGet(token, `/applications/${APP_ID}/submissions/${submissionId}`);
+  const submission = await apiGet(token, getSubmissionPath(submissionId));
 
   // --- Step 6: Update listing ---
-  console.log("\nUpdating store listing (ja-JP)...");
-  if (!submission.listings) submission.listings = {};
-  if (!submission.listings["ja-jp"]) {
-    submission.listings["ja-jp"] = { baseListing: {} };
+  if (!FLIGHT_SUBMISSION) {
+    console.log("\nUpdating store listing (ja-JP)...");
+    if (!submission.listings) submission.listings = {};
+    if (!submission.listings["ja-jp"]) {
+      submission.listings["ja-jp"] = { baseListing: {} };
+    }
+
+    const listing = submission.listings["ja-jp"].baseListing;
+    listing.description = description;
+    listing.shortDescription = shortDescription;
+    listing.features = features;
+    listing.releaseNotes = releaseNotes;
+    if (licenseTerms) listing.licenseTerms = licenseTerms;
+  } else {
+    console.log("\nSkipping store listing update for package flight.");
   }
 
-  const listing = submission.listings["ja-jp"].baseListing;
-  listing.description = description;
-  listing.shortDescription = shortDescription;
-  listing.features = features;
-  listing.releaseNotes = releaseNotes;
-  if (licenseTerms) listing.licenseTerms = licenseTerms;
-
   // --- Step 7: Set application packages (full-submission only) ---
-  if (!LISTING_ONLY) {
+  if (PACKAGE_SUBMISSION) {
     const appxFiles = DRY_RUN ? ["example.appx"] : findAppxFiles();
     console.log(`\nPackages to submit: ${appxFiles.join(", ")}`);
 
@@ -518,10 +562,10 @@ async function main() {
 
   // --- Step 8: PUT updated submission ---
   console.log("\nSaving submission changes...");
-  await apiPut(token, `/applications/${APP_ID}/submissions/${submissionId}`, submission);
+  await apiPut(token, getSubmissionPath(submissionId), submission);
 
   // --- Step 9: Upload packages (full-submission only) ---
-  if (!LISTING_ONLY) {
+  if (PACKAGE_SUBMISSION) {
     if (DRY_RUN) {
       console.log("\n[dry-run] Skipping package ZIP creation and upload.");
     } else {
@@ -534,11 +578,7 @@ async function main() {
 
   // --- Step 10: Commit ---
   console.log("\nCommitting submission...");
-  const commitResponse = await apiPost(
-    token,
-    `/applications/${APP_ID}/submissions/${submissionId}/commit`,
-    null,
-  );
+  const commitResponse = await apiPost(token, `${getSubmissionPath(submissionId)}/commit`, null);
   console.log(`  Commit response: ${JSON.stringify(commitResponse)}`);
 
   // --- Step 11: Poll ---


### PR DESCRIPTION
## Summary
- add Microsoft Store package flight submission mode and flight inspection mode
- add beta workflow-run dispatch for MS Store flight submissions
- configure the Store script to submit packages to package flight submissions instead of the public non-flighted submission

## Verification
- node --check scripts/submit-store.mjs
- npx prettier --check scripts/submit-store.mjs .github/workflows/sync-ms-store-listing.yml .github/workflows/ms-store-flight-submit.yml
- DRY_RUN=true SUBMISSION_MODE=flight-submission STORE_PRODUCT_ID=9TEST PACKAGE_FLIGHT_ID=36ccd796-05a6-4f1b-b205-635b70fd16fe node scripts/submit-store.mjs

## Operational note
MSSTORE_BETA_FLIGHT_ID is already configured in the MicrosoftStore environment as 36ccd796-05a6-4f1b-b205-635b70fd16fe.