### PR TITLE
chore(mas): bump version to 1.3.1 for MAS re-upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "illusions",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## Summary
- App Store Connect rejects re-uploading the same `CFBundleVersion` — `1.3.0` was already consumed by an earlier verification upload (Delivery UUID `4e32c6d9-e529-4f44-a7dd-5bf7885ce272`), which didn't yet include the node-pty exclusion fix (#2101) or the account-deletion link (#2106).
- `build-mas` is the only build job that doesn't override `package.json`'s version at build time — direct-distribution channels (dev/beta/main) do via `npm version ${{ needs.compute-version.outputs.full }}`, and `compute-version` only reads `MAJOR.MINOR` from `package.json`, deriving the patch number independently from git tags. So this bump has no effect on those channels' versioning.

Refs #2038 / #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)