### PR TITLE
fix(mas): accept unpacked MDI runtime

### DIFF
--- a/scripts/__tests__/electron-mdi-runtime.test.ts
+++ b/scripts/__tests__/electron-mdi-runtime.test.ts
@@ -33,10 +33,13 @@ function context(platform: string): PackagingContext {
   };
 }
 
-function wasmPath(packagingContext: PackagingContext): string {
+function wasmPath(
+  packagingContext: PackagingContext,
+  packaging: "asar" | "directory" = "asar",
+): string {
   return path.join(
     packagedResourcesDir(packagingContext),
-    "app.asar.unpacked",
+    packaging === "asar" ? "app.asar.unpacked" : "app",
     "dist-main",
     "node_modules",
     "@illusions-lab",
@@ -63,6 +66,15 @@ describe("packaged Electron MDI runtime", () => {
   it.each(["darwin", "win32", "linux"])("accepts the unpacked WASM asset on %s", (platform) => {
     const packagingContext = context(platform);
     const target = wasmPath(packagingContext);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, Buffer.from("wasm"));
+
+    expect(() => assertMdiWasmPackaged(packagingContext)).not.toThrow();
+  });
+
+  it("accepts the unpacked Resources/app layout used by MAS", () => {
+    const packagingContext = context("darwin");
+    const target = wasmPath(packagingContext, "directory");
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, Buffer.from("wasm"));
 

--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -27,8 +27,7 @@ const os = require("os");
 const { execFileSync } = require("child_process");
 
 const APPEX_NAME = "MDIQuickLook.appex";
-const MDI_WASM_RELATIVE_PATH = path.join(
-  "app.asar.unpacked",
+const MDI_WASM_RUNTIME_RELATIVE_PATH = path.join(
   "dist-main",
   "node_modules",
   "@illusions-lab",
@@ -44,11 +43,22 @@ function packagedResourcesDir(context) {
     : path.join(appOutDir, "resources");
 }
 
-/** Fail packaging when the externalized Rust runtime was not unpacked. */
+/**
+ * Fail packaging when the externalized Rust runtime is absent.
+ *
+ * Regular desktop targets store external main-process dependencies in
+ * `app.asar.unpacked`. MAS packages use an unpacked `Resources/app` directory
+ * instead, where Electron's `__dirname` based module resolution remains valid.
+ */
 function assertMdiWasmPackaged(context) {
-  const wasmPath = path.join(packagedResourcesDir(context), MDI_WASM_RELATIVE_PATH);
-  if (!fs.existsSync(wasmPath)) {
-    throw new Error(`[MDI] Packaged WASM runtime not found: ${wasmPath}`);
+  const resourcesDir = packagedResourcesDir(context);
+  const wasmPaths = [
+    path.join(resourcesDir, "app.asar.unpacked", MDI_WASM_RUNTIME_RELATIVE_PATH),
+    path.join(resourcesDir, "app", MDI_WASM_RUNTIME_RELATIVE_PATH),
+  ];
+  const wasmPath = wasmPaths.find((candidate) => fs.existsSync(candidate));
+  if (!wasmPath) {
+    throw new Error(`[MDI] Packaged WASM runtime not found: ${wasmPaths.join(", ")}`);
   }
   console.log(`[MDI] Verified packaged WASM runtime: ${wasmPath}`);
 }


### PR DESCRIPTION
Fixes the Mac App Store packaging failure from beta build 29935417155. The MDI WASM validation now accepts both electron-builder runtime layouts: app.asar.unpacked for regular desktop targets and Resources/app for MAS.

Adds a regression test for the MAS directory layout.

Validation: targeted electron MDI runtime test passed (7 tests).