### PR TITLE
fix(updater): contain failed Store update checks

### DIFF
--- a/electron/__tests__/auto-updater.test.ts
+++ b/electron/__tests__/auto-updater.test.ts
@@ -41,7 +41,7 @@ describe("auto-updater.js — opt-in wiring", () => {
 
   it("更新チェックの Promise rejection を捕捉し、process-level unhandledRejection に流さない", () => {
     expect(autoUpdaterSrc).toMatch(
-      /try\s*\{\s*await\s+autoUpdater\.checkForUpdates\(\);\s*\}\s*catch\s*\(error\)/s,
+      /try\s*\{[\s\S]*await\s+autoUpdater\.checkForUpdates\(\);[\s\S]*\}\s*catch\s*\(error\)/,
     );
   });
 

--- a/electron/__tests__/auto-updater.test.ts
+++ b/electron/__tests__/auto-updater.test.ts
@@ -39,6 +39,12 @@ describe("auto-updater.js — opt-in wiring", () => {
     expect(autoUpdaterSrc).toMatch(/async function checkForUpdates\s*\(/);
   });
 
+  it("更新チェックの Promise rejection を捕捉し、process-level unhandledRejection に流さない", () => {
+    expect(autoUpdaterSrc).toMatch(
+      /try\s*\{\s*await\s+autoUpdater\.checkForUpdates\(\);\s*\}\s*catch\s*\(error\)/s,
+    );
+  });
+
   it("#1785 回帰防止: autoUpdater.channel を代入しない（latest*.yml フォールバックに依存）", () => {
     expect(autoUpdaterSrc).not.toMatch(/autoUpdater\.channel\s*=/);
   });

--- a/electron/auto-updater.js
+++ b/electron/auto-updater.js
@@ -255,7 +255,15 @@ async function checkForUpdates(manual = false) {
   isManualUpdateCheck = manual;
   // 設定変更を反映するため、チェック直前に opt-in を再評価して channel を確定する
   await applyBetaOptIn();
-  autoUpdater.checkForUpdates();
+  // electron-updater can reject before it emits its `error` event (for example
+  // when a Store package has no app-update.yml). Always consume that promise so
+  // a failed background check never reaches the process-level unhandledRejection
+  // handler or error reporting.
+  try {
+    await autoUpdater.checkForUpdates();
+  } catch (error) {
+    log.error("アップデート確認の開始に失敗しました:", error);
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #2185.\n\nKeep the existing Microsoft Store guard, and also await/catch electron-updater's check promise. This prevents a missing app-update.yml from reaching the process-level unhandledRejection handler if an update check starts unexpectedly.\n\nVerified: electron/__tests__/auto-updater.test.ts (21 tests), lint, diff check.