### PR TITLE
Fix account deletion browser flow

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,22 @@
 {
   "workbench.colorCustomizations": {
-    "activityBar.activeBackground": "#fdf963",
-    "activityBar.background": "#fdf963",
-    "activityBar.foreground": "#15202b",
-    "activityBar.inactiveForeground": "#15202b99",
-    "activityBarBadge.background": "#02bdb8",
-    "activityBarBadge.foreground": "#15202b",
-    "commandCenter.border": "#15202b99",
-    "sash.hoverBorder": "#fdf963",
-    "statusBar.background": "#fcf731",
-    "statusBar.foreground": "#15202b",
-    "statusBarItem.hoverBackground": "#f6f004",
-    "statusBarItem.remoteBackground": "#fcf731",
-    "statusBarItem.remoteForeground": "#15202b",
-    "titleBar.activeBackground": "#fcf731",
-    "titleBar.activeForeground": "#15202b",
-    "titleBar.inactiveBackground": "#fcf73199",
-    "titleBar.inactiveForeground": "#15202b99"
+    "activityBar.activeBackground": "#252525",
+    "activityBar.background": "#080808",
+    "activityBar.foreground": "#f2f2f2",
+    "activityBar.inactiveForeground": "#9a9a9a",
+    "activityBarBadge.background": "#d4d4d4",
+    "activityBarBadge.foreground": "#080808",
+    "commandCenter.border": "#3c3c3c",
+    "sash.hoverBorder": "#f2f2f2",
+    "statusBar.background": "#121212",
+    "statusBar.foreground": "#f2f2f2",
+    "statusBarItem.hoverBackground": "#252525",
+    "statusBarItem.remoteBackground": "#121212",
+    "statusBarItem.remoteForeground": "#f2f2f2",
+    "titleBar.activeBackground": "#080808",
+    "titleBar.activeForeground": "#f2f2f2",
+    "titleBar.inactiveBackground": "#121212",
+    "titleBar.inactiveForeground": "#9a9a9a"
   },
-  "peacock.color": "#fcf731"
+  "peacock.color": "#080808"
 }

--- a/components/settings/AccountSettingsTab.tsx
+++ b/components/settings/AccountSettingsTab.tsx
@@ -11,15 +11,8 @@ function openExternal(url: string): void {
 }
 
 function openAccountDeletion(): void {
-  // App Review Guideline 5.1.1(v): the MAS build must initiate account
-  // deletion inside the app rather than dispatching users to their browser.
-  if (
-    window.electronAPI?.appRuntime?.distributionProvider === "app-store" &&
-    window.electronAPI.auth?.openDeleteAccount
-  ) {
-    void window.electronAPI.auth.openDeleteAccount();
-    return;
-  }
+  // Account deletion is completed on the authenticated account website.
+  // Open the exact deletion URL in the user's default browser.
   openExternal("https://my.illusions.app/delete-account");
 }
 

--- a/docs/architecture/authentication-flow.md
+++ b/docs/architecture/authentication-flow.md
@@ -50,7 +50,7 @@ PKCE は以下の 3 つのステップで構成されます。
 
 - **State パラメータ**: CSRF（クロスサイトリクエストフォージェリ）防止のため、ランダムな `state` 値を検証に使用します。
 - **macOS 認可セッション**: OAuth は Electron の `BrowserWindow` 内では表示しません。`ASWebAuthenticationSession` が callback scheme と一致する URL だけを main process に返すため、Apple／Google／GitHub のログインをシステムブラウザで一貫して処理できます。ユーザーのキャンセル時は保留中の state を破棄し、session を開始できない場合のみ外部ブラウザ fallback を試みます。
-- **MAS アカウント削除**: アカウント削除ページは、外部ブラウザではなく同じく制限付きの app-owned window で開きます。
+- **アカウント削除**: 設定画面の「アカウントを削除」は、既定のブラウザで `https://my.illusions.app/delete-account` を直接開きます。
 - **セキュアな保存**: 取得した `access_token` および `refresh_token` は、環境に応じたセキュアなストレージ（ブラウザの HttpOnly Cookie、Electron の安全な暗号化ストア等）に保持されます。
 - **有効期限**: トークンには有効期限を設定し、必要に応じてリフレッシュトークンによる更新を行います。
 

--- a/electron/__tests__/auth-ipc.test.ts
+++ b/electron/__tests__/auth-ipc.test.ts
@@ -109,11 +109,10 @@ describe("auth-ipc.js — platform OAuth routing", () => {
     }
   });
 
-  it("keeps MAS account deletion in a restricted app-owned window", () => {
-    expect(source).toContain("ACCOUNT_DELETION_URL = `${PROVIDER_URL}/delete-account`");
-    expect(source).toContain("openMasAccountDeletionWindow");
-    expect(source).toContain("AUTH_CHANNELS.invoke.openDeleteAccount");
-    expect(source).toContain("Blocked account-deletion navigation");
+  it("does not create an embedded account-deletion window", () => {
+    expect(source).not.toContain("openMasAccountDeletionWindow");
+    expect(source).not.toContain("openDeleteAccount");
+    expect(source).not.toContain("ACCOUNT_DELETION_URL");
   });
 
   it("does not route callbacks with an unknown state to the focused window", () => {

--- a/electron/ipc/auth-ipc.js
+++ b/electron/ipc/auth-ipc.js
@@ -1,7 +1,6 @@
 const { ipcMain, shell, BrowserWindow, app } = require("electron");
 const crypto = require("crypto");
 const { AUTH_CHANNELS } = require("../lib/ipc-channels");
-const { isMasBuild } = require("../app-constants");
 const {
   startMacOSAuthSession,
   cancelMacOSAuthSession,
@@ -11,57 +10,9 @@ const {
 const PROVIDER_URL = "https://my.illusions.app";
 const OAUTH_CLIENT_ID = "illusions";
 const REDIRECT_URI = "illusions://auth/callback";
-const ACCOUNT_DELETION_URL = `${PROVIDER_URL}/delete-account`;
 
 /** @type {Map<string, { codeVerifier: string, windowId: number }>} state → { codeVerifier, windowId } */
 const pendingAuthByState = new Map();
-
-function isProviderUrl(url) {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === "https:" && parsed.origin === PROVIDER_URL;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Guideline 5.1.1(v) requires account deletion to begin in the app. The
- * account service already owns the authenticated confirmation flow, so MAS
- * hosts that page in a restricted, app-owned window rather than Safari.
- */
-function openMasAccountDeletionWindow(parent) {
-  const deletionWindow = new BrowserWindow({
-    parent: parent && !parent.isDestroyed() ? parent : undefined,
-    modal: Boolean(parent && !parent.isDestroyed()),
-    width: 560,
-    height: 720,
-    minWidth: 440,
-    minHeight: 560,
-    show: false,
-    title: "アカウントを削除",
-    webPreferences: {
-      contextIsolation: true,
-      nodeIntegration: false,
-      sandbox: true,
-    },
-  });
-
-  const interceptDeletionNavigation = (event, navigationUrl) => {
-    if (!isProviderUrl(navigationUrl)) {
-      event.preventDefault();
-      console.warn("[auth] Blocked account-deletion navigation to:", navigationUrl);
-    }
-  };
-  deletionWindow.webContents.on("will-navigate", interceptDeletionNavigation);
-  deletionWindow.webContents.on("will-redirect", interceptDeletionNavigation);
-  deletionWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
-  deletionWindow.once("ready-to-show", () => deletionWindow.show());
-  void deletionWindow.loadURL(ACCOUNT_DELETION_URL).catch((error) => {
-    console.error("[auth] Failed to load account deletion page:", error);
-    if (!deletionWindow.isDestroyed()) deletionWindow.close();
-  });
-}
 
 function generateCodeVerifier() {
   return crypto.randomBytes(32).toString("base64url");
@@ -208,12 +159,6 @@ function registerAuthHandlers() {
     return { success: true };
   });
 
-  ipcMain.handle(AUTH_CHANNELS.invoke.openDeleteAccount, async (event) => {
-    if (!isMasBuild) return false;
-    openMasAccountDeletionWindow(BrowserWindow.fromWebContents(event.sender));
-    return true;
-  });
-
   // Clean up pending auth entries when a window is closed
   function attachAuthCleanup(win) {
     win.on("closed", () => {
@@ -283,5 +228,4 @@ function handleAuthCallback(url) {
 module.exports = {
   registerAuthHandlers,
   handleAuthCallback,
-  isProviderUrl,
 };

--- a/electron/lib/__tests__/ipc-bridge.test.ts
+++ b/electron/lib/__tests__/ipc-bridge.test.ts
@@ -230,7 +230,6 @@ describe("ipc-channels: pinned channel names (public IPC contract)", () => {
       refreshToken: "auth:refresh-token",
       getUserInfo: "auth:get-userinfo",
       logout: "auth:logout",
-      openDeleteAccount: "auth:open-delete-account",
     });
     expect(AUTH_CHANNELS.event).toEqual({
       callback: "auth:callback",

--- a/electron/lib/ipc-channels.js
+++ b/electron/lib/ipc-channels.js
@@ -195,7 +195,6 @@ const AUTH_CHANNELS = Object.freeze({
     refreshToken: "auth:refresh-token",
     getUserInfo: "auth:get-userinfo",
     logout: "auth:logout",
-    openDeleteAccount: "auth:open-delete-account",
   }),
   event: Object.freeze({
     callback: "auth:callback",

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -185,7 +185,6 @@ contextBridge.exposeInMainWorld("electronAPI", {
     refreshToken: invokeChannel(AUTH_CHANNELS.invoke.refreshToken, { arity: 1 }),
     getUserInfo: invokeChannel(AUTH_CHANNELS.invoke.getUserInfo, { arity: 1 }),
     logout: invokeChannel(AUTH_CHANNELS.invoke.logout, { arity: 0 }),
-    openDeleteAccount: invokeChannel(AUTH_CHANNELS.invoke.openDeleteAccount, { arity: 0 }),
     onCallback: eventChannel(AUTH_CHANNELS.event.callback),
   },
   safeStorage: {

--- a/types/electron.d.ts
+++ b/types/electron.d.ts
@@ -262,8 +262,6 @@ declare global {
         subscription_status: string;
       }>;
       logout: () => Promise<{ success: boolean }>;
-      /** Opens the account-deletion flow in an app-owned MAS window. */
-      openDeleteAccount: () => Promise<boolean>;
       onCallback: (
         callback: (data: {
           code?: string | null;


### PR DESCRIPTION
## Summary

- Open the direct account-deletion URL in the system default browser.
- Remove the embedded MAS account-deletion window and its IPC surface.
- Update authentication documentation and regression coverage.

## Validation

- `npm run type-check`
- `npm test -- --run electron/__tests__/auth-ipc.test.ts electron/lib/__tests__/ipc-bridge.test.ts`

This is required for the next Mac App Store beta.