### PR TITLE
fix(project): open Finder-launched MDI projects

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,6 +53,10 @@ import { useTextStatistics } from "@/lib/editor-page/use-text-statistics";
 import { useEditorSettings } from "@/lib/editor-page/use-editor-settings";
 import { useEditorLifecycle } from "@/lib/editor-page/use-editor-lifecycle";
 import { useElectronEvents } from "@/lib/editor-page/use-electron-events";
+import {
+  openPendingSystemFiles,
+  type PendingSystemFile,
+} from "@/lib/editor-page/pending-system-files";
 import { useProjectLifecycle } from "@/lib/editor-page/use-project-lifecycle";
 import { useLinting } from "@/lib/editor-page/use-linting";
 import { CORRECTION_MODES } from "@/lib/linting/correction-modes";
@@ -1250,6 +1254,44 @@ function EditorPageContent() {
     confirmBeforeAction: unsavedWarning.confirmBeforeAction,
     onReportBug: (category) => setBugReportCategory(category),
   });
+
+  // #2181: Finder can deliver a .mdi file before the renderer has registered
+  // its IPC listeners. The main process queues those files; drain the queue
+  // once the project and tab lifecycles are ready.
+  useEffect(() => {
+    if (!isElectron || typeof window === "undefined") return;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const pendingFiles: PendingSystemFile[] =
+          (await window.electronAPI?.getPendingFile?.()) ?? [];
+        if (cancelled || pendingFiles.length === 0) return;
+
+        await openPendingSystemFiles(pendingFiles, {
+          openProject: (projectPath, initialFile) =>
+            unsavedWarning.confirmBeforeAction(() => handleOpenAsProject(projectPath, initialFile)),
+          openStandalone: (filePath, fileContent) => {
+            tabLoadSystemFile(filePath, fileContent);
+            incrementEditorKey();
+          },
+        });
+      } catch (error) {
+        console.error("Failed to open pending system files:", error);
+        notificationManager.error("システムから指定されたファイルを開けませんでした。");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    handleOpenAsProject,
+    incrementEditorKey,
+    isElectron,
+    tabLoadSystemFile,
+    unsavedWarning.confirmBeforeAction,
+  ]);
 
   contentRef.current = content;
 

--- a/src/lib/editor-page/__tests__/pending-system-files.test.ts
+++ b/src/lib/editor-page/__tests__/pending-system-files.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { openPendingSystemFiles } from "../pending-system-files";
+
+describe("openPendingSystemFiles", () => {
+  it("opens queued project and standalone files in OS delivery order", async () => {
+    const openProject = vi.fn().mockResolvedValue(undefined);
+    const openStandalone = vi.fn().mockResolvedValue(undefined);
+
+    await openPendingSystemFiles(
+      [
+        { type: "project", projectPath: "/novel", initialFile: "chapter.mdi" },
+        { type: "standalone", path: "/notes.mdi", content: "本文" },
+      ],
+      { openProject, openStandalone },
+    );
+
+    expect(openProject).toHaveBeenCalledWith("/novel", "chapter.mdi");
+    expect(openStandalone).toHaveBeenCalledWith("/notes.mdi", "本文");
+    expect(openProject.mock.invocationCallOrder[0]).toBeLessThan(
+      openStandalone.mock.invocationCallOrder[0],
+    );
+  });
+});

--- a/src/lib/editor-page/pending-system-files.ts
+++ b/src/lib/editor-page/pending-system-files.ts
@@ -1,0 +1,25 @@
+export type PendingSystemFile =
+  | { type: "project"; projectPath: string; initialFile: string }
+  | { type: "standalone"; path: string; content: string };
+
+interface PendingSystemFileHandlers {
+  openProject: (projectPath: string, initialFile: string) => void | Promise<void>;
+  openStandalone: (path: string, content: string) => void | Promise<void>;
+}
+
+/**
+ * Deliver files that the operating system supplied before the renderer was
+ * ready. Electron drains this queue exactly once, so preserve its ordering.
+ */
+export async function openPendingSystemFiles(
+  files: readonly PendingSystemFile[],
+  { openProject, openStandalone }: PendingSystemFileHandlers,
+): Promise<void> {
+  for (const file of files) {
+    if (file.type === "project") {
+      await openProject(file.projectPath, file.initialFile);
+    } else {
+      await openStandalone(file.path, file.content);
+    }
+  }
+}


### PR DESCRIPTION
Fixes #2181.\n\nFiles received from macOS before renderer IPC listeners are registered are already queued by the main process. The renderer now drains that queue once project/tab lifecycles are ready, preserving delivery order and covering project + standalone files.\n\nVerified: targeted Vitest, type-check, diff check.