### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -37,6 +37,11 @@ jobs:
       - run: npm ci
       - run: npm run generate:credits
       - run: npm run test:coverage
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
       - name: Upload coverage report
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- upload Vitest lcov coverage to Codecov in the quality workflow
- keep the existing GitHub coverage artifact upload

## Testing
- not run; workflow-only change