### PR TITLE
feat(auth): use macOS web authentication sessions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1183,6 +1183,10 @@ function EditorPageContent() {
     onOpenProject: () => void handleOpenProject(),
     onOpenRecentProject: (projectId: string) => openRecentProjectRef.current(projectId),
     onCloseWindow: () => window.close(),
+    onOpenSettings: () => {
+      setSettingsInitialCategory(undefined);
+      setShowSettingsModal(true);
+    },
     onToggleCompactMode: () => toggleCompactModeRef.current(),
     onExport: (format) => void exportAs(format),
     onPrint: () => printDocument(),

--- a/components/ActivityBar.tsx
+++ b/components/ActivityBar.tsx
@@ -512,17 +512,30 @@ export default function ActivityBar({
                   </button>
                 </>
               ) : (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowUserMenu(false);
-                    login();
-                  }}
-                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-hover transition-colors"
-                >
-                  <UserCircle className="w-4 h-4" />
-                  ログイン
-                </button>
+                <>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowUserMenu(false);
+                      onOpenAccountSettings?.();
+                    }}
+                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-hover transition-colors"
+                  >
+                    <Settings className="w-4 h-4" />
+                    設定
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowUserMenu(false);
+                      login();
+                    }}
+                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-hover transition-colors"
+                  >
+                    <UserCircle className="w-4 h-4" />
+                    ログイン
+                  </button>
+                </>
               )}
             </div>
           )}

--- a/components/WelcomeScreen.tsx
+++ b/components/WelcomeScreen.tsx
@@ -209,17 +209,30 @@ export default function WelcomeScreen({
                 </button>
               </>
             ) : (
-              <button
-                type="button"
-                onClick={() => {
-                  setShowUserMenu(false);
-                  login();
-                }}
-                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-hover transition-colors"
-              >
-                <UserCircle className="w-4 h-4" />
-                ログイン
-              </button>
+              <>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowUserMenu(false);
+                    onOpenAccountSettings?.();
+                  }}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-hover transition-colors"
+                >
+                  <Settings className="w-4 h-4" />
+                  設定
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowUserMenu(false);
+                    login();
+                  }}
+                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-hover transition-colors"
+                >
+                  <UserCircle className="w-4 h-4" />
+                  ログイン
+                </button>
+              </>
             )}
           </div>
         )}

--- a/docs/architecture/authentication-flow.md
+++ b/docs/architecture/authentication-flow.md
@@ -42,14 +42,14 @@ PKCE は以下の 3 つのステップで構成されます。
 ### Electron 版のフロー
 
 1. **ログイン開始**: レンダラーから IPC (`auth:login`) を通じてメインプロセスへ要求を送ります。
-2. **ブラウザ起動**: メインプロセスが PKCE パラメータを生成します。通常版は `shell.openExternal` でシステム標準ブラウザを開き、Mac App Store 版は Node API を持たない制限付き `BrowserWindow` 内で認可画面を開きます。
+2. **ブラウザ起動**: メインプロセスが PKCE パラメータを生成します。macOS ではネイティブ bridge 経由で `ASWebAuthenticationSession` を開始し、システムブラウザから `illusions://auth/callback` の結果を直接受け取ります。Windows／Linux では `shell.openExternal` でシステム標準ブラウザを開きます。macOS で session を開始できない場合だけ、同じ PKCE URL を `shell.openExternal` に fallback します。
 3. **認可と返却**: ブラウザで認可が完了すると、カスタムプロトコル（`illusions://auth/callback`）を通じて認可コードが Electron アプリに返されます。
 4. **トークン取得**: メインプロセスがトークン交換を行い、結果をレンダラーに通知します。
 
 ## セキュリティ上の考慮事項
 
 - **State パラメータ**: CSRF（クロスサイトリクエストフォージェリ）防止のため、ランダムな `state` 値を検証に使用します。
-- **MAS 認可ウィンドウ**: ポップアップを拒否し、`my.illusions.app`、GitHub／Google／Apple の既知の認可 origin、および検証済みの `illusions://auth/callback` 以外へのトップレベル遷移を拒否します。キャンセル・ロード失敗・親ウィンドウ終了時には保留中の state を破棄します。
+- **macOS 認可セッション**: OAuth は Electron の `BrowserWindow` 内では表示しません。`ASWebAuthenticationSession` が callback scheme と一致する URL だけを main process に返すため、Apple／Google／GitHub のログインをシステムブラウザで一貫して処理できます。ユーザーのキャンセル時は保留中の state を破棄し、session を開始できない場合のみ外部ブラウザ fallback を試みます。
 - **MAS アカウント削除**: アカウント削除ページは、外部ブラウザではなく同じく制限付きの app-owned window で開きます。
 - **セキュアな保存**: 取得した `access_token` および `refresh_token` は、環境に応じたセキュアなストレージ（ブラウザの HttpOnly Cookie、Electron の安全な暗号化ストア等）に保持されます。
 - **有効期限**: トークンには有効期限を設定し、必要に応じてリフレッシュトークンによる更新を行います。

--- a/electron/__tests__/auth-ipc.test.ts
+++ b/electron/__tests__/auth-ipc.test.ts
@@ -78,6 +78,8 @@ describe("auth-ipc.js — platform OAuth routing", () => {
   });
 
   it("cancels the request that belongs to a closed source window", async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { ...platformDescriptor, value: "darwin" });
     let onClosed: (() => void) | undefined;
     const sourceWindow = {
       id: 41,
@@ -91,15 +93,20 @@ describe("auth-ipc.js — platform OAuth routing", () => {
     startMacOSAuthSession.mockClear();
     cancelMacOSAuthSession.mockClear();
 
-    authIpc.registerAuthHandlers();
-    const startLogin = authHandlers.get("auth:start-login");
-    expect(startLogin).toBeDefined();
-    await startLogin?.({ sender: {} });
+    try {
+      authIpc.registerAuthHandlers();
+      const startLogin = authHandlers.get("auth:start-login");
+      expect(startLogin).toBeDefined();
+      await startLogin?.({ sender: {} });
+      await Promise.resolve();
 
-    const requestId = startMacOSAuthSession.mock.calls[0]?.[2];
-    expect(requestId).toEqual(expect.any(String));
-    onClosed?.();
-    expect(cancelMacOSAuthSession).toHaveBeenCalledWith(requestId);
+      const requestId = startMacOSAuthSession.mock.calls[0]?.[2];
+      expect(requestId).toEqual(expect.any(String));
+      onClosed?.();
+      expect(cancelMacOSAuthSession).toHaveBeenCalledWith(requestId);
+    } finally {
+      Object.defineProperty(process, "platform", platformDescriptor!);
+    }
   });
 
   it("keeps MAS account deletion in a restricted app-owned window", () => {

--- a/electron/__tests__/auth-ipc.test.ts
+++ b/electron/__tests__/auth-ipc.test.ts
@@ -1,72 +1,112 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const source = fs.readFileSync(path.resolve(__dirname, "../ipc/auth-ipc.js"), "utf8");
 const nodeRequire = createRequire(import.meta.url);
 const electronId = nodeRequire.resolve("electron");
+const authHandlers = new Map<string, (event: { sender: unknown }) => Promise<unknown>>();
+const startMacOSAuthSession = vi.fn<
+  (url: string, scheme: string, requestId: string) => Promise<string>
+>(() => new Promise<string>(() => {}));
+const cancelMacOSAuthSession = vi.fn();
+const cancelAllMacOSAuthSessionsForShutdown = vi.fn();
+const electronMock: {
+  app: { on: () => void; once: () => void };
+  ipcMain: {
+    handle: (channel: string, handler: (event: { sender: unknown }) => Promise<unknown>) => void;
+  };
+  shell: { openExternal: (url: string) => Promise<void> };
+  BrowserWindow: {
+    getAllWindows: () => unknown[];
+    fromId: () => unknown;
+    fromWebContents: () => unknown;
+  };
+} = {
+  app: { on: () => {}, once: () => {} },
+  ipcMain: {
+    handle: (channel: string, handler: (event: { sender: unknown }) => Promise<unknown>) => {
+      authHandlers.set(channel, handler);
+    },
+  },
+  shell: { openExternal: async () => {} },
+  BrowserWindow: { getAllWindows: () => [], fromId: () => null, fromWebContents: () => null },
+};
 nodeRequire.cache[electronId] = {
   id: electronId,
   filename: electronId,
   loaded: true,
-  exports: {
-    app: { on: () => {} },
-    ipcMain: { handle: () => {} },
-    shell: { openExternal: async () => {} },
-    BrowserWindow: { getAllWindows: () => [], fromId: () => null, fromWebContents: () => null },
-  },
+  exports: electronMock,
 } as unknown as NodeJS.Module;
-const { isAllowedOAuthUrl } = nodeRequire("../ipc/auth-ipc.js") as {
-  isAllowedOAuthUrl: (url: string) => boolean;
+const macosAuthSessionId = nodeRequire.resolve("../lib/macos-auth-session.js");
+nodeRequire.cache[macosAuthSessionId] = {
+  id: macosAuthSessionId,
+  filename: macosAuthSessionId,
+  loaded: true,
+  exports: { startMacOSAuthSession, cancelMacOSAuthSession, cancelAllMacOSAuthSessionsForShutdown },
+} as unknown as NodeJS.Module;
+const authIpc = nodeRequire("../ipc/auth-ipc.js") as {
+  registerAuthHandlers: () => void;
+  handleAuthCallback: (url: string) => void;
 };
 
-describe("auth-ipc.js — MAS in-app OAuth", () => {
-  it("uses the app-wide MAS build flag and retains shell OAuth for other builds", () => {
-    expect(source).toContain('require("../app-constants")');
-    expect(source).toMatch(/if\s*\(isMasBuild\)[\s\S]*openMasAuthWindow/);
-    expect(source).toMatch(/else\s*\{[\s\S]*shell\.openExternal\(authUrl\)/);
+describe("auth-ipc.js — platform OAuth routing", () => {
+  it("loads without the removed embedded OAuth helpers", () => {
+    expect(authIpc.registerAuthHandlers).toBeTypeOf("function");
+    expect(authIpc.handleAuthCallback).toBeTypeOf("function");
   });
 
-  it("creates an isolated, sandboxed authorization window without a preload", () => {
-    expect(source).toMatch(/contextIsolation:\s*true/);
-    expect(source).toMatch(/nodeIntegration:\s*false/);
-    expect(source).toMatch(/sandbox:\s*true/);
-    expect(source).toContain('setWindowOpenHandler(() => ({ action: "deny" }))');
+  it("uses ASWebAuthenticationSession on macOS without an embedded OAuth BrowserWindow", () => {
+    expect(source).toContain('require("../lib/macos-auth-session")');
+    expect(source).toContain('if (process.platform === "darwin")');
+    expect(source).toContain('startMacOSAuthSession(authUrl, "illusions", state)');
+    expect(source).toContain("handleAuthCallback(callbackUrl)");
+    expect(source).not.toContain("openMasAuthWindow");
+    expect(source).not.toContain("setWindowOpenHandler(({ url })");
   });
 
-  it("only permits the provider, expected IdPs, and the expected custom-scheme callback", () => {
-    expect(source).toContain("parsed.origin === PROVIDER_URL");
-    expect(source).toContain('parsed.protocol === "illusions:"');
-    expect(source).toContain('parsed.host === "auth"');
-    expect(source).toContain('parsed.pathname === "/callback"');
-    expect(source).toContain("Blocked OAuth window navigation");
-    expect(source).toContain('webContents.on("will-navigate", interceptNavigation)');
-    expect(source).toContain('webContents.on("will-redirect", interceptNavigation)');
-    expect(source).toContain("if (receivedCallback)");
+  it("retains system-browser OAuth as the non-macOS path and the macOS fallback", () => {
+    expect(source).toContain("ASWebAuthenticationSession unavailable; opening system browser");
+    expect(source).toContain("await shell.openExternal(authUrl)");
   });
 
-  it("allows only the hosted provider and known social-login origins", () => {
-    expect(isAllowedOAuthUrl("https://my.illusions.app/api/oauth/authorize")).toBe(true);
-    expect(isAllowedOAuthUrl("https://github.com/login/oauth/authorize")).toBe(true);
-    expect(isAllowedOAuthUrl("https://accounts.google.com/o/oauth2/v2/auth")).toBe(true);
-    expect(isAllowedOAuthUrl("https://appleid.apple.com/auth/authorize")).toBe(true);
-    expect(isAllowedOAuthUrl("https://evil.example/redirect")).toBe(false);
-    expect(isAllowedOAuthUrl("http://my.illusions.app/insecure")).toBe(false);
+  it("cancels the matching native session on window close and all sessions before quit", () => {
+    expect(source).toContain("cancelMacOSAuthSession(state)");
+    expect(source).toContain('app.once("before-quit"');
+    expect(source).toContain("cancelAllMacOSAuthSessionsForShutdown()");
   });
 
-  it("keeps MAS account deletion in a restricted in-app window", () => {
+  it("cancels the request that belongs to a closed source window", async () => {
+    let onClosed: (() => void) | undefined;
+    const sourceWindow = {
+      id: 41,
+      on: vi.fn((event: string, listener: () => void) => {
+        if (event === "closed") onClosed = listener;
+      }),
+    };
+    electronMock.BrowserWindow.getAllWindows = () => [sourceWindow];
+    electronMock.BrowserWindow.fromWebContents = () => sourceWindow;
+    authHandlers.clear();
+    startMacOSAuthSession.mockClear();
+    cancelMacOSAuthSession.mockClear();
+
+    authIpc.registerAuthHandlers();
+    const startLogin = authHandlers.get("auth:start-login");
+    expect(startLogin).toBeDefined();
+    await startLogin?.({ sender: {} });
+
+    const requestId = startMacOSAuthSession.mock.calls[0]?.[2];
+    expect(requestId).toEqual(expect.any(String));
+    onClosed?.();
+    expect(cancelMacOSAuthSession).toHaveBeenCalledWith(requestId);
+  });
+
+  it("keeps MAS account deletion in a restricted app-owned window", () => {
     expect(source).toContain("ACCOUNT_DELETION_URL = `${PROVIDER_URL}/delete-account`");
     expect(source).toContain("openMasAccountDeletionWindow");
     expect(source).toContain("AUTH_CHANNELS.invoke.openDeleteAccount");
     expect(source).toContain("Blocked account-deletion navigation");
-    expect(source).toContain('webContents.on("will-redirect", interceptDeletionNavigation)');
-  });
-
-  it("cleans pending state when the auth window is cancelled or cannot load", () => {
-    expect(source).toContain('authWindow.on("closed"');
-    expect(source).toContain("pendingAuthByState.delete(state)");
-    expect(source).toContain("Failed to load OAuth authorization page");
   });
 
   it("does not route callbacks with an unknown state to the focused window", () => {

--- a/electron/app-constants.js
+++ b/electron/app-constants.js
@@ -10,6 +10,9 @@ const isMicrosoftStoreApp = process.windowsStore === true;
 
 // Mac App Store (MAS) ビルドかどうかを判定（Electron が MAS パッケージ時に自動設定）
 // MAS はサンドボックス制約により auto-updater・ターミナル(node-pty)・QuickLook 同梱を無効化する
-const isMasBuild = process.mas === true;
+// `MAS_BUILD=1` enables the same code path during local development. The
+// Electron-provided `process.mas` remains the source of truth in packaged MAS
+// builds, where sandboxing and entitlements are applied by the bundle.
+const isMasBuild = process.mas === true || process.env.MAS_BUILD === "1";
 
 module.exports = { isDev, APP_NAME, isMicrosoftStoreApp, isMasBuild };

--- a/electron/ipc/auth-ipc.js
+++ b/electron/ipc/auth-ipc.js
@@ -2,25 +2,19 @@ const { ipcMain, shell, BrowserWindow, app } = require("electron");
 const crypto = require("crypto");
 const { AUTH_CHANNELS } = require("../lib/ipc-channels");
 const { isMasBuild } = require("../app-constants");
+const {
+  startMacOSAuthSession,
+  cancelMacOSAuthSession,
+  cancelAllMacOSAuthSessionsForShutdown,
+} = require("../lib/macos-auth-session");
 
 const PROVIDER_URL = "https://my.illusions.app";
 const OAUTH_CLIENT_ID = "illusions";
 const REDIRECT_URI = "illusions://auth/callback";
 const ACCOUNT_DELETION_URL = `${PROVIDER_URL}/delete-account`;
 
-// These are the top-level identity-provider origins offered by the hosted
-// sign-in page. Keep the allowlist exact: an OAuth BrowserWindow must not turn
-// into a general-purpose browser just because it hosts third-party sign-in.
-const OAUTH_IDP_ORIGINS = new Set([
-  "https://github.com",
-  "https://accounts.google.com",
-  "https://appleid.apple.com",
-]);
-
 /** @type {Map<string, { codeVerifier: string, windowId: number }>} state → { codeVerifier, windowId } */
 const pendingAuthByState = new Map();
-/** @type {Map<string, Electron.BrowserWindow>} state → MAS authorization window */
-const authWindowByState = new Map();
 
 function isProviderUrl(url) {
   try {
@@ -29,97 +23,6 @@ function isProviderUrl(url) {
   } catch {
     return false;
   }
-}
-
-function isAllowedOAuthUrl(url) {
-  try {
-    const parsed = new URL(url);
-    return (
-      parsed.protocol === "https:" &&
-      (parsed.origin === PROVIDER_URL || OAUTH_IDP_ORIGINS.has(parsed.origin))
-    );
-  } catch {
-    return false;
-  }
-}
-
-function isAuthCallbackUrl(url) {
-  try {
-    const parsed = new URL(url);
-    return (
-      parsed.protocol === "illusions:" && parsed.host === "auth" && parsed.pathname === "/callback"
-    );
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Open the authorization page inside a restricted, parented window for the
- * Mac App Store build. OAuth credentials never receive the app preload or
- * Node APIs, and top-level navigation is limited to the first-party provider
- * until it returns to the custom-scheme callback.
- */
-function openMasAuthWindow({ authUrl, parent, state }) {
-  const authWindow = new BrowserWindow({
-    parent: parent && !parent.isDestroyed() ? parent : undefined,
-    modal: Boolean(parent && !parent.isDestroyed()),
-    width: 520,
-    height: 720,
-    minWidth: 400,
-    minHeight: 500,
-    show: false,
-    title: "Sign in to illusions",
-    webPreferences: {
-      contextIsolation: true,
-      nodeIntegration: false,
-      sandbox: true,
-    },
-  });
-  authWindowByState.set(state, authWindow);
-
-  let receivedCallback = false;
-  const cancelPendingLogin = () => {
-    if (!receivedCallback) pendingAuthByState.delete(state);
-  };
-
-  const interceptNavigation = (event, navigationUrl) => {
-    // Chromium may emit both redirect and navigation events for a redirect;
-    // process the callback exactly once even in that case.
-    if (receivedCallback) {
-      event.preventDefault();
-      return;
-    }
-    if (isAuthCallbackUrl(navigationUrl)) {
-      event.preventDefault();
-      receivedCallback = true;
-      handleAuthCallback(navigationUrl);
-      authWindow.close();
-      return;
-    }
-    if (!isAllowedOAuthUrl(navigationUrl)) {
-      event.preventDefault();
-      console.warn("[auth] Blocked OAuth window navigation to:", navigationUrl);
-    }
-  };
-  authWindow.webContents.on("will-navigate", interceptNavigation);
-  // OAuth server redirects to the custom protocol, so intercept it before
-  // Chromium attempts to hand the URL to an external protocol handler.
-  authWindow.webContents.on("will-redirect", interceptNavigation);
-  authWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
-  authWindow.once("ready-to-show", () => authWindow.show());
-  authWindow.on("closed", () => {
-    authWindowByState.delete(state);
-    cancelPendingLogin();
-  });
-
-  // Do not await loadURL: the renderer should enter its login-pending state
-  // immediately, rather than wait for the user to finish authorization.
-  void authWindow.loadURL(authUrl).catch((error) => {
-    console.error("[auth] Failed to load OAuth authorization page:", error);
-    cancelPendingLogin();
-    if (!authWindow.isDestroyed()) authWindow.close();
-  });
 }
 
 /**
@@ -189,8 +92,32 @@ function registerAuthHandlers() {
     });
 
     const authUrl = `${PROVIDER_URL}/api/oauth/authorize?${params}`;
-    if (isMasBuild) {
-      openMasAuthWindow({ authUrl, parent: win, state });
+    if (process.platform === "darwin") {
+      // ASWebAuthenticationSession uses the system browser and returns the
+      // matching callback directly to this process. It avoids embedding any
+      // identity provider (especially Apple Account) in an Electron view.
+      void Promise.resolve()
+        .then(() => startMacOSAuthSession(authUrl, "illusions", state))
+        .then((callbackUrl) => handleAuthCallback(callbackUrl))
+        .catch(async (error) => {
+          if (error?.code === "ERR_AUTH_CANCELLED") {
+            pendingAuthByState.delete(state);
+            return;
+          }
+          console.warn(
+            "[auth] ASWebAuthenticationSession unavailable; opening system browser:",
+            error,
+          );
+          try {
+            await shell.openExternal(authUrl);
+          } catch (fallbackError) {
+            pendingAuthByState.delete(state);
+            console.error(
+              "[auth] Failed to open OAuth authorization page in browser:",
+              fallbackError,
+            );
+          }
+        });
     } else {
       try {
         await shell.openExternal(authUrl);
@@ -274,8 +201,7 @@ function registerAuthHandlers() {
       for (const [state, entry] of pendingAuthByState) {
         if (entry.windowId === winId) {
           pendingAuthByState.delete(state);
-          const authWindow = authWindowByState.get(state);
-          if (authWindow && !authWindow.isDestroyed()) authWindow.close();
+          cancelMacOSAuthSession(state);
         }
       }
     }
@@ -295,8 +221,7 @@ function registerAuthHandlers() {
       for (const [state, entry] of pendingAuthByState) {
         if (entry.windowId === winId) {
           pendingAuthByState.delete(state);
-          const authWindow = authWindowByState.get(state);
-          if (authWindow && !authWindow.isDestroyed()) authWindow.close();
+          cancelMacOSAuthSession(state);
         }
       }
     });
@@ -308,6 +233,12 @@ function registerAuthHandlers() {
   // Register for future windows
   app.on("browser-window-created", (_, win) => {
     attachAuthCleanup(win);
+  });
+  app.once("before-quit", () => {
+    // Do not let AuthenticationServices call back into a Node runtime that is
+    // being torn down. The native bridge suppresses completion callbacks after
+    // this explicit shutdown cancellation.
+    cancelAllMacOSAuthSessionsForShutdown();
   });
 }
 
@@ -352,6 +283,5 @@ function handleAuthCallback(url) {
 module.exports = {
   registerAuthHandlers,
   handleAuthCallback,
-  isAllowedOAuthUrl,
   isProviderUrl,
 };

--- a/electron/lib/__tests__/macos-auth-session.test.ts
+++ b/electron/lib/__tests__/macos-auth-session.test.ts
@@ -1,0 +1,70 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+const nodeRequire = createRequire(import.meta.url);
+const { startMacOSAuthSession, cancelMacOSAuthSession, cancelAllMacOSAuthSessionsForShutdown } =
+  nodeRequire("../macos-auth-session.js") as {
+    startMacOSAuthSession: (
+      url: string,
+      callbackScheme: string,
+      requestId: string,
+      options: { platform: string; loadBinding: () => { start: ReturnType<typeof vi.fn> } },
+    ) => Promise<string> | null;
+    cancelMacOSAuthSession: (
+      requestId: string,
+      options: { platform: string; loadBinding: () => { cancel: ReturnType<typeof vi.fn> } },
+    ) => void;
+    cancelAllMacOSAuthSessionsForShutdown: (options: {
+      platform: string;
+      loadBinding: () => { cancelAllForShutdown: ReturnType<typeof vi.fn> };
+    }) => void;
+  };
+
+describe("macos-auth-session", () => {
+  it.each(["win32", "linux"])("never loads the macOS native bridge on %s", (platform) => {
+    const loadBinding = vi.fn();
+
+    const result = startMacOSAuthSession("https://example.test/oauth", "illusions", "request-1", {
+      platform,
+      loadBinding,
+    });
+
+    expect(result).toBeNull();
+    expect(loadBinding).not.toHaveBeenCalled();
+  });
+
+  it("loads the bridge and returns its session promise on macOS", async () => {
+    const start = vi.fn().mockResolvedValue("illusions://auth/callback?code=code&state=state");
+    const loadBinding = vi.fn(() => ({ start }));
+
+    await expect(
+      startMacOSAuthSession("https://example.test/oauth", "illusions", "request-1", {
+        platform: "darwin",
+        loadBinding,
+      }),
+    ).resolves.toContain("illusions://auth/callback");
+    expect(loadBinding).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledWith("https://example.test/oauth", "illusions", "request-1");
+  });
+
+  it.each(["win32", "linux"])("does not load the bridge to cancel on %s", (platform) => {
+    const loadBinding = vi.fn();
+
+    cancelMacOSAuthSession("request-1", { platform, loadBinding });
+    cancelAllMacOSAuthSessionsForShutdown({ platform, loadBinding });
+
+    expect(loadBinding).not.toHaveBeenCalled();
+  });
+
+  it("cancels a matching macOS request and all requests during shutdown", () => {
+    const cancel = vi.fn();
+    const cancelAllForShutdown = vi.fn();
+    const loadBinding = vi.fn(() => ({ cancel, cancelAllForShutdown }));
+
+    cancelMacOSAuthSession("request-1", { platform: "darwin", loadBinding });
+    cancelAllMacOSAuthSessionsForShutdown({ platform: "darwin", loadBinding });
+
+    expect(cancel).toHaveBeenCalledWith("request-1");
+    expect(cancelAllForShutdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/lib/macos-auth-session.js
+++ b/electron/lib/macos-auth-session.js
@@ -1,0 +1,43 @@
+"use strict";
+
+/**
+ * Returns null outside macOS without resolving the native package. This keeps
+ * Windows and Linux builds free of a macOS-only binary and its dependencies.
+ */
+function startMacOSAuthSession(
+  authorizationUrl,
+  callbackScheme,
+  requestId,
+  {
+    platform = process.platform,
+    loadBinding = () => require("@illusions/as-web-authentication"),
+  } = {},
+) {
+  if (platform !== "darwin") return null;
+  return loadBinding().start(authorizationUrl, callbackScheme, requestId);
+}
+
+function cancelMacOSAuthSession(
+  requestId,
+  {
+    platform = process.platform,
+    loadBinding = () => require("@illusions/as-web-authentication"),
+  } = {},
+) {
+  if (platform !== "darwin") return;
+  loadBinding().cancel(requestId);
+}
+
+function cancelAllMacOSAuthSessionsForShutdown({
+  platform = process.platform,
+  loadBinding = () => require("@illusions/as-web-authentication"),
+} = {}) {
+  if (platform !== "darwin") return;
+  loadBinding().cancelAllForShutdown();
+}
+
+module.exports = {
+  startMacOSAuthSession,
+  cancelMacOSAuthSession,
+  cancelAllMacOSAuthSessionsForShutdown,
+};

--- a/lib/menu/__tests__/menu-template-drift.test.ts
+++ b/lib/menu/__tests__/menu-template-drift.test.ts
@@ -350,8 +350,8 @@ describe("shared menu template drift prevention", () => {
 // Behavior pinning: the derived Web structure equals the pre-refactor literal
 // ---------------------------------------------------------------------------
 
-describe("WEB_MENU_STRUCTURE preserves the pre-#1433 structure", () => {
-  it("matches the previous hardcoded definition exactly", () => {
+describe("WEB_MENU_STRUCTURE", () => {
+  it("includes the Settings entry in the shared Web menu definition", () => {
     const APP_VERSION = (() => {
       const v = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
       const parts = v.split(".");
@@ -390,6 +390,7 @@ describe("WEB_MENU_STRUCTURE preserves the pre-#1433 structure", () => {
           { type: "separator" },
           { label: "新しいタブ", accelerator: "Ctrl+T", action: "new-tab" },
           { label: "タブを閉じる", accelerator: "Ctrl+W", action: "close-tab" },
+          { label: "設定…", action: "settings" },
         ],
       },
       {
@@ -486,7 +487,7 @@ describe("WEB_MENU_STRUCTURE preserves the pre-#1433 structure", () => {
     expect(WEB_MENU_STRUCTURE).toEqual(expected);
   });
 
-  it("ACTION_TO_COMMAND_ID preserves the pre-#1433 mapping exactly", () => {
+  it("maps Settings to its keyboard command", () => {
     expect(ACTION_TO_COMMAND_ID).toEqual({
       "new-window": "file.newWindow",
       "open-file": "file.open",
@@ -502,6 +503,7 @@ describe("WEB_MENU_STRUCTURE preserves the pre-#1433 structure", () => {
       "zoom-in": "view.zoomIn",
       "zoom-out": "view.zoomOut",
       "toggle-compact-mode": "view.compactMode",
+      settings: "nav.settings",
     });
   });
 });

--- a/lib/menu/menu-template.js
+++ b/lib/menu/menu-template.js
@@ -26,8 +26,8 @@ const SEPARATOR = { type: "separator" };
 /**
  * Native-only Settings entry. On macOS it is placed in the application menu
  * (the platform convention); other desktop platforms place it in File.
- * Keeping its command/channel declaration here lets the native-menu and IPC
- * contract use the same source without exposing a duplicate Web-menu item.
+ * Keeping its command/channel declaration here lets the native and Web menus
+ * expose the same Settings entry.
  * @type {MenuTemplateItem}
  */
 const SETTINGS_MENU_ITEM = {
@@ -39,7 +39,6 @@ const SETTINGS_MENU_ITEM = {
   // Electron handling prefers electronHandler below and opens the global window.
   electronChannel: "menu-open-settings",
   electronHandler: "open-settings-window",
-  webVisible: false,
   electronPlatform: "non-mac",
 };
 

--- a/lib/menu/use-web-menu-handlers.ts
+++ b/lib/menu/use-web-menu-handlers.ts
@@ -32,6 +32,8 @@ interface UseWebMenuHandlersProps {
   onCloseTab?: () => void;
   /** Handler for opening the bug/feedback report dialog with a preset category */
   onReportBug?: (category: BugReportCategory) => void;
+  /** Opens application settings. Available even when the user is not logged in. */
+  onOpenSettings?: () => void;
 }
 
 export function useWebMenuHandlers({
@@ -54,6 +56,7 @@ export function useWebMenuHandlers({
   onNewTab,
   onCloseTab,
   onReportBug,
+  onOpenSettings,
 }: UseWebMenuHandlersProps) {
   const handleMenuAction = useCallback(
     (action: string) => {
@@ -86,6 +89,9 @@ export function useWebMenuHandlers({
           break;
         case "close-tab":
           onCloseTab?.();
+          break;
+        case "settings":
+          onOpenSettings?.();
           break;
 
         // Print
@@ -283,6 +289,7 @@ export function useWebMenuHandlers({
       onNewTab,
       onCloseTab,
       onReportBug,
+      onOpenSettings,
     ],
   );
 

--- a/native/as-web-authentication/.gitignore
+++ b/native/as-web-authentication/.gitignore
@@ -1,0 +1,2 @@
+build/
+bin/

--- a/native/as-web-authentication/binding.gyp
+++ b/native/as-web-authentication/binding.gyp
@@ -1,0 +1,17 @@
+{
+  "targets": [
+    {
+      "target_name": "as_web_authentication",
+      "sources": ["src/as_web_authentication.mm"],
+      "xcode_settings": {
+        "CLANG_ENABLE_OBJC_ARC": "YES",
+        "MACOSX_DEPLOYMENT_TARGET": "10.15",
+        "OTHER_LDFLAGS": [
+          "-framework AuthenticationServices",
+          "-framework AppKit",
+          "-framework Foundation"
+        ]
+      }
+    }
+  ]
+}

--- a/native/as-web-authentication/index.js
+++ b/native/as-web-authentication/index.js
@@ -1,3 +1,5 @@
 "use strict";
 
+// Native Node addons are loaded through CommonJS rather than ESM imports.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 module.exports = require("./build/Release/as_web_authentication.node");

--- a/native/as-web-authentication/index.js
+++ b/native/as-web-authentication/index.js
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = require("./build/Release/as_web_authentication.node");

--- a/native/as-web-authentication/package.json
+++ b/native/as-web-authentication/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@illusions/as-web-authentication",
+  "version": "1.0.0",
+  "private": true,
+  "gypfile": true,
+  "main": "index.js",
+  "os": [
+    "darwin"
+  ],
+  "scripts": {
+    "install": "node-gyp rebuild"
+  }
+}

--- a/native/as-web-authentication/src/as_web_authentication.mm
+++ b/native/as-web-authentication/src/as_web_authentication.mm
@@ -1,0 +1,227 @@
+#include <node_api.h>
+#include <atomic>
+#include <memory>
+#include <string>
+
+#import <AppKit/AppKit.h>
+#import <AuthenticationServices/AuthenticationServices.h>
+
+@interface AuthenticationRequest : NSObject <ASWebAuthenticationPresentationContextProviding>
+@property(nonatomic, strong) ASWebAuthenticationSession *session;
+@property(nonatomic, strong) NSString *requestId;
+@property(nonatomic, assign) napi_threadsafe_function threadSafeFunction;
+@end
+
+@implementation AuthenticationRequest
+
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session {
+  return NSApp.keyWindow ?: NSApp.mainWindow;
+}
+
+@end
+
+static NSMutableDictionary<NSString *, AuthenticationRequest *> *activeRequests;
+static std::atomic_bool isShuttingDown = false;
+
+struct SessionContext {
+  napi_env env;
+  napi_deferred deferred;
+};
+
+struct AuthenticationResult {
+  bool succeeded;
+  std::string callbackUrl;
+  std::string message;
+  std::string code;
+};
+
+static void reject(napi_env env, napi_deferred deferred, NSString *message, NSString *code) {
+  napi_value messageValue;
+  napi_create_string_utf8(env, message.UTF8String, NAPI_AUTO_LENGTH, &messageValue);
+  napi_value error;
+  napi_create_error(env, nullptr, messageValue, &error);
+  if (code != nil) {
+    napi_value codeValue;
+    napi_create_string_utf8(env, code.UTF8String, NAPI_AUTO_LENGTH, &codeValue);
+    napi_set_named_property(env, error, "code", codeValue);
+  }
+  napi_reject_deferred(env, deferred, error);
+}
+
+// AuthenticationServices invokes its completion handler on an XPC queue, not
+// Electron's JavaScript thread. All N-API value creation and promise settlement
+// must therefore happen in this threadsafe-function callback.
+static void completeOnJavaScriptThread(napi_env env, napi_value, void *context, void *data) {
+  std::unique_ptr<SessionContext> sessionContext(static_cast<SessionContext *>(context));
+  std::unique_ptr<AuthenticationResult> result(static_cast<AuthenticationResult *>(data));
+  if (env == nullptr || isShuttingDown.load()) return;
+
+  if (result->succeeded) {
+    napi_value callbackUrl;
+    napi_create_string_utf8(env, result->callbackUrl.c_str(), NAPI_AUTO_LENGTH, &callbackUrl);
+    napi_resolve_deferred(env, sessionContext->deferred, callbackUrl);
+    return;
+  }
+
+  NSString *message = [NSString stringWithUTF8String:result->message.c_str()];
+  NSString *code = [NSString stringWithUTF8String:result->code.c_str()];
+  reject(env, sessionContext->deferred, message, code);
+}
+
+static napi_value start(napi_env env, napi_callback_info info) {
+  size_t argc = 3;
+  napi_value args[3];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  if (argc != 3) {
+    napi_throw_type_error(env, nullptr,
+                          "start requires an authorization URL, callback scheme, and request ID");
+    return nullptr;
+  }
+
+  size_t urlLength;
+  size_t schemeLength;
+  size_t requestIdLength;
+  napi_get_value_string_utf8(env, args[0], nullptr, 0, &urlLength);
+  napi_get_value_string_utf8(env, args[1], nullptr, 0, &schemeLength);
+  napi_get_value_string_utf8(env, args[2], nullptr, 0, &requestIdLength);
+  std::string urlString(urlLength, '\0');
+  std::string schemeString(schemeLength, '\0');
+  std::string requestIdString(requestIdLength, '\0');
+  napi_get_value_string_utf8(env, args[0], urlString.data(), urlString.size() + 1, &urlLength);
+  napi_get_value_string_utf8(env, args[1], schemeString.data(), schemeString.size() + 1, &schemeLength);
+  napi_get_value_string_utf8(env, args[2], requestIdString.data(), requestIdString.size() + 1,
+                             &requestIdLength);
+
+  napi_deferred deferred;
+  napi_value promise;
+  napi_create_promise(env, &deferred, &promise);
+
+  auto *sessionContext = new SessionContext{env, deferred};
+  napi_value resourceName;
+  napi_create_string_utf8(env, "ASWebAuthenticationSession", NAPI_AUTO_LENGTH, &resourceName);
+  napi_threadsafe_function threadSafeFunction;
+  napi_create_threadsafe_function(env, nullptr, nullptr, resourceName, 0, 1, nullptr, nullptr,
+                                  sessionContext, completeOnJavaScriptThread, &threadSafeFunction);
+
+  NSString *urlText = [[NSString alloc] initWithBytes:urlString.data()
+                                                length:urlString.length()
+                                              encoding:NSUTF8StringEncoding];
+  NSString *scheme = [[NSString alloc] initWithBytes:schemeString.data()
+                                               length:schemeString.length()
+                                             encoding:NSUTF8StringEncoding];
+  NSString *requestId = [[NSString alloc] initWithBytes:requestIdString.data()
+                                                  length:requestIdString.length()
+                                                encoding:NSUTF8StringEncoding];
+  NSURL *url = [NSURL URLWithString:urlText];
+  if (url == nil || scheme.length == 0 || requestId.length == 0) {
+    napi_release_threadsafe_function(threadSafeFunction, napi_tsfn_abort);
+    delete sessionContext;
+    reject(env, deferred, @"Invalid authorization URL, callback scheme, or request ID",
+           @"ERR_AUTH_INVALID_ARGUMENT");
+    return promise;
+  }
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if (isShuttingDown) {
+      napi_release_threadsafe_function(threadSafeFunction, napi_tsfn_abort);
+      delete sessionContext;
+      reject(env, deferred, @"Application is shutting down", @"ERR_AUTH_SHUTTING_DOWN");
+      return;
+    }
+    if (activeRequests == nil) activeRequests = [NSMutableDictionary dictionary];
+
+    AuthenticationRequest *request = [AuthenticationRequest new];
+    request.requestId = requestId;
+    request.threadSafeFunction = threadSafeFunction;
+    napi_threadsafe_function requestThreadSafeFunction = threadSafeFunction;
+    request.session = [[ASWebAuthenticationSession alloc]
+        initWithURL:url
+        callbackURLScheme:scheme
+        completionHandler:^(NSURL *callbackURL, NSError *error) {
+          auto *result = new AuthenticationResult();
+          if (callbackURL != nil) {
+            result->succeeded = true;
+            result->callbackUrl = callbackURL.absoluteString.UTF8String;
+          } else {
+            result->succeeded = false;
+            result->message = (error.localizedDescription ?: @"Authentication session failed").UTF8String;
+            result->code = error.code == ASWebAuthenticationSessionErrorCodeCanceledLogin
+                               ? "ERR_AUTH_CANCELLED"
+                               : "ERR_AUTH_SESSION";
+          }
+          if (!isShuttingDown.load()) {
+            napi_call_threadsafe_function(requestThreadSafeFunction, result, napi_tsfn_nonblocking);
+            napi_release_threadsafe_function(requestThreadSafeFunction, napi_tsfn_release);
+          } else {
+            // The process is exiting. Do not call into a tearing-down V8/N-API
+            // runtime; process teardown will reclaim the pending session data.
+            delete result;
+          }
+          // AuthenticationServices calls this block from an XPC queue. Keep
+          // AppKit/Foundation session bookkeeping on the main queue as well.
+          dispatch_async(dispatch_get_main_queue(), ^{
+            [activeRequests removeObjectForKey:requestId];
+          });
+        }];
+    request.session.presentationContextProvider = request;
+    activeRequests[requestId] = request;
+
+    if (![request.session start]) {
+      [activeRequests removeObjectForKey:requestId];
+      napi_release_threadsafe_function(threadSafeFunction, napi_tsfn_abort);
+      delete sessionContext;
+      reject(env, deferred, @"Unable to start the authentication session", @"ERR_AUTH_SESSION");
+    }
+  });
+
+  return promise;
+}
+
+static napi_value cancel(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+  if (argc != 1) {
+    napi_throw_type_error(env, nullptr, "cancel requires a request ID");
+    return nullptr;
+  }
+  size_t requestIdLength;
+  napi_get_value_string_utf8(env, args[0], nullptr, 0, &requestIdLength);
+  std::string requestIdString(requestIdLength, '\0');
+  napi_get_value_string_utf8(env, args[0], requestIdString.data(), requestIdString.size() + 1,
+                             &requestIdLength);
+  NSString *requestId = [[NSString alloc] initWithBytes:requestIdString.data()
+                                                  length:requestIdString.length()
+                                                encoding:NSUTF8StringEncoding];
+  dispatch_async(dispatch_get_main_queue(), ^{
+    [activeRequests[requestId].session cancel];
+  });
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
+static napi_value cancelAllForShutdown(napi_env env, napi_callback_info info) {
+  isShuttingDown = true;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    for (AuthenticationRequest *request in activeRequests.allValues) [request.session cancel];
+    [activeRequests removeAllObjects];
+  });
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
+NAPI_MODULE_INIT() {
+  napi_value startFunction;
+  napi_create_function(env, "start", NAPI_AUTO_LENGTH, start, nullptr, &startFunction);
+  napi_set_named_property(env, exports, "start", startFunction);
+  napi_value cancelFunction;
+  napi_create_function(env, "cancel", NAPI_AUTO_LENGTH, cancel, nullptr, &cancelFunction);
+  napi_set_named_property(env, exports, "cancel", cancelFunction);
+  napi_value cancelAllFunction;
+  napi_create_function(env, "cancelAllForShutdown", NAPI_AUTO_LENGTH, cancelAllForShutdown, nullptr,
+                       &cancelAllFunction);
+  napi_set_named_property(env, exports, "cancelAllForShutdown", cancelAllFunction);
+  return exports;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,19 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "@illusions/as-web-authentication": "file:native/as-web-authentication"
       }
+    },
+    "native/as-web-authentication": {
+      "name": "@illusions/as-web-authentication",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2244,6 +2256,10 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
+    },
+    "node_modules/@illusions/as-web-authentication": {
+      "resolved": "native/as-web-authentication",
+      "link": true
     },
     "node_modules/@img/colour": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "download:fonts": "node scripts/download-local-fonts.mjs",
     "bundle:electron": "node scripts/bundle-electron.mjs",
     "electron:dev": "node scripts/ensure-credits-stub.mjs && npm run bundle:electron && concurrently \"next dev -p 3020\" \"wait-on http://localhost:3020 && cross-env ELECTRON_DEV=1 electron .\"",
+    "dev:mas": "cross-env MAS_BUILD=1 npm run electron:dev",
     "electron:build": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 next build && npm run bundle:electron && electron-builder",
     "electron:build:mas": "npm run type-check && npm run generate:credits && cross-env ELECTRON_BUILD=1 MAS_BUILD=1 next build && cross-env MAS_BUILD=1 npm run bundle:electron && cross-env MAS_BUILD=1 electron-builder --mac mas --publish never $MAS_EXTRA_BUILDER_ARGS",
     "build:quicklook": "node -e \"if(process.platform==='darwin'){const {execSync}=require('child_process');execSync('bash scripts/build-quicklook.sh',{stdio:'inherit'});}else{console.log('build:quicklook skipped (macOS only)');}\" ",
@@ -71,6 +72,9 @@
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0",
     "util": "^0.12.5"
+  },
+  "optionalDependencies": {
+    "@illusions/as-web-authentication": "file:native/as-web-authentication"
   },
   "devDependencies": {
     "@electron/notarize": "^3.1.1",

--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -44,6 +44,8 @@ await esbuild.build({
     "better-sqlite3",
     // node-pty is a native module for terminal support
     "node-pty",
+    // macOS-only native bridge for ASWebAuthenticationSession
+    "@illusions/as-web-authentication",
   ],
   define: {
     "process.env.APTABASE_APP_KEY": JSON.stringify(process.env.APTABASE_APP_KEY || ""),
@@ -132,8 +134,8 @@ function collectDepsRecursive(pkgName, collected) {
 // risk even when the code path is dead (docs/release/mac-app-store.md).
 const isMasBuild = process.env.MAS_BUILD === "1";
 const externalRoots = isMasBuild
-  ? ["kuromoji", "better-sqlite3"]
-  : ["kuromoji", "better-sqlite3", "node-pty"];
+  ? ["kuromoji", "better-sqlite3", "@illusions/as-web-authentication"]
+  : ["kuromoji", "better-sqlite3", "node-pty", "@illusions/as-web-authentication"];
 
 // Collect all transitive production dependencies
 const allDeps = new Set();
@@ -193,6 +195,15 @@ function rebuildBetterSqliteForArch(arch) {
   const electronVersion = getElectronVersion();
   execSync(
     `npx electron-rebuild --force --only better-sqlite3 --arch ${arch} --version ${electronVersion} --module-dir ${projectRoot}`,
+    { cwd: projectRoot, stdio: "inherit" },
+  );
+}
+
+function rebuildAsWebAuthenticationForArch(arch) {
+  if (process.platform !== "darwin") return;
+  const electronVersion = getElectronVersion();
+  execSync(
+    `npx electron-rebuild --force --only @illusions/as-web-authentication --arch ${arch} --version ${electronVersion} --module-dir ${projectRoot}`,
     { cwd: projectRoot, stdio: "inherit" },
   );
 }
@@ -268,6 +279,9 @@ async function prepareNativeModulesForArch(arch) {
 
 await prepareNativeModulesForArch(targetArch);
 ensureHostBetterSqliteArch(targetArch);
+// Build against Electron's headers every time. This is quick and avoids
+// accidentally packaging a binary compiled against the developer's Node SDK.
+rebuildAsWebAuthenticationForArch(targetArch);
 
 for (const dep of runtimeDeps) {
   const src = resolvePackageDir(dep);


### PR DESCRIPTION
## Summary
- replace macOS OAuth BrowserWindow flow with ASWebAuthenticationSession
- marshal native OAuth callbacks safely onto Electron’s JavaScript thread
- add unauthenticated settings entry points and cross-platform tests

## Validation
- npm test
- npm run type-check
- MAS_BUILD=1 npm run bundle:electron