### PR TITLE
Disable terminal controls in App Store builds

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ import { notificationManager } from "@/lib/services/notification-manager";
 import { renameProjectFile, type RenameOutcome } from "@/lib/tab-manager/rename-file";
 import { useWebMenuHandlers } from "@/lib/menu/use-web-menu-handlers";
 import { useGlobalShortcuts } from "@/lib/hooks/use-global-shortcuts";
-import { isElectronRenderer } from "@/lib/utils/runtime-env";
+import { getAppRuntimeInfo, isElectronRenderer } from "@/lib/utils/runtime-env";
 import WebMenuBar from "@/components/WebMenuBar";
 import ConfirmDialog from "@/shared/ui/ConfirmDialog";
 import { useEditorMode } from "@/contexts/EditorModeContext";
@@ -207,6 +207,8 @@ export default function EditorPage() {
   } = settingsHandlers;
 
   const isElectron = typeof window !== "undefined" && isElectronRenderer();
+  const isTerminalAvailable =
+    isElectron && getAppRuntimeInfo().distributionProvider !== "app-store";
 
   // Rule metas of every installed external ruleset (all lint rules now live in
   // external rulesets). The inspector's correction-mode dropdown derives its
@@ -730,11 +732,11 @@ export default function EditorPage() {
       const items = [
         { label: "新規ファイル", action: "new-file" },
         { label: "ファイルを開く…", action: "open-file" },
-        ...(isElectron ? [{ label: "新規ターミナル", action: "new-terminal" }] : []),
+        ...(isTerminalAvailable ? [{ label: "新規ターミナル", action: "new-terminal" }] : []),
       ];
       void showTabBarMenu(e, items);
     },
-    [showTabBarMenu, isElectron],
+    [showTabBarMenu, isTerminalAvailable],
   );
 
   const handleTabBarMenuAction = useCallback(
@@ -1693,7 +1695,7 @@ export default function EditorPage() {
           bottomView,
           setTopView,
           setBottomView,
-          handleNewTerminalTab,
+          handleNewTerminalTab: isTerminalAvailable ? handleNewTerminalTab : undefined,
         }}
         mainArea={{
           tabs,

--- a/components/EditorLayout.tsx
+++ b/components/EditorLayout.tsx
@@ -151,7 +151,7 @@ interface EditorLayoutProps {
     bottomView: ActivityBarView;
     setTopView: (view: ActivityBarView) => void;
     setBottomView: (view: ActivityBarView) => void;
-    handleNewTerminalTab: () => void;
+    handleNewTerminalTab?: () => void;
   };
   mainArea: {
     tabs: TabState[];

--- a/components/settings/TerminalSettingsTab.tsx
+++ b/components/settings/TerminalSettingsTab.tsx
@@ -4,6 +4,7 @@ import type React from "react";
 import clsx from "clsx";
 
 import { useTerminalSettings } from "@/contexts/EditorSettingsContext";
+import { getAppRuntimeInfo } from "@/lib/utils/runtime-env";
 import { SettingsField, SettingsSection, SettingsToggle, SliderField } from "./primitives";
 import TerminalAnsiColorGrid from "./terminal/TerminalAnsiColorGrid";
 
@@ -36,6 +37,7 @@ const CURSOR_STYLES: ReadonlyArray<{
  * Electron-only feature; all settings are persisted via AppState.
  */
 export default function TerminalSettingsTab(): React.ReactElement {
+  const isAppStoreBuild = getAppRuntimeInfo().distributionProvider === "app-store";
   const {
     terminalBackground,
     terminalForeground,
@@ -66,202 +68,230 @@ export default function TerminalSettingsTab(): React.ReactElement {
 
   return (
     <div className="space-y-8">
-      <SettingsSection
-        title="Shell"
-        description="ターミナルで使用する Shell や操作の設定を変更します。"
-      >
-        <SettingsField
-          label="デフォルト Shell"
-          description="絶対パス（例: C:\\Windows\\System32\\cmd.exe）または Shell 名（例: powershell、pwsh、cmd、bash、zsh）を入力できます。空欄の場合はシステムのデフォルト Shell を使用します。"
-          htmlFor="terminal-default-shell"
+      {isAppStoreBuild && (
+        <div
+          role="note"
+          className="rounded-lg border border-border bg-background-secondary p-4 text-sm text-foreground-secondary"
         >
-          <input
-            id="terminal-default-shell"
-            type="text"
-            value={terminalDefaultShell}
-            onChange={(e) => onTerminalDefaultShellChange(e.target.value)}
-            placeholder="自動検出（例: powershell、cmd、/bin/zsh）"
-            className="w-full px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent placeholder:text-foreground-muted"
-          />
-        </SettingsField>
-
-        <SettingsField
-          label="選択時に自動コピー"
-          description="テキストを選択すると自動的にクリップボードにコピーします。"
-          htmlFor="terminal-copy-on-select"
-          inline
-        >
-          <SettingsToggle
-            id="terminal-copy-on-select"
-            checked={terminalCopyOnSelect}
-            onChange={onTerminalCopyOnSelectChange}
-          />
-        </SettingsField>
-
-        <SettingsField
-          label="Option キーを Meta として使用"
-          description="macOS で Option キーを Alt/Meta キーとして扱います（Emacs キーバインドなどに便利）。"
-          htmlFor="terminal-mac-option-meta"
-          inline
-        >
-          <SettingsToggle
-            id="terminal-mac-option-meta"
-            checked={terminalMacOptionIsMeta}
-            onChange={onTerminalMacOptionIsMetaChange}
-          />
-        </SettingsField>
-      </SettingsSection>
-
-      <div className="border-t border-border" />
-
-      <SettingsSection title="フォント">
-        <SettingsField label="フォントファミリー" htmlFor="terminal-font-family">
-          <select
-            id="terminal-font-family"
-            value={terminalFontFamily}
-            onChange={(e) => onTerminalFontFamilyChange(e.target.value)}
-            className="w-full px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+          <p>
+            App Store
+            版ではターミナル機能をご利用いただけません。ターミナル機能を使用するには、直販版をダウンロードしてください。
+          </p>
+          <a
+            href="https://www.illusions.app/downloads/"
+            target="_blank"
+            rel="noreferrer"
+            onClick={(event) => {
+              if (window.electronAPI?.openExternal) {
+                event.preventDefault();
+                void window.electronAPI.openExternal(event.currentTarget.href);
+              }
+            }}
+            className="mt-2 inline-block font-medium text-accent underline underline-offset-4"
           >
-            {FONT_OPTIONS.map((opt) => (
-              <option key={opt.label} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </SettingsField>
-
-        <SliderField
-          label="フォントサイズ"
-          value={terminalFontSize}
-          min={10}
-          max={24}
-          step={1}
-          formatValue={(v) => `${v}px`}
-          onChange={onTerminalFontSizeChange}
-        />
-
-        <SliderField
-          label="行の高さ"
-          value={terminalLineHeight}
-          min={1.0}
-          max={2.0}
-          step={0.1}
-          formatValue={(v) => v.toFixed(1)}
-          onChange={onTerminalLineHeightChange}
-        />
-      </SettingsSection>
-
-      <div className="border-t border-border" />
-
-      <SettingsSection title="カーソル">
-        <SettingsField label="カーソルスタイル">
-          <div className="flex gap-2">
-            {CURSOR_STYLES.map(({ value, label, preview }) => (
-              <button
-                key={value}
-                type="button"
-                onClick={() => onTerminalCursorStyleChange(value)}
-                className={clsx(
-                  "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition-colors",
-                  terminalCursorStyle === value
-                    ? "border-accent bg-accent/10 text-accent"
-                    : "border-border text-foreground-secondary hover:bg-hover",
-                )}
-              >
-                <span className="font-mono text-lg leading-none">{preview}</span>
-                <span>{label}</span>
-              </button>
-            ))}
-          </div>
-        </SettingsField>
-
-        <SettingsField label="カーソルを点滅させる" htmlFor="terminal-cursor-blink" inline>
-          <SettingsToggle
-            id="terminal-cursor-blink"
-            checked={terminalCursorBlink}
-            onChange={onTerminalCursorBlinkChange}
-          />
-        </SettingsField>
-      </SettingsSection>
-
-      <div className="border-t border-border" />
-
-      <SettingsSection title="スクロールバック">
-        <SliderField
-          label="最大行数"
-          value={terminalScrollback}
-          min={1000}
-          max={50000}
-          step={1000}
-          formatValue={(v) => `${v.toLocaleString()} 行`}
-          onChange={onTerminalScrollbackChange}
-        />
-        <p className="text-xs text-foreground-tertiary">
-          値を大きくするとメモリ使用量が増加します。通常は 5,000 行で十分です。
-        </p>
-      </SettingsSection>
-
-      <div className="border-t border-border" />
-
-      <SettingsSection title="カラー">
-        <div className="grid grid-cols-2 gap-4">
-          <SettingsField label="背景色" htmlFor="terminal-bg">
-            <div className="flex items-center gap-3">
-              <input
-                type="color"
-                value={terminalBackground}
-                onChange={(e) => onTerminalBackgroundChange(e.target.value)}
-                className="w-10 h-10 rounded border border-border cursor-pointer bg-transparent"
-                aria-label="背景色ピッカー"
-              />
-              <input
-                id="terminal-bg"
-                type="text"
-                value={terminalBackground}
-                onChange={(e) => onTerminalBackgroundChange(e.target.value)}
-                className="flex-1 px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-accent"
-              />
-            </div>
-          </SettingsField>
-
-          <SettingsField label="前景色（テキスト）" htmlFor="terminal-fg">
-            <div className="flex items-center gap-3">
-              <input
-                type="color"
-                value={terminalForeground}
-                onChange={(e) => onTerminalForegroundChange(e.target.value)}
-                className="w-10 h-10 rounded border border-border cursor-pointer bg-transparent"
-                aria-label="前景色ピッカー"
-              />
-              <input
-                id="terminal-fg"
-                type="text"
-                value={terminalForeground}
-                onChange={(e) => onTerminalForegroundChange(e.target.value)}
-                className="flex-1 px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-accent"
-              />
-            </div>
-          </SettingsField>
+            直販版をダウンロード
+          </a>
         </div>
-      </SettingsSection>
+      )}
 
-      <div className="border-t border-border" />
+      <fieldset disabled={isAppStoreBuild} className="space-y-8 disabled:opacity-50">
+        <SettingsSection
+          title="Shell"
+          description="ターミナルで使用する Shell や操作の設定を変更します。"
+        >
+          <SettingsField
+            label="デフォルト Shell"
+            description="絶対パス（例: C:\\Windows\\System32\\cmd.exe）または Shell 名（例: powershell、pwsh、cmd、bash、zsh）を入力できます。空欄の場合はシステムのデフォルト Shell を使用します。"
+            htmlFor="terminal-default-shell"
+          >
+            <input
+              id="terminal-default-shell"
+              type="text"
+              value={terminalDefaultShell}
+              onChange={(e) => onTerminalDefaultShellChange(e.target.value)}
+              placeholder="自動検出（例: powershell、cmd、/bin/zsh）"
+              className="w-full px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent placeholder:text-foreground-muted"
+            />
+          </SettingsField>
 
-      <TerminalAnsiColorGrid
-        colors={terminalAnsiColors}
-        onColorChange={onTerminalAnsiColorChange}
-        onReset={onTerminalAnsiColorsReset}
-        previewBackground={terminalBackground}
-        previewForeground={terminalForeground}
-        previewFontFamily={terminalFontFamily}
-        previewFontSize={terminalFontSize}
-      />
+          <SettingsField
+            label="選択時に自動コピー"
+            description="テキストを選択すると自動的にクリップボードにコピーします。"
+            htmlFor="terminal-copy-on-select"
+            inline
+          >
+            <SettingsToggle
+              id="terminal-copy-on-select"
+              checked={terminalCopyOnSelect}
+              onChange={onTerminalCopyOnSelectChange}
+            />
+          </SettingsField>
 
-      <div className="border-t border-border pt-4">
-        <p className="text-xs text-foreground-tertiary">
-          ※ フォント・カーソル・カラーの変更は、新しく開くターミナルから反映されます。
-        </p>
-      </div>
+          <SettingsField
+            label="Option キーを Meta として使用"
+            description="macOS で Option キーを Alt/Meta キーとして扱います（Emacs キーバインドなどに便利）。"
+            htmlFor="terminal-mac-option-meta"
+            inline
+          >
+            <SettingsToggle
+              id="terminal-mac-option-meta"
+              checked={terminalMacOptionIsMeta}
+              onChange={onTerminalMacOptionIsMetaChange}
+            />
+          </SettingsField>
+        </SettingsSection>
+
+        <div className="border-t border-border" />
+
+        <SettingsSection title="フォント">
+          <SettingsField label="フォントファミリー" htmlFor="terminal-font-family">
+            <select
+              id="terminal-font-family"
+              value={terminalFontFamily}
+              onChange={(e) => onTerminalFontFamilyChange(e.target.value)}
+              className="w-full px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
+            >
+              {FONT_OPTIONS.map((opt) => (
+                <option key={opt.label} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </SettingsField>
+
+          <SliderField
+            label="フォントサイズ"
+            value={terminalFontSize}
+            min={10}
+            max={24}
+            step={1}
+            formatValue={(v) => `${v}px`}
+            onChange={onTerminalFontSizeChange}
+          />
+
+          <SliderField
+            label="行の高さ"
+            value={terminalLineHeight}
+            min={1.0}
+            max={2.0}
+            step={0.1}
+            formatValue={(v) => v.toFixed(1)}
+            onChange={onTerminalLineHeightChange}
+          />
+        </SettingsSection>
+
+        <div className="border-t border-border" />
+
+        <SettingsSection title="カーソル">
+          <SettingsField label="カーソルスタイル">
+            <div className="flex gap-2">
+              {CURSOR_STYLES.map(({ value, label, preview }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => onTerminalCursorStyleChange(value)}
+                  className={clsx(
+                    "flex-1 flex items-center justify-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition-colors",
+                    terminalCursorStyle === value
+                      ? "border-accent bg-accent/10 text-accent"
+                      : "border-border text-foreground-secondary hover:bg-hover",
+                  )}
+                >
+                  <span className="font-mono text-lg leading-none">{preview}</span>
+                  <span>{label}</span>
+                </button>
+              ))}
+            </div>
+          </SettingsField>
+
+          <SettingsField label="カーソルを点滅させる" htmlFor="terminal-cursor-blink" inline>
+            <SettingsToggle
+              id="terminal-cursor-blink"
+              checked={terminalCursorBlink}
+              onChange={onTerminalCursorBlinkChange}
+            />
+          </SettingsField>
+        </SettingsSection>
+
+        <div className="border-t border-border" />
+
+        <SettingsSection title="スクロールバック">
+          <SliderField
+            label="最大行数"
+            value={terminalScrollback}
+            min={1000}
+            max={50000}
+            step={1000}
+            formatValue={(v) => `${v.toLocaleString()} 行`}
+            onChange={onTerminalScrollbackChange}
+          />
+          <p className="text-xs text-foreground-tertiary">
+            値を大きくするとメモリ使用量が増加します。通常は 5,000 行で十分です。
+          </p>
+        </SettingsSection>
+
+        <div className="border-t border-border" />
+
+        <SettingsSection title="カラー">
+          <div className="grid grid-cols-2 gap-4">
+            <SettingsField label="背景色" htmlFor="terminal-bg">
+              <div className="flex items-center gap-3">
+                <input
+                  type="color"
+                  value={terminalBackground}
+                  onChange={(e) => onTerminalBackgroundChange(e.target.value)}
+                  className="w-10 h-10 rounded border border-border cursor-pointer bg-transparent"
+                  aria-label="背景色ピッカー"
+                />
+                <input
+                  id="terminal-bg"
+                  type="text"
+                  value={terminalBackground}
+                  onChange={(e) => onTerminalBackgroundChange(e.target.value)}
+                  className="flex-1 px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+                />
+              </div>
+            </SettingsField>
+
+            <SettingsField label="前景色（テキスト）" htmlFor="terminal-fg">
+              <div className="flex items-center gap-3">
+                <input
+                  type="color"
+                  value={terminalForeground}
+                  onChange={(e) => onTerminalForegroundChange(e.target.value)}
+                  className="w-10 h-10 rounded border border-border cursor-pointer bg-transparent"
+                  aria-label="前景色ピッカー"
+                />
+                <input
+                  id="terminal-fg"
+                  type="text"
+                  value={terminalForeground}
+                  onChange={(e) => onTerminalForegroundChange(e.target.value)}
+                  className="flex-1 px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground font-mono text-sm focus:outline-none focus:ring-2 focus:ring-accent"
+                />
+              </div>
+            </SettingsField>
+          </div>
+        </SettingsSection>
+
+        <div className="border-t border-border" />
+
+        <TerminalAnsiColorGrid
+          colors={terminalAnsiColors}
+          onColorChange={onTerminalAnsiColorChange}
+          onReset={onTerminalAnsiColorsReset}
+          previewBackground={terminalBackground}
+          previewForeground={terminalForeground}
+          previewFontFamily={terminalFontFamily}
+          previewFontSize={terminalFontSize}
+        />
+
+        <div className="border-t border-border pt-4">
+          <p className="text-xs text-foreground-tertiary">
+            ※ フォント・カーソル・カラーの変更は、新しく開くターミナルから反映されます。
+          </p>
+        </div>
+      </fieldset>
     </div>
   );
 }


### PR DESCRIPTION
## 変更内容

- MAS 版のアクティビティバー、空のエディター画面、タブ領域メニューからターミナル導線を非表示にしました。
- MAS 版ではターミナル設定の全項目を無効化しました。
- App Store 版ではターミナルを利用できない旨と、直販版のダウンロードリンクを日本語で表示します。

## 背景

Mac App Store のサンドボックス制約により、MAS 版ではターミナル機能を提供していません。利用できない操作を UI から除外し、直販版への案内を明確にします。

## ユーザーへの影響

MAS 版のユーザーは使用不能なターミナルを起動できなくなり、設定画面から対応する直販版を取得できます。直販版の挙動は変わりません。

## 確認

- npm run type-check
- git diff --check
- npm run check:boundaries（push フック）