### PR TITLE
docs(policy): add GitHub API budget rules to base policy

### DIFF
--- a/.github/ai/base-policy.md
+++ b/.github/ai/base-policy.md
@@ -37,3 +37,10 @@ Status: Active canonical policy
 
 - Prioritize correctness, data integrity, security, and user-facing regressions.
 - Do not block merges for purely stylistic nitpicks that do not change behavior.
+
+## 7. GitHub API Budget
+
+- Treat GitHub API quota as a shared, limited resource.
+- Do not use high-frequency polling (`gh run watch`, repeated `gh pr checks`, or equivalent API loops) for CI or release status.
+- Query only when the result can change the next action; prefer a single final status check, webhook/event-driven updates when available, or non-API evidence such as a pushed Git tag.
+- After a rate-limit response, stop API polling immediately and use a low-frequency alternative rather than retrying the same endpoint.


### PR DESCRIPTION
## Summary

- `.github/ai/base-policy.md` に「GitHub API Budget」章を追加（メインチェックアウトに未コミットで残っていた方針を回収）
- `gh run watch` 等の高頻度ポーリング禁止・単発の最終確認・rate-limit 後の即時バックオフを明文化

## Test plan

- [x] ドキュメントのみの変更（CI への影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)