### PR TITLE
fix(editor): preserve search selection and block macOS Option text

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -66,6 +66,7 @@ import { useKeyboardShortcuts } from "@/lib/editor-page/use-keyboard-shortcuts";
 import { usePanelState } from "@/lib/editor-page/use-panel-state";
 import { findSearchMatches, type SearchRange } from "@/lib/editor-page/find-search-matches";
 import { useSearchHighlight, isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
+import { takeEditorSelectionForSearch } from "@/lib/editor-page/search-selection";
 import { useSaveToast } from "@/lib/editor-page/use-save-toast";
 import { useTerminalTabs } from "@/lib/editor-page/use-terminal-tabs";
 import { useDiffTabs } from "@/lib/editor-page/use-diff-tabs";
@@ -555,6 +556,14 @@ function EditorPageContent() {
     editorViewRef.current = view; // ref FIRST so sync consumers see fresh value
     setEditorViewInstanceRaw(view);
   }, []);
+
+  // Snapshot selection before SearchDialog moves focus to its input, then keep
+  // a collapsed editor caret while the dialog owns DOM focus.
+  const handleOpenSearchFromShortcut = useCallback(() => {
+    const selectedText = takeEditorSelectionForSearch(editorViewRef.current);
+    if (selectedText !== undefined) setSearchTerm(selectedText);
+    setSearchOpenTrigger((prev) => prev + 1);
+  }, [setSearchTerm]);
 
   // --- 検索ハイライトの単一ソース ---
   // いずれかの検索 UI が表示中か。両方非表示ならハイライトを消す（要求2）。
@@ -1288,6 +1297,7 @@ function EditorPageContent() {
     handleToggleTcy,
     setShowSettingsModal,
     setSearchOpenTrigger,
+    openSearchFromShortcut: handleOpenSearchFromShortcut,
     incrementEditorKey,
     nextTab,
     prevTab,

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -17,6 +17,7 @@ import MilkdownEditor from "./editor/MilkdownEditor";
 import { buildSegments, buildSpeechChunks, buildSpeechMap } from "@/lib/hooks/speech-utils";
 import { scrollToSpeechTarget, cancelSpeechScroll } from "@/lib/editor-page/speech-auto-scroll";
 import { useSelectionTracking } from "@/lib/editor-page/use-selection-tracking";
+import { takeEditorSelectionForSearch } from "@/lib/editor-page/search-selection";
 import type { SelectionSearchRange } from "@/lib/editor-page/use-selection-tracking";
 import { localPreferences } from "@/lib/storage/local-preferences";
 import type { LintIssue } from "@/lib/linting";
@@ -195,8 +196,12 @@ export default function NovelEditor({
   /** コンテキストメニューの「検索」アクション。選択テキストを共有検索語へ反映して窓を開く。 */
   const handleFind = useCallback(
     (initialTerm?: string) => {
-      if (initialTerm !== undefined) {
-        onSearchTermChange(initialTerm);
+      // Collapse the live editor range before the dialog focuses its input.
+      // The context menu supplies `initialTerm`, but the selection still must
+      // be collapsed while focus moves to the dialog.
+      const selectedText = takeEditorSelectionForSearch(editorViewRef.current) ?? initialTerm;
+      if (selectedText !== undefined) {
+        onSearchTermChange(selectedText);
       }
       onOpenSearchDialog();
     },

--- a/src/components/editor/MilkdownEditor.tsx
+++ b/src/components/editor/MilkdownEditor.tsx
@@ -60,6 +60,7 @@ import {
 import { usePosHighlightActivation } from "@/lib/editor-page/use-pos-highlight-activation";
 import { isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
 import { dispatchIfEditorViewAlive } from "@/shared/lib/editor-view-safety";
+import { createMacOptionInputGuardPlugin } from "@/lib/editor-page/mac-option-input-guard";
 
 interface MilkdownEditorProps {
   initialContent: string;
@@ -287,6 +288,9 @@ export default function MilkdownEditor({
         .use(history)
         .use(clipboard)
         .use(cursor)
+        // Prevent macOS Option-generated characters (for example ⌥V → √)
+        // without stopping propagation to the global shortcut listener.
+        .use($prose(() => createMacOptionInputGuardPlugin()))
         .use(verticalScrollPlugin)
         .use($prose(() => searchHighlightPlugin))
         .use($prose(() => speechHighlightPlugin))

--- a/src/lib/editor-page/__tests__/mac-option-input-guard.test.ts
+++ b/src/lib/editor-page/__tests__/mac-option-input-guard.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  shouldSuppressMacOptionTextInput,
+  suppressMacOptionTextInput,
+} from "../mac-option-input-guard";
+
+describe("macOS Option text input guard", () => {
+  it("suppresses printable Option output and dead keys", () => {
+    expect(shouldSuppressMacOptionTextInput({ altKey: true, key: "√" }, true)).toBe(true);
+    expect(shouldSuppressMacOptionTextInput({ altKey: true, key: "Dead" }, true)).toBe(true);
+  });
+
+  it("prevents the browser default only for macOS Option text input", () => {
+    const preventDefault = vi.fn();
+
+    expect(suppressMacOptionTextInput({ altKey: true, key: "√", preventDefault }, true)).toBe(true);
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+
+  it("does not affect ordinary input, bare Option, navigation, or other platforms", () => {
+    expect(shouldSuppressMacOptionTextInput({ altKey: false, key: "v" }, true)).toBe(false);
+    expect(shouldSuppressMacOptionTextInput({ altKey: true, key: "Alt" }, true)).toBe(false);
+    expect(shouldSuppressMacOptionTextInput({ altKey: true, key: "ArrowLeft" }, true)).toBe(false);
+    expect(shouldSuppressMacOptionTextInput({ altKey: true, key: "√" }, false)).toBe(false);
+  });
+});

--- a/src/lib/editor-page/__tests__/search-selection.test.ts
+++ b/src/lib/editor-page/__tests__/search-selection.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { EditorState, TextSelection, type Transaction } from "@milkdown/prose/state";
+import type { EditorView } from "@milkdown/prose/view";
+import { Schema } from "@milkdown/prose/model";
+
+import { selectedEditorTextForSearch, takeEditorSelectionForSearch } from "../search-selection";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "text*" },
+    text: { group: "inline" },
+  },
+});
+
+describe("selectedEditorTextForSearch", () => {
+  it("returns the selected text before search moves focus away from the editor (#2218)", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, schema.text("選択テキスト")),
+    ]);
+    const state = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, 1, 7),
+    });
+
+    expect(selectedEditorTextForSearch(state)).toBe("選択テキスト");
+  });
+
+  it("does not replace an existing query when the editor has no selected text", () => {
+    const doc = schema.node("doc", null, [schema.node("paragraph", null, schema.text("本文"))]);
+    const state = EditorState.create({ doc, selection: TextSelection.create(doc, 1) });
+
+    expect(selectedEditorTextForSearch(state)).toBeUndefined();
+  });
+
+  it("captures text then collapses the editor range before another control takes focus", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, schema.text("選択テキスト")),
+    ]);
+    const initialState = EditorState.create({
+      doc,
+      selection: TextSelection.create(doc, 1, 7),
+    });
+    const fakeView = {
+      state: initialState,
+      docView: {},
+      dispatch(transaction: Transaction) {
+        fakeView.state = fakeView.state.apply(transaction);
+      },
+    };
+    const view = fakeView as unknown as EditorView;
+
+    expect(takeEditorSelectionForSearch(view)).toBe("選択テキスト");
+    expect(fakeView.state.selection.empty).toBe(true);
+    expect(fakeView.state.selection.from).toBe(7);
+  });
+});

--- a/src/lib/editor-page/__tests__/use-keyboard-shortcuts-tab-nav.test.tsx
+++ b/src/lib/editor-page/__tests__/use-keyboard-shortcuts-tab-nav.test.tsx
@@ -46,6 +46,7 @@ interface Spies {
   prevTab: ReturnType<typeof vi.fn<() => void>>;
   newTab: ReturnType<typeof vi.fn<() => void>>;
   switchToIndex: ReturnType<typeof vi.fn<(index: number) => void>>;
+  openSearchFromShortcut: ReturnType<typeof vi.fn<() => void>>;
 }
 
 function makeSpies(): Spies {
@@ -55,6 +56,7 @@ function makeSpies(): Spies {
     prevTab: vi.fn<() => void>(),
     newTab: vi.fn<() => void>(),
     switchToIndex: vi.fn<(index: number) => void>(),
+    openSearchFromShortcut: vi.fn<() => void>(),
   };
 }
 
@@ -81,6 +83,7 @@ function HookHost({ spies, isElectron }: { spies: Spies; isElectron: boolean }):
     handleToggleTcy: () => {},
     setShowSettingsModal: () => {},
     setSearchOpenTrigger: () => {},
+    openSearchFromShortcut: spies.openSearchFromShortcut,
     incrementEditorKey: spies.incrementEditorKey,
     nextTab: spies.nextTab,
     prevTab: spies.prevTab,
@@ -151,6 +154,15 @@ function dispatchCtrl(key: string, extra: Partial<KeyboardEventInit> = {}): void
 }
 
 describe("useKeyboardShortcuts — tab navigation must not remount the editor (#1878)", () => {
+  it("opens search through the selection-aware callback for CmdOrCtrl+F (#2218)", () => {
+    const spies = makeSpies();
+    mount(spies);
+
+    dispatchCmdOrCtrl("f");
+
+    expect(spies.openSearchFromShortcut).toHaveBeenCalledTimes(1);
+  });
+
   it("⌘1 switches to index 0 without bumping the editor key", () => {
     const spies = makeSpies();
     mount(spies);

--- a/src/lib/editor-page/mac-option-input-guard.ts
+++ b/src/lib/editor-page/mac-option-input-guard.ts
@@ -1,0 +1,39 @@
+import { Plugin } from "@milkdown/prose/state";
+
+import { isMacOS } from "@/lib/utils/runtime-env";
+
+type OptionKeyEvent = Pick<KeyboardEvent, "altKey" | "key" | "preventDefault">;
+
+/**
+ * macOS turns many Option combinations into text before the editor receives
+ * input (for example, Option+V produces `√`). Keep non-text Option shortcuts
+ * such as Option+Arrow available to the browser/editor.
+ */
+export function shouldSuppressMacOptionTextInput(
+  event: Pick<OptionKeyEvent, "altKey" | "key">,
+  isMac = isMacOS(),
+): boolean {
+  if (!isMac || !event.altKey || event.key === "Alt") return false;
+
+  // Dead keys must also be consumed: they produce text only after the next
+  // keystroke, so waiting for a printable key would be too late.
+  return event.key === "Dead" || event.key.length === 1;
+}
+
+/** Prevents macOS Option-generated text while allowing the event to bubble to global shortcuts. */
+export function suppressMacOptionTextInput(event: OptionKeyEvent, isMac = isMacOS()): boolean {
+  if (!shouldSuppressMacOptionTextInput(event, isMac)) return false;
+  event.preventDefault();
+  return true;
+}
+
+/** ProseMirror integration for the editor's editable DOM only. */
+export function createMacOptionInputGuardPlugin(): Plugin {
+  return new Plugin({
+    props: {
+      handleDOMEvents: {
+        keydown: (_view, event) => suppressMacOptionTextInput(event),
+      },
+    },
+  });
+}

--- a/src/lib/editor-page/search-selection.ts
+++ b/src/lib/editor-page/search-selection.ts
@@ -1,0 +1,43 @@
+import { TextSelection, type EditorState } from "@milkdown/prose/state";
+import type { EditorView } from "@milkdown/prose/view";
+
+import { dispatchIfEditorViewAlive } from "@/shared/lib/editor-view-safety";
+
+/**
+ * Return the text selected in the editor, if there is any usable text.
+ *
+ * `undefined` deliberately differs from an empty string: callers must retain
+ * the existing query when a node/empty selection has no text to search for.
+ */
+export function selectedEditorTextForSearch(state: EditorState): string | undefined {
+  const { selection, doc } = state;
+  if (selection.empty) return undefined;
+
+  const text = doc.textBetween(selection.from, selection.to, "\n");
+  return text || undefined;
+}
+
+/**
+ * Snapshot the selected text and collapse the native editor selection before a
+ * search UI takes focus.
+ *
+ * The text is read first, so Cmd+F and the context-menu search action retain
+ * the original range while the focused control receives a collapsed caret.
+ */
+export function takeEditorSelectionForSearch(view: EditorView | null): string | undefined {
+  if (!view) return undefined;
+
+  const text = selectedEditorTextForSearch(view.state);
+  const { selection } = view.state;
+
+  // Cmd+F only needs to transfer text selections. Leave node selections alone:
+  // forcing a TextSelection at an arbitrary node boundary is not always valid.
+  if (!selection.empty && selection instanceof TextSelection) {
+    const caret = selection.to;
+    dispatchIfEditorViewAlive(view, (aliveView) =>
+      aliveView.state.tr.setSelection(TextSelection.create(aliveView.state.doc, caret)),
+    );
+  }
+
+  return text;
+}

--- a/src/lib/editor-page/use-keyboard-shortcuts.ts
+++ b/src/lib/editor-page/use-keyboard-shortcuts.ts
@@ -18,6 +18,8 @@ interface UseKeyboardShortcutsParams {
   handleToggleTcy: () => void;
   setShowSettingsModal: (value: boolean) => void;
   setSearchOpenTrigger: Dispatch<SetStateAction<number>>;
+  /** Opens search from its keyboard binding, preserving selected editor text when present. */
+  openSearchFromShortcut?: () => void;
   /**
    * エディタ強制再マウント用キーのインクリメント。
    * NOTE: タブナビゲーションでは呼ばない（#1878: タブ往復で Undo/Redo が消える退行）。
@@ -67,6 +69,7 @@ export function useKeyboardShortcuts({
   handleToggleTcy,
   setShowSettingsModal,
   setSearchOpenTrigger,
+  openSearchFromShortcut,
   nextTab,
   prevTab,
   newTab,
@@ -155,7 +158,15 @@ export function useKeyboardShortcuts({
           setShowSettingsModal(true);
         }
       },
-      "nav.search": isEditorTabActive ? () => setSearchOpenTrigger((prev) => prev + 1) : undefined,
+      "nav.search": isEditorTabActive
+        ? () => {
+            if (openSearchFromShortcut) {
+              openSearchFromShortcut();
+            } else {
+              setSearchOpenTrigger((prev) => prev + 1);
+            }
+          }
+        : undefined,
       // タブ往復で history を保つため remount しない (#1878)。
       "nav.nextTab": () => nextTab(),
       "nav.prevTab": () => prevTab(),
@@ -186,6 +197,7 @@ export function useKeyboardShortcuts({
     handleToggleTcy,
     setShowSettingsModal,
     setSearchOpenTrigger,
+    openSearchFromShortcut,
     nextTab,
     prevTab,
     newTab,

--- a/src/lib/keymap/__tests__/keymap-utils.test.ts
+++ b/src/lib/keymap/__tests__/keymap-utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesEvent } from "../keymap-utils";
+
+function macOptionEvent(key: string, code: string): KeyboardEvent {
+  return {
+    key,
+    code,
+    altKey: true,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+  } as KeyboardEvent;
+}
+
+describe("matchesEvent", () => {
+  it("matches an Option shortcut by physical key when macOS reports generated text", () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+    Object.defineProperty(navigator, "platform", { configurable: true, value: "MacIntel" });
+
+    try {
+      expect(matchesEvent({ modifiers: ["Alt"], key: "v" }, macOptionEvent("√", "KeyV"))).toBe(
+        true,
+      );
+    } finally {
+      if (originalPlatform) Object.defineProperty(navigator, "platform", originalPlatform);
+    }
+  });
+
+  it("also preserves custom Option shortcuts bound to punctuation keys", () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(navigator, "platform");
+    Object.defineProperty(navigator, "platform", { configurable: true, value: "MacIntel" });
+
+    try {
+      expect(
+        matchesEvent({ modifiers: ["Alt"], key: "[" }, macOptionEvent("“", "BracketLeft")),
+      ).toBe(true);
+    } finally {
+      if (originalPlatform) Object.defineProperty(navigator, "platform", originalPlatform);
+    }
+  });
+});

--- a/src/lib/keymap/keymap-utils.ts
+++ b/src/lib/keymap/keymap-utils.ts
@@ -1,6 +1,20 @@
 import type { KeyBinding } from "./keymap-types";
 import { isMacOS, isElectronRenderer } from "@/lib/utils/runtime-env";
 
+const PUNCTUATION_BY_CODE: Record<string, string> = {
+  Backquote: "`",
+  Minus: "-",
+  Equal: "=",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Backslash: "\\",
+  Semicolon: ";",
+  Quote: "'",
+  Comma: ",",
+  Period: ".",
+  Slash: "/",
+};
+
 /**
  * Returns the platform-specific display string for a key binding.
  * e.g. { modifiers: ["CmdOrCtrl", "Shift"], key: "s" } -> "Cmd+Shift+S" (macOS) / "Ctrl+Shift+S" (Win/Linux)
@@ -87,11 +101,25 @@ export function matchesEvent(binding: KeyBinding | null, event: KeyboardEvent): 
   if (!binding.modifiers.includes("Shift") && event.shiftKey) return false;
   if (!binding.modifiers.includes("Alt") && event.altKey) return false;
 
-  // Normalize the event key for comparison
-  const eventKey = event.key.toLowerCase();
+  // On macOS, Option changes KeyboardEvent.key to the generated character
+  // (for example, ⌥V reports `√`). Match letter/digit bindings by physical
+  // key so Option shortcuts remain usable while the editor suppresses the
+  // generated text input.
+  const eventKey = keyForBinding(event);
   const bindingKey = binding.key.toLowerCase();
 
   return eventKey === bindingKey;
+}
+
+function keyForBinding(event: KeyboardEvent): string {
+  if (isMacOS() && event.altKey) {
+    const codeMatch = /^(?:Key([A-Z])|Digit([0-9]))$/.exec(event.code);
+    const physicalKey = codeMatch?.[1] ?? codeMatch?.[2];
+    if (physicalKey) return physicalKey.toLowerCase();
+
+    if (PUNCTUATION_BY_CODE[event.code]) return PUNCTUATION_BY_CODE[event.code];
+  }
+  return event.key.toLowerCase();
 }
 
 /**


### PR DESCRIPTION
## Summary

- prevent macOS Option-generated text and dead keys from reaching the editor while keeping Option shortcuts functional
- populate Cmd/Ctrl+F from the active editor selection without overwriting an existing query when there is no selection
- collapse the editor range before search focus transfers, including the context-menu search flow
- add regressions for Option input, physical-key shortcuts, and selection-aware search

## Related issues

Fixes #2221 and #2218.

The existing dev commit 9f856cf upgrades ProseMirror DOM-selection handling for #2220 and #2219; this beta will include that update.

## Validation

- npm test: 263 files, 2708 passed, 1 skipped
- npm run type-check
- npm run lint
- npm run check:boundaries