### PR TITLE
fix(settings): unify editor font selection

### DIFF
--- a/src/components/explorer/FontSelector.tsx
+++ b/src/components/explorer/FontSelector.tsx
@@ -15,12 +15,14 @@ import type { FontInfo, SystemFontInfo } from "@/lib/utils/fonts";
 import { detectOSPlatform } from "@/lib/utils/runtime-env";
 
 interface FontSelectorProps {
+  /** Connects an external label (for example SettingsField) to the trigger. */
+  id?: string;
   value: string;
   onChange: (font: string) => void;
 }
 
 /** Font picker dropdown with system fonts, featured fonts, and search */
-export function FontSelector({ value, onChange }: FontSelectorProps) {
+export function FontSelector({ id, value, onChange }: FontSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -109,6 +111,7 @@ export function FontSelector({ value, onChange }: FontSelectorProps) {
     <div className="relative" ref={dropdownRef}>
       {/* Selected font display */}
       <button
+        id={id}
         type="button"
         onClick={() => setIsOpen(!isOpen)}
         className="w-full px-3 py-2 text-sm border border-border-secondary rounded focus:outline-none focus:ring-2 focus:ring-accent bg-background text-foreground text-left flex items-center justify-between"

--- a/src/components/settings/TypographySettingsTab.tsx
+++ b/src/components/settings/TypographySettingsTab.tsx
@@ -3,8 +3,8 @@
 import type React from "react";
 import clsx from "clsx";
 
-import { FEATURED_JAPANESE_FONTS } from "@/lib/utils/fonts";
 import { useTypographySettings, useUISettings } from "@/contexts/EditorSettingsContext";
+import { FontSelector } from "@/components/explorer/FontSelector";
 import { SettingsField, SettingsSection, SettingsToggle, SliderField } from "./primitives";
 
 /**
@@ -37,18 +37,11 @@ export default function TypographySettingsTab(): React.ReactElement {
     <div className="space-y-6">
       <SettingsSection title="文字組み">
         <SettingsField label="フォント" htmlFor="typography-font-family">
-          <select
+          <FontSelector
             id="typography-font-family"
             value={fontFamily}
-            onChange={(e) => onFontFamilyChange(e.target.value)}
-            className="w-full px-3 py-2 border border-border-secondary rounded-lg bg-background text-foreground focus:outline-none focus:ring-2 focus:ring-accent"
-          >
-            {FEATURED_JAPANESE_FONTS.map((font) => (
-              <option key={font.family} value={font.family}>
-                {font.localizedName ? `${font.family} (${font.localizedName})` : font.family}
-              </option>
-            ))}
-          </select>
+            onChange={onFontFamilyChange}
+          />
         </SettingsField>
 
         <SliderField


### PR DESCRIPTION
Fixes #2193.\n\nTypography settings now reuse the Inspector's FontSelector instead of maintaining an 8-font native select. Both surfaces consequently share the same Google/system font catalog, search UI, and localized display names.\n\nVerified: type-check, lint (0 errors), diff check.