### PR TITLE
fix(mas): materialize MDI WASM runtime

### DIFF
--- a/scripts/__tests__/electron-mdi-runtime.test.ts
+++ b/scripts/__tests__/electron-mdi-runtime.test.ts
@@ -10,15 +10,17 @@ const require = createRequire(import.meta.url);
 const {
   packagedResourcesDir,
   assertMdiWasmPackaged,
+  materializeMasMdiRuntime,
 }: {
   packagedResourcesDir: (context: PackagingContext) => string;
   assertMdiWasmPackaged: (context: PackagingContext) => void;
+  materializeMasMdiRuntime: (context: PackagingContext) => void;
 } = require("../embed-quicklook.js");
 
 interface PackagingContext {
   electronPlatformName: string;
   appOutDir: string;
-  packager: { appInfo: { productFilename: string } };
+  packager: { appInfo: { productFilename: string }; projectDir: string };
 }
 
 const temporaryDirectories: string[] = [];
@@ -29,7 +31,7 @@ function context(platform: string): PackagingContext {
   return {
     electronPlatformName: platform,
     appOutDir,
-    packager: { appInfo: { productFilename: "illusions" } },
+    packager: { appInfo: { productFilename: "illusions" }, projectDir: appOutDir },
   };
 }
 
@@ -88,6 +90,32 @@ describe("packaged Electron MDI runtime", () => {
     const target = wasmPath(packagingContext, "flattened-directory");
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, Buffer.from("wasm"));
+
+    expect(() => assertMdiWasmPackaged(packagingContext)).not.toThrow();
+  });
+
+  it("materializes the bundled MDI runtime into the MAS application", () => {
+    const packagingContext = context("darwin");
+    const source = path.join(
+      packagingContext.packager.projectDir,
+      "dist-main",
+      "node_modules",
+      "@illusions-lab",
+      "mdi-core",
+      "dist",
+      "mdi_core_bg.wasm",
+    );
+    fs.mkdirSync(path.dirname(source), { recursive: true });
+    fs.writeFileSync(source, Buffer.from("wasm"));
+    const previousMasBuild = process.env.MAS_BUILD;
+    process.env.MAS_BUILD = "1";
+
+    try {
+      materializeMasMdiRuntime(packagingContext);
+    } finally {
+      if (previousMasBuild === undefined) delete process.env.MAS_BUILD;
+      else process.env.MAS_BUILD = previousMasBuild;
+    }
 
     expect(() => assertMdiWasmPackaged(packagingContext)).not.toThrow();
   });

--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -44,6 +44,39 @@ function packagedResourcesDir(context) {
 }
 
 /**
+ * MAS flattens Electron's application tree and may omit the WASM payload from
+ * the generated node_modules entry. Copy the already bundled, smoke-tested
+ * mdi-core package into the runtime location before the app is signed.
+ */
+function materializeMasMdiRuntime(context) {
+  if (context.electronPlatformName !== "darwin" || process.env.MAS_BUILD !== "1") return;
+
+  const source = path.join(
+    context.packager.projectDir,
+    "dist-main",
+    "node_modules",
+    "@illusions-lab",
+    "mdi-core",
+  );
+  const destination = path.join(
+    packagedResourcesDir(context),
+    "app",
+    "node_modules",
+    "@illusions-lab",
+    "mdi-core",
+  );
+
+  if (!fs.existsSync(source)) {
+    throw new Error(`[MDI] Bundled WASM runtime not found: ${source}`);
+  }
+
+  fs.rmSync(destination, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.cpSync(source, destination, { recursive: true });
+  console.log(`[MDI] Materialized MAS runtime: ${destination}`);
+}
+
+/**
  * Fail packaging when the externalized Rust runtime is absent.
  *
  * Regular desktop targets store external main-process dependencies in
@@ -199,6 +232,7 @@ function signAppex(appexPath) {
 exports.default = async function embedQuickLook(context) {
   const { electronPlatformName, appOutDir, packager } = context;
 
+  materializeMasMdiRuntime(context);
   assertMdiWasmPackaged(context);
 
   if (electronPlatformName !== "darwin") {
@@ -239,3 +273,4 @@ exports.default = async function embedQuickLook(context) {
 
 exports.packagedResourcesDir = packagedResourcesDir;
 exports.assertMdiWasmPackaged = assertMdiWasmPackaged;
+exports.materializeMasMdiRuntime = materializeMasMdiRuntime;


### PR DESCRIPTION
Fixes the remaining MAS packaging failure from beta build 29938743730. electron-builder creates the MAS node_modules directory but omits the MDI WASM payload, so afterPack now copies the already bundle-verified mdi-core package into Resources/app/node_modules before signing.

Adds a regression test that materializes the runtime and verifies the packaged WASM path.

Validation: targeted electron MDI runtime test passed (9 tests).