### PR TITLE
feat(ci): auto-run MAS build + TestFlight on every beta push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,13 +345,16 @@ jobs:
 
   build-mas:
     name: Build (Mac App Store)
-    needs: compute-version
-    # 初期移行中は手動入力が明示されたときだけ実行し、タグpushでは走らせない。
+    needs: [detect-changes, compute-version]
+    # beta への push で自動実行し、内部TestFlightへ配信する。workflow_dispatch でも手動起動可能。
+    # タグpush（main向け安定版）ではまだ走らせない。
     if: |
       always() &&
-      github.event_name == 'workflow_dispatch' &&
-      inputs.run_mas_build == true &&
-      needs.compute-version.result == 'success'
+      needs.compute-version.result == 'success' &&
+      (
+        (github.event_name == 'workflow_dispatch' && inputs.run_mas_build == true) ||
+        (github.event_name == 'push' && github.ref == 'refs/heads/beta' && needs.detect-changes.outputs.desktop_changed == 'true')
+      )
     runs-on: macos-latest
     environment: Apple
     env:


### PR DESCRIPTION
## Summary
User confirmed explicitly: `build-mas` should now run automatically on every push to `beta`, not just via manual `workflow_dispatch`. Each run builds, signs, uploads to App Store Connect, and enables the build for internal TestFlight testing (via #2109's `asc-testflight-enable.mjs`).

## Cost tradeoff (confirmed accepted)
- Consumes a version number from the shared `v1.3.*` sequence on every beta push (same sequence dev/beta/main all draw from)
- Runs an additional macOS CI job (slower/costlier runner) on every beta push, with no per-push manual gate
- `workflow_dispatch` with `run_mas_build=true` still works for manual/ad-hoc runs

Tag-push (main / stable) is intentionally still excluded for now.

Refs #2038 / #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)