### PR TITLE
fix(security): loop HTML comment stripping to a fixed point

### DIFF
--- a/scripts/asc-submit-appstore-version.mjs
+++ b/scripts/asc-submit-appstore-version.mjs
@@ -101,8 +101,16 @@ async function marketingVersion(buildId) {
 
 async function storeText(path) {
   const source = await fs.readFile(path, "utf8");
-  const content = source.includes("\n---\n") ? source.split("\n---\n", 2)[1] : source;
-  return content.replace(/<!--[^]*?-->/g, "").trim();
+  let content = source.includes("\n---\n") ? source.split("\n---\n", 2)[1] : source;
+  // A single non-global-loop replace() only removes matches found in the
+  // original string; nested/overlapping comment markers can survive one
+  // pass. Loop to a fixed point so no "<!--...-->" fragment remains.
+  let previous;
+  do {
+    previous = content;
+    content = content.replace(/<!--[^]*?-->/g, "");
+  } while (content !== previous);
+  return content.trim();
 }
 
 async function releaseNotes(versionString, fallback) {


### PR DESCRIPTION
## Summary
- CodeQL flagged \`js/incomplete-sanitization\` (high) in \`scripts/asc-submit-appstore-version.mjs:105\`, introduced by the new App Store version-submission script.
- \`String.replace(/<!--[^]*?-->/g, "")\` only scans the *original* string once; a crafted nested/overlapping \`<!-- -->\` sequence can leave a comment marker behind after a single pass.
- Loop the replace to a fixed point so no \`<!--...-->\` fragment survives before the text (release notes pulled from repo files / GitHub Release body) is submitted to App Store Connect.

## Test plan
- [ ] CI green
- [ ] CodeQL no longer flags this alert

🤖 Generated with Claude Code