### PR TITLE
fix(ci): wire build-mas into compute-version's auto-incrementing version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,10 +345,13 @@ jobs:
 
   build-mas:
     name: Build (Mac App Store)
+    needs: compute-version
     # 初期移行中は手動入力が明示されたときだけ実行し、タグpushでは走らせない。
     if: |
+      always() &&
       github.event_name == 'workflow_dispatch' &&
-      inputs.run_mas_build == true
+      inputs.run_mas_build == true &&
+      needs.compute-version.result == 'success'
     runs-on: macos-latest
     environment: Apple
     env:
@@ -427,6 +430,14 @@ jobs:
           mkdir -p "$HOME/.appstoreconnect/private_keys"
           printf '%s' "$ASC_API_KEY" | base64 --decode > "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
           chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+
+      - name: Apply computed version
+        # CFBundleVersion must be plain dot-separated integers, so this uses
+        # the clean `base` output (no beta.<timestamp> suffix) — same
+        # ephemeral, uncommitted bump every other channel does via
+        # compute-version, so each MAS upload gets a fresh version
+        # automatically instead of colliding with the previous one.
+        run: npm version ${{ needs.compute-version.outputs.base }} --no-git-tag-version --allow-same-version
 
       - name: Download local fonts
         run: npm run download:fonts


### PR DESCRIPTION
## Summary
- `build-mas` was the only build job that didn't apply the CI-computed version before packaging. Every other channel overwrites `package.json`'s version ephemerally via `npm version <computed> --no-git-tag-version` right before building; `build-mas` shipped whatever was hardcoded in the committed `package.json` instead.
- This meant every MAS upload got the same `CFBundleVersion`, and App Store Connect rejected re-uploads as duplicates (hit this directly last night).
- Fix: add `needs: compute-version` and apply `needs.compute-version.outputs.base` the same way `build-macos`/Windows/Linux already do. Uses `base` (plain `X.Y.Z`) rather than `full`, since beta builds' `-beta.<timestamp>` suffix isn't a legal `CFBundleVersion`.

This replaces an earlier attempt (closed PR #2107) that manually bumped the committed `package.json` version — wrong approach, since version numbers here are entirely CI-computed from git tags and never hand-edited.

Refs #2038 / #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)