### PR TITLE
fix(ci): resolve latest release by published_at, not created_at

### DIFF
--- a/.github/workflows/store-publish.yml
+++ b/.github/workflows/store-publish.yml
@@ -71,7 +71,7 @@ jobs:
             exit 0
           fi
           RELEASE_TAG=$(gh api repos/${{ github.repository }}/releases \
-            --jq '[.[] | select(.draft == false and .prerelease == true and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.")))] | sort_by(.created_at) | last | .tag_name')
+            --jq '[.[] | select(.draft == false and .prerelease == true and (.tag_name | test("^v[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.")))] | sort_by(.published_at) | last | .tag_name')
           if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
             echo "::error::No beta prerelease found"
             exit 1
@@ -115,7 +115,7 @@ jobs:
             exit 0
           fi
           RELEASE_TAG=$(gh api repos/${{ github.repository }}/releases \
-            --jq '[.[] | select(.draft == false and .prerelease == false)] | sort_by(.created_at) | last | .tag_name')
+            --jq '[.[] | select(.draft == false and .prerelease == false)] | sort_by(.published_at) | last | .tag_name')
           if [ -z "$RELEASE_TAG" ] || [ "$RELEASE_TAG" = "null" ]; then
             echo "::error::No stable release found"
             exit 1


### PR DESCRIPTION
## Summary
- \`store-publish.yml\`'s tag-resolution steps sorted GitHub Releases by \`created_at\`, but that field reflects the underlying tag's target commit date — which is identical across every automated build in this repo, not the actual publish time.
- This made \`resolve-msstore-flight-tag\` / \`resolve-msstore-stable-tag\` pick a stale release instead of the newest one. Confirmed with logs: the flight-submission job resolved \`v1.3.5-beta.20260717.135445\` when the newest beta release (\`v1.3.5-beta.20260720.64111\`) had already been published minutes earlier.
- Switched both jq queries to sort by \`published_at\`, which is monotonically increasing and correct.

## Test plan
- [x] Confirmed via GitHub API that \`published_at\` is reliable while \`created_at\` is frozen for these releases
- [ ] CI green
- [ ] Next store-publish.yml run resolves the correct latest tag

🤖 Generated with Claude Code