### PR TITLE
feat(mas): auto-enable uploaded builds for internal TestFlight testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -471,6 +471,12 @@ jobs:
             --apiKey "$ASC_KEY_ID" \
             --apiIssuer "$ASC_ISSUER_ID"
 
+      - name: Enable build for internal TestFlight testers
+        # Apple takes a few minutes to finish processing an uploaded build
+        # before it's visible via the API, hence the polling/retry loop
+        # inside this script.
+        run: node scripts/asc-testflight-enable.mjs ${{ needs.compute-version.outputs.base }}
+
   # ---------------------------------------------------------------------------
   # Windows — shared build step, then separate NSIS / MSIX packaging
   # ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "extendInfo": {
+        "ITSAppUsesNonExemptEncryption": false,
         "UTExportedTypeDeclarations": [
           {
             "UTTypeIdentifier": "app.illusions.mdi",

--- a/scripts/asc-testflight-enable.mjs
+++ b/scripts/asc-testflight-enable.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Makes an already-uploaded build available to internal TestFlight testers.
+ *
+ * Requires env: ASC_KEY_ID, ASC_ISSUER_ID, ASC_API_KEY (base64 .p8), ASC_APP_ID.
+ * Usage: node scripts/asc-testflight-enable.mjs <version>  (e.g. 1.3.3)
+ */
+import crypto from "crypto";
+
+const { ASC_KEY_ID, ASC_ISSUER_ID, ASC_API_KEY, ASC_APP_ID } = process.env;
+const version = process.argv[2];
+
+if (!ASC_KEY_ID || !ASC_ISSUER_ID || !ASC_API_KEY || !ASC_APP_ID) {
+  console.error("Missing ASC_KEY_ID / ASC_ISSUER_ID / ASC_API_KEY / ASC_APP_ID");
+  process.exit(1);
+}
+if (!version) {
+  console.error("Usage: node scripts/asc-testflight-enable.mjs <version>");
+  process.exit(1);
+}
+
+function base64url(input) {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function makeJwt() {
+  const privateKeyPem = Buffer.from(ASC_API_KEY, "base64").toString("utf8");
+  const header = { alg: "ES256", kid: ASC_KEY_ID, typ: "JWT" };
+  const now = Math.floor(Date.now() / 1000);
+  const payload = { iss: ASC_ISSUER_ID, iat: now, exp: now + 1200, aud: "appstoreconnect-v1" };
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+  const signature = crypto
+    .createSign("SHA256")
+    .update(signingInput)
+    .sign({ key: privateKeyPem, dsaEncoding: "ieee-p1363" });
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+const BASE = "https://api.appstoreconnect.apple.com/v1";
+
+async function asc(path, options = {}) {
+  const jwt = makeJwt();
+  const res = await fetch(`${BASE}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+  });
+  const text = await res.text();
+  const body = text ? JSON.parse(text) : null;
+  if (!res.ok) {
+    console.error(`ASC API ${options.method || "GET"} ${path} -> ${res.status}`);
+    console.error(JSON.stringify(body, null, 2));
+    throw new Error(`ASC API request failed: ${res.status}`);
+  }
+  return body;
+}
+
+async function findBuild(version, { retries = 20, delayMs = 30000 } = {}) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    const res = await asc(
+      `/builds?filter[app]=${ASC_APP_ID}&filter[version]=${encodeURIComponent(version)}&sort=-uploadedDate&limit=5`,
+    );
+    const build = res.data?.[0];
+    if (build) {
+      console.log(`Found build ${build.id} (state: ${build.attributes.processingState})`);
+      if (build.attributes.processingState === "VALID") {
+        return build;
+      }
+      console.log(`  still processing (${build.attributes.processingState}), waiting...`);
+    } else {
+      console.log(`Build ${version} not visible yet, waiting... (attempt ${attempt}/${retries})`);
+    }
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  throw new Error(`Build ${version} did not become VALID within timeout`);
+}
+
+async function ensureExportCompliance(buildId) {
+  await asc(`/builds/${buildId}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      data: { type: "builds", id: buildId, attributes: { usesNonExemptEncryption: false } },
+    }),
+  });
+  console.log("Export compliance confirmed (exempt encryption only).");
+}
+
+async function findOrGetInternalGroup() {
+  const res = await asc(`/apps/${ASC_APP_ID}/betaGroups?filter[isInternalGroup]=true`);
+  const group = res.data?.[0];
+  if (!group) {
+    throw new Error(
+      "No internal beta group found for this app. Create one in App Store Connect → TestFlight → Internal Testing first (this is a one-time manual step Apple requires).",
+    );
+  }
+  console.log(`Internal group: ${group.attributes.name} (${group.id})`);
+  return group;
+}
+
+async function addBuildToGroup(groupId, buildId) {
+  await asc(`/betaGroups/${groupId}/relationships/builds`, {
+    method: "POST",
+    body: JSON.stringify({ data: [{ type: "builds", id: buildId }] }),
+  });
+  console.log("Build added to internal TestFlight group.");
+}
+
+const build = await findBuild(version);
+await ensureExportCompliance(build.id);
+const group = await findOrGetInternalGroup();
+await addBuildToGroup(group.id, build.id);
+console.log(`\n✅ Build ${version} is now available via TestFlight to internal testers.`);


### PR DESCRIPTION
## Summary
- Declares `ITSAppUsesNonExemptEncryption: false` in the MAS Info.plist (illusions only uses standard TLS/HTTPS, no custom crypto) — this was blocking TestFlight availability since App Store Connect asks for export compliance confirmation on every build otherwise.
- Adds `scripts/asc-testflight-enable.mjs`: uses the existing App Store Connect API credentials to poll for a newly-uploaded build, confirm export compliance via the API too, and add it to the app's internal TestFlight group.
- Wired in as a new step in `build-mas`, right after the existing `altool` upload.

## Why
Sideloading the raw `.pkg` to test locally requires `sudo installer`, which installs to the same `/Applications/illusions.app` path as the Developer-ID-signed direct-distribution build — overwriting it. TestFlight avoids that entirely.

## Scope note
Trigger is **unchanged** — still `workflow_dispatch` only. This PR does not make `build-mas` run automatically on every `beta` push; that's a separate, more consequential decision (recurring CI cost, consumes a version number every time, auto-publishes to real testers) that should be confirmed explicitly before enabling.

Refs #2038 / #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)