### PR TITLE
feat: support self-hosted Aptabase via APTABASE_HOST

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,6 +262,7 @@ jobs:
       CSC_LINK: ${{ secrets.CSC_LINK }}
       CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
       APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
+      APTABASE_HOST: ${{ secrets.APTABASE_HOST }}
       ERROR_REPORT_DSN: ${{ secrets.ERROR_REPORT_DSN }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
@@ -361,6 +362,7 @@ jobs:
       ASC_API_KEY: ${{ secrets.ASC_API_KEY }}
       ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
       APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
+      APTABASE_HOST: ${{ secrets.APTABASE_HOST }}
       ERROR_REPORT_DSN: ${{ secrets.ERROR_REPORT_DSN }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
@@ -472,6 +474,7 @@ jobs:
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'windows-latest' }}
     env:
       APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
+      APTABASE_HOST: ${{ secrets.APTABASE_HOST }}
       ERROR_REPORT_DSN: ${{ secrets.ERROR_REPORT_DSN }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
@@ -570,6 +573,7 @@ jobs:
         arch: [x64, arm64]
     env:
       APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
+      APTABASE_HOST: ${{ secrets.APTABASE_HOST }}
       ERROR_REPORT_DSN: ${{ secrets.ERROR_REPORT_DSN }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
@@ -696,6 +700,7 @@ jobs:
       version: ${{ needs.compute-version.outputs.full }}
     env:
       APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
+      APTABASE_HOST: ${{ secrets.APTABASE_HOST }}
       ERROR_REPORT_DSN: ${{ secrets.ERROR_REPORT_DSN }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
@@ -840,6 +845,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
+      APTABASE_HOST: ${{ secrets.APTABASE_HOST }}
       ERROR_REPORT_DSN: ${{ secrets.ERROR_REPORT_DSN }}
       ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
               - '!docs/**'
               - '!README.md'
               - '!TERMS.md'
+              - '!NOTICE'
               - '!MDI.md'
               - '!.github/workflows/sync-ms-store-listing.yml'
               # Keep build.yml included so workflow edits validate desktop builds

--- a/electron/main.js
+++ b/electron/main.js
@@ -58,9 +58,10 @@ const { DICT_CHANNELS, POWER_CHANNELS, RULESETS_CHANNELS } = require("./lib/ipc-
 // privileged scheme として登録するため）。App Key はビルド時に esbuild の define で
 // 埋め込まれる（scripts/bundle-electron.mjs）。未設定（OSSビルド等）の場合は計測を無効化する。
 const APTABASE_APP_KEY = process.env.APTABASE_APP_KEY || "";
+const APTABASE_HOST = process.env.APTABASE_HOST || "";
 if (APTABASE_APP_KEY) {
   const { initialize: initializeAnalytics } = require("@aptabase/electron/main");
-  initializeAnalytics(APTABASE_APP_KEY);
+  initializeAnalytics(APTABASE_APP_KEY, APTABASE_HOST ? { host: APTABASE_HOST } : undefined);
 }
 
 const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000;

--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -47,6 +47,7 @@ await esbuild.build({
   ],
   define: {
     "process.env.APTABASE_APP_KEY": JSON.stringify(process.env.APTABASE_APP_KEY || ""),
+    "process.env.APTABASE_HOST": JSON.stringify(process.env.APTABASE_HOST || ""),
     "process.env.ERROR_REPORT_DSN": JSON.stringify(process.env.ERROR_REPORT_DSN || ""),
   },
   format: "cjs",


### PR DESCRIPTION
## Summary

- Aptabase moved from the SaaS to a self-hosted instance (`https://stats.api.illusions.app`), whose App Key uses the `SH` (self-hosted) region and requires an explicit host to be passed to the SDK, otherwise tracking silently disables itself.
- CI/CD desktop build skip for NOTICE-only changes (pre-existing local commit, bundled here since it was already ahead of `origin/dev`).

## Changes

| Area | Change |
|---|---|
| `electron/main.js` | Reads `APTABASE_HOST` and passes `{ host }` to `@aptabase/electron`'s `initialize()` when set |
| `scripts/bundle-electron.mjs` | Embeds `APTABASE_HOST` at build time via esbuild `define`, same as `APTABASE_APP_KEY` |
| `.github/workflows/build.yml` | Wires `secrets.APTABASE_HOST` into all 6 build jobs alongside `APTABASE_APP_KEY` |

GitHub secrets `APTABASE_APP_KEY` (now `A-SH-3152444032`) and `APTABASE_HOST` (`https://stats.api.illusions.app`) have already been updated on the repo.

## Test plan

- [ ] Desktop build picks up the new secrets and initializes Aptabase against the self-hosted host without warnings
- [ ] Verify events show up in the self-hosted Aptabase dashboard after using the app
- [ ] Confirm `stats.api.illusions.app/healthz` stays healthy under real app traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)