### PR TITLE
fix: retry TestFlight build association

### DIFF
--- a/.github/workflows/store-publish.yml
+++ b/.github/workflows/store-publish.yml
@@ -29,6 +29,11 @@ on:
         description: "Desktop Build and Release run ID to pull the signed MAS .pkg from (appstore-testflight — defaults to latest successful build-mas run if omitted)"
         required: false
         type: string
+      skip_appstore_upload:
+        description: "Skip uploading the MAS package and only enable an already-uploaded build for internal TestFlight testers"
+        required: false
+        type: boolean
+        default: false
       dry_run:
         description: "Dry run — log actions without mutating store state (Microsoft Store jobs only)"
         required: false
@@ -202,6 +207,7 @@ jobs:
           chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
 
       - name: Upload to App Store Connect
+        if: ${{ !inputs.skip_appstore_upload }}
         shell: bash
         run: |
           PKG_FILE=$(find dist-electron -name "*.pkg" -type f | head -n 1)

--- a/scripts/asc-testflight-enable.mjs
+++ b/scripts/asc-testflight-enable.mjs
@@ -60,7 +60,9 @@ async function asc(path, options = {}) {
   if (!res.ok) {
     console.error(`ASC API ${options.method || "GET"} ${path} -> ${res.status}`);
     console.error(JSON.stringify(body, null, 2));
-    throw new Error(`ASC API request failed: ${res.status}`);
+    const error = new Error(`ASC API request failed: ${res.status}`);
+    error.status = res.status;
+    throw error;
   }
   return body;
 }
@@ -105,16 +107,29 @@ async function findOrGetInternalGroup() {
   return group;
 }
 
-async function grantGroupAccessToBuild(groupId, buildId) {
+async function grantGroupAccessToBuild(groupId, buildId, { retries = 20, delayMs = 30000 } = {}) {
   // App Store Connect exposes the association from both resources. Creating it
-  // from the build side is more reliable immediately after upload: the build
-  // is already addressable at /builds/{id}, while its reverse lookup from a
-  // beta group can still return RESOURCE_NOT_FOUND for a short period.
-  await asc(`/builds/${buildId}/relationships/betaGroups`, {
-    method: "POST",
-    body: JSON.stringify({ data: [{ type: "betaGroups", id: groupId }] }),
-  });
-  console.log("Internal TestFlight group granted access to build.");
+  // from the build side. Apple can report the build as VALID before that
+  // relationship endpoint has caught up; retry its temporary 404 rather than
+  // failing the release after a successful upload.
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      await asc(`/builds/${buildId}/relationships/betaGroups`, {
+        method: "POST",
+        body: JSON.stringify({ data: [{ type: "betaGroups", id: groupId }] }),
+      });
+      console.log("Internal TestFlight group granted access to build.");
+      return;
+    } catch (error) {
+      if (error.status !== 404 || attempt === retries) {
+        throw error;
+      }
+      console.log(
+        `Build relationship is not ready yet, waiting... (attempt ${attempt}/${retries})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
 }
 
 const build = await findBuild(buildNumber);


### PR DESCRIPTION
Retry App Store Connect's temporary 404 after a build reaches VALID, and allow manual TestFlight enabling without re-uploading an already-uploaded MAS package.\n\nValidation: node --check scripts/asc-testflight-enable.mjs; git diff --check.