### PR TITLE
fix(mas): recognize MAS platform in runtime hook

### DIFF
--- a/scripts/__tests__/electron-mdi-runtime.test.ts
+++ b/scripts/__tests__/electron-mdi-runtime.test.ts
@@ -77,7 +77,7 @@ describe("packaged Electron MDI runtime", () => {
   });
 
   it("accepts the unpacked Resources/app layout used by MAS", () => {
-    const packagingContext = context("darwin");
+    const packagingContext = context("mas");
     const target = wasmPath(packagingContext, "directory");
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, Buffer.from("wasm"));
@@ -86,7 +86,7 @@ describe("packaged Electron MDI runtime", () => {
   });
 
   it("accepts the flattened Resources/app/node_modules layout used by MAS", () => {
-    const packagingContext = context("darwin");
+    const packagingContext = context("mas");
     const target = wasmPath(packagingContext, "flattened-directory");
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, Buffer.from("wasm"));
@@ -95,7 +95,7 @@ describe("packaged Electron MDI runtime", () => {
   });
 
   it("materializes the bundled MDI runtime into the MAS application", () => {
-    const packagingContext = context("darwin");
+    const packagingContext = context("mas");
     const source = path.join(
       packagingContext.packager.projectDir,
       "dist-main",

--- a/scripts/embed-quicklook.js
+++ b/scripts/embed-quicklook.js
@@ -36,9 +36,16 @@ const MDI_WASM_RUNTIME_RELATIVE_PATH = path.join(
   "mdi_core_bg.wasm",
 );
 
+function isMacPlatform(electronPlatformName) {
+  // electron-builder reports the Mac App Store target as "mas", not
+  // "darwin", even though its application bundle has the standard macOS
+  // layout.
+  return electronPlatformName === "darwin" || electronPlatformName === "mas";
+}
+
 function packagedResourcesDir(context) {
   const { electronPlatformName, appOutDir, packager } = context;
-  return electronPlatformName === "darwin"
+  return isMacPlatform(electronPlatformName)
     ? path.join(appOutDir, `${packager.appInfo.productFilename}.app`, "Contents", "Resources")
     : path.join(appOutDir, "resources");
 }
@@ -49,7 +56,7 @@ function packagedResourcesDir(context) {
  * mdi-core package into the runtime location before the app is signed.
  */
 function materializeMasMdiRuntime(context) {
-  if (context.electronPlatformName !== "darwin" || process.env.MAS_BUILD !== "1") return;
+  if (!isMacPlatform(context.electronPlatformName) || process.env.MAS_BUILD !== "1") return;
 
   const source = path.join(
     context.packager.projectDir,


### PR DESCRIPTION
electron-builder reports Mac App Store builds as the mas platform. Treat it as macOS so the MDI WASM runtime is copied into the application bundle and verified before signing. Includes regression coverage.