### PR TITLE
fix: resolve npx.cmd on Windows for execFileSync electron-rebuild calls

### DIFF
--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -15,6 +15,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "..");
 
+// On Windows, npx is a .cmd shim; execFileSync (unlike execSync) doesn't
+// go through a shell, so it needs the literal .cmd extension to resolve it.
+const NPX_CMD = process.platform === "win32" ? "npx.cmd" : "npx";
+
 const targetArchIndex = process.argv.indexOf("--target-arch");
 const targetArch = targetArchIndex !== -1 ? process.argv[targetArchIndex + 1] : process.arch;
 console.log(`🏗️  Target architecture: ${targetArch}`);
@@ -198,7 +202,7 @@ function rebuildBetterSqliteForArch(arch) {
   // projectRoot's absolute path can never be misinterpreted as shell
   // syntax regardless of what characters it contains.
   execFileSync(
-    "npx",
+    NPX_CMD,
     [
       "electron-rebuild",
       "--force",
@@ -219,7 +223,7 @@ function rebuildAsWebAuthenticationForArch(arch) {
   if (process.platform !== "darwin") return;
   const electronVersion = getElectronVersion();
   execFileSync(
-    "npx",
+    NPX_CMD,
     [
       "electron-rebuild",
       "--force",


### PR DESCRIPTION
## Summary
Regression from #2203: switching \`execSync\` -> \`execFileSync\` for the electron-rebuild calls broke Windows Store/NSIS arm64 builds with \`spawnSync npx ENOENT\`.

\`execFileSync\` doesn't spawn through a shell (that's the whole point — it's what avoids the shell-injection class of bug), but that also means it doesn't resolve Windows's \`npx.cmd\` shim the way \`execSync\` implicitly did via cmd.exe. Fixed by resolving the literal \`npx.cmd\` on \`win32\`.

Confirmed via failure log on the #2198 push-triggered build (run 29727340835): \`Build (Windows NSIS arm64)\` and \`Build (Windows Store arm64)\` both failed with this exact error, tracing back to \`scripts/bundle-electron.mjs:200\` (\`rebuildBetterSqliteForArch\`).

Same fix also pushed to #2202 (dev) so both branches stay consistent.

## Test plan
- [ ] CI green, including Windows Store/NSIS arm64 builds

🤖 Generated with Claude Code