### PR TITLE
fix(error-reporting): preserve project-relative paths for source stack frames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
               - '!docs/**'
               - '!README.md'
               - '!TERMS.md'
+              - '!NOTICE'
               - '!MDI.md'
               - '!.github/workflows/sync-ms-store-listing.yml'
               # Keep build.yml included so workflow edits validate desktop builds

--- a/electron/__tests__/error-reporting.test.ts
+++ b/electron/__tests__/error-reporting.test.ts
@@ -111,12 +111,16 @@ describe("electron/error-reporting", () => {
       source: "error-boundary",
       sectionName: "エディタ",
       message: "failed to render /Users/test/Novel/第三章.mdi",
-      stack: "at render (C:\\Users\\test\\Novel\\第四章.mdi:10:1)",
+      stack: [
+        "at render (C:\\Users\\test\\Novel\\第四章.mdi:10:1)",
+        "at apply (/Users/test/Repos/illusions/components/editor/MilkdownEditor.tsx:224001:1)",
+      ].join("\n"),
     });
 
     const captured = captureExceptionMock.mock.calls[0]?.[0] as Error;
     expect(captured.message).toContain("[file].mdi");
     expect(captured.message).not.toContain("第三章.mdi");
     expect(captured.stack).toContain("[path]");
+    expect(captured.stack).toContain("components/editor/MilkdownEditor.tsx:224001:1");
   });
 });

--- a/lib/error-reporting/__tests__/scrub-error-event.test.ts
+++ b/lib/error-reporting/__tests__/scrub-error-event.test.ts
@@ -20,6 +20,23 @@ describe("sanitizeErrorText", () => {
     expect(sanitized).toContain("[file].mdi");
     expect(sanitized).toContain("[path]");
   });
+
+  it("keeps source file names and project-relative source paths in stack traces", () => {
+    const value = [
+      "TypeError: failed",
+      "at render (/Users/test/Repos/illusions/components/editor/MilkdownEditor.tsx:42:7)",
+      "at run (C:\\Users\\test\\Repos\\illusions\\electron\\error-reporting.js:12:3)",
+      "at plugin (/Users/test/.config/illusions/plugins/custom-rule.mjs:5:1)",
+    ].join("\n");
+
+    const sanitized = sanitizeErrorText(value);
+
+    expect(sanitized).not.toContain("/Users/test");
+    expect(sanitized).not.toContain("C:\\Users\\test");
+    expect(sanitized).toContain("components/editor/MilkdownEditor.tsx:42:7");
+    expect(sanitized).toContain("electron/error-reporting.js:12:3");
+    expect(sanitized).toContain("[path]/custom-rule.mjs:5:1");
+  });
 });
 
 describe("scrubSentryEvent", () => {
@@ -46,6 +63,10 @@ describe("scrubSentryEvent", () => {
                   filename: "/Users/test/Novel/第三章.mdi",
                   function: "openDocument",
                 },
+                {
+                  filename: "/Users/test/Repos/illusions/lib/error-reporting/scrub-error-event.ts",
+                  function: "sanitizeErrorText",
+                },
               ],
             },
           },
@@ -68,6 +89,9 @@ describe("scrubSentryEvent", () => {
     });
     expect(scrubbed?.exception.values[0].value).toContain("[file].mdi");
     expect(scrubbed?.exception.values[0].stacktrace.frames[0].filename).toBe("[path]/[file].mdi");
+    expect(scrubbed?.exception.values[0].stacktrace.frames[1].filename).toBe(
+      "lib/error-reporting/scrub-error-event.ts",
+    );
   });
 });
 
@@ -88,5 +112,25 @@ describe("scrubRendererErrorPayload", () => {
     expect(scrubbed.message).not.toContain("第三章.mdi");
     expect(scrubbed.stack).toContain("[path]");
     expect(scrubbed.stack).toContain("[file].mdi");
+  });
+
+  it("preserves renderer source filenames for actionable JS stack traces", () => {
+    const payload = {
+      source: "window-error" as const,
+      message: "TypeError: missing",
+      stack: [
+        "at o (C:\\Users\\test\\Repos\\illusions\\components\\editor\\MilkdownEditor.tsx:99065:2)",
+        "at f.get (/Users/test/Repos/illusions/lib/editor-page/use-editor-lifecycle.ts:101783:4)",
+        "at Object.apply (/private/var/folders/app.asar/out/chunks/webpack-runtime.js:224001:1)",
+      ].join("\n"),
+    };
+
+    const scrubbed = scrubRendererErrorPayload(payload);
+
+    expect(scrubbed.stack).not.toContain("C:\\Users\\test");
+    expect(scrubbed.stack).not.toContain("/Users/test");
+    expect(scrubbed.stack).toContain("components/editor/MilkdownEditor.tsx:99065:2");
+    expect(scrubbed.stack).toContain("lib/editor-page/use-editor-lifecycle.ts:101783:4");
+    expect(scrubbed.stack).toContain("[path]/webpack-runtime.js:224001:1");
   });
 });

--- a/lib/error-reporting/scrub-error-event.js
+++ b/lib/error-reporting/scrub-error-event.js
@@ -1,14 +1,42 @@
 const WINDOWS_PATH_RE = /[A-Za-z]:\\(?:[^\\\s:]+\\)*[^\\\s:]+/g;
-const POSIX_PATH_RE = /\/(?:[^/\s:]+\/)+[^/\s:]+/g;
+const POSIX_PATH_RE = /(?<![A-Za-z0-9_.\]-])\/(?:[^/\s:]+\/)+[^/\s:]+/g;
 const FILE_NAME_RE = /([^/\\\s:]+)\.(mdi|md|txt|docx|pdf|epub)\b/gi;
+const SOURCE_CODE_EXTENSIONS = new Set(["cjs", "cts", "js", "jsx", "mjs", "mts", "ts", "tsx"]);
+const PROJECT_PATH_ANCHORS = new Set([
+  "app",
+  "components",
+  "contexts",
+  "electron",
+  "lib",
+  "packages",
+  "platform",
+  "scripts",
+  "shared",
+  "types",
+]);
 
 function sanitizeMatchedPath(match, separator) {
   const leaf = match.split(separator).pop() || "";
   const fileMatch = leaf.match(/\.([A-Za-z0-9]+)$/);
   if (fileMatch) {
+    const extension = fileMatch[1].toLowerCase();
+    if (SOURCE_CODE_EXTENSIONS.has(extension)) {
+      return sourcePathLabel(match, separator, leaf);
+    }
     return `[path]${separator}[file].${fileMatch[1]}`;
   }
   return "[path]";
+}
+
+function sourcePathLabel(match, separator, leaf) {
+  const segments = match.split(separator).filter(Boolean);
+  const anchorIndex = segments.findIndex((segment) =>
+    PROJECT_PATH_ANCHORS.has(segment.toLowerCase()),
+  );
+  if (anchorIndex >= 0) {
+    return segments.slice(anchorIndex).join("/");
+  }
+  return `[path]${separator}${leaf}`;
 }
 
 function sanitizePathLike(value) {

--- a/lib/error-reporting/scrub-error-event.ts
+++ b/lib/error-reporting/scrub-error-event.ts
@@ -1,8 +1,21 @@
 import type { RendererErrorPayload } from "./error-reporting-types";
 
 const WINDOWS_PATH_RE = /[A-Za-z]:\\(?:[^\\\s:]+\\)*[^\\\s:]+/g;
-const POSIX_PATH_RE = /\/(?:[^/\s:]+\/)+[^/\s:]+/g;
+const POSIX_PATH_RE = /(?<![A-Za-z0-9_.\]-])\/(?:[^/\s:]+\/)+[^/\s:]+/g;
 const FILE_NAME_RE = /([^/\\\s:]+)\.(mdi|md|txt|docx|pdf|epub)\b/gi;
+const SOURCE_CODE_EXTENSIONS = new Set(["cjs", "cts", "js", "jsx", "mjs", "mts", "ts", "tsx"]);
+const PROJECT_PATH_ANCHORS = new Set([
+  "app",
+  "components",
+  "contexts",
+  "electron",
+  "lib",
+  "packages",
+  "platform",
+  "scripts",
+  "shared",
+  "types",
+]);
 
 function sanitizePathLike(value: string): string {
   return value
@@ -14,9 +27,24 @@ function sanitizeMatchedPath(match: string, separator: "/" | "\\"): string {
   const leaf = match.split(separator).pop() ?? "";
   const fileMatch = leaf.match(/\.([A-Za-z0-9]+)$/);
   if (fileMatch) {
+    const extension = fileMatch[1].toLowerCase();
+    if (SOURCE_CODE_EXTENSIONS.has(extension)) {
+      return sourcePathLabel(match, separator, leaf);
+    }
     return `[path]${separator}[file].${fileMatch[1]}`;
   }
   return "[path]";
+}
+
+function sourcePathLabel(match: string, separator: "/" | "\\", leaf: string): string {
+  const segments = match.split(separator).filter(Boolean);
+  const anchorIndex = segments.findIndex((segment) =>
+    PROJECT_PATH_ANCHORS.has(segment.toLowerCase()),
+  );
+  if (anchorIndex >= 0) {
+    return segments.slice(anchorIndex).join("/");
+  }
+  return `[path]${separator}${leaf}`;
 }
 
 function sanitizeFileNames(value: string): string {


### PR DESCRIPTION
## Summary

- Stack trace scrubbing was redacting every path uniformly, turning useful source frames like `components/editor/MilkdownEditor.tsx:224001:1` into an opaque `[path]`, which made captured errors hard to debug.
- Source-code file extensions (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.mts`, `.cts`) now keep their path starting from the nearest recognized project anchor (`app/`, `lib/`, `electron/`, etc.) instead of being fully redacted.
- User document paths (`.mdi`, `.md`, `.txt`, etc.) are still fully scrubbed to `[path]/[file].ext` as before.
- Also includes a small CI fix: skip desktop release builds for NOTICE-only changes.

## Changes

| Area | Change |
|---|---|
| `lib/error-reporting/scrub-error-event.ts` / `.js` | Add source-path-aware scrubbing (mirrored TS/JS implementations) |
| `electron/__tests__/error-reporting.test.ts` | Cover multi-frame stacks retaining source paths |
| `lib/error-reporting/__tests__/scrub-error-event.test.ts` | Unit tests for the new source path behavior |
| `.github/workflows/build.yml` | Exclude `NOTICE` from desktop build trigger paths |

## Test plan

- [x] `npx vitest run lib/error-reporting electron/__tests__/error-reporting.test.ts` — 12/12 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)