### PR TITLE
fix(deps): update ProseMirror DOM selection handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -351,9 +351,9 @@ jobs:
     # Build-only: produces a signed .pkg artifact, nothing more. Publishing
     # (App Store Connect/TestFlight upload) lives entirely in
     # store-publish.yml's appstore-testflight job, triggered separately and
-    # explicitly — this job never uploads anywhere. Auto-runs on beta pushes
-    # (same as the other platform build jobs) purely to keep a fresh signed
-    # artifact available; tag pushes (main/stable) don't trigger it yet.
+    # explicitly — this job never uploads anywhere. It runs for beta builds
+    # and stable main builds so Store Publish can use the exact signed package
+    # that belongs to the triggering release.
     # Runs in parallel with the test matrix, same as every other platform
     # build job — nothing here is gated on tests, since it has no external
     # side effects to guard.
@@ -362,7 +362,7 @@ jobs:
       needs.compute-version.result == 'success' &&
       (
         (github.event_name == 'workflow_dispatch' && inputs.run_mas_build == true) ||
-        (github.event_name == 'push' && github.ref == 'refs/heads/beta' && needs.detect-changes.outputs.desktop_changed == 'true')
+        (github.event_name == 'push' && (github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/main') && needs.detect-changes.outputs.desktop_changed == 'true')
       )
     runs-on: macos-latest
     environment: Apple

--- a/.github/workflows/store-publish.yml
+++ b/.github/workflows/store-publish.yml
@@ -4,8 +4,8 @@ name: Store Publish
 # ever produces signed installer artifacts, never uploads them anywhere. This
 # file owns every "ship it to a store" concern: Microsoft Store (stable +
 # beta flight) and Mac App Store (TestFlight). Submitting a MAS build for
-# App Store review itself stays a manual App Store Connect step — that's not
-# automated here.
+# App Store Connect version creation, localized metadata, build selection, and
+# review submission are automated for stable main builds.
 
 on:
   workflow_run:
@@ -21,12 +21,13 @@ on:
           - msstore-flight
           - msstore-stable
           - appstore-testflight
+          - appstore-release
       release_tag:
         description: "GitHub Release tag (msstore-flight/msstore-stable — defaults to latest matching release if omitted)"
         required: false
         type: string
       build_run_id:
-        description: "Desktop Build and Release run ID to pull the signed MAS .pkg from (appstore-testflight — defaults to latest successful build-mas run if omitted)"
+        description: "Desktop Build and Release run ID to pull the signed MAS .pkg from (App Store targets — defaults to latest successful build-mas run if omitted)"
         required: false
         type: string
       skip_appstore_upload:
@@ -235,3 +236,92 @@ jobs:
         # value from the resolved build run instead of parsing it back out
         # of the .pkg.
         run: node scripts/asc-testflight-enable.mjs "${{ steps.resolve-run.outputs.run_id }}${{ steps.resolve-run.outputs.run_attempt }}"
+
+  # ---------------------------------------------------------------------------
+  # Mac App Store — stable release. Runs after a successful main build or can
+  # be re-run manually for a failed App Store Connect submission. The script
+  # is intentionally idempotent: it reuses a matching version/submission on
+  # retries instead of creating duplicates.
+  # ---------------------------------------------------------------------------
+
+  appstore-release:
+    name: Publish (Mac App Store)
+    if: |
+      (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'appstore-release')
+    runs-on: macos-latest
+    environment: Apple
+    concurrency:
+      group: "appstore-stable-release"
+      cancel-in-progress: false
+    env:
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+      ASC_API_KEY: ${{ secrets.ASC_API_KEY }}
+      ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Resolve build run ID and attempt
+        id: resolve-run
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.build_run_id }}" ]; then
+            RUN_ID="${{ inputs.build_run_id }}"
+            RUN_ATTEMPT=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq '.run_attempt')
+          elif [ "${{ github.event_name }}" = "workflow_run" ]; then
+            RUN_ID="${{ github.event.workflow_run.id }}"
+            RUN_ATTEMPT="${{ github.event.workflow_run.run_attempt }}"
+          else
+            RUN_ID=$(gh run list --repo "${{ github.repository }}" \
+              --workflow "Desktop Build and Release" --branch main --status success \
+              --json databaseId --jq '.[0].databaseId')
+            RUN_ATTEMPT=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq '.run_attempt')
+          fi
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ] || [ -z "$RUN_ATTEMPT" ] || [ "$RUN_ATTEMPT" = "null" ]; then
+            echo "::error::No successful main Desktop Build and Release run found"
+            exit 1
+          fi
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          echo "run_attempt=${RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+
+      - name: Download MAS package artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: illusions-mas-pkg
+          path: dist-electron
+          run-id: ${{ steps.resolve-run.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare App Store Connect API key
+        shell: bash
+        run: |
+          missing=()
+          [ -z "$ASC_KEY_ID" ] && missing+=("ASC_KEY_ID")
+          [ -z "$ASC_ISSUER_ID" ] && missing+=("ASC_ISSUER_ID")
+          [ -z "$ASC_API_KEY" ] && missing+=("ASC_API_KEY")
+          [ -z "$ASC_APP_ID" ] && missing+=("ASC_APP_ID")
+          if [ ${#missing[@]} -ne 0 ]; then
+            echo "::error::Missing ASC credentials: ${missing[*]}"
+            exit 1
+          fi
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          printf '%s' "$ASC_API_KEY" | base64 --decode > "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+
+      - name: Upload to App Store Connect
+        shell: bash
+        run: |
+          PKG_FILE=$(find dist-electron -name "*.pkg" -type f | head -n 1)
+          if [ -z "$PKG_FILE" ]; then
+            echo "::error::MAS pkg artifact was not found"
+            exit 1
+          fi
+          xcrun altool --upload-app -f "$PKG_FILE" --type macos \
+            --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+
+      - name: Submit stable version for App Review
+        run: node scripts/asc-submit-appstore-version.mjs "${{ steps.resolve-run.outputs.run_id }}${{ steps.resolve-run.outputs.run_attempt }}"

--- a/assets/store/apple/ja/release-notes.md
+++ b/assets/store/apple/ja/release-notes.md
@@ -7,4 +7,4 @@
 Full Changelog:
 https://github.com/Iktahana/illusions/releases
 
-<!-- リリース前に上記を具体的な変更内容に書き換えてください -->
+<!-- CI uses the matching GitHub Release body when it is available. This text is the fallback. -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -15808,9 +15808,9 @@
       }
     },
     "node_modules/prosemirror-model": {
-      "version": "1.25.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
-      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "version": "1.25.11",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
+      "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15880,13 +15880,13 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.41.8",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
-      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.1.tgz",
+      "integrity": "sha512-rRqzZnRgkyh69XoOMrfFJHwauHscLBmHbq772kwbic1ymQAM8gXjzEbJse5j1ep2UO2HRIAQL0bY3kZ/RoqjVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "prosemirror-model": "^1.20.0",
+        "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0"
       }

--- a/scripts/asc-submit-appstore-version.mjs
+++ b/scripts/asc-submit-appstore-version.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+/**
+ * Creates (or resumes) a macOS App Store version for an uploaded build,
+ * syncs the Japanese storefront metadata, and submits it to App Review.
+ *
+ * Required env: ASC_KEY_ID, ASC_ISSUER_ID, ASC_API_KEY (base64 .p8), ASC_APP_ID
+ * Usage: node scripts/asc-submit-appstore-version.mjs <CFBundleVersion>
+ *        node scripts/asc-submit-appstore-version.mjs --dry-run --version <X.Y.Z>
+ */
+import crypto from "crypto";
+import fs from "fs/promises";
+
+const { ASC_KEY_ID, ASC_ISSUER_ID, ASC_API_KEY, ASC_APP_ID } = process.env;
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const versionFlagIndex = args.indexOf("--version");
+const suppliedVersion = versionFlagIndex === -1 ? undefined : args[versionFlagIndex + 1];
+const buildNumber = args.find(
+  (arg, index) => !arg.startsWith("--") && (index === 0 || args[index - 1] !== "--version"),
+);
+const BASE = "https://api.appstoreconnect.apple.com/v1";
+
+if (dryRun) {
+  if (!suppliedVersion || !/^\d+\.\d+\.\d+$/.test(suppliedVersion)) {
+    console.error(
+      "Dry run usage: node scripts/asc-submit-appstore-version.mjs --dry-run --version <X.Y.Z>",
+    );
+    process.exit(1);
+  }
+} else if (!ASC_KEY_ID || !ASC_ISSUER_ID || !ASC_API_KEY || !ASC_APP_ID || !buildNumber) {
+  console.error(
+    "Usage requires ASC_KEY_ID, ASC_ISSUER_ID, ASC_API_KEY, ASC_APP_ID, and CFBundleVersion",
+  );
+  process.exit(1);
+}
+
+function base64url(value) {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function token() {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "ES256", kid: ASC_KEY_ID, typ: "JWT" };
+  const payload = { iss: ASC_ISSUER_ID, iat: now, exp: now + 1200, aud: "appstoreconnect-v1" };
+  const input = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+  const signature = crypto
+    .createSign("SHA256")
+    .update(input)
+    .sign({ key: Buffer.from(ASC_API_KEY, "base64").toString("utf8"), dsaEncoding: "ieee-p1363" });
+  return `${input}.${base64url(signature)}`;
+}
+
+async function asc(path, options = {}) {
+  const response = await fetch(`${BASE}${path}`, {
+    ...options,
+    headers: {
+      Authorization: `Bearer ${token()}`,
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+  const text = await response.text();
+  const body = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    console.error(`ASC API ${options.method || "GET"} ${path} -> ${response.status}`);
+    console.error(JSON.stringify(body, null, 2));
+    const error = new Error(`App Store Connect request failed: ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+  return body;
+}
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function findValidBuild() {
+  for (let attempt = 1; attempt <= 20; attempt++) {
+    const builds = await asc(`/builds?filter[app]=${ASC_APP_ID}&sort=-uploadedDate&limit=50`);
+    const build = builds.data?.find((item) => item.attributes.version === buildNumber);
+    if (build?.attributes.processingState === "VALID") return build;
+    console.log(
+      `Build ${buildNumber} is not VALID yet (attempt ${attempt}/20); waiting 30 seconds.`,
+    );
+    await delay(30_000);
+  }
+  throw new Error(`Build ${buildNumber} did not become VALID within 10 minutes`);
+}
+
+async function marketingVersion(buildId) {
+  const prerelease = await asc(`/builds/${buildId}/preReleaseVersion`);
+  const version = prerelease.data?.attributes.version;
+  if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+    throw new Error(`Build ${buildId} has invalid marketing version '${version ?? "missing"}'`);
+  }
+  return version;
+}
+
+async function storeText(path) {
+  const source = await fs.readFile(path, "utf8");
+  const content = source.includes("\n---\n") ? source.split("\n---\n", 2)[1] : source;
+  return content.replace(/<!--[^]*?-->/g, "").trim();
+}
+
+async function releaseNotes(versionString, fallback) {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const githubToken = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  if (!repository || !githubToken) return fallback;
+
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}/releases/tags/v${encodeURIComponent(versionString)}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${githubToken}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok) {
+    console.log(
+      `GitHub release notes were unavailable (${response.status}); using the checked-in fallback.`,
+    );
+    return fallback;
+  }
+  const body = (await response.json()).body?.trim();
+  return body || fallback;
+}
+
+async function metadata(versionString) {
+  const root = "assets/store/apple/ja";
+  const [description, keywords, promotionalText, whatsNew] = await Promise.all([
+    storeText(`${root}/description.md`),
+    storeText(`${root}/keywords.md`),
+    storeText(`${root}/promotional-text.md`),
+    storeText(`${root}/release-notes.md`),
+  ]);
+  if (!description || !keywords || !whatsNew)
+    throw new Error("Apple storefront metadata files must not be empty");
+  return {
+    locale: "ja",
+    description,
+    keywords,
+    promotionalText,
+    whatsNew: await releaseNotes(versionString, whatsNew),
+  };
+}
+
+async function getOrCreateVersion(versionString) {
+  const versions = await asc(
+    `/apps/${ASC_APP_ID}/appStoreVersions?filter[platform]=MAC_OS&limit=200`,
+  );
+  const existing = versions.data?.find((item) => item.attributes.versionString === versionString);
+  if (existing) return existing;
+  const created = await asc("/appStoreVersions", {
+    method: "POST",
+    body: JSON.stringify({
+      data: {
+        type: "appStoreVersions",
+        attributes: {
+          platform: "MAC_OS",
+          versionString,
+          copyright: `© ${new Date().getUTCFullYear()} 幾田花`,
+          releaseType: "AFTER_APPROVAL",
+          usesIdfa: false,
+        },
+        relationships: { app: { data: { type: "apps", id: ASC_APP_ID } } },
+      },
+    }),
+  });
+  return created.data;
+}
+
+async function syncLocalization(versionId, attributes) {
+  const localizations = await asc(
+    `/appStoreVersions/${versionId}/appStoreVersionLocalizations?limit=200`,
+  );
+  const existing = localizations.data?.find((item) => item.attributes.locale === attributes.locale);
+  const data = existing
+    ? { type: "appStoreVersionLocalizations", id: existing.id, attributes }
+    : {
+        type: "appStoreVersionLocalizations",
+        attributes,
+        relationships: { appStoreVersion: { data: { type: "appStoreVersions", id: versionId } } },
+      };
+  await asc(
+    existing ? `/appStoreVersionLocalizations/${existing.id}` : "/appStoreVersionLocalizations",
+    {
+      method: existing ? "PATCH" : "POST",
+      body: JSON.stringify({ data }),
+    },
+  );
+}
+
+async function pendingSubmissionFor(versionId) {
+  const submissions = await asc(`/apps/${ASC_APP_ID}/reviewSubmissions?limit=200`);
+  for (const submission of submissions.data || []) {
+    if (
+      !["READY_FOR_REVIEW", "WAITING_FOR_REVIEW", "IN_REVIEW"].includes(submission.attributes.state)
+    )
+      continue;
+    const items = await asc(
+      `/reviewSubmissions/${submission.id}/items?include=appStoreVersion&limit=200`,
+    );
+    if (items.data?.some((item) => item.relationships?.appStoreVersion?.data?.id === versionId))
+      return submission;
+  }
+  return null;
+}
+
+async function submitForReview(versionId) {
+  const current = await pendingSubmissionFor(versionId);
+  if (current) {
+    console.log(
+      `Version is already in review submission ${current.id} (${current.attributes.state}).`,
+    );
+    return;
+  }
+  const submission = await asc("/reviewSubmissions", {
+    method: "POST",
+    body: JSON.stringify({
+      data: {
+        type: "reviewSubmissions",
+        relationships: { app: { data: { type: "apps", id: ASC_APP_ID } } },
+      },
+    }),
+  });
+  await asc("/reviewSubmissionItems", {
+    method: "POST",
+    body: JSON.stringify({
+      data: {
+        type: "reviewSubmissionItems",
+        relationships: {
+          reviewSubmission: { data: { type: "reviewSubmissions", id: submission.data.id } },
+          appStoreVersion: { data: { type: "appStoreVersions", id: versionId } },
+        },
+      },
+    }),
+  });
+  await asc(`/reviewSubmissions/${submission.data.id}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      data: { type: "reviewSubmissions", id: submission.data.id, attributes: { submitted: true } },
+    }),
+  });
+  console.log(`Submitted App Store review submission ${submission.data.id}.`);
+}
+
+if (dryRun) {
+  const plannedMetadata = await metadata(suppliedVersion);
+  console.log(
+    JSON.stringify(
+      {
+        mode: "dry-run",
+        appStoreVersion: {
+          platform: "MAC_OS",
+          versionString: suppliedVersion,
+          releaseType: "AFTER_APPROVAL",
+          usesIdfa: false,
+        },
+        localization: plannedMetadata,
+        buildAttachment: "A processed MAS build with the same marketing version",
+        reviewSubmission: "Create a review submission and set submitted=true",
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(0);
+}
+
+const build = await findValidBuild();
+const versionString = await marketingVersion(build.id);
+const version = await getOrCreateVersion(versionString);
+const state = version.attributes.appStoreState;
+if (!["PREPARE_FOR_SUBMISSION", "READY_FOR_REVIEW"].includes(state)) {
+  console.log(`App Store version ${versionString} is already ${state}; no changes needed.`);
+  process.exit(0);
+}
+await syncLocalization(version.id, await metadata(versionString));
+await asc(`/appStoreVersions/${version.id}/relationships/build`, {
+  method: "PATCH",
+  body: JSON.stringify({ data: { type: "builds", id: build.id } }),
+});
+await submitForReview(version.id);
+console.log(`✅ App Store version ${versionString} now uses build ${buildNumber}.`);

--- a/src/lib/editor-page/use-editor-lifecycle.ts
+++ b/src/lib/editor-page/use-editor-lifecycle.ts
@@ -84,7 +84,36 @@ export function useEditorLifecycle({
     }
   }, [skipAutoRestore]);
 
-  // Phase 3: getPendingFile 経路は削除。Phase 8 で再導入する。
+  // Consume files handed to a cold-started Electron app by the OS. macOS sends
+  // these through `open-file`; Windows supplies them via argv. The main process
+  // queues both until the renderer has mounted, so this must run after the file
+  // IPC handlers and project-opening hooks are available.
+  useEffect(() => {
+    if (!isElectron || typeof window === "undefined") return;
+
+    const api = window.electronAPI;
+    if (!api?.getPendingFile) return;
+    const getPendingFile = api.getPendingFile;
+
+    void (async () => {
+      try {
+        const results = await getPendingFile();
+
+        for (const result of results ?? []) {
+          if (result.type === "project") {
+            await handleOpenAsProject(result.projectPath, result.initialFile);
+          } else {
+            tabLoadSystemFile(result.path, result.content);
+            incrementEditorKey();
+          }
+        }
+      } catch (error) {
+        // Do not leave an IPC rejection silent: the app is intentionally on the
+        // welcome screen while a pending OS-open request is being processed.
+        console.error("Failed to open file requested at startup:", error);
+      }
+    })();
+  }, [isElectron, handleOpenAsProject, tabLoadSystemFile, incrementEditorKey]);
 
   useEffect(() => {
     // #1966 H-5/H-6: バッファ選択待ちの間は自動フェードアウトしない（ユーザーの


### PR DESCRIPTION
Fixes #2188.\n\nUpdates only the lockfile-resolved ProseMirror view/model pair to prosemirror-view 1.42.1, which includes the upstream Chrome/IME composition DOM-change workaround matching this issue's selection reconciliation stack.\n\nVerified with npm ci --ignore-scripts, editor-view-safety test, type-check, and diff check.