### PR TITLE
fix(ci): repair split-arg script paths missed by src/ migration

### DIFF
--- a/electron/lib/__tests__/standalone-files.test.ts
+++ b/electron/lib/__tests__/standalone-files.test.ts
@@ -81,7 +81,8 @@ describe("standalone-files (#1965 persisted allowlist)", () => {
     // The 5 oldest should have been evicted; the newest must remain.
     expect(set.has("/abs/file-0.mdi")).toBe(false);
     expect(set.has(`/abs/file-${MAX_STANDALONE_PATHS + 4}.mdi`)).toBe(true);
-  });
+    // 505 sequential JSON writes exceed the 5s default on slow Windows CI disks.
+  }, 20000);
 
   it("tolerates a corrupt JSON file (treats as empty)", async () => {
     await fs.writeFile(file, "{ not valid json", "utf-8");

--- a/scripts/__tests__/repo-structure.test.ts
+++ b/scripts/__tests__/repo-structure.test.ts
@@ -102,6 +102,15 @@ describe("repository structure integrity", () => {
     }
   });
 
+  it("script-internal path.join/resolve targets exist", () => {
+    // These are built from split arguments ("app", "local-fonts.css"), so the
+    // literal-path sweeps that catch "app/..." strings miss them — the exact
+    // gap that broke the first post-src/ beta build.
+    for (const target of ["src/app/local-fonts.css", "assets/store/microsoft/ja-JP"]) {
+      expect(exists(target), `script target missing: ${target}`).toBe(true);
+    }
+  });
+
   it("vitest setup file exists", () => {
     const source = fs.readFileSync(path.join(repoRoot, "vitest.config.ts"), "utf8");
     const match = source.match(/setupFiles:\s*\["([^"]+)"\]/);

--- a/scripts/clean-local-artifacts.mjs
+++ b/scripts/clean-local-artifacts.mjs
@@ -10,15 +10,15 @@ const apply = process.argv.includes("--apply");
 const generatedDirectories = [".next", "coverage", "dist-electron", "dist-main", "out", "reviews"];
 
 const sourceRoots = [
-  "app",
   "assets",
   "build",
-  "components",
   "docs",
   "electron",
-  "lib",
+  "native",
   "packages",
   "public",
+  "scripts",
+  "src",
 ];
 
 const candidates = generatedDirectories

--- a/scripts/download-local-fonts.mjs
+++ b/scripts/download-local-fonts.mjs
@@ -83,7 +83,7 @@ async function downloadToFile(url, filePath) {
 
 async function main() {
   const publicFontsDir = path.join(repoRoot, "public", "fonts");
-  const appCssPath = path.join(repoRoot, "app", "local-fonts.css");
+  const appCssPath = path.join(repoRoot, "src", "app", "local-fonts.css");
 
   await mkdir(publicFontsDir, { recursive: true });
 

--- a/scripts/submit-store.mjs
+++ b/scripts/submit-store.mjs
@@ -52,7 +52,7 @@ const MSIX_DIR = resolve(process.env.MSIX_DIR ?? "msix-packages");
 const POLL_TIMEOUT_MS = Number(process.env.POLL_TIMEOUT_MS ?? 1_200_000);
 
 const API_BASE = "https://manage.devcenter.microsoft.com/v1.0/my";
-const STORE_METADATA_DIR = resolve(__dirname, "..", "store", "microsoft", "ja-JP");
+const STORE_METADATA_DIR = resolve(__dirname, "..", "assets", "store", "microsoft", "ja-JP");
 const TERMS_PATH = resolve(__dirname, "..", "TERMS.md");
 const TERMS_CANONICAL_URL = "https://github.com/Iktahana/illusions/blob/main/TERMS.md";
 


### PR DESCRIPTION
## Summary

- beta ビルド全 job が「Download local fonts」step で失敗する問題を修正（run 29714150951）
- `download-local-fonts.mjs` が `path.join(root, "app", "local-fonts.css")` と分割引数でパスを構築していたため、src/ 移行時のリテラルパス走査（`app/...` 文字列検索)から漏れていた
- 同パターンを `submit-store.mjs`（store metadata dir → `assets/store/`）と `clean-local-artifacts.mjs`（sourceRoots 更新）でも修正
- 同じ run で落ちた `standalone-files` eviction テストは 505 回の逐次 JSON 書き込みが Windows CI の 5s デフォルトを超過するタイムアウト起因 — 20s に緩和
- 再発防止として `repo-structure.test.ts` に分割引数パス 2 件の実在検証を追加

## Test plan

- [x] `node scripts/download-local-fonts.mjs` がローカルで成功（`src/app/local-fonts.css` 書き込み確認）
- [x] 対象テスト 2 ファイル green（18 tests）
- [x] type-check / boundaries は変更対象外（scripts + test のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)