### PR TITLE
ci: skip desktop release for NOTICE-only changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
               - '!docs/**'
               - '!README.md'
               - '!TERMS.md'
+              - '!NOTICE'
               - '!MDI.md'
               - '!.github/workflows/sync-ms-store-listing.yml'
               # Keep build.yml included so workflow edits validate desktop builds


### PR DESCRIPTION
## Summary

- Add `NOTICE` to the desktop release path filter on the dev line.
- Keeps future NOTICE-only edits from computing/publishing desktop releases after the main hotfix.

## Validation

- `npm run check:boundaries` via pre-push hook
