### PR TITLE
Defer selection word info updates

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,6 +77,36 @@ import type { SupportedFileExtension } from "@/lib/project/project-types";
 // lookup. Caps the synchronous textBetween() cost on段落/全選択 and avoids
 // pointless Genji lookups while dragging across大量のテキスト (#1639).
 const SELECTED_WORD_MAX_CHARS = 30;
+const SELECTED_WORD_MAX_DOC_RANGE = 120;
+const SELECTED_WORD_EXTRACT_DEBOUNCE_MS = 120;
+const SELECTED_WORD_EXTRACT_IDLE_TIMEOUT_MS = 800;
+
+type IdleCallbackHandle = number;
+type IdleCallbackDeadline = { didTimeout: boolean; timeRemaining: () => number };
+type WindowWithIdleCallback = Window & {
+  requestIdleCallback?: (
+    callback: (deadline: IdleCallbackDeadline) => void,
+    options?: { timeout?: number },
+  ) => IdleCallbackHandle;
+  cancelIdleCallback?: (handle: IdleCallbackHandle) => void;
+};
+
+function extractSelectedWordForLookup(
+  view: EditorView | null,
+  range: SearchRange | null,
+): string | null {
+  if (!view || !range || range.to <= range.from) return null;
+  // Avoid synchronous text extraction for paragraph/full-document selections.
+  // Dictionary lookup is useful only for a short word-like selection.
+  if (range.to - range.from > SELECTED_WORD_MAX_DOC_RANGE) return null;
+
+  const text = view.state.doc.textBetween(range.from, range.to, "").trim();
+  if (!text) return null;
+
+  const word = text.split(/\s+/)[0] ?? "";
+  if (Array.from(word).length > SELECTED_WORD_MAX_CHARS) return null;
+  return word || null;
+}
 
 // Module-level flag: persists across React StrictMode/HMR remounts,
 // but resets on page refresh (module re-evaluated).
@@ -548,6 +578,9 @@ export default function EditorPage() {
   const [selectedManuscriptPages, setSelectedManuscriptPages] = useState(0);
   const [selectedWord, setSelectedWord] = useState<string | null>(null);
   const [searchSelectionRange, setSearchSelectionRange] = useState<SearchRange | null>(null);
+  const selectedWordDebounceRef = useRef<number | null>(null);
+  const selectedWordIdleRef = useRef<IdleCallbackHandle | null>(null);
+  const selectedWordJobIdRef = useRef(0);
   const { menu: tabBarMenu, show: showTabBarMenu, close: closeTabBarMenu } = useContextMenu();
   const hasAutoRecoveredRef = useRef(false);
   const [editorViewInstance, setEditorViewInstanceRaw] = useState<EditorView | null>(null);
@@ -556,6 +589,68 @@ export default function EditorPage() {
     editorViewRef.current = view; // ref FIRST so sync consumers see fresh value
     setEditorViewInstanceRaw(view);
   }, []);
+
+  const clearSelectedWordJob = useCallback(() => {
+    if (selectedWordDebounceRef.current !== null) {
+      window.clearTimeout(selectedWordDebounceRef.current);
+      selectedWordDebounceRef.current = null;
+    }
+    if (selectedWordIdleRef.current !== null) {
+      const idleWindow = window as WindowWithIdleCallback;
+      if (idleWindow.cancelIdleCallback) {
+        idleWindow.cancelIdleCallback(selectedWordIdleRef.current);
+      } else {
+        window.clearTimeout(selectedWordIdleRef.current);
+      }
+      selectedWordIdleRef.current = null;
+    }
+  }, []);
+
+  const scheduleSelectedWordExtraction = useCallback(
+    (range: SearchRange | null) => {
+      clearSelectedWordJob();
+      const jobId = ++selectedWordJobIdRef.current;
+      if (!range) {
+        setSelectedWord(null);
+        return;
+      }
+
+      selectedWordDebounceRef.current = window.setTimeout(() => {
+        selectedWordDebounceRef.current = null;
+
+        const run = () => {
+          selectedWordIdleRef.current = null;
+          const view = editorViewRef.current;
+          if (
+            jobId !== selectedWordJobIdRef.current ||
+            !view ||
+            view.state.selection.from !== range.from ||
+            view.state.selection.to !== range.to
+          ) {
+            return;
+          }
+          setSelectedWord(extractSelectedWordForLookup(view, range));
+        };
+
+        const idleWindow = window as WindowWithIdleCallback;
+        if (idleWindow.requestIdleCallback) {
+          selectedWordIdleRef.current = idleWindow.requestIdleCallback(run, {
+            timeout: SELECTED_WORD_EXTRACT_IDLE_TIMEOUT_MS,
+          });
+        } else {
+          selectedWordIdleRef.current = window.setTimeout(run, 0);
+        }
+      }, SELECTED_WORD_EXTRACT_DEBOUNCE_MS);
+    },
+    [clearSelectedWordJob],
+  );
+
+  useEffect(() => {
+    return () => {
+      clearSelectedWordJob();
+      selectedWordJobIdRef.current += 1;
+    };
+  }, [clearSelectedWordJob]);
 
   // --- 検索ハイライトの単一ソース ---
   // いずれかの検索 UI が表示中か。両方非表示ならハイライトを消す（要求2）。
@@ -1740,23 +1835,11 @@ export default function EditorPage() {
             setSelectedCharCount(count);
             setSelectedManuscriptCells(cells);
             setSelectedManuscriptPages(pages);
-            // 選択語を幻辞ルックアップ用に保持する。
-            // 大きな選択（段落・全選択）では textBetween が O(n) で重く、語の辞書引きにも
-            // 不向きなので閾値を超えたら早期に null。実際の辞書引きの debounce は
-            // useGenjiWordInfo 側で行う（選択ドラッグ中の連続 IPC を抑制）。
-            if (count > 0 && count <= SELECTED_WORD_MAX_CHARS && editorViewRef.current) {
-              const { selection, doc } = editorViewRef.current.state;
-              const text = doc.textBetween(selection.from, selection.to, "").trim();
-              // 単語単位（空白区切り）の先頭語、または選択全体（日本語は空白なし）
-              const word = text.split(/\s+/)[0] ?? null;
-              setSelectedWord(word || null);
-            } else {
-              setSelectedWord(null);
-            }
           },
           onSelectionRangeChange: (range: SearchRange | null) => {
             setSearchSelectionRange(range);
             if (!range) setSelectionOnly(false);
+            scheduleSelectedWordExtraction(range);
           },
           searchOpenTrigger,
           searchInitialTerm,

--- a/lib/editor-page/use-selection-tracking.ts
+++ b/lib/editor-page/use-selection-tracking.ts
@@ -41,6 +41,16 @@ interface UseSelectionTrackingOptions {
   onSelectionRangeChange?: (range: SelectionSearchRange | null) => void;
 }
 
+type IdleCallbackHandle = number;
+type IdleCallbackDeadline = { didTimeout: boolean; timeRemaining: () => number };
+type WindowWithIdleCallback = Window & {
+  requestIdleCallback?: (
+    callback: (deadline: IdleCallbackDeadline) => void,
+    options?: { timeout?: number },
+  ) => IdleCallbackHandle;
+  cancelIdleCallback?: (handle: IdleCallbackHandle) => void;
+};
+
 const EMPTY_SELECTION_STATE: EditorSelectionState = {
   hasSelection: false,
   selectionCount: 0,
@@ -52,6 +62,9 @@ const EMPTY_SELECTION_STATE: EditorSelectionState = {
   rangeRect: null,
   pointerClientY: null,
 };
+
+const SELECTION_STATS_DEBOUNCE_MS = 120;
+const SELECTION_STATS_IDLE_TIMEOUT_MS = 800;
 
 function toViewportRect(rect: {
   top: number;
@@ -129,7 +142,18 @@ export function useSelectionTracking({
   // 原稿用紙マス数も保持する。可視文字数が同じでも禁則処理でマス数は変わり得るため、
   // 範囲を選び直したときに古い値が残らないよう、マス数の変化でも callback を発火させる。
   const lastReportedCellsRef = useRef(0);
+  const lastComputedStatsRef = useRef<{
+    doc: unknown;
+    from: number;
+    to: number;
+    selectionCount: number;
+    manuscriptCells: number;
+    manuscriptPages: number;
+  } | null>(null);
   const frameRef = useRef<number | null>(null);
+  const statsDebounceRef = useRef<number | null>(null);
+  const statsIdleRef = useRef<IdleCallbackHandle | null>(null);
+  const statsJobIdRef = useRef(0);
 
   useEffect(() => {
     selectionStateRef.current = selectionState;
@@ -154,11 +178,142 @@ export function useSelectionTracking({
     [],
   );
 
+  const clearScheduledStats = useCallback(() => {
+    if (statsDebounceRef.current !== null) {
+      window.clearTimeout(statsDebounceRef.current);
+      statsDebounceRef.current = null;
+    }
+    if (statsIdleRef.current !== null) {
+      const idleWindow = window as WindowWithIdleCallback;
+      if (idleWindow.cancelIdleCallback) {
+        idleWindow.cancelIdleCallback(statsIdleRef.current);
+      } else {
+        window.clearTimeout(statsIdleRef.current);
+      }
+      statsIdleRef.current = null;
+    }
+  }, []);
+
+  const publishSelectionStats = useCallback(
+    (
+      view: EditorView,
+      doc: unknown,
+      from: number,
+      to: number,
+      selectionCount: number,
+      manuscriptCells: number,
+      manuscriptPages: number,
+    ) => {
+      lastComputedStatsRef.current = {
+        doc,
+        from,
+        to,
+        selectionCount,
+        manuscriptCells,
+        manuscriptPages,
+      };
+
+      setSelectionState((prev) => {
+        if (prev.from !== from || prev.to !== to || !prev.hasSelection) return prev;
+        const next = {
+          ...prev,
+          selectionCount,
+          hasSelection: selectionCount > 0,
+        };
+        return sameSelectionState(prev, next) ? prev : next;
+      });
+
+      if (
+        view.state.doc === doc &&
+        view.state.selection.from === from &&
+        view.state.selection.to === to &&
+        (lastReportedCountRef.current !== selectionCount ||
+          lastReportedCellsRef.current !== manuscriptCells)
+      ) {
+        lastReportedCountRef.current = selectionCount;
+        lastReportedCellsRef.current = manuscriptCells;
+        onSelectionChangeRef.current?.(selectionCount, manuscriptCells, manuscriptPages);
+      }
+    },
+    [],
+  );
+
+  const scheduleSelectionStats = useCallback(
+    (view: EditorView, from: number, to: number) => {
+      const { doc } = view.state;
+      const cachedStats = lastComputedStatsRef.current;
+      if (
+        cachedStats &&
+        cachedStats.doc === doc &&
+        cachedStats.from === from &&
+        cachedStats.to === to
+      ) {
+        publishSelectionStats(
+          view,
+          doc,
+          from,
+          to,
+          cachedStats.selectionCount,
+          cachedStats.manuscriptCells,
+          cachedStats.manuscriptPages,
+        );
+        return;
+      }
+
+      clearScheduledStats();
+      const jobId = ++statsJobIdRef.current;
+      statsDebounceRef.current = window.setTimeout(() => {
+        statsDebounceRef.current = null;
+
+        const run = () => {
+          statsIdleRef.current = null;
+          if (
+            jobId !== statsJobIdRef.current ||
+            view.state.doc !== doc ||
+            view.state.selection.from !== from ||
+            view.state.selection.to !== to
+          ) {
+            return;
+          }
+
+          const selectedText = doc.textBetween(from, to);
+          // MDI 記法を含む可能性があるため extractVisibleText で記法を剥がしてからカウント
+          const visibleText = extractVisibleText(selectedText);
+          const selectionCount = countVisibleChars(visibleText);
+          const manuscriptCells = countManuscriptCells(visibleText);
+          const manuscriptPages = countManuscriptPages(manuscriptCells);
+          publishSelectionStats(
+            view,
+            doc,
+            from,
+            to,
+            selectionCount,
+            manuscriptCells,
+            manuscriptPages,
+          );
+        };
+
+        const idleWindow = window as WindowWithIdleCallback;
+        if (idleWindow.requestIdleCallback) {
+          statsIdleRef.current = idleWindow.requestIdleCallback(run, {
+            timeout: SELECTION_STATS_IDLE_TIMEOUT_MS,
+          });
+        } else {
+          statsIdleRef.current = window.setTimeout(run, 0);
+        }
+      }, SELECTION_STATS_DEBOUNCE_MS);
+    },
+    [clearScheduledStats, publishSelectionStats],
+  );
+
   const updateSelectionState = useCallback(() => {
     if (!editorViewInstance) {
+      clearScheduledStats();
+      statsJobIdRef.current += 1;
       if (lastReportedCountRef.current !== 0 || lastReportedCellsRef.current !== 0) {
         lastReportedCountRef.current = 0;
         lastReportedCellsRef.current = 0;
+        lastComputedStatsRef.current = null;
         onSelectionChangeRef.current?.(0, 0, 0);
       }
       setSelectionState((prev) =>
@@ -181,20 +336,20 @@ export function useSelectionTracking({
     };
 
     if (!selection.empty && belongsToEditor) {
-      const selectedText = state.doc.textBetween(selection.from, selection.to);
-      // MDI 記法を含む可能性があるため extractVisibleText で記法を剥がしてからカウント
-      const visibleText = extractVisibleText(selectedText);
-      const selectionCount = countVisibleChars(visibleText);
-      const selectionManuscriptCells = countManuscriptCells(visibleText);
-      const selectionManuscriptPages = countManuscriptPages(selectionManuscriptCells);
+      const cachedStats = lastComputedStatsRef.current;
+      const hasCachedStats =
+        cachedStats &&
+        cachedStats.doc === state.doc &&
+        cachedStats.from === selection.from &&
+        cachedStats.to === selection.to;
       const range =
         domSelection && domSelection.rangeCount > 0
           ? domSelection.getRangeAt(0).getBoundingClientRect()
           : null;
 
       nextState = {
-        hasSelection: selectionCount > 0,
-        selectionCount,
+        hasSelection: true,
+        selectionCount: hasCachedStats ? cachedStats.selectionCount : 0,
         isCollapsed: false,
         from: selection.from,
         to: selection.to,
@@ -206,26 +361,29 @@ export function useSelectionTracking({
       };
 
       if (
-        lastReportedCountRef.current !== selectionCount ||
-        lastReportedCellsRef.current !== selectionManuscriptCells
+        !hasCachedStats &&
+        (lastReportedCountRef.current !== 0 || lastReportedCellsRef.current !== 0)
       ) {
-        lastReportedCountRef.current = selectionCount;
-        lastReportedCellsRef.current = selectionManuscriptCells;
-        onSelectionChangeRef.current?.(
-          selectionCount,
-          selectionManuscriptCells,
-          selectionManuscriptPages,
-        );
+        lastReportedCountRef.current = 0;
+        lastReportedCellsRef.current = 0;
+        onSelectionChangeRef.current?.(0, 0, 0);
       }
+      scheduleSelectionStats(editorViewInstance, selection.from, selection.to);
     } else if (lastReportedCountRef.current !== 0 || lastReportedCellsRef.current !== 0) {
+      clearScheduledStats();
+      statsJobIdRef.current += 1;
       lastReportedCountRef.current = 0;
       lastReportedCellsRef.current = 0;
+      lastComputedStatsRef.current = null;
       onSelectionChangeRef.current?.(0, 0, 0);
+    } else {
+      clearScheduledStats();
+      statsJobIdRef.current += 1;
     }
 
     reportSelectionRange(selection);
     setSelectionState((prev) => (sameSelectionState(prev, nextState) ? prev : nextState));
-  }, [editorViewInstance, reportSelectionRange]);
+  }, [clearScheduledStats, editorViewInstance, reportSelectionRange, scheduleSelectionStats]);
 
   const scheduleUpdate = useCallback(
     (pointerClientY?: number | null) => {
@@ -305,8 +463,10 @@ export function useSelectionTracking({
         cancelAnimationFrame(frameRef.current);
         frameRef.current = null;
       }
+      clearScheduledStats();
+      statsJobIdRef.current += 1;
     };
-  }, [editorViewInstance, scheduleUpdate, scrollContainerRef]);
+  }, [clearScheduledStats, editorViewInstance, scheduleUpdate, scrollContainerRef]);
 
   return selectionState;
 }

--- a/lib/utils/genji-word-info.ts
+++ b/lib/utils/genji-word-info.ts
@@ -138,11 +138,25 @@ export type GenjiWordInfoState =
   | { status: "found"; viewModel: GenjiWordInfoViewModel }
   | { status: "not-found" }
   | { status: "unavailable" };
+type CompletedGenjiWordInfoState = Exclude<GenjiWordInfoState, { status: "idle" | "loading" }>;
 
 const IDLE: GenjiWordInfoState = { status: "idle" };
 const LOADING: GenjiWordInfoState = { status: "loading" };
-const NOT_FOUND: GenjiWordInfoState = { status: "not-found" };
-const UNAVAILABLE: GenjiWordInfoState = { status: "unavailable" };
+const NOT_FOUND: CompletedGenjiWordInfoState = { status: "not-found" };
+const UNAVAILABLE: CompletedGenjiWordInfoState = { status: "unavailable" };
+const LOOKUP_CACHE_LIMIT = 128;
+const lookupCache = new Map<string, CompletedGenjiWordInfoState>();
+
+function cacheLookupState(word: string, state: CompletedGenjiWordInfoState): void {
+  if (lookupCache.has(word)) {
+    lookupCache.delete(word);
+  }
+  lookupCache.set(word, state);
+  if (lookupCache.size > LOOKUP_CACHE_LIMIT) {
+    const oldestKey = lookupCache.keys().next().value;
+    if (oldestKey) lookupCache.delete(oldestKey);
+  }
+}
 
 /**
  * Async hook that looks up `selectedWord` in the Genji dictionary and returns
@@ -170,6 +184,12 @@ export function useGenjiWordInfo(selectedWord: string | null | undefined): Genji
       return;
     }
 
+    const cached = lookupCache.get(word);
+    if (cached) {
+      setState(cached);
+      return;
+    }
+
     let cancelled = false;
 
     // Defer the (potentially IPC-backed) lookup until the selection stops
@@ -187,18 +207,23 @@ export function useGenjiWordInfo(selectedWord: string | null | undefined): Genji
           if (cancelled) return;
 
           if (result.providerUnavailable) {
+            cacheLookupState(word, UNAVAILABLE);
             setState(UNAVAILABLE);
             return;
           }
 
           const viewModel = buildGenjiWordInfoViewModel(word, result);
           if (viewModel) {
-            setState({ status: "found", viewModel });
+            const nextState = { status: "found" as const, viewModel };
+            cacheLookupState(word, nextState);
+            setState(nextState);
           } else {
+            cacheLookupState(word, NOT_FOUND);
             setState(NOT_FOUND);
           }
         } catch {
           if (!cancelled) {
+            cacheLookupState(word, UNAVAILABLE);
             setState(UNAVAILABLE);
           }
         }


### PR DESCRIPTION
## Summary

- Move selection statistics work out of the synchronous selection event path.
- Defer selected-word extraction for the Genji word info panel with debounce, idle scheduling, and stale selection guards.
- Keep a small completed lookup cache for repeated Genji word-info results.

## Why

Selecting text could synchronously run text extraction and counting work on the renderer thread. On slower CPUs this could briefly freeze the editor during selection drag.

## Validation

- npm run type-check
- npm test -- lib/editor-page/__tests__/selection-search-range.test.ts lib/utils/__tests__/genji-word-info.test.ts
- git diff --check