### PR TITLE
feat(settings): allow macOS Option character input

### DIFF
--- a/src/components/editor/MilkdownEditor.tsx
+++ b/src/components/editor/MilkdownEditor.tsx
@@ -56,6 +56,7 @@ import {
   usePosHighlightSettings,
   usePowerSettings,
   useScrollSettings,
+  useKeyboardInputSettings,
 } from "@/contexts/EditorSettingsContext";
 import { usePosHighlightActivation } from "@/lib/editor-page/use-pos-highlight-activation";
 import { isEditorViewAlive } from "@/lib/editor-page/use-search-highlight";
@@ -148,6 +149,7 @@ export default function MilkdownEditor({
     usePosHighlightSettings();
   const { powerSaveMode } = usePowerSettings();
   const { verticalScrollBehavior, scrollSensitivity } = useScrollSettings();
+  const { allowOptionKeySpecialCharacterInput } = useKeyboardInputSettings();
   const { measureRef: charMeasureRef, charWidth } = useCharWidth({
     fontFamily,
     fontScale,
@@ -168,6 +170,8 @@ export default function MilkdownEditor({
   const onInsertTextRef = useRef(onInsertText);
   const onLintIssuesUpdatedRef = useRef(onLintIssuesUpdated);
   const onNlpErrorRef = useRef(onNlpError);
+  const allowOptionKeySpecialCharacterInputRef = useRef(allowOptionKeySpecialCharacterInput);
+  allowOptionKeySpecialCharacterInputRef.current = allowOptionKeySpecialCharacterInput;
 
   // コールバックが変わったら ref を更新する
 
@@ -290,7 +294,11 @@ export default function MilkdownEditor({
         .use(cursor)
         // Prevent macOS Option-generated characters (for example ⌥V → √)
         // without stopping propagation to the global shortcut listener.
-        .use($prose(() => createMacOptionInputGuardPlugin()))
+        .use(
+          $prose(() =>
+            createMacOptionInputGuardPlugin(() => allowOptionKeySpecialCharacterInputRef.current),
+          ),
+        )
         .use(verticalScrollPlugin)
         .use($prose(() => searchHighlightPlugin))
         .use($prose(() => speechHighlightPlugin))

--- a/src/components/settings/KeymapSettingsTab.tsx
+++ b/src/components/settings/KeymapSettingsTab.tsx
@@ -3,15 +3,40 @@
 import type React from "react";
 
 import KeymapSettings from "./KeymapSettings";
-import { SettingsSection } from "./primitives";
+import { SettingsField, SettingsSection, SettingsToggle } from "./primitives";
+import { useKeyboardInputSettings } from "@/contexts/EditorSettingsContext";
+import { isMacOS } from "@/lib/utils/runtime-env";
 
 /**
  * Settings tab for keyboard shortcut (keymap) configuration.
  */
 export default function KeymapSettingsTab(): React.ReactElement {
+  const { allowOptionKeySpecialCharacterInput, onAllowOptionKeySpecialCharacterInputChange } =
+    useKeyboardInputSettings();
+  const isMac = isMacOS();
+
   return (
-    <SettingsSection title="キーマップ">
-      <KeymapSettings />
-    </SettingsSection>
+    <div className="space-y-8">
+      <SettingsSection title="キーマップ">
+        <KeymapSettings />
+      </SettingsSection>
+
+      {isMac && (
+        <SettingsSection title="入力">
+          <SettingsField
+            label="Option キーで特殊文字を入力"
+            description="Option キーを押して √ や € などの特殊文字を入力できるようにします。オンにすると、一部の Option キーのショートカットは文字入力として扱われます。"
+            htmlFor="allow-option-key-special-character-input"
+            inline
+          >
+            <SettingsToggle
+              id="allow-option-key-special-character-input"
+              checked={allowOptionKeySpecialCharacterInput}
+              onChange={onAllowOptionKeySpecialCharacterInputChange}
+            />
+          </SettingsField>
+        </SettingsSection>
+      )}
+    </div>
   );
 }

--- a/src/components/settings/__tests__/KeymapSettingsTab.test.tsx
+++ b/src/components/settings/__tests__/KeymapSettingsTab.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import KeymapSettingsTab from "../KeymapSettingsTab";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const keyboardInputSettingsMock = vi.fn();
+const isMacOSMock = vi.fn();
+
+vi.mock("../KeymapSettings", () => ({ default: () => null }));
+vi.mock("@/contexts/EditorSettingsContext", () => ({
+  useKeyboardInputSettings: () => keyboardInputSettingsMock(),
+}));
+vi.mock("@/lib/utils/runtime-env", () => ({
+  isMacOS: () => isMacOSMock(),
+}));
+
+let root: Root;
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  keyboardInputSettingsMock.mockReturnValue({
+    allowOptionKeySpecialCharacterInput: false,
+    onAllowOptionKeySpecialCharacterInputChange: vi.fn(),
+  });
+  isMacOSMock.mockReset();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("KeymapSettingsTab", () => {
+  it("shows the Option character-input setting on macOS", async () => {
+    isMacOSMock.mockReturnValue(true);
+
+    await act(async () => {
+      root.render(<KeymapSettingsTab />);
+    });
+
+    expect(container.querySelector("#allow-option-key-special-character-input")).not.toBeNull();
+  });
+
+  it("hides the Option character-input setting outside macOS", async () => {
+    isMacOSMock.mockReturnValue(false);
+
+    await act(async () => {
+      root.render(<KeymapSettingsTab />);
+    });
+
+    expect(container.querySelector("#allow-option-key-special-character-input")).toBeNull();
+  });
+});

--- a/src/contexts/EditorSettingsContext.tsx
+++ b/src/contexts/EditorSettingsContext.tsx
@@ -201,6 +201,19 @@ export function useUISettings() {
   );
 }
 
+/** Keyboard input behavior configuration. */
+export function useKeyboardInputSettings() {
+  const { settings, handlers } = useEditorSettingsContext();
+  return useMemo(
+    () => ({
+      allowOptionKeySpecialCharacterInput: settings.allowOptionKeySpecialCharacterInput,
+      onAllowOptionKeySpecialCharacterInputChange:
+        handlers.handleAllowOptionKeySpecialCharacterInputChange,
+    }),
+    [settings, handlers],
+  );
+}
+
 /** Speech / TTS configuration */
 export function useSpeechSettings() {
   const { settings, handlers } = useEditorSettingsContext();

--- a/src/lib/editor-page/__tests__/mac-option-input-guard.test.ts
+++ b/src/lib/editor-page/__tests__/mac-option-input-guard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  createMacOptionInputGuardPlugin,
   shouldSuppressMacOptionTextInput,
   suppressMacOptionTextInput,
 } from "../mac-option-input-guard";
@@ -23,5 +24,20 @@ describe("macOS Option text input guard", () => {
     expect(shouldSuppressMacOptionTextInput({ altKey: true, key: "Alt" }, true)).toBe(false);
     expect(shouldSuppressMacOptionTextInput({ altKey: true, key: "ArrowLeft" }, true)).toBe(false);
     expect(shouldSuppressMacOptionTextInput({ altKey: true, key: "√" }, false)).toBe(false);
+  });
+
+  it("does not suppress Option text when the input preference is enabled", () => {
+    const plugin = createMacOptionInputGuardPlugin(() => true);
+    const keydown = plugin.props.handleDOMEvents?.keydown;
+    const preventDefault = vi.fn();
+
+    expect(
+      keydown?.call(
+        plugin,
+        {} as never,
+        { altKey: true, key: "√", preventDefault } as unknown as KeyboardEvent,
+      ),
+    ).toBe(false);
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/editor-page/mac-option-input-guard.ts
+++ b/src/lib/editor-page/mac-option-input-guard.ts
@@ -28,11 +28,16 @@ export function suppressMacOptionTextInput(event: OptionKeyEvent, isMac = isMacO
 }
 
 /** ProseMirror integration for the editor's editable DOM only. */
-export function createMacOptionInputGuardPlugin(): Plugin {
+export function createMacOptionInputGuardPlugin(
+  isOptionCharacterInputAllowed: () => boolean = () => false,
+): Plugin {
   return new Plugin({
     props: {
       handleDOMEvents: {
-        keydown: (_view, event) => suppressMacOptionTextInput(event),
+        keydown: (_view, event) => {
+          if (isOptionCharacterInputAllowed()) return false;
+          return suppressMacOptionTextInput(event);
+        },
       },
     },
   });

--- a/src/lib/editor-page/use-display-settings.ts
+++ b/src/lib/editor-page/use-display-settings.ts
@@ -19,6 +19,7 @@ export interface DisplaySettings {
   verticalScrollBehavior: "auto" | "mouse" | "trackpad";
   scrollSensitivity: number;
   compactMode: boolean;
+  allowOptionKeySpecialCharacterInput: boolean;
   showSettingsModal: boolean;
   speechVoiceURI: string;
   speechRate: number;
@@ -56,6 +57,7 @@ export interface DisplaySettingsHandlers {
   handleVerticalScrollBehaviorChange: (value: "auto" | "mouse" | "trackpad") => void;
   handleScrollSensitivityChange: (value: number) => void;
   handleToggleCompactMode: () => void;
+  handleAllowOptionKeySpecialCharacterInputChange: (value: boolean) => void;
   setShowSettingsModal: (value: boolean) => void;
   handleSpeechVoiceURIChange: (value: string) => void;
   handleSpeechRateChange: (value: number) => void;
@@ -123,6 +125,8 @@ export function useDisplaySettings(incrementEditorKey: () => void): UseDisplaySe
   >("auto");
   const [scrollSensitivity, setScrollSensitivity] = useState(1.0);
   const [compactMode, setCompactMode] = useState(false);
+  const [allowOptionKeySpecialCharacterInput, setAllowOptionKeySpecialCharacterInput] =
+    useState(false);
 
   // Terminal settings
   const [terminalBackground, setTerminalBackground] = useState("#000000");
@@ -187,6 +191,9 @@ export function useDisplaySettings(incrementEditorKey: () => void): UseDisplaySe
     if (typeof appState.scrollSensitivity === "number")
       setScrollSensitivity(appState.scrollSensitivity);
     if (typeof appState.compactMode === "boolean") setCompactMode(appState.compactMode);
+    if (typeof appState.allowOptionKeySpecialCharacterInput === "boolean") {
+      setAllowOptionKeySpecialCharacterInput(appState.allowOptionKeySpecialCharacterInput);
+    }
     if (typeof appState.speechVoiceURI === "string") setSpeechVoiceURI(appState.speechVoiceURI);
     if (typeof appState.speechRate === "number") setSpeechRate(appState.speechRate);
     if (typeof appState.speechPitch === "number") setSpeechPitch(appState.speechPitch);
@@ -400,6 +407,13 @@ export function useDisplaySettings(incrementEditorKey: () => void): UseDisplaySe
     });
   }, []);
 
+  const handleAllowOptionKeySpecialCharacterInputChange = useCallback((value: boolean) => {
+    setAllowOptionKeySpecialCharacterInput(value);
+    void persistAppState({ allowOptionKeySpecialCharacterInput: value }).catch((e) =>
+      console.error("Failed to persist allowOptionKeySpecialCharacterInput:", e),
+    );
+  }, []);
+
   const handleSpeechVoiceURIChange = useCallback((value: string) => {
     setSpeechVoiceURI(value);
     void persistAppState({ speechVoiceURI: value }).catch((e) =>
@@ -569,6 +583,7 @@ export function useDisplaySettings(incrementEditorKey: () => void): UseDisplaySe
       verticalScrollBehavior,
       scrollSensitivity,
       compactMode,
+      allowOptionKeySpecialCharacterInput,
       showSettingsModal,
       speechVoiceURI,
       speechRate,
@@ -604,6 +619,7 @@ export function useDisplaySettings(incrementEditorKey: () => void): UseDisplaySe
       handleVerticalScrollBehaviorChange,
       handleScrollSensitivityChange,
       handleToggleCompactMode,
+      handleAllowOptionKeySpecialCharacterInputChange,
       setShowSettingsModal,
       handleSpeechVoiceURIChange,
       handleSpeechRateChange,

--- a/src/lib/storage/storage-types.ts
+++ b/src/lib/storage/storage-types.ts
@@ -76,6 +76,9 @@ export interface AppState {
   // コンパクトUIモード
   compactMode?: boolean;
 
+  // macOS の Option キーによる特殊文字入力
+  allowOptionKeySpecialCharacterInput?: boolean;
+
   // リンティング設定
   lintingEnabled?: boolean;
   lintingRuleConfigs?: Record<


### PR DESCRIPTION
Adds a macOS-only Keymap setting for allowing Option-key special character input such as √ and €. The preference is persisted and takes effect immediately in the editor while preserving the default protective behavior. Includes guard and visibility regression tests.