### PR TITLE
Fix better-sqlite3 arch during electron bundling

### DIFF
--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -9,7 +9,7 @@ import * as esbuild from "esbuild";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import fs from "fs";
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -175,6 +175,53 @@ function resolvePackageDir(dep) {
   return null;
 }
 
+function getElectronVersion() {
+  const electronPkgPath = join(projectRoot, "node_modules", "electron", "package.json");
+  const electronPkg = JSON.parse(fs.readFileSync(electronPkgPath, "utf-8"));
+  return electronPkg.version;
+}
+
+function rebuildBetterSqliteForArch(arch) {
+  const electronVersion = getElectronVersion();
+  execSync(
+    `npx electron-rebuild --force --only better-sqlite3 --arch ${arch} --version ${electronVersion} --module-dir ${projectRoot}`,
+    { cwd: projectRoot, stdio: "inherit" },
+  );
+}
+
+function getMachOArchs(filePath) {
+  if (process.platform !== "darwin" || !fs.existsSync(filePath)) return [];
+
+  try {
+    return execFileSync("lipo", ["-archs", filePath], { encoding: "utf-8" })
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function expectedMachOArch(arch) {
+  return arch === "x64" ? "x86_64" : arch;
+}
+
+function ensureHostBetterSqliteArch(arch) {
+  if (arch !== process.arch || process.platform !== "darwin") return;
+
+  const bsqlDir = resolvePackageDir("better-sqlite3");
+  if (!bsqlDir) return;
+
+  const nativeAddonPath = join(bsqlDir, "build", "Release", "better_sqlite3.node");
+  const archs = getMachOArchs(nativeAddonPath);
+  const expectedArch = expectedMachOArch(arch);
+  if (archs.includes(expectedArch)) return;
+
+  const foundArchs = archs.length > 0 ? archs.join(", ") : "missing";
+  console.log(`  ⚙️  Rebuilding better-sqlite3 for ${arch}; native addon arch is ${foundArchs}`);
+  rebuildBetterSqliteForArch(arch);
+}
+
 // When cross-compiling for a different architecture, swap native binaries
 // so the packaged app contains the correct arch-specific modules.
 async function prepareNativeModulesForArch(arch) {
@@ -183,21 +230,17 @@ async function prepareNativeModulesForArch(arch) {
   // --- better-sqlite3: download correct prebuild for target arch ---
   const bsqlDir = resolvePackageDir("better-sqlite3");
   if (bsqlDir) {
-    const electronPkgPath = join(projectRoot, "node_modules", "electron", "package.json");
-    const electronPkg = JSON.parse(fs.readFileSync(electronPkgPath, "utf-8"));
+    const electronVersion = getElectronVersion();
     console.log(`  📥 Downloading better-sqlite3 prebuild for win32-${arch}...`);
     try {
       execSync(
-        `npx prebuild-install --arch ${arch} --platform win32 --runtime electron --target ${electronPkg.version}`,
+        `npx prebuild-install --arch ${arch} --platform win32 --runtime electron --target ${electronVersion}`,
         { cwd: bsqlDir, stdio: "inherit" },
       );
       console.log(`  ✅ better-sqlite3 prebuild ready for ${arch}`);
     } catch {
       console.log(`  ⚙️  No better-sqlite3 prebuild for ${arch}; rebuilding from source...`);
-      execSync(
-        `npx electron-rebuild --force --only better-sqlite3 --arch ${arch} --version ${electronPkg.version} --module-dir ${projectRoot} --build-from-source`,
-        { cwd: projectRoot, stdio: "inherit" },
-      );
+      rebuildBetterSqliteForArch(arch);
       console.log(`  ✅ better-sqlite3 rebuilt from source for ${arch}`);
     }
   }
@@ -216,6 +259,7 @@ async function prepareNativeModulesForArch(arch) {
 }
 
 await prepareNativeModulesForArch(targetArch);
+ensureHostBetterSqliteArch(targetArch);
 
 for (const dep of runtimeDeps) {
   const src = resolvePackageDir(dep);


### PR DESCRIPTION
## Summary

Fixes Electron dev/runtime failures caused by a stale better-sqlite3 native addon being copied into dist-main with the wrong macOS architecture.

## Root Cause

bundle-electron.mjs cleaned and recopied dist-main/node_modules, but when bundling for the host architecture it trusted the existing root node_modules/better-sqlite3 binary. If that dependency had been installed or rebuilt under x64/Rosetta, the staged addon stayed x86_64 on Apple Silicon and Electron failed to load storage IPC handlers.

## Changes

- Adds a macOS host-architecture check for better_sqlite3.node before staging runtime dependencies.
- Rebuilds better-sqlite3 for the current Electron version and target arch when the Mach-O arch is missing or stale.
- Reuses the Electron version lookup and rebuild command in the cross-arch fallback path.

## Validation

- npm run bundle:electron passed in the original checkout after rebuilding the addon.
- Verified dist-main/node_modules/better-sqlite3/build/Release/better_sqlite3.node is Mach-O 64-bit bundle arm64.
- Verified Electron can require the staged better-sqlite3 module and execute select 1.
- Prettier check passed for scripts/bundle-electron.mjs.