### PR TITLE
fix(security): loop HTML comment stripping to a fixed point (beta)

### DIFF
--- a/scripts/asc-submit-appstore-version.mjs
+++ b/scripts/asc-submit-appstore-version.mjs
@@ -101,8 +101,16 @@ async function marketingVersion(buildId) {
 
 async function storeText(path) {
   const source = await fs.readFile(path, "utf8");
-  const content = source.includes("\n---\n") ? source.split("\n---\n", 2)[1] : source;
-  return content.replace(/<!--[^]*?-->/g, "").trim();
+  let content = source.includes("\n---\n") ? source.split("\n---\n", 2)[1] : source;
+  // A single non-global-loop replace() only removes matches found in the
+  // original string; nested/overlapping comment markers can survive one
+  // pass. Loop to a fixed point so no "<!--...-->" fragment remains.
+  let previous;
+  do {
+    previous = content;
+    content = content.replace(/<!--[^]*?-->/g, "");
+  } while (content !== previous);
+  return content.trim();
 }
 
 async function releaseNotes(versionString, fallback) {


### PR DESCRIPTION
## Summary
Same fix as #2200 (targeting dev), applied directly against `beta` so the pending `beta -> main` release PR (#2198) isn't blocked on the CodeQL alert while #2200 goes through normal dev review. Both will carry the same fix going forward.

CodeQL flagged \`js/incomplete-sanitization\` (high) in \`scripts/asc-submit-appstore-version.mjs:105\`: \`String.replace(/<!--[^]*?-->/g, "")\` only scans the original string once, so a crafted nested/overlapping \`<!-- -->\` sequence can survive a single pass. Looped to a fixed point.

🤖 Generated with Claude Code