### PR TITLE
fix(ci): pass --publish never to MAS electron-builder invocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bundle:electron": "node scripts/bundle-electron.mjs",
     "electron:dev": "node scripts/ensure-credits-stub.mjs && npm run bundle:electron && concurrently \"next dev -p 3020\" \"wait-on http://localhost:3020 && cross-env ELECTRON_DEV=1 electron .\"",
     "electron:build": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 next build && npm run bundle:electron && electron-builder",
-    "electron:build:mas": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 MAS_BUILD=1 next build && npm run bundle:electron && cross-env MAS_BUILD=1 electron-builder --mac mas",
+    "electron:build:mas": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 MAS_BUILD=1 next build && npm run bundle:electron && cross-env MAS_BUILD=1 electron-builder --mac mas --publish never",
     "build:quicklook": "node -e \"if(process.platform==='darwin'){const {execSync}=require('child_process');execSync('bash scripts/build-quicklook.sh',{stdio:'inherit'});}else{console.log('build:quicklook skipped (macOS only)');}\" ",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- `build-mas` was the only platform build job not passing `--publish never` to electron-builder, unlike `build-macos`/Windows/Linux which all do (`.github/workflows/build.yml:335,672,796,918`).
- On GitHub Actions, electron-builder auto-detects CI and attempted to publish to GitHub Releases after signing, failing with `GitHub Personal Access Token is not set` even though the signed `.pkg` had already built successfully (see run 29149949015).

## Fix
Add `--publish never` to the `electron:build:mas` npm script, matching the existing pattern for every other build target.

## Test plan
- [x] Verified via `workflow_dispatch` run on `fix/mas-build-publish-never` (beta-based branch with the same fix) that the MAS build no longer fails at the publish step
- Refs #2038 / #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)