### PR TITLE
fix(mas): exclude node-pty binaries from the MAS bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bundle:electron": "node scripts/bundle-electron.mjs",
     "electron:dev": "node scripts/ensure-credits-stub.mjs && npm run bundle:electron && concurrently \"next dev -p 3020\" \"wait-on http://localhost:3020 && cross-env ELECTRON_DEV=1 electron .\"",
     "electron:build": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 next build && npm run bundle:electron && electron-builder",
-    "electron:build:mas": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 MAS_BUILD=1 next build && npm run bundle:electron && cross-env MAS_BUILD=1 electron-builder --mac mas --publish never",
+    "electron:build:mas": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 MAS_BUILD=1 next build && cross-env MAS_BUILD=1 npm run bundle:electron && cross-env MAS_BUILD=1 electron-builder --mac mas --publish never",
     "build:quicklook": "node -e \"if(process.platform==='darwin'){const {execSync}=require('child_process');execSync('bash scripts/build-quicklook.sh',{stdio:'inherit'});}else{console.log('build:quicklook skipped (macOS only)');}\" ",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -126,7 +126,14 @@ function collectDepsRecursive(pkgName, collected) {
 
 // Root external modules that cannot be bundled by esbuild
 // kuromoji: dictionary loading at runtime; better-sqlite3: native addon
-const externalRoots = ["kuromoji", "better-sqlite3", "node-pty"];
+// node-pty: terminal support, but the MAS build gates it out entirely at
+// runtime (electron/ipc/pty-ipc.js), so it's excluded from the MAS bundle
+// too — App Store review treats bundled shell-spawn binaries as a rejection
+// risk even when the code path is dead (docs/release/mac-app-store.md).
+const isMasBuild = process.env.MAS_BUILD === "1";
+const externalRoots = isMasBuild
+  ? ["kuromoji", "better-sqlite3"]
+  : ["kuromoji", "better-sqlite3", "node-pty"];
 
 // Collect all transitive production dependencies
 const allDeps = new Set();


### PR DESCRIPTION
## Summary
- `pty-ipc.js` already gates node-pty behind `isMasBuild` at runtime, but `bundle-electron.mjs` copied the compiled native module (including cross-platform prebuilds) into every build regardless of target. The MAS-signed `.pkg` shipped an unused but present shell-spawn binary — exactly the review risk `docs/release/mac-app-store.md` calls out as highest priority to eliminate entirely, not just gate at runtime.
- Also fixes `electron:build:mas` — `MAS_BUILD=1` was scoped only to the `next build` command via `cross-env`, so `bundle-electron.mjs` never actually received it and this bug was silently inert.

## Verification
- Confirmed on the uploaded MAS pkg from PR #2098's verification run (before this fix): `node-pty` and its prebuilds were present under `Contents/Resources/app.asar.unpacked/dist-main/node_modules/node-pty/`
- Locally: `MAS_BUILD=1 node scripts/bundle-electron.mjs` → no `node-pty` in `dist-main/node_modules/`; plain `node scripts/bundle-electron.mjs` → `node-pty` still present (direct-distribution build unaffected)
- Re-running `workflow_dispatch` on this branch to confirm end-to-end in the actual signed MAS package

Refs #2038 / #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)