### PR TITLE
feat(analytics): split autosave_completed from save_completed

### DIFF
--- a/lib/analytics/usage-event-contract.json
+++ b/lib/analytics/usage-event-contract.json
@@ -124,6 +124,10 @@
       "target_kind": ["file", "untitled", "handle", "unknown"],
       "activity": ["foreground", "background", "unknown"]
     },
+    "autosave_completed": {
+      "target_kind": ["file", "untitled", "handle", "unknown"],
+      "activity": ["foreground", "background", "unknown"]
+    },
     "autosave_failed": {
       "target_kind": ["file", "untitled", "handle", "unknown"],
       "reason": [

--- a/lib/analytics/usage-events.ts
+++ b/lib/analytics/usage-events.ts
@@ -21,6 +21,7 @@ export type UsageEventName =
   | "save_blocked"
   | "save_all_completed"
   | "autosave_attempted"
+  | "autosave_completed"
   | "autosave_failed"
   | "save_conflict_blocked"
   | "project_create_started"

--- a/lib/tab-manager/use-auto-save.ts
+++ b/lib/tab-manager/use-auto-save.ts
@@ -123,10 +123,11 @@ export function useAutoSave(params: UseAutoSaveParams): void {
         // #1579) and re-checks the conflicted transition right before
         // writing (#1562 b).
         const activity = getWindowActivitySnapshot();
+        const activityLabel =
+          activity.isWindowFocused && activity.isDocumentVisible ? "foreground" : "background";
         trackUsageEvent("autosave_attempted", {
           target_kind: getTelemetryTargetKind(tab.file),
-          activity:
-            activity.isWindowFocused && activity.isDocumentVisible ? "foreground" : "background",
+          activity: activityLabel,
         });
         void (async () => {
           const outcome = await executeTabSave({
@@ -140,7 +141,12 @@ export function useAutoSave(params: UseAutoSaveParams): void {
             isAutoSave: true,
             isMounted: () => mountedRef.current,
           });
-          if (outcome.status === "failed") {
+          if (outcome.status === "saved") {
+            trackUsageEvent("autosave_completed", {
+              target_kind: getTelemetryTargetKind(tab.file),
+              activity: activityLabel,
+            });
+          } else if (outcome.status === "failed") {
             trackUsageEvent("autosave_failed", {
               target_kind: getTelemetryTargetKind(tab.file),
               reason: classifySaveOutcome(outcome),

--- a/lib/tab-manager/use-file-io.ts
+++ b/lib/tab-manager/use-file-io.ts
@@ -385,17 +385,25 @@ export function useFileIO(params: UseFileIOParams): UseFileIOReturn {
         });
 
         if (outcome.status === "saved" && outcome.persistFailed) {
-          trackUsageEvent("save_completed", {
-            trigger: isAutoSave ? "auto" : "manual",
-            mode: isProjectRef.current ? "project" : "standalone",
-            target_kind: getTelemetryTargetKind(outcome.descriptor),
+          trackUsageEvent(isAutoSave ? "autosave_completed" : "save_completed", {
+            ...(isAutoSave
+              ? { target_kind: getTelemetryTargetKind(outcome.descriptor), activity: "unknown" }
+              : {
+                  trigger: "manual",
+                  mode: isProjectRef.current ? "project" : "standalone",
+                  target_kind: getTelemetryTargetKind(outcome.descriptor),
+                }),
           });
           notificationManager.warning(PERSIST_FAILURE_WARNING);
         } else if (outcome.status === "saved") {
-          trackUsageEvent("save_completed", {
-            trigger: isAutoSave ? "auto" : "manual",
-            mode: isProjectRef.current ? "project" : "standalone",
-            target_kind: getTelemetryTargetKind(outcome.descriptor),
+          trackUsageEvent(isAutoSave ? "autosave_completed" : "save_completed", {
+            ...(isAutoSave
+              ? { target_kind: getTelemetryTargetKind(outcome.descriptor), activity: "unknown" }
+              : {
+                  trigger: "manual",
+                  mode: isProjectRef.current ? "project" : "standalone",
+                  target_kind: getTelemetryTargetKind(outcome.descriptor),
+                }),
           });
         } else if (outcome.status === "conflicted") {
           trackUsageEvent("save_conflict_blocked", {


### PR DESCRIPTION
## Summary

- `save_completed` fired for both manual saves and auto-saves, distinguished only by an internal `trigger: "manual" | "auto"` prop — unlike `save_attempted`/`autosave_attempted` and `save_failed`/`autosave_failed`, which already had separate event names for the two paths. This inconsistency made it hard to isolate auto-save success rate in analytics.
- Background-tab auto-saves (the non-active-tab path in `use-auto-save.ts`) had **no success event at all** — only failures were tracked.
- `save_completed` now only fires for manual saves; all auto-save successes (active-tab and background-tab) fire the new `autosave_completed` event, matching the existing `attempted`/`failed` split.

## Changes

| File | Change |
|---|---|
| `lib/analytics/usage-events.ts` | Add `"autosave_completed"` to `UsageEventName` |
| `lib/analytics/usage-event-contract.json` | Whitelist `autosave_completed` with `{ target_kind, activity }` props (required — the main-process IPC handler silently drops any event/prop not in this contract) |
| `lib/tab-manager/use-file-io.ts` | Active-tab save success now branches on `isAutoSave` to emit `autosave_completed` vs `save_completed`, mirroring the existing attempted/failed split |
| `lib/tab-manager/use-auto-save.ts` | Background-tab auto-save success now emits `autosave_completed` (previously untracked) |

## Test plan

- [x] `npx tsc --noEmit` — no errors
- [x] `npx vitest run lib/tab-manager lib/analytics electron/ipc/__tests__/analytics-ipc.test.ts` — 365/365 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)