### PR TITLE
fix: enable shell:true on Windows for execFileSync npx.cmd calls

### DIFF
--- a/scripts/bundle-electron.mjs
+++ b/scripts/bundle-electron.mjs
@@ -200,7 +200,13 @@ function rebuildBetterSqliteForArch(arch) {
   // execFileSync with an argv array (instead of execSync with an
   // interpolated shell string) avoids shell parsing entirely, so
   // projectRoot's absolute path can never be misinterpreted as shell
-  // syntax regardless of what characters it contains.
+  // syntax regardless of what characters it contains. Windows still
+  // needs shell:true here: npx.cmd is a batch script, and Win32's
+  // CreateProcess (which spawnSync/execFileSync call without a shell)
+  // can only launch real .exe binaries directly. With shell:true, Node
+  // does its own platform-correct argv escaping, so this doesn't
+  // reintroduce the string-interpolation injection this function used
+  // to have.
   execFileSync(
     NPX_CMD,
     [
@@ -215,7 +221,7 @@ function rebuildBetterSqliteForArch(arch) {
       "--module-dir",
       projectRoot,
     ],
-    { cwd: projectRoot, stdio: "inherit" },
+    { cwd: projectRoot, stdio: "inherit", shell: process.platform === "win32" },
   );
 }
 


### PR DESCRIPTION
## Summary
Second regression fix in this chain (#2203 -> #2204 -> this).

#2204 fixed the \`spawnSync npx ENOENT\` by resolving \`npx.cmd\` on Windows, but the very next build hit a new failure: \`spawnSync npx.cmd EINVAL\`. Root cause: Win32's \`CreateProcess\` (which \`spawnSync\`/\`execFileSync\` call directly when \`shell\` isn't set) can only launch real \`.exe\` binaries — \`.cmd\`/\`.bat\` files are batch scripts that require \`cmd.exe\` to interpret them, regardless of the literal filename passed.

Fix: \`shell: process.platform === "win32"\` on the \`execFileSync\` call. Node still does its own platform-correct argv escaping for the array of arguments when \`shell: true\` is combined with an array (as opposed to a single pre-concatenated string), so this doesn't reintroduce the original CodeQL-flagged manual string-interpolation vulnerability from #2203.

Confirmed via failure log on run 29738167801 (the windows-latest push build after #2204 merged):
\`\`\`
Error: spawnSync npx.cmd EINVAL
    at rebuildBetterSqliteForArch (bundle-electron.mjs:204:3)
\`\`\`

Same fix pushed to #2202 (dev) too.

## Test plan
- [ ] CI green, including Build (Windows NSIS arm64) / Build (Windows Store arm64) on windows-latest

🤖 Generated with Claude Code