### PR TITLE
perf(ci): split build-mas into build+sign and publish, only gate publish on tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,17 +345,16 @@ jobs:
 
   build-mas:
     name: Build (Mac App Store)
-    needs: [detect-changes, compute-version, test-windows, test-macos]
+    needs: [detect-changes, compute-version]
     # beta への push で自動実行し、内部TestFlightへ配信する。workflow_dispatch でも手動起動可能。
     # タグpush（main向け安定版）ではまだ走らせない。
-    # Also gated on the cross-platform test matrix succeeding, since this job
-    # uploads directly to App Store Connect/TestFlight — it's an independent
-    # publish point that isn't downstream of the `release` job.
+    # Build+sign runs in parallel with the test matrix (same as the other
+    # platform build jobs) — only the publish-mas job below (upload to App
+    # Store Connect/TestFlight) is gated on tests passing, so a slow/failing
+    # test run no longer blocks the ~4 minutes of build+sign work too.
     if: |
       always() &&
       needs.compute-version.result == 'success' &&
-      needs.test-windows.result == 'success' &&
-      needs.test-macos.result == 'success' &&
       (
         (github.event_name == 'workflow_dispatch' && inputs.run_mas_build == true) ||
         (github.event_name == 'push' && github.ref == 'refs/heads/beta' && needs.detect-changes.outputs.desktop_changed == 'true')
@@ -368,10 +367,6 @@ jobs:
       CSC_INSTALLER_LINK: ${{ secrets.CSC_INSTALLER_LINK }}
       CSC_INSTALLER_KEY_PASSWORD: ${{ secrets.CSC_INSTALLER_KEY_PASSWORD }}
       MAS_PROVISIONING_PROFILE: ${{ secrets.MAS_PROVISIONING_PROFILE }}
-      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
-      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
-      ASC_API_KEY: ${{ secrets.ASC_API_KEY }}
-      ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
       APTABASE_APP_KEY: ${{ secrets.APTABASE_APP_KEY }}
       APTABASE_HOST: ${{ secrets.APTABASE_HOST }}
       ERROR_REPORT_DSN: ${{ secrets.ERROR_REPORT_DSN }}
@@ -413,7 +408,7 @@ jobs:
             fi
           done
 
-      - name: Prepare MAS credentials
+      - name: Prepare MAS signing credentials
         shell: bash
         run: |
           missing=()
@@ -422,10 +417,6 @@ jobs:
           [ -z "$CSC_INSTALLER_LINK" ] && missing+=("CSC_INSTALLER_LINK")
           [ -z "$CSC_INSTALLER_KEY_PASSWORD" ] && missing+=("CSC_INSTALLER_KEY_PASSWORD")
           [ -z "$MAS_PROVISIONING_PROFILE" ] && missing+=("MAS_PROVISIONING_PROFILE")
-          [ -z "$ASC_KEY_ID" ] && missing+=("ASC_KEY_ID")
-          [ -z "$ASC_ISSUER_ID" ] && missing+=("ASC_ISSUER_ID")
-          [ -z "$ASC_API_KEY" ] && missing+=("ASC_API_KEY")
-          [ -z "$ASC_APP_ID" ] && missing+=("ASC_APP_ID")
           if [ ${#missing[@]} -ne 0 ]; then
             echo "::error::Missing MAS credentials: ${missing[*]}"
             exit 1
@@ -433,11 +424,6 @@ jobs:
 
           # electron-builder は build.mas.provisioningProfile のパスをそのまま読む。
           printf '%s' "$MAS_PROVISIONING_PROFILE" | base64 --decode > build/illusions.provisionprofile
-
-          # altool はこの標準パスから App Store Connect API キーを探す。
-          mkdir -p "$HOME/.appstoreconnect/private_keys"
-          printf '%s' "$ASC_API_KEY" | base64 --decode > "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
-          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
 
       - name: Apply computed version
         # CFBundleVersion must be plain dot-separated integers, so this uses
@@ -473,6 +459,54 @@ jobs:
           name: illusions-mas-pkg
           path: dist-electron/**/*.pkg
 
+  publish-mas:
+    name: Publish (Mac App Store / TestFlight)
+    needs: [build-mas, test-windows, test-macos]
+    # Only this small upload+TestFlight step waits on the cross-platform
+    # test matrix — the build+sign work above already ran in parallel with
+    # it. `always()` lets us inspect build-mas's result even though it's
+    # itself conditional (would otherwise be treated as skipped).
+    if: |
+      always() &&
+      needs.build-mas.result == 'success' &&
+      needs.test-windows.result == 'success' &&
+      needs.test-macos.result == 'success'
+    runs-on: macos-latest
+    environment: Apple
+    env:
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_API_KEY: ${{ secrets.ASC_API_KEY }}
+      ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Download MAS package artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: illusions-mas-pkg
+          path: dist-electron
+
+      - name: Prepare App Store Connect API key
+        shell: bash
+        run: |
+          missing=()
+          [ -z "$ASC_KEY_ID" ] && missing+=("ASC_KEY_ID")
+          [ -z "$ASC_ISSUER_ID" ] && missing+=("ASC_ISSUER_ID")
+          [ -z "$ASC_API_KEY" ] && missing+=("ASC_API_KEY")
+          [ -z "$ASC_APP_ID" ] && missing+=("ASC_APP_ID")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing ASC credentials: ${missing[*]}"
+            exit 1
+          fi
+
+          # altool はこの標準パスから App Store Connect API キーを探す。
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          printf '%s' "$ASC_API_KEY" | base64 --decode > "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+
       - name: Upload to App Store Connect
         shell: bash
         run: |
@@ -487,6 +521,11 @@ jobs:
             --type macos \
             --apiKey "$ASC_KEY_ID" \
             --apiIssuer "$ASC_ISSUER_ID"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
 
       - name: Enable build for internal TestFlight testers
         # Apple takes a few minutes to finish processing an uploaded build
@@ -967,8 +1006,8 @@ jobs:
   # (same push-only gating as the "full build" steps in those jobs). Linux is
   # already covered by the "Test & Coverage" job in quality.yml, so only
   # Windows/macOS runners are needed here. Nothing downstream of these jobs
-  # waits on them except the actual publish steps (release, build-mas), so a
-  # test failure never slows down compilation/packaging — it only blocks
+  # waits on them except the actual publish steps (release, publish-mas), so
+  # a test failure never slows down compilation/packaging — it only blocks
   # shipping.
   # ---------------------------------------------------------------------------
 

--- a/scripts/asc-testflight-enable.mjs
+++ b/scripts/asc-testflight-enable.mjs
@@ -90,16 +90,6 @@ async function findBuild(buildNumber, { retries = 20, delayMs = 30000 } = {}) {
   throw new Error(`Build ${buildNumber} did not become VALID within timeout`);
 }
 
-async function ensureExportCompliance(buildId) {
-  await asc(`/builds/${buildId}`, {
-    method: "PATCH",
-    body: JSON.stringify({
-      data: { type: "builds", id: buildId, attributes: { usesNonExemptEncryption: false } },
-    }),
-  });
-  console.log("Export compliance confirmed (exempt encryption only).");
-}
-
 async function findOrGetInternalGroup() {
   // `filter[isInternalGroup]` isn't a supported query param on this
   // endpoint (confirmed via a 400 PARAMETER_ERROR.ILLEGAL response) — fetch
@@ -124,7 +114,11 @@ async function addBuildToGroup(groupId, buildId) {
 }
 
 const build = await findBuild(buildNumber);
-await ensureExportCompliance(build.id);
+// Export compliance is declared once via ITSAppUsesNonExemptEncryption in
+// the Info.plist (package.json's mac.extendInfo) — App Store Connect reads
+// it from the binary automatically, and re-confirming the same value via
+// PATCH /builds/{id} 409s with "You cannot update when the value is already
+// set", so there's nothing to do here.
 const group = await findOrGetInternalGroup();
 await addBuildToGroup(group.id, build.id);
 console.log(`\n✅ Build ${buildNumber} is now available via TestFlight to internal testers.`);


### PR DESCRIPTION
## Summary
`build-mas` previously waited on `test-windows`/`test-macos` before starting at all, serializing ~4 minutes of build+sign work behind the test matrix even though every other platform build job runs in parallel with tests.

Split into:
- **build-mas**: build, sign, package — starts as soon as `compute-version` is ready, same as `build-windows-core`/`build-linux`/`build-macos`
- **publish-mas**: upload to App Store Connect + enable TestFlight — the only part that actually needs to wait on tests passing, since it's the real "ship it" step

Only `publish-mas` carries the `ASC_*` API credentials now; `build-mas` keeps only the `CSC_*`/provisioning signing credentials it actually uses.

## Also fixes
Found while verifying end-to-end: the TestFlight script's `ensureExportCompliance` PATCH call 409s ("You cannot update when the value is already set") because `ITSAppUsesNonExemptEncryption` is already declared in the Info.plist and Apple reads it automatically — the PATCH was redundant and actively broke the run. Removed.

Refs #2038 / #2079

🤖 Generated with [Claude Code](https://claude.com/claude-code)