### PR TITLE
feat: Mac App Store submission prep (B-1〜B-5, Phase E)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,13 @@ on:
     paths-ignore:
       - "store/**"
       - ".github/workflows/sync-ms-store-listing.yml"
+  workflow_dispatch:
+    inputs:
+      run_mas_build:
+        description: "MAS向けpkgをビルドしてApp Store Connectへアップロードする"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -333,6 +340,122 @@ jobs:
         with:
           name: illusions-macos-${{ matrix.arch }}-${{ needs.compute-version.outputs.full }}
           path: dist-electron/**
+
+  build-mas:
+    name: Build (Mac App Store)
+    # 初期移行中は手動入力が明示されたときだけ実行し、タグpushでは走らせない。
+    if: |
+      github.event_name == 'workflow_dispatch' &&
+      inputs.run_mas_build == true
+    runs-on: macos-latest
+    environment: Apple
+    env:
+      CSC_LINK: ${{ secrets.MAS_CSC_LINK }}
+      CSC_KEY_PASSWORD: ${{ secrets.MAS_CSC_KEY_PASSWORD }}
+      CSC_INSTALLER_LINK: ${{ secrets.CSC_INSTALLER_LINK }}
+      CSC_INSTALLER_KEY_PASSWORD: ${{ secrets.CSC_INSTALLER_KEY_PASSWORD }}
+      MAS_PROVISIONING_PROFILE: ${{ secrets.MAS_PROVISIONING_PROFILE }}
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_API_KEY: ${{ secrets.ASC_API_KEY }}
+      ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+      APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
+      ERROR_REPORT_DSN: ${{ secrets.ERROR_REPORT_DSN }}
+      ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Restore Electron caches
+        uses: actions/cache@v6
+        with:
+          path: |
+            ${{ env.ELECTRON_CACHE }}
+            ${{ env.ELECTRON_BUILDER_CACHE }}
+          key: electron-${{ runner.os }}-mas-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            electron-${{ runner.os }}-mas-
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          for i in 1 2 3; do
+            npm install && break
+            if [ $i -lt 3 ]; then
+              echo "::warning::npm install failed (attempt $i/3), retrying in 15s..."
+              sleep 15
+            else
+              echo "::error::npm install failed after 3 attempts"
+              exit 1
+            fi
+          done
+
+      - name: Prepare MAS credentials
+        shell: bash
+        run: |
+          missing=()
+          [ -z "$CSC_LINK" ] && missing+=("MAS_CSC_LINK")
+          [ -z "$CSC_KEY_PASSWORD" ] && missing+=("MAS_CSC_KEY_PASSWORD")
+          [ -z "$CSC_INSTALLER_LINK" ] && missing+=("CSC_INSTALLER_LINK")
+          [ -z "$CSC_INSTALLER_KEY_PASSWORD" ] && missing+=("CSC_INSTALLER_KEY_PASSWORD")
+          [ -z "$MAS_PROVISIONING_PROFILE" ] && missing+=("MAS_PROVISIONING_PROFILE")
+          [ -z "$ASC_KEY_ID" ] && missing+=("ASC_KEY_ID")
+          [ -z "$ASC_ISSUER_ID" ] && missing+=("ASC_ISSUER_ID")
+          [ -z "$ASC_API_KEY" ] && missing+=("ASC_API_KEY")
+          [ -z "$ASC_APP_ID" ] && missing+=("ASC_APP_ID")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing MAS credentials: ${missing[*]}"
+            exit 1
+          fi
+
+          # electron-builder は build.mas.provisioningProfile のパスをそのまま読む。
+          printf '%s' "$MAS_PROVISIONING_PROFILE" | base64 --decode > build/illusions.provisionprofile
+
+          # altool はこの標準パスから App Store Connect API キーを探す。
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          printf '%s' "$ASC_API_KEY" | base64 --decode > "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+
+      - name: Download local fonts
+        run: npm run download:fonts
+
+      - name: Build Quick Look plugin
+        run: npm run build:quicklook
+
+      - name: Build MAS package
+        run: MAS_BUILD=1 npm run electron:build:mas
+        env:
+          DEBUG: electron-builder
+
+      - name: Upload MAS package artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: illusions-mas-pkg
+          path: dist-electron/**/*.pkg
+
+      - name: Upload to App Store Connect
+        shell: bash
+        run: |
+          PKG_FILE=$(find dist-electron -name "*.pkg" -type f | head -n 1)
+          if [ -z "$PKG_FILE" ]; then
+            echo "::error::MAS pkg artifact was not found"
+            exit 1
+          fi
+          echo "Uploading $PKG_FILE to App Store Connect app $ASC_APP_ID"
+          xcrun altool --upload-app \
+            -f "$PKG_FILE" \
+            --type macos \
+            --apiKey "$ASC_KEY_ID" \
+            --apiIssuer "$ASC_ISSUER_ID"
 
   # ---------------------------------------------------------------------------
   # Windows — shared build step, then separate NSIS / MSIX packaging

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@
 !/build/mdi-icon.png
 !/build/appx/
 !/build/appx/*.png
+!/build/entitlements.mas.plist
+!/build/entitlements.mas.inherit.plist
 # Quick Look extension is rebuilt by `npm run build:quicklook` in CI
 /build/quicklook/
 /dist*

--- a/build/entitlements.mas.inherit.plist
+++ b/build/entitlements.mas.inherit.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.inherit</key>
+    <true/>
+  </dict>
+</plist>

--- a/build/entitlements.mas.plist
+++ b/build/entitlements.mas.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <key>com.apple.security.files.bookmarks.app-scope</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+  </dict>
+</plist>

--- a/components/settings/AboutSection.tsx
+++ b/components/settings/AboutSection.tsx
@@ -169,7 +169,7 @@ export default function AboutSection(): React.ReactElement {
               : "border-transparent text-foreground-secondary hover:text-foreground",
           )}
         >
-          利用規約
+          利用規約・プライバシー
         </button>
         <button
           onClick={() => setActiveTab("license")}

--- a/electron/__tests__/auto-updater.test.ts
+++ b/electron/__tests__/auto-updater.test.ts
@@ -54,7 +54,7 @@ describe("auto-updater.js — opt-in wiring", () => {
     // setup と checkForUpdates と reevaluate の各所でガードに使われていること
     expect(autoUpdaterSrc).toMatch(/if\s*\(\s*isUnpublishedChannelBuild\s*\)/);
     expect(autoUpdaterSrc).toMatch(
-      /if\s*\(\s*isDev\s*\|\|\s*isUnpublishedChannelBuild\s*\|\|\s*isMicrosoftStoreApp\s*\)/,
+      /if\s*\(\s*isDev\s*\|\|\s*isUnpublishedChannelBuild\s*\|\|\s*isMicrosoftStoreApp\s*\|\|\s*isMasBuild\s*\)/,
     );
   });
 });

--- a/electron/app-constants.js
+++ b/electron/app-constants.js
@@ -8,4 +8,8 @@ const APP_NAME = "illusions";
 // Store 版はストア経由で更新されるため、electron-updater を無効化する
 const isMicrosoftStoreApp = process.windowsStore === true;
 
-module.exports = { isDev, APP_NAME, isMicrosoftStoreApp };
+// Mac App Store (MAS) ビルドかどうかを判定（Electron が MAS パッケージ時に自動設定）
+// MAS はサンドボックス制約により auto-updater・ターミナル(node-pty)・QuickLook 同梱を無効化する
+const isMasBuild = process.mas === true;
+
+module.exports = { isDev, APP_NAME, isMicrosoftStoreApp, isMasBuild };

--- a/electron/auto-updater.js
+++ b/electron/auto-updater.js
@@ -3,7 +3,7 @@
 const { app, dialog } = require("electron");
 const { autoUpdater } = require("electron-updater");
 const log = require("electron-log");
-const { isDev, isMicrosoftStoreApp } = require("./app-constants");
+const { isDev, isMicrosoftStoreApp, isMasBuild } = require("./app-constants");
 const { resolveUpdaterFlags, isUnpublishedChannelVersion } = require("./lib/update-policy");
 
 // dev/alpha ブランチのビルドは GitHub Release を持たない CI 専用成果物のため、
@@ -67,6 +67,12 @@ function setupAutoUpdater() {
   // Microsoft Store 版ではストア更新と衝突するため無効化
   if (isMicrosoftStoreApp) {
     log.info("Microsoft Store 版のため auto-updater は無効です");
+    return;
+  }
+
+  // Mac App Store 版では electron-updater の使用が規約上禁止されているため無効化
+  if (isMasBuild) {
+    log.info("Mac App Store 版のため auto-updater は無効です");
     return;
   }
 
@@ -228,6 +234,24 @@ async function checkForUpdates(manual = false) {
     return;
   }
 
+  if (isMasBuild) {
+    if (manual) {
+      const { getMainWindow } = require("./window-manager");
+      const mainWindow = getMainWindow();
+      if (mainWindow) {
+        dialog.showMessageBox(mainWindow, {
+          type: "info",
+          title: "アップデート",
+          message: "Mac App Store 版",
+          detail:
+            "このバージョンは Mac App Store 経由で更新されます。App Store アプリからアップデートを確認してください。",
+          buttons: ["OK"],
+        });
+      }
+    }
+    return;
+  }
+
   isManualUpdateCheck = manual;
   // 設定変更を反映するため、チェック直前に opt-in を再評価して channel を確定する
   await applyBetaOptIn();
@@ -240,7 +264,7 @@ async function checkForUpdates(manual = false) {
  * ダイアログ表示のみ。OFF にした場合も latest へ戻す）。
  */
 async function reevaluateUpdateChannel() {
-  if (isDev || isUnpublishedChannelBuild || isMicrosoftStoreApp) return;
+  if (isDev || isUnpublishedChannelBuild || isMicrosoftStoreApp || isMasBuild) return;
   await checkForUpdates(false);
 }
 

--- a/electron/ipc/__tests__/vfs-approved-paths-persist.test.ts
+++ b/electron/ipc/__tests__/vfs-approved-paths-persist.test.ts
@@ -17,9 +17,10 @@ import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 
-/** @type {{ loadApprovals, saveApprovals, clearApprovalsCache }} */
+/** @type {{ loadApprovals, loadApprovalEntries, saveApprovals, clearApprovalsCache }} */
 const {
   loadApprovals,
+  loadApprovalEntries,
   saveApprovals,
   clearApprovalsCache,
 } = require("../../../electron/lib/vfs-approvals.js");
@@ -69,6 +70,25 @@ describe("saveApprovals()", () => {
     expect(data.approvals[0].projectId).toBe("proj_001");
     expect(data.approvals[0].path).toBe("/Users/alice/novel1");
     expect(typeof data.approvals[0].approvedAt).toBe("string");
+  });
+
+  it("persists optional security-scoped bookmarks by path", async () => {
+    const paths = new Set(["/Users/alice/novel1", "/Users/alice/novel2"]);
+    const bookmarks = new Map([["/Users/alice/novel2", "bookmark-base64"]]);
+
+    await saveApprovals(tmpFile, "proj_001", paths, bookmarks);
+
+    const raw = fsSync.readFileSync(tmpFile, "utf-8");
+    const data = JSON.parse(raw);
+    const entryWithoutBookmark = data.approvals.find(
+      (a: { path: string }) => a.path === "/Users/alice/novel1",
+    );
+    const entryWithBookmark = data.approvals.find(
+      (a: { path: string }) => a.path === "/Users/alice/novel2",
+    );
+
+    expect(entryWithoutBookmark.bookmark).toBeUndefined();
+    expect(entryWithBookmark.bookmark).toBe("bookmark-base64");
   });
 
   it("replaces only the given projectId, keeping other projects intact", async () => {
@@ -157,6 +177,71 @@ describe("loadApprovals()", () => {
 
     const restored = await loadApprovals(tmpFile, "proj_restart");
     expect(restored.has("/Users/carol/myProject")).toBe(true);
+  });
+
+  it("loads old approval entries that do not have bookmark fields", async () => {
+    const data = {
+      version: 1,
+      approvals: [
+        {
+          projectId: "proj_old",
+          path: "/Users/alice/oldProject",
+          approvedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    };
+    fsSync.writeFileSync(tmpFile, JSON.stringify(data));
+    clearApprovalsCache();
+
+    const result = await loadApprovals(tmpFile, "proj_old");
+    expect(result.has("/Users/alice/oldProject")).toBe(true);
+  });
+});
+
+describe("loadApprovalEntries()", () => {
+  it("round-trips path approvals with optional bookmark metadata", async () => {
+    await saveApprovals(
+      tmpFile,
+      "proj_bookmark",
+      new Set(["/Users/alice/bookmarked"]),
+      new Map([["/Users/alice/bookmarked", "bookmark-base64"]]),
+    );
+    clearApprovalsCache();
+
+    const entries = await loadApprovalEntries(tmpFile, "proj_bookmark");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].path).toBe("/Users/alice/bookmarked");
+    expect(entries[0].bookmark).toBe("bookmark-base64");
+  });
+
+  it("keeps approvals when bookmark is missing or malformed", async () => {
+    const data = {
+      version: 1,
+      approvals: [
+        {
+          projectId: "proj_compat",
+          path: "/Users/alice/noBookmark",
+          approvedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          projectId: "proj_compat",
+          path: "/Users/alice/badBookmark",
+          approvedAt: "2026-01-01T00:00:00.000Z",
+          bookmark: 123,
+        },
+      ],
+    };
+    fsSync.writeFileSync(tmpFile, JSON.stringify(data));
+    clearApprovalsCache();
+
+    const entries = await loadApprovalEntries(tmpFile, "proj_compat");
+    expect(entries.map((entry: { path: string }) => entry.path).sort()).toEqual([
+      "/Users/alice/badBookmark",
+      "/Users/alice/noBookmark",
+    ]);
+    expect(entries.every((entry: { bookmark?: string }) => entry.bookmark === undefined)).toBe(
+      true,
+    );
   });
 });
 

--- a/electron/ipc/pty-ipc.js
+++ b/electron/ipc/pty-ipc.js
@@ -25,6 +25,7 @@ const {
   killSession,
 } = require("./terminal-session-registry");
 const { PTY_CHANNELS } = require("../lib/ipc-channels");
+const { isMasBuild } = require("../app-constants");
 
 // -----------------------------------------------------------------------
 // node-pty availability guard
@@ -34,11 +35,17 @@ const { PTY_CHANNELS } = require("../lib/ipc-channels");
 let nodePty = null;
 let ptyAvailable = false;
 
-try {
-  nodePty = require("node-pty");
-  ptyAvailable = true;
-} catch (err) {
-  console.warn("[PTY] node-pty not available — terminal feature disabled:", err.message);
+// Mac App Store 版は任意シェル起動が審査で許可されないため、node-pty の
+// require 自体を行わず機能ごと無効化する（App Sandbox 制約）。
+if (isMasBuild) {
+  console.log("[PTY] Mac App Store 版のためターミナル機能は無効です");
+} else {
+  try {
+    nodePty = require("node-pty");
+    ptyAvailable = true;
+  } catch (err) {
+    console.warn("[PTY] node-pty not available — terminal feature disabled:", err.message);
+  }
 }
 
 // -----------------------------------------------------------------------

--- a/electron/ipc/vfs-ipc.js
+++ b/electron/ipc/vfs-ipc.js
@@ -16,8 +16,12 @@ const {
 const { isSensitiveSystemPath, MAX_CONTENT_BYTES } = require("../lib/path-policy");
 const { VFS_CHANNELS } = require("../lib/ipc-channels");
 const { readFileStrictUtf8 } = require("../lib/text-decode");
+const {
+  startSecurityScopedAccess,
+  stopSecurityScopedAccess,
+} = require("../lib/security-scoped-access");
 // #1476: rehydration — begin
-const { loadApprovals, saveApprovals } = require("../lib/vfs-approvals");
+const { loadApprovalEntries, saveApprovals } = require("../lib/vfs-approvals");
 const { createIndexLockManager } = require("../lib/index-lock");
 const { setVfsRoot, clearVfsRoot } = require("../lib/vfs-root-registry");
 // #1476: rehydration — end
@@ -26,8 +30,31 @@ function registerVFSHandlers() {
   // Track the opened root directory per window for path validation.
   // #1559: each entry stores both the lexical root (as seen by the renderer)
   // and its physical realpath so symlink-collapsed containment can be checked.
-  /** @type {Map<number, { path: string, realPath: string }>} */
+  /** @type {Map<number, { path: string, realPath: string, stopAccessing?: () => void }>} */
   const allowedRoots = new Map();
+
+  function getFirstBookmark(result) {
+    const bookmark = result?.bookmarks?.[0];
+    return typeof bookmark === "string" && bookmark ? bookmark : undefined;
+  }
+
+  function replaceAllowedRoot(senderId, rootEntry) {
+    const previous = allowedRoots.get(senderId);
+    if (previous && previous !== rootEntry) {
+      stopSecurityScopedAccess(previous);
+    }
+    allowedRoots.set(senderId, rootEntry);
+    setVfsRoot(senderId, rootEntry);
+  }
+
+  function clearAllowedRoot(senderId) {
+    const previous = allowedRoots.get(senderId);
+    if (previous) {
+      stopSecurityScopedAccess(previous);
+      allowedRoots.delete(senderId);
+    }
+    clearVfsRoot(senderId);
+  }
 
   /**
    * Resolve the realpath of a root directory, falling back to the lexical
@@ -77,12 +104,13 @@ function registerVFSHandlers() {
    * Debounced wrapper for saveApprovals — flushes after 500 ms of inactivity.
    * @param {string} projectId
    * @param {Set<string>} paths
+   * @param {Map<string, string>} [bookmarksByPath]
    */
-  function scheduleSaveApprovals(projectId, paths) {
+  function scheduleSaveApprovals(projectId, paths, bookmarksByPath) {
     if (saveDebounceTimer) clearTimeout(saveDebounceTimer);
     saveDebounceTimer = setTimeout(() => {
       saveDebounceTimer = null;
-      saveApprovals(APPROVED_PATHS_FILE, projectId, paths).catch((err) => {
+      saveApprovals(APPROVED_PATHS_FILE, projectId, paths, bookmarksByPath).catch((err) => {
         console.error("[VFS IPC] Failed to persist approved paths:", err);
       });
     }, 500);
@@ -94,9 +122,44 @@ function registerVFSHandlers() {
    * Delegates to the shared per-window registry (electron/lib/approved-paths.js).
    * @param {number} senderId - The webContents ID of the approving window
    * @param {string} p - The path to approve
+   * @param {string} [bookmark] - Optional security-scoped bookmark for the path
    */
-  function approveDialogPath(senderId, p) {
+  function approveDialogPath(senderId, p, bookmark) {
     dialogApprovedPaths.approve(senderId, p);
+    if (bookmark) {
+      const bookmarks = dialogApprovedBookmarks.get(senderId) ?? new Map();
+      bookmarks.set(normalizePath(p), bookmark);
+      dialogApprovedBookmarks.set(senderId, bookmarks);
+    }
+  }
+
+  /** @type {Map<number, Map<string, string>>} */
+  const dialogApprovedBookmarks = new Map();
+
+  function getDialogApprovedBookmark(senderId, p) {
+    const bookmarks = dialogApprovedBookmarks.get(senderId);
+    return bookmarks?.get(normalizePath(p));
+  }
+
+  function getDialogApprovedTreeBookmark(senderId, p) {
+    const requested = normalizePath(p);
+    const approvedPath = dialogApprovedPaths
+      .listWindowPaths(senderId)
+      .find((approved) => isWithinApprovedTree([normalizePath(approved)], requested));
+    return approvedPath ? getDialogApprovedBookmark(senderId, approvedPath) : undefined;
+  }
+
+  function listDialogApprovedBookmarks(senderId) {
+    const result = new Map();
+    for (const approvedPath of dialogApprovedPaths.listWindowPaths(senderId)) {
+      const bookmark =
+        getDialogApprovedBookmark(senderId, approvedPath) ??
+        getDialogApprovedTreeBookmark(senderId, approvedPath);
+      if (bookmark) {
+        result.set(approvedPath, bookmark);
+      }
+    }
+    return result;
   }
 
   /**
@@ -149,6 +212,7 @@ function registerVFSHandlers() {
   ipcMain.handle(VFS_CHANNELS.invoke.openDirectory, async (event) => {
     const result = await dialog.showOpenDialog({
       properties: ["openDirectory", "createDirectory"],
+      securityScopedBookmarks: true,
     });
 
     if (result.canceled || !result.filePaths[0]) {
@@ -156,16 +220,17 @@ function registerVFSHandlers() {
     }
 
     const dirPath = result.filePaths[0];
+    const bookmark = getFirstBookmark(result);
     const name = path.basename(dirPath);
 
     // Update the allowed root for this window
     // #1559: store the realpath so symlink-collapsed containment can be checked
-    allowedRoots.set(event.sender.id, {
+    replaceAllowedRoot(event.sender.id, {
       path: dirPath,
       realPath: await resolveRootRealPath(dirPath),
+      stopAccessing: startSecurityScopedAccess(app, bookmark),
     });
-    setVfsRoot(event.sender.id, allowedRoots.get(event.sender.id));
-    approveDialogPath(event.sender.id, dirPath);
+    approveDialogPath(event.sender.id, dirPath, bookmark);
 
     return {
       path: dirPath,
@@ -412,24 +477,32 @@ function registerVFSHandlers() {
         .listWindowPaths(event.sender.id)
         .map((approved) => normalizePath(approved));
       if (isWithinApprovedTree(approvedTrees, normalizedResolved)) {
-        approveDialogPath(event.sender.id, resolved);
+        approveDialogPath(
+          event.sender.id,
+          resolved,
+          getDialogApprovedTreeBookmark(event.sender.id, resolved),
+        );
         alreadyApprovedInSession = true;
       }
     }
 
     let alreadyApprovedFromDisk = false;
     if (!alreadyApprovedInSession && effectiveProjectId) {
-      const persistedSet = await loadApprovals(APPROVED_PATHS_FILE, effectiveProjectId);
+      const persistedEntries = await loadApprovalEntries(APPROVED_PATHS_FILE, effectiveProjectId);
       // Persisted entries were written from earlier dialog confirmations, so on
       // macOS they may carry the on-disk NFD form while the requested path is
       // NFC (or vice versa). Fold both sides to NFC so a Japanese-named project
       // matches its stored approval regardless of Unicode encoding (#1955).
-      const persistedNFC = new Set([...persistedSet].map((p) => normalizePath(p)));
-      alreadyApprovedFromDisk =
-        persistedNFC.has(resolvedReal) || persistedNFC.has(normalizedResolved);
-      if (alreadyApprovedFromDisk) {
+      const persistedByNormalizedPath = new Map(
+        persistedEntries.map((entry) => [normalizePath(entry.path), entry]),
+      );
+      const persistedEntry =
+        persistedByNormalizedPath.get(resolvedReal) ??
+        persistedByNormalizedPath.get(normalizedResolved);
+      if (persistedEntry) {
+        alreadyApprovedFromDisk = true;
         // Restore in-session approval so subsequent calls are fast
-        approveDialogPath(event.sender.id, resolved);
+        approveDialogPath(event.sender.id, resolved, persistedEntry.bookmark);
       }
     }
 
@@ -445,6 +518,7 @@ function registerVFSHandlers() {
         title: "プロジェクトフォルダへのアクセスを許可",
         defaultPath: resolved,
         properties: ["openDirectory"],
+        securityScopedBookmarks: true,
         message: `「${path.basename(resolved)}」フォルダへのアクセスを許可しますか？`,
       });
 
@@ -454,34 +528,55 @@ function registerVFSHandlers() {
 
       // Only accept the exact path the user confirmed in the dialog
       const confirmedPath = path.resolve(result.filePaths[0]);
+      const bookmark = getFirstBookmark(result);
       if (normalizePath(confirmedPath) !== normalizedResolved) {
         throw new Error("選択されたディレクトリが要求されたパスと一致しません");
       }
 
-      approveDialogPath(event.sender.id, confirmedPath);
+      approveDialogPath(event.sender.id, confirmedPath, bookmark);
 
       // #1476: rehydration — persist the newly approved path so restart skips the dialog
       if (effectiveProjectId) {
         const windowPaths = dialogApprovedPaths.listWindowPaths(event.sender.id);
         const pathsToSave = new Set(windowPaths.length > 0 ? windowPaths : [confirmedPath]);
-        scheduleSaveApprovals(effectiveProjectId, pathsToSave);
+        scheduleSaveApprovals(
+          effectiveProjectId,
+          pathsToSave,
+          listDialogApprovedBookmarks(event.sender.id),
+        );
       }
     }
 
     // #1559: store the realpath alongside the lexical root so per-I/O
     // symlink-collapsed containment checks have a trusted physical root
-    const rootEntry = { path: resolved, realPath: resolvedReal };
-    allowedRoots.set(event.sender.id, rootEntry);
-    setVfsRoot(event.sender.id, rootEntry);
+    const rootBookmark =
+      getDialogApprovedBookmark(event.sender.id, resolved) ??
+      getDialogApprovedTreeBookmark(event.sender.id, resolved);
+    const rootEntry = {
+      path: resolved,
+      realPath: resolvedReal,
+      stopAccessing: startSecurityScopedAccess(app, rootBookmark),
+    };
+    replaceAllowedRoot(event.sender.id, rootEntry);
+
+    if (effectiveProjectId) {
+      const windowPaths = dialogApprovedPaths.listWindowPaths(event.sender.id);
+      const pathsToSave = new Set(windowPaths.length > 0 ? windowPaths : [resolved]);
+      scheduleSaveApprovals(
+        effectiveProjectId,
+        pathsToSave,
+        listDialogApprovedBookmarks(event.sender.id),
+      );
+    }
     return { path: resolved, name: path.basename(resolved) };
   });
 
   // Clean up allowedRoots, dialogApprovedPaths, and senderProjectId when a window is destroyed
   app.on("web-contents-created", (_, contents) => {
     contents.on("destroyed", () => {
-      allowedRoots.delete(contents.id);
-      clearVfsRoot(contents.id);
+      clearAllowedRoot(contents.id);
       dialogApprovedPaths.revokeWindow(contents.id);
+      dialogApprovedBookmarks.delete(contents.id);
       // #1476: rehydration — clean up projectId association
       senderProjectId.delete(contents.id);
     });
@@ -493,6 +588,7 @@ function registerVFSHandlers() {
   ipcMain.handle(VFS_CHANNELS.invoke.openFile, async (event, opts) => {
     const result = await dialog.showOpenDialog({
       properties: ["openFile"],
+      securityScopedBookmarks: true,
       filters: opts?.filters ?? [{ name: "テキスト", extensions: ["txt"] }],
     });
 
@@ -501,9 +597,15 @@ function registerVFSHandlers() {
     }
 
     const filePath = result.filePaths[0];
-    // R2: approveDialogPath requires 2-arg (senderId, path) signature
-    approveDialogPath(event.sender.id, filePath);
-    const buf = await fs.readFile(filePath);
+    const bookmark = getFirstBookmark(result);
+    approveDialogPath(event.sender.id, filePath, bookmark);
+    const stopAccessing = startSecurityScopedAccess(app, bookmark);
+    let buf;
+    try {
+      buf = await fs.readFile(filePath);
+    } finally {
+      if (stopAccessing) stopAccessing();
+    }
     return { path: filePath, name: path.basename(filePath), buf };
   });
 

--- a/electron/lib/__tests__/security-scoped-access.test.ts
+++ b/electron/lib/__tests__/security-scoped-access.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
+const { startSecurityScopedAccess, stopSecurityScopedAccess } =
+  require("../security-scoped-access.js") as {
+    startSecurityScopedAccess: (
+      electronApp: { startAccessingSecurityScopedResource?: (bookmark: string) => unknown } | null,
+      bookmark?: string,
+    ) => (() => void) | undefined;
+    stopSecurityScopedAccess: (rootEntry?: { stopAccessing?: () => void }) => void;
+  };
+
+describe("security-scoped access helpers", () => {
+  it("is harmless when the Electron API is unavailable", () => {
+    expect(startSecurityScopedAccess({}, "bookmark-base64")).toBeUndefined();
+    expect(startSecurityScopedAccess(null, "bookmark-base64")).toBeUndefined();
+  });
+
+  it("is harmless when no bookmark is present", () => {
+    const electronApp = {
+      startAccessingSecurityScopedResource: vi.fn(),
+    };
+
+    expect(startSecurityScopedAccess(electronApp, undefined)).toBeUndefined();
+    expect(electronApp.startAccessingSecurityScopedResource).not.toHaveBeenCalled();
+  });
+
+  it("returns the stop function from Electron for a bookmark", () => {
+    const stop = vi.fn();
+    const electronApp = {
+      startAccessingSecurityScopedResource: vi.fn(() => stop),
+    };
+
+    expect(startSecurityScopedAccess(electronApp, "bookmark-base64")).toBe(stop);
+    expect(electronApp.startAccessingSecurityScopedResource).toHaveBeenCalledWith(
+      "bookmark-base64",
+    );
+  });
+
+  it("stops once and clears the stored stop function", () => {
+    const stop = vi.fn();
+    const rootEntry = { stopAccessing: stop };
+
+    stopSecurityScopedAccess(rootEntry);
+    stopSecurityScopedAccess(rootEntry);
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(rootEntry.stopAccessing).toBeUndefined();
+  });
+});

--- a/electron/lib/security-scoped-access.js
+++ b/electron/lib/security-scoped-access.js
@@ -1,0 +1,35 @@
+"use strict";
+
+function startSecurityScopedAccess(electronApp, bookmark) {
+  if (
+    !bookmark ||
+    !electronApp ||
+    typeof electronApp.startAccessingSecurityScopedResource !== "function"
+  ) {
+    return undefined;
+  }
+  try {
+    const stopAccessing = electronApp.startAccessingSecurityScopedResource(bookmark);
+    return typeof stopAccessing === "function" ? stopAccessing : undefined;
+  } catch (error) {
+    console.warn("[VFS IPC] Failed to start security-scoped access:", error);
+    return undefined;
+  }
+}
+
+function stopSecurityScopedAccess(rootEntry) {
+  const stopAccessing = rootEntry?.stopAccessing;
+  if (typeof stopAccessing !== "function") return;
+  try {
+    stopAccessing();
+  } catch (error) {
+    console.warn("[VFS IPC] Failed to stop security-scoped access:", error);
+  } finally {
+    rootEntry.stopAccessing = undefined;
+  }
+}
+
+module.exports = {
+  startSecurityScopedAccess,
+  stopSecurityScopedAccess,
+};

--- a/electron/lib/vfs-approvals.js
+++ b/electron/lib/vfs-approvals.js
@@ -10,7 +10,12 @@
  * {
  *   "version": 1,
  *   "approvals": [
- *     { "projectId": "proj_abc123", "path": "/Users/.../novel1", "approvedAt": "2026-..." }
+ *     {
+ *       "projectId": "proj_abc123",
+ *       "path": "/Users/.../novel1",
+ *       "approvedAt": "2026-...",
+ *       "bookmark": "base64..."
+ *     }
  *   ]
  * }
  *
@@ -27,7 +32,7 @@ const fs = require("fs/promises");
 /**
  * In-memory cache so we don't re-read the JSON file on every approval check.
  * Invalidated (set to null) whenever saveApprovals() writes new data.
- * @type {Array<{projectId: string, path: string, approvedAt: string}> | null}
+ * @type {Array<{projectId: string, path: string, approvedAt?: string, bookmark?: string}> | null}
  */
 let approvalsCache = null;
 
@@ -36,7 +41,7 @@ let approvalsCache = null;
  * Returns an empty array when the file is missing or corrupt.
  *
  * @param {string} filePath - Absolute path to approved-vfs-paths.json
- * @returns {Promise<Array<{projectId: string, path: string, approvedAt: string}>>}
+ * @returns {Promise<Array<{projectId: string, path: string, approvedAt?: string, bookmark?: string}>>}
  */
 async function loadAllApprovals(filePath) {
   if (approvalsCache !== null) return approvalsCache;
@@ -46,14 +51,22 @@ async function loadAllApprovals(filePath) {
     if (data?.version !== 1 || !Array.isArray(data.approvals)) {
       approvalsCache = [];
     } else {
-      // Defensive: keep only well-formed entries
-      approvalsCache = data.approvals.filter(
-        (a) =>
-          a !== null &&
-          typeof a === "object" &&
-          typeof a.projectId === "string" &&
-          typeof a.path === "string",
-      );
+      // Defensive: keep only well-formed required fields. bookmark remains
+      // optional so older files and malformed bookmark values still load.
+      approvalsCache = data.approvals
+        .filter(
+          (a) =>
+            a !== null &&
+            typeof a === "object" &&
+            typeof a.projectId === "string" &&
+            typeof a.path === "string",
+        )
+        .map((a) => ({
+          projectId: a.projectId,
+          path: a.path,
+          approvedAt: typeof a.approvedAt === "string" ? a.approvedAt : undefined,
+          ...(typeof a.bookmark === "string" ? { bookmark: a.bookmark } : {}),
+        }));
     }
   } catch {
     approvalsCache = [];
@@ -76,6 +89,33 @@ async function loadApprovals(filePath, projectId) {
 }
 
 /**
+ * Load approved entries for a specific project, including optional bookmark
+ * metadata used to resume macOS security-scoped access.
+ *
+ * @param {string} filePath - Absolute path to approved-vfs-paths.json
+ * @param {string} projectId - Project identifier
+ * @returns {Promise<Array<{projectId: string, path: string, approvedAt?: string, bookmark?: string}>>}
+ */
+async function loadApprovalEntries(filePath, projectId) {
+  if (typeof projectId !== "string" || !projectId) return [];
+  const all = await loadAllApprovals(filePath);
+  return all.filter((a) => a.projectId === projectId);
+}
+
+function getBookmarkForPath(bookmarksByPath, p) {
+  if (!bookmarksByPath) return undefined;
+  if (bookmarksByPath instanceof Map) {
+    const value = bookmarksByPath.get(p);
+    return typeof value === "string" ? value : undefined;
+  }
+  if (typeof bookmarksByPath === "object") {
+    const value = bookmarksByPath[p];
+    return typeof value === "string" ? value : undefined;
+  }
+  return undefined;
+}
+
+/**
  * Persist the approval set for a specific project, replacing any existing entries
  * for that project. Entries for other projects are kept intact.
  * Invalidates the in-memory cache.
@@ -83,16 +123,21 @@ async function loadApprovals(filePath, projectId) {
  * @param {string} filePath - Absolute path to approved-vfs-paths.json
  * @param {string} projectId - Project identifier
  * @param {Set<string>} paths - Set of approved absolute paths
+ * @param {Map<string, string> | Record<string, string>} [bookmarksByPath] - Optional bookmark by path
  */
-async function saveApprovals(filePath, projectId, paths) {
+async function saveApprovals(filePath, projectId, paths, bookmarksByPath) {
   if (typeof projectId !== "string" || !projectId) return;
   const all = await loadAllApprovals(filePath);
   const others = all.filter((a) => a.projectId !== projectId);
-  const fresh = [...paths].map((p) => ({
-    projectId,
-    path: p,
-    approvedAt: new Date().toISOString(),
-  }));
+  const fresh = [...paths].map((p) => {
+    const bookmark = getBookmarkForPath(bookmarksByPath, p);
+    return {
+      projectId,
+      path: p,
+      approvedAt: new Date().toISOString(),
+      ...(bookmark ? { bookmark } : {}),
+    };
+  });
   approvalsCache = [...others, ...fresh];
   await fs.writeFile(
     filePath,
@@ -110,4 +155,10 @@ function clearApprovalsCache() {
 
 // #1476: rehydration — end
 
-module.exports = { loadAllApprovals, loadApprovals, saveApprovals, clearApprovalsCache };
+module.exports = {
+  loadAllApprovals,
+  loadApprovals,
+  loadApprovalEntries,
+  saveApprovals,
+  clearApprovalsCache,
+};

--- a/electron/lib/vfs-root-registry.js
+++ b/electron/lib/vfs-root-registry.js
@@ -9,7 +9,7 @@
  * or trusting renderer-supplied absolute paths.
  */
 
-/** @type {Map<number, { path: string, realPath: string }>} */
+/** @type {Map<number, { path: string, realPath: string, stopAccessing?: () => void }>} */
 const rootsBySender = new Map();
 
 function setVfsRoot(senderId, root) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bundle:electron": "node scripts/bundle-electron.mjs",
     "electron:dev": "node scripts/ensure-credits-stub.mjs && npm run bundle:electron && concurrently \"next dev -p 3020\" \"wait-on http://localhost:3020 && cross-env ELECTRON_DEV=1 electron .\"",
     "electron:build": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 next build && npm run bundle:electron && electron-builder",
+    "electron:build:mas": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 MAS_BUILD=1 next build && npm run bundle:electron && cross-env MAS_BUILD=1 electron-builder --mac mas",
     "build:quicklook": "node -e \"if(process.platform==='darwin'){const {execSync}=require('child_process');execSync('bash scripts/build-quicklook.sh',{stdio:'inherit'});}else{console.log('build:quicklook skipped (macOS only)');}\" ",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -218,6 +219,13 @@
           "role": "Editor"
         }
       ]
+    },
+    "mas": {
+      "entitlements": "build/entitlements.mas.plist",
+      "entitlementsInherit": "build/entitlements.mas.inherit.plist",
+      "provisioningProfile": "build/illusions.provisionprofile",
+      "hardenedRuntime": false,
+      "type": "distribution"
     },
     "win": {
       "icon": "build/icon.ico",

--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -158,6 +158,13 @@ exports.default = async function embedQuickLook(context) {
     return;
   }
 
+  if (process.env.MAS_BUILD === "1") {
+    // MAS 版は App Sandbox 内の別署名(Apple Distribution)が必要で、Developer ID
+    // 署名を前提にした本フックでは対応できないため同梱を省略する（将来 appex で再実装）。
+    console.log(`[QuickLook] Skipping ${APPEX_NAME} embed for MAS build`);
+    return;
+  }
+
   const appexSource = path.join(__dirname, "..", "build", "quicklook", APPEX_NAME);
 
   if (!fs.existsSync(appexSource)) {

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -52,6 +52,13 @@ exports.default = async function notarizing(context) {
     return;
   }
 
+  if (process.env.MAS_BUILD === "1") {
+    console.log(
+      "[Notarize] Skipping notarization for MAS build (App Store builds are not notarized)",
+    );
+    return;
+  }
+
   const appName = context.packager.appInfo.productFilename;
   const appPath = `${appOutDir}/${appName}.app`;
 


### PR DESCRIPTION
## Summary

- MAS build infrastructure: `MAS_BUILD=1` flag, `electron:build:mas` script, electron-builder `mas` target with dedicated entitlements (`build/entitlements.mas.plist` / `.inherit.plist`), notarization skipped for MAS, QuickLook appex embed skipped for MAS
- Feature gating for MAS: terminal (node-pty) disabled, auto-updater disabled with appropriate user-facing dialog
- VFS security-scoped bookmark support (`electron/lib/security-scoped-access.js`, `electron/lib/vfs-approvals.js`, `electron/ipc/vfs-ipc.js`) — implemented as a **unified code path for all macOS builds** (not gated behind `isMasBuild`), since `startAccessingSecurityScopedResource`/`stopAccessingSecurityScopedResource` are no-ops outside a sandbox. Falls back transparently to raw paths when no bookmark is present (old data, non-macOS).
- Phase E: new `build-mas` CI job in `.github/workflows/build.yml`, gated behind `workflow_dispatch` with a `run_mas_build` input (not on tag push, per the epic's "manual first" rollout plan). Builds, signs, and uploads the `.pkg` to App Store Connect via `xcrun altool`.
- Minor: About screen's Terms tab now labeled "利用規約・プライバシー" to make clear the tab includes the privacy policy content (App Store Review Guideline 5.1.1(i)).

## Context

Part of #2038 (MAS submission epic). B-6 (localhost sandbox load verification) required no code change — production already loads via `file://`, not `http://localhost`, confirmed by reading `electron/window-manager.js`.

An App Store Review Guidelines self-audit (using a newly-installed review skill) surfaced three additional compliance items that need product/business decisions or coordination with the separate `my.illusions.app` repo, so those were filed as standalone issues rather than fixed here: #2080 (account deletion not reachable in-app), #2081 (Pro/Enterprise plan IAP compliance), #2082 (Sign in with Apple applicability).

## Test plan

- [x] `npx vitest run` — 2664 tests pass
- [x] `npm run type-check` — clean
- [x] `electron-builder --mac mas --dir --publish never` run locally — config accepted, entitlements loaded correctly (fails only on missing local signing identity, as expected — certs live in CI secrets)
- [ ] Real sandbox verification (file open/close, VFS restore after restart, terminal/QuickLook disabled) — tracked separately in #2079, requires a signed build and manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)