### PR TITLE
fix: guard stale Milkdown editor views

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1295,6 +1295,7 @@ export default function EditorPage() {
 
     import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
       .then(({ updateLintingSettings }) => {
+        if (!isEditorViewAlive(editorViewInstance)) return;
         updateLintingSettings(editorViewInstance, { ignoredCorrections }, "ignored-correction");
       })
       .catch((err) => {
@@ -1308,6 +1309,7 @@ export default function EditorPage() {
 
     import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
       .then(({ updateLintingSettings }) => {
+        if (!isEditorViewAlive(editorViewInstance)) return;
         updateLintingSettings(editorViewInstance, { knownTerms }, "known-terms-change");
       })
       .catch((err) => {

--- a/components/Editor.tsx
+++ b/components/Editor.tsx
@@ -23,6 +23,7 @@ import type { LintIssue } from "@/lib/linting";
 import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import { useTypographySettings, useSpeechSettings } from "@/contexts/EditorSettingsContext";
 import { useCharWidth, MEASURE_TEXT } from "@/lib/editor-page/use-char-width";
+import { dispatchIfEditorViewAlive } from "@/shared/lib/editor-view-safety";
 
 interface EditorProps {
   initialContent?: string;
@@ -203,7 +204,9 @@ export default function NovelEditor({
     cancelSpeechScroll();
     const view = editorViewRef.current;
     if (!view) return;
-    view.dispatch(view.state.tr.setMeta("speechDecorations", []));
+    dispatchIfEditorViewAlive(view, (aliveView) =>
+      aliveView.state.tr.setMeta("speechDecorations", []),
+    );
   }, []);
 
   const startSpeechFromPos = useCallback(
@@ -235,7 +238,9 @@ export default function NovelEditor({
             const to = (m.positions[chunk.highlightEnd - 1] ?? from) + 1;
             if (from == null) return;
             const deco = Decoration.inline(from, to, { class: "speech-reading" });
-            v.dispatch(v.state.tr.setMeta("speechDecorations", [deco]));
+            dispatchIfEditorViewAlive(v, (aliveView) =>
+              aliveView.state.tr.setMeta("speechDecorations", [deco]),
+            );
             // Auto-scroll to keep the highlighted word in view
             const container = scrollContainerRef.current;
             if (container) {

--- a/components/SearchResults.tsx
+++ b/components/SearchResults.tsx
@@ -36,6 +36,7 @@ import {
 import { ProjectSearchWorkerClient } from "@/lib/editor-page/project-search-worker-client";
 import { addSearchHistoryEntry, loadSearchHistory } from "@/lib/editor-page/search-history";
 import { isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
+import { dispatchIfEditorViewAlive } from "@/shared/lib/editor-view-safety";
 
 type SearchScope = "project" | "current" | "folder";
 const EMPTY_PROJECT_BUFFERS: ReadonlyMap<string, string> = new Map();
@@ -273,11 +274,11 @@ export default function SearchResults({
       const [step] = createReplacementSteps([match], replaceTerm, searchOptions);
       if (!step) return;
 
-      const { state, dispatch } = editorView;
-      const tr = step.text
-        ? state.tr.replaceWith(step.from, step.to, state.schema.text(step.text))
-        : state.tr.delete(step.from, step.to);
-      dispatch(tr);
+      dispatchIfEditorViewAlive(editorView, (view) =>
+        step.text
+          ? view.state.tr.replaceWith(step.from, step.to, view.state.schema.text(step.text))
+          : view.state.tr.delete(step.from, step.to),
+      );
     },
     [editorView, replaceTerm, searchOptions],
   );
@@ -287,14 +288,15 @@ export default function SearchResults({
     const steps = createReplacementSteps(matches, replaceTerm, searchOptions);
     if (steps.length === 0) return;
 
-    const { state, dispatch } = editorView;
-    let tr = state.tr;
-    for (const step of steps) {
-      tr = step.text
-        ? tr.replaceWith(step.from, step.to, state.schema.text(step.text))
-        : tr.delete(step.from, step.to);
-    }
-    dispatch(tr);
+    dispatchIfEditorViewAlive(editorView, (view) => {
+      let tr = view.state.tr;
+      for (const step of steps) {
+        tr = step.text
+          ? tr.replaceWith(step.from, step.to, view.state.schema.text(step.text))
+          : tr.delete(step.from, step.to);
+      }
+      return tr;
+    });
     setConfirmReplaceAll(false);
   }, [editorView, matches, replaceTerm, searchOptions]);
 

--- a/components/editor/MilkdownEditor.tsx
+++ b/components/editor/MilkdownEditor.tsx
@@ -58,6 +58,8 @@ import {
   useScrollSettings,
 } from "@/contexts/EditorSettingsContext";
 import { usePosHighlightActivation } from "@/lib/editor-page/use-pos-highlight-activation";
+import { isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
+import { dispatchIfEditorViewAlive } from "@/shared/lib/editor-view-safety";
 
 interface MilkdownEditorProps {
   initialContent: string;
@@ -463,6 +465,7 @@ export default function MilkdownEditor({
 
     import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
       .then(({ updateLintingSettings }) => {
+        if (!isEditorViewAlive(editorViewInstance)) return;
         updateLintingSettings(
           editorViewInstance,
           {
@@ -766,10 +769,10 @@ export default function MilkdownEditor({
           navigator.clipboard
             .readText()
             .then((text) => {
-              const { state, dispatch } = editorViewInstance;
-              const { from, to } = state.selection;
-              const transaction = state.tr.insertText(text, from, to);
-              dispatch(transaction);
+              dispatchIfEditorViewAlive(editorViewInstance, (view) => {
+                const { from, to } = view.state.selection;
+                return view.state.tr.insertText(text, from, to);
+              });
             })
             .catch((err) => {
               console.error("Failed to paste:", err);
@@ -780,10 +783,10 @@ export default function MilkdownEditor({
             .readText()
             .then((text) => {
               // Strip formatting by using plain text
-              const { state, dispatch } = editorViewInstance;
-              const { from, to } = state.selection;
-              const transaction = state.tr.insertText(text, from, to);
-              dispatch(transaction);
+              dispatchIfEditorViewAlive(editorViewInstance, (view) => {
+                const { from, to } = view.state.selection;
+                return view.state.tr.insertText(text, from, to);
+              });
             })
             .catch((err) => {
               console.error("Failed to paste plain text:", err);
@@ -798,9 +801,10 @@ export default function MilkdownEditor({
           break;
         }
         case "select-all": {
-          const { state: st, dispatch: dp } = editorViewInstance;
-          const allSelection = new AllSelection(st.doc);
-          dp(st.tr.setSelection(allSelection));
+          dispatchIfEditorViewAlive(editorViewInstance, (view) => {
+            const allSelection = new AllSelection(view.state.doc);
+            return view.state.tr.setSelection(allSelection);
+          });
           break;
         }
         case "ruby":

--- a/lib/editor-page/__tests__/editor-view-safety.test.ts
+++ b/lib/editor-page/__tests__/editor-view-safety.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Transaction } from "@milkdown/prose/state";
+import type { EditorView } from "@milkdown/prose/view";
+import {
+  dispatchIfEditorViewAlive,
+  isEditorViewAlive,
+  isEditorViewTeardownError,
+} from "@/shared/lib/editor-view-safety";
+
+function makeView(options: { alive?: boolean; dispatch?: () => void } = {}): EditorView {
+  const dispatch = vi.fn(options.dispatch ?? (() => {}));
+  return {
+    docView: options.alive === false ? null : {},
+    dispatch,
+  } as unknown as EditorView;
+}
+
+describe("editor-view-safety", () => {
+  it("detects ProseMirror views destroyed during Milkdown teardown", () => {
+    expect(isEditorViewAlive(makeView())).toBe(true);
+    expect(isEditorViewAlive(makeView({ alive: false }))).toBe(false);
+    expect(isEditorViewAlive(null)).toBe(false);
+  });
+
+  it("does not build or dispatch transactions for destroyed views", () => {
+    const view = makeView({ alive: false });
+    const createTransaction = vi.fn();
+
+    expect(dispatchIfEditorViewAlive(view, createTransaction)).toBe(false);
+    expect(createTransaction).not.toHaveBeenCalled();
+  });
+
+  it("suppresses known teardown errors from stale dispatches", () => {
+    const editorStateError = new Error(
+      'Context "editorState" not found, do you forget to inject it?',
+    );
+    const nextSiblingError = new TypeError(
+      "Cannot read properties of null (reading 'nextSibling')",
+    );
+
+    expect(isEditorViewTeardownError(editorStateError)).toBe(true);
+    expect(isEditorViewTeardownError(nextSiblingError)).toBe(true);
+    expect(
+      dispatchIfEditorViewAlive(
+        makeView({
+          dispatch: () => {
+            throw editorStateError;
+          },
+        }),
+        () => ({}) as Transaction,
+      ),
+    ).toBe(false);
+    expect(
+      dispatchIfEditorViewAlive(
+        makeView({
+          dispatch: () => {
+            throw nextSiblingError;
+          },
+        }),
+        () => ({}) as Transaction,
+      ),
+    ).toBe(false);
+  });
+
+  it("rethrows unexpected dispatch errors", () => {
+    const unexpected = new Error("schema exploded");
+    expect(() =>
+      dispatchIfEditorViewAlive(
+        makeView({
+          dispatch: () => {
+            throw unexpected;
+          },
+        }),
+        () => ({}) as Transaction,
+      ),
+    ).toThrow(unexpected);
+  });
+});

--- a/lib/editor-page/__tests__/pos-highlight-activation.test.tsx
+++ b/lib/editor-page/__tests__/pos-highlight-activation.test.tsx
@@ -168,4 +168,10 @@ describe("#1466 — effective POS highlight follows window activity", () => {
     await mountHook(makeParams({ view: null }));
     expect(updatePosHighlightSettings).not.toHaveBeenCalled();
   });
+
+  it("does nothing when the view has already been destroyed", async () => {
+    const destroyedView = { docView: null } as unknown as EditorView;
+    await mountHook(makeParams({ view: destroyedView }));
+    expect(updatePosHighlightSettings).not.toHaveBeenCalled();
+  });
 });

--- a/lib/editor-page/clear-formatting.ts
+++ b/lib/editor-page/clear-formatting.ts
@@ -1,5 +1,6 @@
 import { liftTarget } from "@milkdown/prose/transform";
 import type { EditorView } from "@milkdown/prose/view";
+import { dispatchIfEditorViewAlive } from "@/shared/lib/editor-view-safety";
 
 /**
  * 選択範囲を標準本文（段落・装飾なし）に戻す。
@@ -60,6 +61,6 @@ export function clearFormatting(view: EditorView): void {
     }
   });
 
-  view.dispatch(tr.scrollIntoView());
+  dispatchIfEditorViewAlive(view, () => tr.scrollIntoView());
   view.focus();
 }

--- a/lib/editor-page/use-editor-lifecycle.ts
+++ b/lib/editor-page/use-editor-lifecycle.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react";
 import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 
 import type { EditorView } from "@milkdown/prose/view";
+import { dispatchIfEditorViewAlive } from "@/shared/lib/editor-view-safety";
 
 interface UseEditorLifecycleParams {
   flushTabState: () => Promise<void>;
@@ -115,10 +116,10 @@ export function useEditorLifecycle({
   const insertTextAtSelectionOrAppend = useCallback(
     (text: string) => {
       if (editorViewInstance) {
-        const { state, dispatch } = editorViewInstance;
-        const { from, to } = state.selection;
-        const tr = state.tr.insertText(text, from, to);
-        dispatch(tr);
+        dispatchIfEditorViewAlive(editorViewInstance, (view) => {
+          const { from, to } = view.state.selection;
+          return view.state.tr.insertText(text, from, to);
+        });
       } else {
         const currentContent = contentRef.current;
         const newContent = currentContent ? `${currentContent}\n\n${text}` : text;

--- a/lib/editor-page/use-lint-handlers.ts
+++ b/lib/editor-page/use-lint-handlers.ts
@@ -3,6 +3,7 @@ import { notificationManager } from "@/lib/services/notification-manager";
 import type { EditorView } from "@milkdown/prose/view";
 import type { LintIssue } from "@/lib/linting/types";
 import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
+import { dispatchIfEditorViewAlive, isEditorViewAlive } from "@/shared/lib/editor-view-safety";
 
 /**
  * Get the exact text a lint issue flagged.
@@ -85,11 +86,14 @@ export function useLintHandlers({
     (issue: LintIssue) => {
       if (!editorViewInstance) return;
       void import("@milkdown/prose/state").then(({ TextSelection }) => {
-        const { state, dispatch } = editorViewInstance;
+        if (!isEditorViewAlive(editorViewInstance)) return;
+        const { state } = editorViewInstance;
         const clampedTo = Math.min(issue.to, state.doc.content.size);
         const clampedFrom = Math.min(issue.from, clampedTo);
-        const selection = TextSelection.create(state.doc, clampedFrom, clampedTo);
-        dispatch(state.tr.setSelection(selection));
+        dispatchIfEditorViewAlive(editorViewInstance, (view) => {
+          const selection = TextSelection.create(view.state.doc, clampedFrom, clampedTo);
+          return view.state.tr.setSelection(selection);
+        });
         centerEditorPosition(editorViewInstance, clampedFrom);
 
         editorViewInstance.focus();
@@ -153,7 +157,7 @@ export function useLintHandlers({
   const handleApplyFix = useCallback(
     (issue: LintIssue & { originalText?: string }) => {
       if (!editorViewInstance || !issue.fix) return;
-      const { state, dispatch } = editorViewInstance;
+      const { state } = editorViewInstance;
       if (issue.to > state.doc.content.size) {
         notificationManager.warning("テキストが変更されたため修正を適用できません");
         return;
@@ -163,8 +167,9 @@ export function useLintHandlers({
         notificationManager.warning("テキストが変更されたため修正を適用できません");
         return;
       }
-      const tr = state.tr.insertText(issue.fix.replacement, issue.from, issue.to);
-      dispatch(tr);
+      dispatchIfEditorViewAlive(editorViewInstance, (view) =>
+        view.state.tr.insertText(issue.fix!.replacement, issue.from, issue.to),
+      );
     },
     [editorViewInstance],
   );

--- a/lib/editor-page/use-linting.ts
+++ b/lib/editor-page/use-linting.ts
@@ -11,6 +11,7 @@ import {
   type RuleRunnerLike,
 } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import { syncLoadedRulesets, subscribeRulesetChanges } from "@/lib/linting/external-ruleset-loader";
+import { isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
 
 export interface UseLintingResult {
   /** May be `null` until the worker has been spun up after mount. */
@@ -129,6 +130,10 @@ export function useLinting(
     setIsLinting(true);
     import("@/packages/milkdown-plugin-japanese-novel/linting-plugin")
       .then(({ updateLintingSettings }) => {
+        if (!isEditorViewAlive(editorViewInstance)) {
+          setIsLinting(false);
+          return;
+        }
         const nlpClient = ruleRunner.hasMorphologicalRules() ? getNlpClient() : null;
 
         updateLintingSettings(

--- a/lib/editor-page/use-pos-highlight-activation.ts
+++ b/lib/editor-page/use-pos-highlight-activation.ts
@@ -5,6 +5,7 @@ import { shouldEnablePosHighlight } from "./power-policy";
 import { getWindowActivitySnapshot, subscribeWindowActivity } from "./window-activity";
 import type { WindowActivityState } from "./window-activity";
 import type { EditorView } from "@milkdown/prose/view";
+import { isEditorViewAlive } from "./use-search-highlight";
 
 // ---------------------------------------------------------------------------
 // Params
@@ -66,7 +67,7 @@ export function usePosHighlightActivation(params: UsePosHighlightActivationParam
       // 動的 import で plugin 本体（kuromoji 含む）を初期バンドルから外す
       import("@/packages/milkdown-plugin-japanese-novel/pos-highlight")
         .then(({ updatePosHighlightSettings }) => {
-          if (disposed) return;
+          if (disposed || !isEditorViewAlive(view)) return;
           updatePosHighlightSettings(view, {
             enabled: shouldEnablePosHighlight(activity, { posHighlightEnabled, powerSaveMode }),
             colors: posHighlightColors,

--- a/lib/editor-page/use-ruby-tcy.ts
+++ b/lib/editor-page/use-ruby-tcy.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from "react";
 import type { MutableRefObject } from "react";
 import { Fragment } from "@milkdown/prose/model";
 import type { EditorView } from "@milkdown/prose/view";
+import { dispatchIfEditorViewAlive } from "@/shared/lib/editor-view-safety";
 
 interface UseRubyTcyOptions {
   editorViewRef: MutableRefObject<EditorView | null>;
@@ -43,12 +44,13 @@ export function useRubyTcy({
       if (!view) return;
       const sel = rubySelectionRef.current;
       if (!sel) return;
-      const { state, dispatch } = view;
+      const { state } = view;
       const rubyNodeType = state.schema.nodes.ruby;
       if (!rubyNodeType) {
         // Fallback: insert as plain text if ruby node type is not available
-        const tr = state.tr.insertText(rubyMarkup, sel.from, sel.to);
-        dispatch(tr);
+        dispatchIfEditorViewAlive(view, (aliveView) =>
+          aliveView.state.tr.insertText(rubyMarkup, sel.from, sel.to),
+        );
         rubySelectionRef.current = null;
         return;
       }
@@ -68,8 +70,9 @@ export function useRubyTcy({
         nodes.push(state.schema.text(rubyMarkup.slice(lastIndex)));
       }
       const fragment = Fragment.from(nodes);
-      const tr = state.tr.replaceWith(sel.from, sel.to, fragment);
-      dispatch(tr);
+      dispatchIfEditorViewAlive(view, (aliveView) =>
+        aliveView.state.tr.replaceWith(sel.from, sel.to, fragment),
+      );
       rubySelectionRef.current = null;
     },
     // editorViewRef is a stable ref object; including it here satisfies the React Compiler
@@ -80,7 +83,7 @@ export function useRubyTcy({
   const handleToggleTcy = useCallback(() => {
     const view = editorViewRef.current;
     if (!view) return;
-    const { state, dispatch } = view;
+    const { state } = view;
     const { from, to } = state.selection;
     if (from === to) return;
     const text = state.doc.textBetween(from, to);
@@ -88,11 +91,13 @@ export function useRubyTcy({
     // Toggle: if already wrapped in ^...^, unwrap; otherwise wrap
     if (text.startsWith("^") && text.endsWith("^") && text.length >= 2) {
       const unwrapped = text.slice(1, -1);
-      const tr = state.tr.insertText(unwrapped, from, to);
-      dispatch(tr);
+      dispatchIfEditorViewAlive(view, (aliveView) =>
+        aliveView.state.tr.insertText(unwrapped, from, to),
+      );
     } else {
-      const tr = state.tr.insertText(`^${text}^`, from, to);
-      dispatch(tr);
+      dispatchIfEditorViewAlive(view, (aliveView) =>
+        aliveView.state.tr.insertText(`^${text}^`, from, to),
+      );
     }
     // editorViewRef is a stable ref object; including it here satisfies the React Compiler
   }, [editorViewRef]);

--- a/lib/editor-page/use-search-highlight.ts
+++ b/lib/editor-page/use-search-highlight.ts
@@ -3,17 +3,9 @@ import { Decoration, type EditorView } from "@milkdown/prose/view";
 import { TextSelection } from "@milkdown/prose/state";
 import { centerEditorPosition } from "@/lib/editor-page/center-editor-position";
 import type { SearchMatch } from "@/lib/editor-page/find-search-matches";
+import { dispatchIfEditorViewAlive, isEditorViewAlive } from "@/shared/lib/editor-view-safety";
 
-/**
- * #1507: After a tab switch the parent's editorView reference may briefly point
- * at a destroyed EditorView (ProseMirror sets `docView` to null on destroy).
- * Dispatching on it routes through torn-down Milkdown plugins and throws
- * "Context editorState not found". This guard is the single chokepoint for that
- * check now that highlight dispatch is centralized here.
- */
-export function isEditorViewAlive(view: EditorView | null): view is EditorView {
-  return view !== null && (view as unknown as { docView: unknown }).docView !== null;
-}
+export { isEditorViewAlive } from "@/shared/lib/editor-view-safety";
 
 interface UseSearchHighlightParams {
   editorView: EditorView | null;
@@ -61,16 +53,13 @@ export function useSearchHighlight({
   // TextSelection とスクロールは実行しない（#1857）。
   useEffect(() => {
     if (!isEditorViewAlive(editorView)) return;
-    const { state, dispatch } = editorView;
 
     // 非表示時・検索語空時はハイライトを消す（要求2: 検索窓を閉じた／
     // 検索パネル非表示でハイライト除去）。
     if (!isSearchVisible || !searchTerm || matches.length === 0) {
-      try {
-        dispatch(state.tr.setMeta("searchDecorations", []));
-      } catch {
-        // view が dispatch 途中で破棄された場合のベストエフォート
-      }
+      dispatchIfEditorViewAlive(editorView, (view) =>
+        view.state.tr.setMeta("searchDecorations", []),
+      );
       return;
     }
 
@@ -80,11 +69,9 @@ export function useSearchHighlight({
       }),
     );
 
-    try {
-      dispatch(state.tr.setMeta("searchDecorations", decorations));
-    } catch {
-      // #1507: view が検索中に破棄された — decorations も一緒に消える
-    }
+    dispatchIfEditorViewAlive(editorView, (view) =>
+      view.state.tr.setMeta("searchDecorations", decorations),
+    );
   }, [editorView, matches, currentMatchIndex, searchTerm, isSearchVisible]);
 
   // Effect 2: 明示的ナビゲーション時のみ選択移動＋スクロール（#1857）。
@@ -102,9 +89,9 @@ export function useSearchHighlight({
     if (!current) return;
 
     try {
-      editorView.dispatch(
-        editorView.state.tr.setSelection(
-          TextSelection.create(editorView.state.doc, current.from, current.from),
+      dispatchIfEditorViewAlive(editorView, (view) =>
+        view.state.tr.setSelection(
+          TextSelection.create(view.state.doc, current.from, current.from),
         ),
       );
       centerEditorPosition(editorView, current.from);

--- a/lib/menu/use-web-menu-handlers.ts
+++ b/lib/menu/use-web-menu-handlers.ts
@@ -2,6 +2,7 @@
 
 import { useCallback } from "react";
 import type { EditorView } from "@milkdown/prose/view";
+import { dispatchIfEditorViewAlive } from "@/shared/lib/editor-view-safety";
 import type { BugReportCategory } from "@/lib/bug-report/bug-report-types";
 
 interface UseWebMenuHandlersProps {
@@ -151,9 +152,13 @@ export function useWebMenuHandlers({
               .readText()
               .then((text) => {
                 if (!text) return;
-                const { state, dispatch } = editorView;
-                const tr = state.tr.insertText(text, state.selection.from, state.selection.to);
-                dispatch(tr);
+                dispatchIfEditorViewAlive(editorView, (view) =>
+                  view.state.tr.insertText(
+                    text,
+                    view.state.selection.from,
+                    view.state.selection.to,
+                  ),
+                );
                 editorView.focus();
               })
               .catch((err: unknown) => {

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/decoration-plugin.ts
@@ -32,6 +32,10 @@ import type {
 } from "./types";
 import { isSilentCancelError } from "./worker/protocol";
 import type { DictSnapshotPayload } from "./worker/protocol";
+import {
+  dispatchIfEditorViewAlive,
+  isEditorViewAlive,
+} from "../../../shared/lib/editor-view-safety";
 
 export const lintingKey = new PluginKey<LintingPluginState>("linting");
 
@@ -310,6 +314,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
         immediateRebuild = false;
 
         debounceTimer = setTimeout(async () => {
+          if (!isEditorViewAlive(view)) return;
           const state = lintingKey.getState(view.state);
           if (!state?.enabled || !currentRuleRunner) return;
 
@@ -520,6 +525,7 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
           }
 
           if (version !== processingVersion) return;
+          if (!isEditorViewAlive(view)) return;
 
           // Build decorations from all paragraphs that have cached results
           const allDecorations: Decoration[] = [];
@@ -583,8 +589,10 @@ export function createLintingPlugin(options: LintingPluginOptions): Plugin<Linti
             allDecorations.length > 0
               ? DecorationSet.create(view.state.doc, allDecorations)
               : DecorationSet.empty;
-          const tr = view.state.tr.setMeta(lintingKey, { decorations });
-          view.dispatch(tr);
+          const didDispatch = dispatchIfEditorViewAlive(view, (aliveView) =>
+            aliveView.state.tr.setMeta(lintingKey, { decorations }),
+          );
+          if (!didDispatch) return;
 
           // Diagnostics for #1964: a packaged lint pass that re-lints paragraphs
           // yet yields nothing is the exact symptom. Logging only this case keeps

--- a/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/linting-plugin/index.ts
@@ -11,6 +11,7 @@ import type { IgnoredCorrection } from "@/lib/project/project-types";
 import type { ConfigChangeReason } from "@/lib/linting/correction-config";
 import type { LintingSettingsUpdate, RuleRunnerLike } from "./types";
 import { createLintingPlugin, lintingKey } from "./decoration-plugin";
+import { dispatchIfEditorViewAlive } from "../../../shared/lib/editor-view-safety";
 
 // Export the plugin key for external use
 export { lintingKey } from "./decoration-plugin";
@@ -81,13 +82,5 @@ export function updateLintingSettings(
   if (reason !== undefined) {
     meta.changeReason = reason;
   }
-  try {
-    const tr = view.state.tr.setMeta(lintingKey, meta);
-    view.dispatch(tr);
-  } catch (err: unknown) {
-    // Milkdown throws "Context ... not found" when the editor is destroyed or not yet initialized.
-    // Only suppress that specific error; let unexpected failures propagate.
-    const msg = err instanceof Error ? err.message : "";
-    if (!msg.includes("not found")) throw err;
-  }
+  dispatchIfEditorViewAlive(view, (aliveView) => aliveView.state.tr.setMeta(lintingKey, meta));
 }

--- a/packages/milkdown-plugin-japanese-novel/plugins/heading-id-fixer.ts
+++ b/packages/milkdown-plugin-japanese-novel/plugins/heading-id-fixer.ts
@@ -1,5 +1,6 @@
 import { Plugin, PluginKey } from "@milkdown/prose/state";
 import type { Node } from "@milkdown/prose/model";
+import { dispatchIfEditorViewAlive } from "../../../shared/lib/editor-view-safety";
 
 const HEADING_ID_FIXER_META_COMPOSING = "headingIdFixerComposing";
 const HEADING_ID_FIXER_META_FORCE_RECONCILE = "headingIdFixerForceReconcile";
@@ -44,8 +45,8 @@ export function createHeadingIdFixerPlugin() {
 
       const handleCompositionEnd = () => {
         composing = false;
-        editorView.dispatch(
-          editorView.state.tr.setMeta(HEADING_ID_FIXER_META_FORCE_RECONCILE, true),
+        dispatchIfEditorViewAlive(editorView, (view) =>
+          view.state.tr.setMeta(HEADING_ID_FIXER_META_FORCE_RECONCILE, true),
         );
       };
 

--- a/packages/milkdown-plugin-japanese-novel/pos-highlight/decoration-plugin.ts
+++ b/packages/milkdown-plugin-japanese-novel/pos-highlight/decoration-plugin.ts
@@ -14,6 +14,10 @@ import { LRUCache } from "@/shared/lib/lru-cache";
 import { getAtomOffset, collectParagraphs } from "../shared/paragraph-helpers";
 import { getPosColor, DEFAULT_POS_COLORS } from "./pos-colors";
 import type { PosColorConfig } from "./types";
+import {
+  dispatchIfEditorViewAlive,
+  isEditorViewAlive,
+} from "../../../shared/lib/editor-view-safety";
 
 export const posHighlightKey = new PluginKey("posHighlight");
 
@@ -123,6 +127,7 @@ export function createPosHighlightPlugin(
         const version = ++processingVersion;
 
         debounceTimer = setTimeout(async () => {
+          if (!isEditorViewAlive(view)) return;
           const state = posHighlightKey.getState(view.state);
           if (!state?.enabled) return;
 
@@ -153,6 +158,7 @@ export function createPosHighlightPlugin(
           }
 
           if (version !== processingVersion) return;
+          if (!isEditorViewAlive(view)) return;
 
           // キャッシュ済みトークンからすべての段落のデコレーションを構築
           // （ビューポート外でもキャッシュがあれば着色を維持）
@@ -194,8 +200,9 @@ export function createPosHighlightPlugin(
             allDecorations.length > 0
               ? DecorationSet.create(view.state.doc, allDecorations)
               : DecorationSet.empty;
-          const tr = view.state.tr.setMeta(posHighlightKey, { decorations });
-          view.dispatch(tr);
+          dispatchIfEditorViewAlive(view, (aliveView) =>
+            aliveView.state.tr.setMeta(posHighlightKey, { decorations }),
+          );
         }, debounceMs);
       }
 

--- a/packages/milkdown-plugin-japanese-novel/pos-highlight/index.ts
+++ b/packages/milkdown-plugin-japanese-novel/pos-highlight/index.ts
@@ -8,6 +8,7 @@ import { createPosHighlightPlugin, posHighlightKey } from "./decoration-plugin";
 import { DEFAULT_POS_COLORS } from "./pos-colors";
 import type { EditorView } from "@milkdown/prose/view";
 import type { PosColorConfig, PosHighlightSettings } from "./types";
+import { dispatchIfEditorViewAlive } from "../../../shared/lib/editor-view-safety";
 
 // 型定義と定数をエクスポート
 export type { PosColorConfig, PosHighlightSettings, Token } from "./types";
@@ -56,6 +57,7 @@ export function updatePosHighlightSettings(
   view: EditorView,
   settings: Partial<PosHighlightSettings>,
 ) {
-  const tr = view.state.tr.setMeta(posHighlightKey, settings);
-  view.dispatch(tr);
+  dispatchIfEditorViewAlive(view, (aliveView) =>
+    aliveView.state.tr.setMeta(posHighlightKey, settings),
+  );
 }

--- a/shared/lib/editor-view-safety.ts
+++ b/shared/lib/editor-view-safety.ts
@@ -1,0 +1,36 @@
+import type { Transaction } from "@milkdown/prose/state";
+import type { EditorView } from "@milkdown/prose/view";
+
+/**
+ * ProseMirror sets `docView` to null during EditorView.destroy(). React can
+ * still hold that view briefly while tab/editor teardown finishes.
+ */
+export function isEditorViewAlive(view: EditorView | null): view is EditorView {
+  return view !== null && (view as unknown as { docView?: unknown }).docView !== null;
+}
+
+export function isEditorViewTeardownError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes('Context "editorState" not found') ||
+    message.includes("Context editorState not found") ||
+    message.includes("reading 'nextSibling'")
+  );
+}
+
+export function dispatchIfEditorViewAlive(
+  view: EditorView | null,
+  createTransaction: (view: EditorView) => Transaction,
+): boolean {
+  if (!isEditorViewAlive(view)) return false;
+
+  try {
+    const transaction = createTransaction(view);
+    if (!isEditorViewAlive(view)) return false;
+    view.dispatch(transaction);
+    return true;
+  } catch (error) {
+    if (isEditorViewTeardownError(error)) return false;
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the GlitchTip renderer teardown crashes reported in issues 3, 4, 5, and 6:

- MilkdownError: Context editorState not found
- TypeError: Cannot read properties of null (reading nextSibling)

## Root Cause

React can briefly retain a non-null ProseMirror EditorView while Milkdown/ProseMirror teardown is already underway. Some delayed or event-driven paths still dispatched transactions through that stale view. Depending on timing, this surfaced either as Milkdown missing editorState context or as ProseMirror DOM reconciliation trying to read nextSibling from a removed DOM node.

## Changes

- Add a shared dispatchIfEditorViewAlive helper that skips destroyed views and suppresses known teardown-only dispatch failures.
- Route app-level editor dispatches through the helper: search highlights/replacements, context-menu paste, web-menu paste, lint navigation/fixes, Ruby/TCY, speech decorations, clear formatting, and editor lifecycle text insertion.
- Guard POS-highlight and linting decoration refreshes before reading view state and while applying async decorations.
- Keep POS/lint settings update helpers tolerant of stale views.
- Add regression coverage for destroyed views and both teardown error signatures.

## Validation

- npm test -- lib/editor-page/__tests__/editor-view-safety.test.ts lib/editor-page/__tests__/pos-highlight-activation.test.tsx lib/editor-page/__tests__/use-search-highlight.test.tsx components/__tests__/SearchResults-destroyed-view.test.tsx
- npm run type-check
- npm run check:boundaries
- Push hook: npm run check:boundaries