### PR TITLE
fix(mas): decouple CFBundleVersion from compute-version's git-tag-based patch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -449,9 +449,18 @@ jobs:
         run: npm run build:quicklook
 
       - name: Build MAS package
+        # CFBundleVersion (the App Store Connect "build number") must be
+        # unique on every upload, but compute-version's clean `base` output
+        # (used above for CFBundleShortVersionString) only advances when a
+        # stable git tag is cut — which doesn't happen on every beta push or
+        # manual re-run, causing duplicate-version upload rejections. Set
+        # CFBundleVersion independently to the numeric, always-unique
+        # run_id+run_attempt so every build gets a fresh one regardless of
+        # tag state.
         run: MAS_BUILD=1 npm run electron:build:mas
         env:
           DEBUG: electron-builder
+          MAS_EXTRA_BUILDER_ARGS: --config.mas.bundleVersion=${{ github.run_id }}${{ github.run_attempt }}
 
       - name: Upload MAS package artifact
         uses: actions/upload-artifact@v7

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bundle:electron": "node scripts/bundle-electron.mjs",
     "electron:dev": "node scripts/ensure-credits-stub.mjs && npm run bundle:electron && concurrently \"next dev -p 3020\" \"wait-on http://localhost:3020 && cross-env ELECTRON_DEV=1 electron .\"",
     "electron:build": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 next build && npm run bundle:electron && electron-builder",
-    "electron:build:mas": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 MAS_BUILD=1 next build && cross-env MAS_BUILD=1 npm run bundle:electron && cross-env MAS_BUILD=1 electron-builder --mac mas --publish never",
+    "electron:build:mas": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 MAS_BUILD=1 next build && cross-env MAS_BUILD=1 npm run bundle:electron && cross-env MAS_BUILD=1 electron-builder --mac mas --publish never $MAS_EXTRA_BUILDER_ARGS",
     "build:quicklook": "node -e \"if(process.platform==='darwin'){const {execSync}=require('child_process');execSync('bash scripts/build-quicklook.sh',{stdio:'inherit'});}else{console.log('build:quicklook skipped (macOS only)');}\" ",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
PR #2108 wired `build-mas` into `compute-version`'s `base` output for `CFBundleVersion`. That output only advances when a **stable** git tag is cut (only during main promotion) — it's frozen across every beta push and manual re-run in between (confirmed: the same "1.3.3" caused a second `ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE` rejection tonight, right after #2108 was supposed to fix this exact problem).

## Fix
`CFBundleVersion` and `CFBundleShortVersionString` are independent Info.plist fields — electron-builder exposes the former via `mas.bundleVersion`. Set it via `--config.mas.bundleVersion=<run_id><run_attempt>` (always unique, purely numeric — satisfies Apple's format requirement) while `CFBundleShortVersionString` keeps using the semantic `compute-version` base, same as every other channel.

Refs #2038 / #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)