### PR TITLE
feat(settings): add direct account deletion link

### DIFF
--- a/components/settings/AccountSettingsTab.tsx
+++ b/components/settings/AccountSettingsTab.tsx
@@ -108,6 +108,14 @@ export default function AccountSettingsTab() {
           ログアウト
         </button>
       </div>
+
+      <button
+        type="button"
+        onClick={() => openExternal("https://my.illusions.app/delete-account")}
+        className="text-xs text-foreground-tertiary underline-offset-2 hover:text-foreground-secondary hover:underline"
+      >
+        アカウントを削除
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- App Store Review Guideline 5.1.1(v) requires apps with account creation to also make account deletion reachable from within the app, not just a link to the general account-management site.
- my.illusions.app now hosts a direct deletion page at `/delete-account`. Adds a small text link to it in `AccountSettingsTab.tsx`, next to the existing "アカウントを管理" / "ログアウト" buttons.

Refs #2038 (was tracked as #2080, closed as out-of-scope before the direct URL existed on the my.illusions.app side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)