### PR TITLE
fix(mas): verify flattened MDI runtime

### DIFF
--- a/scripts/__tests__/electron-mdi-runtime.test.ts
+++ b/scripts/__tests__/electron-mdi-runtime.test.ts
@@ -35,13 +35,15 @@ function context(platform: string): PackagingContext {
 
 function wasmPath(
   packagingContext: PackagingContext,
-  packaging: "asar" | "directory" = "asar",
+  packaging: "asar" | "directory" | "flattened-directory" = "asar",
 ): string {
+  const runtimePath =
+    packaging === "flattened-directory"
+      ? ["app", "node_modules"]
+      : [packaging === "asar" ? "app.asar.unpacked" : "app", "dist-main", "node_modules"];
   return path.join(
     packagedResourcesDir(packagingContext),
-    packaging === "asar" ? "app.asar.unpacked" : "app",
-    "dist-main",
-    "node_modules",
+    ...runtimePath,
     "@illusions-lab",
     "mdi-core",
     "dist",
@@ -75,6 +77,15 @@ describe("packaged Electron MDI runtime", () => {
   it("accepts the unpacked Resources/app layout used by MAS", () => {
     const packagingContext = context("darwin");
     const target = wasmPath(packagingContext, "directory");
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, Buffer.from("wasm"));
+
+    expect(() => assertMdiWasmPackaged(packagingContext)).not.toThrow();
+  });
+
+  it("accepts the flattened Resources/app/node_modules layout used by MAS", () => {
+    const packagingContext = context("darwin");
+    const target = wasmPath(packagingContext, "flattened-directory");
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, Buffer.from("wasm"));
 

--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -55,6 +55,16 @@ function assertMdiWasmPackaged(context) {
   const wasmPaths = [
     path.join(resourcesDir, "app.asar.unpacked", MDI_WASM_RUNTIME_RELATIVE_PATH),
     path.join(resourcesDir, "app", MDI_WASM_RUNTIME_RELATIVE_PATH),
+    // MAS flattens `dist-main/node_modules` into the application root.
+    path.join(
+      resourcesDir,
+      "app",
+      "node_modules",
+      "@illusions-lab",
+      "mdi-core",
+      "dist",
+      "mdi_core_bg.wasm",
+    ),
   ];
   const wasmPath = wasmPaths.find((candidate) => fs.existsSync(candidate));
   if (!wasmPath) {


### PR DESCRIPTION
Fixes the remaining MAS failure in beta build 29937734773. MAS flattens dist-main/node_modules to Resources/app/node_modules, so the packaged MDI WASM verification now accepts that observed electron-builder layout.

Adds a regression test for the exact layout recorded in the failed MAS job.

Validation: targeted electron MDI runtime test passed (8 tests).