### PR TITLE
ci: generate credits.json before the new cross-platform test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -993,6 +993,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Generate credits
+        run: npm run generate:credits
+
       - name: Run unit tests
         run: npm test
 
@@ -1016,6 +1019,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Generate credits
+        run: npm run generate:credits
 
       - name: Run unit tests
         run: npm test


### PR DESCRIPTION
## Summary
- `test-windows`/`test-macos` (added in #2113) were missing the `npm run generate:credits` step that `quality.yml`'s Linux test job already has, so `AboutSection.test.tsx` (which imports `@/generated/credits.json`) failed on both platforms in the first real beta run.

## Test plan
- [x] Confirmed via the beta build run (29185808477) that macOS's only failure was this missing-file issue (1 failed / 241 total)
- [ ] Confirm both jobs pass cleanly on the next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)