### PR TITLE
HTMLエクスポート設定とiframeプレビューを追加

### DIFF
--- a/electron/ipc/__tests__/file-ipc-html-export.test.ts
+++ b/electron/ipc/__tests__/file-ipc-html-export.test.ts
@@ -5,28 +5,51 @@ import { describe, expect, it } from "vitest";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const source = readFileSync(path.resolve(here, "../file-ipc.js"), "utf-8");
-const handler =
+const validation =
   source.match(
-    /ipcMain\.handle\(EXPORT_CHANNELS\.invoke\.exportHtml[\s\S]*?(?=\n\s*ipcMain\.handle\()/,
+    /function validateHtmlRenderRequest\([\s\S]*?(?=\n\s*\/\*\* @param \{unknown\} options \*\/)/,
   )?.[0] ?? "";
+
+function getHandler(channel: string): string {
+  return (
+    source.match(
+      new RegExp(
+        `ipcMain\\.handle\\(\\s*EXPORT_CHANNELS\\.invoke\\.${channel}[\\s\\S]*?(?=\\n\\s*ipcMain\\.handle\\()`,
+      ),
+    )?.[0] ?? ""
+  );
+}
+
+const previewHandler = getHandler("generateHtmlPreview");
+const exportHandler = getHandler("exportHtml");
 
 describe("native MDI HTML export IPC", () => {
   it("opens a native save dialog before invoking the Rust renderer", () => {
-    expect(handler).toContain("dialog.showSaveDialog");
-    expect(handler).toContain("safeExportBaseName(title)");
-    expect(handler).toContain('extensions: ["html", "htm"]');
-    expect(handler.indexOf("dialog.showSaveDialog")).toBeLessThan(
-      handler.indexOf("generateHtml(content, fileType)"),
+    expect(exportHandler).toContain("dialog.showSaveDialog");
+    expect(exportHandler).toContain("safeExportBaseName(title)");
+    expect(exportHandler).toContain('extensions: ["html", "htm"]');
+    expect(exportHandler.indexOf("dialog.showSaveDialog")).toBeLessThan(
+      exportHandler.indexOf("generateHtml(content, fileType"),
     );
-    expect(handler).toContain("if (!filePath) return null");
+    expect(exportHandler).toContain("if (!filePath) return null");
   });
 
-  it("validates the shared 50 MB ceiling and writes standalone HTML durably as UTF-8", () => {
-    expect(handler).toContain("MAX_CONTENT_BYTES");
-    expect(handler).toContain('code: "CONTENT_TOO_LARGE"');
-    expect(handler).toContain('Buffer.from(html, "utf-8")');
-    expect(handler).toContain("writeBufferDurably");
-    expect(handler).not.toContain("Blob");
-    expect(handler).not.toContain("createObjectURL");
+  it("validates the shared 50 MB ceiling and the upstream bodyOnly option", () => {
+    expect(validation).toContain("MAX_CONTENT_BYTES");
+    expect(validation).toContain('code: "CONTENT_TOO_LARGE"');
+    expect(validation).toContain('key !== "bodyOnly"');
+    expect(validation).toContain('typeof options.bodyOnly !== "boolean"');
+  });
+
+  it("renders previews and durable files through the same Rust HTML options", () => {
+    expect(previewHandler).toContain("validateHtmlRenderRequest(content, options)");
+    expect(previewHandler).toContain("normalizeHtmlRenderOptions(options)");
+    expect(previewHandler).toContain("return { success: true, html }");
+    expect(exportHandler).toContain("validateHtmlRenderRequest(content, options)");
+    expect(exportHandler).toContain("normalizeHtmlRenderOptions(options)");
+    expect(exportHandler).toContain('Buffer.from(html, "utf-8")');
+    expect(exportHandler).toContain("writeBufferDurably");
+    expect(exportHandler).not.toContain("Blob");
+    expect(exportHandler).not.toContain("createObjectURL");
   });
 });

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -15,6 +15,44 @@ const { addStandalonePath, hasStandalonePath } = require("../lib/standalone-file
 const TEXT_EXPORT_FORMATS = new Set(["txt", "txt-ruby", "narou", "kakuyomu", "aozora"]);
 
 /**
+ * Validate the Rust HTML renderer boundary and reject unsupported option keys.
+ * @param {unknown} content
+ * @param {unknown} options
+ * @returns {{ success: false, error: string, code?: string } | null}
+ */
+function validateHtmlRenderRequest(content, options) {
+  if (typeof content !== "string") {
+    return { success: false, error: "Invalid HTML render request" };
+  }
+  if (Buffer.byteLength(content, "utf-8") > MAX_CONTENT_BYTES) {
+    return {
+      success: false,
+      error: "コンテンツが大きすぎて処理できません（50 MB）",
+      code: "CONTENT_TOO_LARGE",
+    };
+  }
+  if (
+    options != null &&
+    (typeof options !== "object" ||
+      Array.isArray(options) ||
+      Object.keys(options).some((key) => key !== "bodyOnly") ||
+      ("bodyOnly" in options &&
+        options.bodyOnly !== undefined &&
+        typeof options.bodyOnly !== "boolean"))
+  ) {
+    return { success: false, error: "Invalid HTML render options" };
+  }
+  return null;
+}
+
+/** @param {unknown} options */
+function normalizeHtmlRenderOptions(options) {
+  return options && typeof options === "object" && options.bodyOnly === true
+    ? { bodyOnly: true }
+    : {};
+}
+
+/**
  * Validate text conversion requests before loading the Rust-backed MDI renderer.
  * Both file export and clipboard copy use the same ceiling and format allowlist.
  * @param {unknown} content
@@ -495,37 +533,49 @@ function registerFileHandlers() {
 
   // --- Export handlers ---
 
-  ipcMain.handle(EXPORT_CHANNELS.invoke.exportHtml, async (_event, content, fileType, title) => {
-    if (typeof content !== "string") {
-      return { success: false, error: "Invalid HTML export request" };
-    }
-    if (Buffer.byteLength(content, "utf-8") > MAX_CONTENT_BYTES) {
-      return {
-        success: false,
-        error: "コンテンツが大きすぎてエクスポートできません（50 MB）",
-        code: "CONTENT_TOO_LARGE",
-      };
-    }
+  ipcMain.handle(
+    EXPORT_CHANNELS.invoke.generateHtmlPreview,
+    async (_event, content, fileType, options) => {
+      const invalid = validateHtmlRenderRequest(content, options);
+      if (invalid) return invalid;
 
-    try {
-      const { safeExportBaseName } = require("../../src/lib/export/safe-export-filename");
-      const { filePath } = await dialog.showSaveDialog({
-        title: "HTMLとしてエクスポート",
-        defaultPath: `${safeExportBaseName(title)}.html`,
-        filters: [{ name: "HTMLファイル", extensions: ["html", "htm"] }],
-      });
-      if (!filePath) return null;
+      try {
+        const { generateHtml } = require("../../src/lib/export/html-exporter");
+        const html = await generateHtml(content, fileType, normalizeHtmlRenderOptions(options));
+        return { success: true, html };
+      } catch (error) {
+        log.error("HTML preview generation failed:", error);
+        return { success: false, error: error?.message || "HTML preview generation failed" };
+      }
+    },
+  );
 
-      const { generateHtml } = require("../../src/lib/export/html-exporter");
-      const html = await generateHtml(content, fileType);
-      await writeBufferDurably(filePath, Buffer.from(html, "utf-8"));
-      log.info(`Exported HTML: ${filePath}`);
-      return filePath;
-    } catch (error) {
-      log.error("HTML export failed:", error);
-      return { success: false, error: error?.message || "HTML export failed" };
-    }
-  });
+  ipcMain.handle(
+    EXPORT_CHANNELS.invoke.exportHtml,
+    async (_event, content, fileType, title, options) => {
+      const invalid = validateHtmlRenderRequest(content, options);
+      if (invalid) return invalid;
+
+      try {
+        const { safeExportBaseName } = require("../../src/lib/export/safe-export-filename");
+        const { filePath } = await dialog.showSaveDialog({
+          title: "HTMLとしてエクスポート",
+          defaultPath: `${safeExportBaseName(title)}.html`,
+          filters: [{ name: "HTMLファイル", extensions: ["html", "htm"] }],
+        });
+        if (!filePath) return null;
+
+        const { generateHtml } = require("../../src/lib/export/html-exporter");
+        const html = await generateHtml(content, fileType, normalizeHtmlRenderOptions(options));
+        await writeBufferDurably(filePath, Buffer.from(html, "utf-8"));
+        log.info(`Exported HTML: ${filePath}`);
+        return filePath;
+      } catch (error) {
+        log.error("HTML export failed:", error);
+        return { success: false, error: error?.message || "HTML export failed" };
+      }
+    },
+  );
 
   ipcMain.handle(
     EXPORT_CHANNELS.invoke.exportMdiText,

--- a/electron/lib/__tests__/ipc-bridge.test.ts
+++ b/electron/lib/__tests__/ipc-bridge.test.ts
@@ -135,6 +135,7 @@ describe("ipc-channels: pinned channel names (public IPC contract)", () => {
     expect(EXPORT_CHANNELS.invoke).toEqual({
       generatePdfPreview: "generate-pdf-preview",
       cancelPdfPreview: "cancel-pdf-preview",
+      generateHtmlPreview: "generate-html-preview",
       exportHtml: "export-html",
       exportMdiText: "export-mdi-text",
       copyMdiText: "copy-mdi-text",

--- a/electron/lib/ipc-channels.js
+++ b/electron/lib/ipc-channels.js
@@ -91,6 +91,7 @@ const EXPORT_CHANNELS = Object.freeze({
   invoke: Object.freeze({
     generatePdfPreview: "generate-pdf-preview",
     cancelPdfPreview: "cancel-pdf-preview",
+    generateHtmlPreview: "generate-html-preview",
     exportHtml: "export-html",
     exportMdiText: "export-mdi-text",
     copyMdiText: "copy-mdi-text",

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -102,7 +102,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Export
   generatePdfPreview: invokeChannel(EXPORT_CHANNELS.invoke.generatePdfPreview, { arity: 3 }),
   cancelPdfPreview: invokeChannel(EXPORT_CHANNELS.invoke.cancelPdfPreview, { arity: 0 }),
-  exportHTML: invokeChannel(EXPORT_CHANNELS.invoke.exportHtml, { arity: 3 }),
+  generateHtmlPreview: invokeChannel(EXPORT_CHANNELS.invoke.generateHtmlPreview, { arity: 3 }),
+  exportHTML: invokeChannel(EXPORT_CHANNELS.invoke.exportHtml, { arity: 4 }),
   exportMdiText: invokeChannel(EXPORT_CHANNELS.invoke.exportMdiText, { arity: 5 }),
   copyMdiText: invokeChannel(EXPORT_CHANNELS.invoke.copyMdiText, { arity: 4 }),
   exportPDF: invokeChannel(EXPORT_CHANNELS.invoke.exportPdf, { arity: 2 }),

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,6 +35,7 @@ import type { ExportMetadata } from "@/lib/export/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { UnifiedExportSettings } from "@/lib/export/export-settings";
 import type { EpubExportOptions } from "@/lib/export/epub-shared";
+import type { HtmlExportOptions } from "@/lib/export/html-shared";
 import { notificationManager } from "@/lib/services/notification-manager";
 import { renameProjectFile, type RenameOutcome } from "@/lib/tab-manager/rename-file";
 import { useWebMenuHandlers } from "@/lib/menu/use-web-menu-handlers";
@@ -810,9 +811,9 @@ function EditorPageContent() {
     return (tab && isEditorTab(tab) ? tab.fileType : undefined) ?? ".mdi";
   }, [tabs, activeTabId]);
 
-  // Export dialog state (PDF / DOCX share a single state slot)
+  // Shared export dialog state for HTML / PDF / DOCX / EPUB.
   interface ExportDialogState {
-    format: "pdf" | "docx" | "epub";
+    format: "html" | "pdf" | "docx" | "epub";
     content: string;
     metadata: ExportMetadata;
     /** Snapshot of the active tab's file type at the moment the dialog opened. */
@@ -863,7 +864,7 @@ function EditorPageContent() {
   }, []);
 
   const handleExportDialogRequest = useCallback(
-    (format: "pdf" | "docx" | "epub", content: string, metadata: ExportMetadata) => {
+    (format: "html" | "pdf" | "docx" | "epub", content: string, metadata: ExportMetadata) => {
       const state: ExportDialogState = {
         format,
         content,
@@ -875,6 +876,43 @@ function EditorPageContent() {
     },
     [],
   );
+
+  const handleHtmlExportConfirm = useCallback(async (options: HtmlExportOptions) => {
+    const dialogState = exportDialogStateRef.current;
+    if (!dialogState) return;
+
+    if (window.electronAPI?.exportHTML) {
+      setExportDialogState(null);
+
+      const progressId = notificationManager.showProgress("HTMLをエクスポート中...", {
+        type: "info",
+      });
+
+      try {
+        const result = await window.electronAPI.exportHTML(
+          dialogState.content,
+          dialogState.fileType,
+          dialogState.metadata.title,
+          options,
+        );
+
+        notificationManager.dismiss(progressId);
+        if (result === null || result === undefined) return;
+        if (typeof result === "object" && "success" in result && !result.success) {
+          notificationManager.error(`HTMLのエクスポートに失敗しました: ${result.error}`);
+          return;
+        }
+        notificationManager.success("HTMLをエクスポートしました");
+      } catch (error) {
+        notificationManager.dismiss(progressId);
+        const message = error instanceof Error ? error.message : "不明なエラー";
+        notificationManager.error(`HTMLのエクスポートに失敗しました: ${message}`);
+      }
+      return;
+    }
+
+    notificationManager.error("HTMLエクスポート機能を利用できません。アプリを再起動してください");
+  }, []);
 
   const handlePdfExportConfirm = useCallback(async (settings: PdfExportSettings) => {
     const dialogState = exportDialogStateRef.current;
@@ -1631,6 +1669,7 @@ function EditorPageContent() {
           exportDialog: {
             state: exportDialogState,
             onClose: () => setExportDialogState(null),
+            onHtmlExport: handleHtmlExportConfirm,
             onPdfExport: handlePdfExportConfirm,
             onDocxExport: handleDocxExportConfirm,
             onEpubExport: handleEpubExportConfirm,

--- a/src/components/EditorLayout.tsx
+++ b/src/components/EditorLayout.tsx
@@ -51,6 +51,7 @@ import type { LintIssue } from "@/lib/linting/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { UnifiedExportSettings } from "@/lib/export/export-settings";
 import type { EpubExportOptions } from "@/lib/export/epub-shared";
+import type { HtmlExportOptions } from "@/lib/export/html-shared";
 import type { ExportMetadata } from "@/lib/export/types";
 import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import { decideResponsivePanels } from "@/lib/editor-page/responsive-layout";
@@ -107,14 +108,19 @@ interface EditorLayoutProps {
     rubySelectedText: string;
     handleApplyRuby: React.ComponentProps<typeof RubyDialog>["onApply"];
     exportDialog: {
-      state: { format: "pdf" | "docx" | "epub"; content: string; metadata: ExportMetadata } | null;
+      state: {
+        format: "html" | "pdf" | "docx" | "epub";
+        content: string;
+        metadata: ExportMetadata;
+      } | null;
       onClose: () => void;
+      onHtmlExport: (options: HtmlExportOptions) => void;
       onPdfExport: (settings: PdfExportSettings) => void;
       onDocxExport: (settings: UnifiedExportSettings) => void;
       onEpubExport: (options: EpubExportOptions) => void;
       content: string;
       metadata: ExportMetadata;
-      fileType?: string;
+      fileType?: SupportedFileExtension;
     };
     printDialog: {
       state: { content: string; metadata: ExportMetadata } | null;
@@ -122,7 +128,7 @@ interface EditorLayoutProps {
       onPrint: (settings: PdfExportSettings) => void;
       content: string;
       metadata: ExportMetadata;
-      fileType?: string;
+      fileType?: SupportedFileExtension;
     };
   };
   recovery: {
@@ -339,6 +345,7 @@ export default function EditorLayout({
                 isOpen={dialogs.exportDialog.state != null}
                 initialFormat={dialogs.exportDialog.state?.format ?? "pdf"}
                 onClose={dialogs.exportDialog.onClose}
+                onExportHtml={dialogs.exportDialog.onHtmlExport}
                 onExportPdf={dialogs.exportDialog.onPdfExport}
                 onExportDocx={dialogs.exportDialog.onDocxExport}
                 onExportEpub={dialogs.exportDialog.onEpubExport}

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -22,13 +22,15 @@ import type {
 } from "@/lib/export/export-settings";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
 import type { EpubExportOptions, ChapterSplitLevel } from "@/lib/export/epub-shared";
+import type { HtmlExportOptions } from "@/lib/export/html-shared";
+import type { SupportedFileExtension } from "@/lib/project/project-types";
 import type { ExportMetadata } from "@/lib/export/types";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type ExportDialogFormat = "pdf" | "docx" | "epub";
+export type ExportDialogFormat = "html" | "pdf" | "docx" | "epub";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -39,6 +41,7 @@ interface ExportDialogProps {
   mode?: "export" | "print";
   initialFormat: ExportDialogFormat;
   onClose: () => void;
+  onExportHtml?: (options: HtmlExportOptions) => void;
   onExportPdf: (settings: PdfExportSettings) => void;
   onExportDocx: (settings: UnifiedExportSettings) => void;
   onExportEpub?: (options: EpubExportOptions) => void;
@@ -49,7 +52,7 @@ interface ExportDialogProps {
    * pipeline un-escapes MDI macros only for ".mdi" and preserves \[\[blank]]
    * literals in ".md"/".txt". Absent → ".mdi".
    */
-  fileType?: string;
+  fileType?: SupportedFileExtension;
 }
 
 // ---------------------------------------------------------------------------
@@ -113,6 +116,7 @@ export default function ExportDialog({
   mode = "export",
   initialFormat,
   onClose,
+  onExportHtml,
   onExportPdf,
   onExportDocx,
   onExportEpub,
@@ -126,6 +130,7 @@ export default function ExportDialog({
       mode={mode}
       initialFormat={initialFormat}
       onClose={onClose}
+      onExportHtml={onExportHtml}
       onExportPdf={onExportPdf}
       onExportDocx={onExportDocx}
       onExportEpub={onExportEpub}
@@ -140,6 +145,7 @@ function ExportDialogInner({
   mode = "export",
   initialFormat,
   onClose,
+  onExportHtml,
   onExportPdf,
   onExportDocx,
   onExportEpub,
@@ -164,8 +170,11 @@ function ExportDialogInner({
     };
   }, []);
 
+  const isHtml = selectedFormat === "html";
   const isEpub = selectedFormat === "epub";
   const hasPreviewApi = typeof window !== "undefined" && !!window.electronAPI?.generatePdfPreview;
+  const hasHtmlPreviewApi =
+    typeof window !== "undefined" && !!window.electronAPI?.generateHtmlPreview;
 
   // --- Author auto-fill from auth context ---
   const authContext = useAuthSafe();
@@ -205,6 +214,10 @@ function ExportDialogInner({
   const [previewMaxPagesPreference] = useState(() => localPreferences.getPdfPreviewMaxPages());
   const generationIdRef = useRef(0);
   const previewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [htmlPreview, setHtmlPreview] = useState<string | null>(null);
+  const [htmlPreviewLoading, setHtmlPreviewLoading] = useState(false);
+  const [htmlPreviewError, setHtmlPreviewError] = useState<string | null>(null);
+  const htmlGenerationIdRef = useRef(0);
 
   const updateField = useCallback(
     <K extends keyof UnifiedExportSettings>(key: K, value: UnifiedExportSettings[K]) => {
@@ -274,6 +287,11 @@ function ExportDialogInner({
   const handleExport = useCallback(() => {
     void saveExportSettings(settings);
 
+    if (isHtml && onExportHtml) {
+      onExportHtml({ bodyOnly: settings.htmlBodyOnly });
+      return;
+    }
+
     if (isEpub && onExportEpub) {
       const options = toEpubExportOptions(
         settings,
@@ -298,7 +316,9 @@ function ExportDialogInner({
     settings,
     selectedFormat,
     mode,
+    isHtml,
     isEpub,
+    onExportHtml,
     onExportPdf,
     onExportDocx,
     onExportEpub,
@@ -313,7 +333,7 @@ function ExportDialogInner({
   useEffect(() => {
     const id = ++generationIdRef.current;
 
-    if (!hasPreviewApi || isEpub) {
+    if (!hasPreviewApi || isEpub || isHtml) {
       void window.electronAPI?.cancelPdfPreview?.();
       setPreviewLoading(false);
       setPreviewError(null);
@@ -405,12 +425,64 @@ function ExportDialogInner({
       if (previewTimeoutRef.current) clearTimeout(previewTimeoutRef.current);
       void window.electronAPI?.cancelPdfPreview?.();
     };
-  }, [hasPreviewApi, isEpub, settings, content, metadata, fileType, previewMaxPagesPreference]);
+  }, [
+    hasPreviewApi,
+    isEpub,
+    isHtml,
+    settings,
+    content,
+    metadata,
+    fileType,
+    previewMaxPagesPreference,
+  ]);
+
+  // --- Electron: Rust HTML renderer preview, displayed directly in a sandboxed iframe ---
+  useEffect(() => {
+    const id = ++htmlGenerationIdRef.current;
+
+    if (!isHtml || !hasHtmlPreviewApi) {
+      setHtmlPreview(null);
+      setHtmlPreviewLoading(false);
+      setHtmlPreviewError(null);
+      return;
+    }
+
+    setHtmlPreviewLoading(true);
+    setHtmlPreviewError(null);
+
+    void window.electronAPI!.generateHtmlPreview!(content, fileType, {
+      bodyOnly: settings.htmlBodyOnly,
+    })
+      .then((result) => {
+        if (id !== htmlGenerationIdRef.current) return;
+        if (result.success) {
+          setHtmlPreview(result.html);
+        } else {
+          setHtmlPreview(null);
+          setHtmlPreviewError(result.error);
+        }
+      })
+      .catch((error: unknown) => {
+        if (id !== htmlGenerationIdRef.current) return;
+        setHtmlPreview(null);
+        setHtmlPreviewError(
+          error instanceof Error ? error.message : "HTMLプレビューの生成に失敗しました",
+        );
+      })
+      .finally(() => {
+        if (id === htmlGenerationIdRef.current) setHtmlPreviewLoading(false);
+      });
+
+    return () => {
+      if (htmlGenerationIdRef.current === id) htmlGenerationIdRef.current += 1;
+    };
+  }, [isHtml, hasHtmlPreviewApi, content, fileType, settings.htmlBodyOnly]);
 
   // Cleanup blob URLs on unmount (refs always hold the latest values)
   useEffect(() => {
     return () => {
       generationIdRef.current += 1;
+      htmlGenerationIdRef.current += 1;
       coverReaderRef.current?.abort();
       coverReaderRef.current = null;
       if (pdfUrlRef.current) URL.revokeObjectURL(pdfUrlRef.current);
@@ -426,9 +498,11 @@ function ExportDialogInner({
       ? "印刷"
       : isEpub
         ? "EPUBとしてエクスポート"
-        : selectedFormat === "pdf"
-          ? "PDFとしてエクスポート"
-          : "DOCXとしてエクスポート";
+        : isHtml
+          ? "HTMLとしてエクスポート"
+          : selectedFormat === "pdf"
+            ? "PDFとしてエクスポート"
+            : "DOCXとしてエクスポート";
 
   return (
     <GlassDialog
@@ -452,7 +526,7 @@ function ExportDialogInner({
             {/* Format toggle (hidden in print mode) */}
             {mode !== "print" && (
               <div className="flex gap-1 p-1 bg-background-secondary rounded-lg">
-                {(["pdf", "docx", "epub"] as const).map((fmt) => (
+                {(["pdf", "docx", "epub", "html"] as const).map((fmt) => (
                   <button
                     key={fmt}
                     type="button"
@@ -477,6 +551,52 @@ function ExportDialogInner({
               isEpub && "max-w-lg mx-auto w-full",
             )}
           >
+            {/* ══════════════════════════════════════════════════════════ */}
+            {/* HTML-only: options owned by @illusions-lab/mdi           */}
+            {/* ══════════════════════════════════════════════════════════ */}
+            {isHtml && (
+              <>
+                <div>
+                  <label className={labelClass}>出力範囲</label>
+                  <div className="flex flex-col gap-2">
+                    <button
+                      type="button"
+                      className={clsx(
+                        "w-full px-3 py-3 rounded-lg border text-left transition-colors",
+                        !settings.htmlBodyOnly
+                          ? "bg-accent text-accent-foreground border-accent"
+                          : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                      )}
+                      onClick={() => updateField("htmlBodyOnly", false)}
+                    >
+                      <span className="block text-sm font-medium">完全なHTML文書</span>
+                      <span className="block mt-1 text-xs opacity-75">
+                        DOCTYPE、メタデータ、MDI用CSSを含めます
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className={clsx(
+                        "w-full px-3 py-3 rounded-lg border text-left transition-colors",
+                        settings.htmlBodyOnly
+                          ? "bg-accent text-accent-foreground border-accent"
+                          : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                      )}
+                      onClick={() => updateField("htmlBodyOnly", true)}
+                    >
+                      <span className="block text-sm font-medium">本文のみ</span>
+                      <span className="block mt-1 text-xs opacity-75">
+                        body要素の中身だけを書き出します
+                      </span>
+                    </button>
+                  </div>
+                </div>
+                <p className="text-xs text-foreground-tertiary leading-relaxed">
+                  言語、書名、組方向はMDIフロントマターの設定を使用します。
+                </p>
+              </>
+            )}
+
             {/* ══════════════════════════════════════════════════════════ */}
             {/* EPUB-only: Metadata section                              */}
             {/* ══════════════════════════════════════════════════════════ */}
@@ -604,7 +724,7 @@ function ExportDialogInner({
             {/* ══════════════════════════════════════════════════════════ */}
             {/* Page layout section (hidden for EPUB)                     */}
             {/* ══════════════════════════════════════════════════════════ */}
-            {!isEpub && (
+            {!isEpub && !isHtml && (
               <>
                 {/* Paper size */}
                 <div>
@@ -649,47 +769,49 @@ function ExportDialogInner({
             )}
 
             {/* Writing direction (shared: PDF/DOCX/EPUB) */}
-            <div>
-              <label className={labelClass}>組方向</label>
-              {isEpub && (
-                <p className="text-xs text-foreground-tertiary mb-1">
-                  EPUBのCSS writing-modeに反映
-                </p>
-              )}
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  className={clsx(
-                    "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
-                    settings.verticalWriting
-                      ? "bg-accent text-accent-foreground border-accent"
-                      : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
-                  )}
-                  onClick={() => updateField("verticalWriting", true)}
-                >
-                  縦書き
-                </button>
-                <button
-                  type="button"
-                  className={clsx(
-                    "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
-                    !settings.verticalWriting
-                      ? "bg-accent text-accent-foreground border-accent"
-                      : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
-                  )}
-                  onClick={() => updateField("verticalWriting", false)}
-                >
-                  横書き
-                </button>
+            {!isHtml && (
+              <div>
+                <label className={labelClass}>組方向</label>
+                {isEpub && (
+                  <p className="text-xs text-foreground-tertiary mb-1">
+                    EPUBのCSS writing-modeに反映
+                  </p>
+                )}
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    className={clsx(
+                      "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                      settings.verticalWriting
+                        ? "bg-accent text-accent-foreground border-accent"
+                        : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                    )}
+                    onClick={() => updateField("verticalWriting", true)}
+                  >
+                    縦書き
+                  </button>
+                  <button
+                    type="button"
+                    className={clsx(
+                      "flex-1 px-3 py-2 rounded-lg border text-sm transition-colors",
+                      !settings.verticalWriting
+                        ? "bg-accent text-accent-foreground border-accent"
+                        : "bg-background text-foreground-secondary border-border-secondary hover:bg-hover",
+                    )}
+                    onClick={() => updateField("verticalWriting", false)}
+                  >
+                    横書き
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
 
-            <hr className="border-border" />
+            {!isHtml && <hr className="border-border" />}
 
             {/* ── Typography section ── */}
 
             {/* Chars per line + Lines per page (PDF/DOCX only) */}
-            {!isEpub && (
+            {!isEpub && !isHtml && (
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className={labelClass}>一行の文字数</label>
@@ -719,30 +841,34 @@ function ExportDialogInner({
             )}
 
             {/* Font (shared) */}
-            <div>
-              <label className={labelClass}>フォント</label>
-              <FontSelector
-                value={settings.fontFamily}
-                onChange={(font) => updateField("fontFamily", font)}
-              />
-            </div>
+            {!isHtml && (
+              <div>
+                <label className={labelClass}>フォント</label>
+                <FontSelector
+                  value={settings.fontFamily}
+                  onChange={(font) => updateField("fontFamily", font)}
+                />
+              </div>
+            )}
 
             {/* Indent (shared) */}
-            <div>
-              <label className={labelClass}>字下げ（em）</label>
-              <input
-                type="number"
-                className={numberInputClass + " w-full"}
-                min={0}
-                max={4}
-                step={0.5}
-                value={settings.textIndent}
-                onChange={(e) => updateField("textIndent", clampFloat(e.target.value, 0, 4))}
-              />
-            </div>
+            {!isHtml && (
+              <div>
+                <label className={labelClass}>字下げ（em）</label>
+                <input
+                  type="number"
+                  className={numberInputClass + " w-full"}
+                  min={0}
+                  max={4}
+                  step={0.5}
+                  value={settings.textIndent}
+                  onChange={(e) => updateField("textIndent", clampFloat(e.target.value, 0, 4))}
+                />
+              </div>
+            )}
 
             {/* Full-width-space indent toggle (PDF/DOCX only) */}
-            {!isEpub && (
+            {!isEpub && !isHtml && (
               <div>
                 <div className="flex items-center justify-between">
                   <label className={labelClass + " mb-0"}>全角スペースで字下げ</label>
@@ -777,7 +903,7 @@ function ExportDialogInner({
             )}
 
             {/* ── Page number section (PDF/DOCX only) ── */}
-            {!isEpub && (
+            {!isEpub && !isHtml && (
               <>
                 <hr className="border-border" />
 
@@ -892,8 +1018,13 @@ function ExportDialogInner({
               <div className="flex items-center justify-between">
                 <span className="text-sm font-medium text-foreground">プレビュー</span>
                 <span className="text-xs text-foreground-tertiary">
-                  {settings.pageSize} · {settings.landscape ? "横置き" : "縦置き"} ·{" "}
-                  {settings.verticalWriting ? "縦書き" : "横書き"}
+                  {isHtml
+                    ? settings.htmlBodyOnly
+                      ? "本文のみ"
+                      : "完全なHTML文書"
+                    : `${settings.pageSize} · ${settings.landscape ? "横置き" : "縦置き"} · ${
+                        settings.verticalWriting ? "縦書き" : "横書き"
+                      }`}
                 </span>
               </div>
               {previewInfo && (
@@ -907,7 +1038,35 @@ function ExportDialogInner({
             </div>
 
             <div className="flex-1 overflow-hidden">
-              {hasPreviewApi ? (
+              {isHtml ? (
+                !hasHtmlPreviewApi ? (
+                  <div className="flex items-center justify-center h-full px-6">
+                    <p className="text-sm text-danger text-center">
+                      HTMLプレビューを利用できません。アプリを再起動してください。
+                    </p>
+                  </div>
+                ) : htmlPreviewError ? (
+                  <div className="w-full h-full flex items-center justify-center px-6">
+                    <span className="text-sm text-danger">{htmlPreviewError}</span>
+                  </div>
+                ) : htmlPreview !== null ? (
+                  <iframe
+                    title="HTMLプレビュー"
+                    srcDoc={htmlPreview}
+                    sandbox=""
+                    referrerPolicy="no-referrer"
+                    className="w-full h-full border-0 bg-white"
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center">
+                    {htmlPreviewLoading && (
+                      <span className="text-sm text-foreground-tertiary">
+                        プレビューを生成中...
+                      </span>
+                    )}
+                  </div>
+                )
+              ) : hasPreviewApi ? (
                 previewError ? (
                   <div className="w-full h-full flex items-center justify-center px-6">
                     <span className="text-sm text-danger">{previewError}</span>

--- a/src/components/__tests__/ExportDialog-html.test.tsx
+++ b/src/components/__tests__/ExportDialog-html.test.tsx
@@ -1,0 +1,171 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_EXPORT_SETTINGS } from "@/lib/export/export-settings";
+
+vi.mock("@/contexts/AuthContext", () => ({ useAuthSafe: () => null }));
+vi.mock("@/shared/ui/GlassDialog", () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/components/explorer/FontSelector", () => ({ FontSelector: () => null }));
+vi.mock("@/components/PageSizeSelector", () => ({ PageSizeSelector: () => null }));
+
+const exportSettingsMocks = vi.hoisted(() => ({
+  loadExportSettings: vi.fn(),
+  saveExportSettings: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/export/export-settings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/export/export-settings")>();
+  return {
+    ...actual,
+    loadExportSettings: exportSettingsMocks.loadExportSettings,
+    saveExportSettings: exportSettingsMocks.saveExportSettings,
+  };
+});
+
+const { default: ExportDialog } = await import("../ExportDialog");
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+const generateHtmlPreview = vi.fn();
+const onExportHtml = vi.fn();
+let root: Root;
+let container: HTMLDivElement;
+
+function renderDialog(): void {
+  root.render(
+    <ExportDialog
+      isOpen
+      initialFormat="html"
+      onClose={vi.fn()}
+      onExportHtml={onExportHtml}
+      onExportPdf={vi.fn()}
+      onExportDocx={vi.fn()}
+      content={"# 第一章\n\n本文。"}
+      metadata={{ title: "HTMLテスト" }}
+      fileType=".mdi"
+    />,
+  );
+}
+
+function button(label: string): HTMLButtonElement {
+  const normalizedLabel = label.replace(/\s/g, "");
+  const found = Array.from(container.querySelectorAll("button")).find(
+    (candidate) => candidate.textContent?.replace(/\s/g, "") === normalizedLabel,
+  );
+  if (!found) throw new Error(`button not found: ${label}`);
+  return found;
+}
+
+async function flushPreview(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  exportSettingsMocks.loadExportSettings.mockResolvedValue(DEFAULT_EXPORT_SETTINGS);
+  generateHtmlPreview.mockImplementation(
+    async (_content: string, _fileType: string, options: { bodyOnly?: boolean }) => ({
+      success: true,
+      html: options.bodyOnly
+        ? "<h1>第一章</h1><p>本文。</p>"
+        : "<!DOCTYPE html><html><body><h1>第一章</h1><p>本文。</p></body></html>",
+    }),
+  );
+  Object.defineProperty(window, "electronAPI", {
+    configurable: true,
+    value: { generateHtmlPreview },
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => renderDialog());
+  await flushPreview();
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("ExportDialog HTML options and iframe preview", () => {
+  it("shows only the upstream HTML option and renders a sandboxed iframe", () => {
+    expect(container.textContent).toContain("出力範囲");
+    expect(container.textContent).toContain("完全なHTML文書");
+    expect(container.textContent).toContain("本文のみ");
+    expect(container.textContent).not.toContain("用紙サイズ");
+
+    expect(generateHtmlPreview).toHaveBeenCalledWith("# 第一章\n\n本文。", ".mdi", {
+      bodyOnly: false,
+    });
+    const iframe = container.querySelector("iframe");
+    expect(iframe?.title).toBe("HTMLプレビュー");
+    expect(iframe?.getAttribute("srcdoc")).toContain("<!DOCTYPE html>");
+    expect(iframe?.hasAttribute("sandbox")).toBe(true);
+    expect(iframe?.getAttribute("sandbox")).toBe("");
+    expect(iframe?.getAttribute("referrerpolicy")).toBe("no-referrer");
+  });
+
+  it("previews and exports the selected bodyOnly option", async () => {
+    await act(async () => button("本文のみbody要素の中身だけを書き出します").click());
+    await flushPreview();
+
+    expect(generateHtmlPreview).toHaveBeenLastCalledWith("# 第一章\n\n本文。", ".mdi", {
+      bodyOnly: true,
+    });
+    expect(container.querySelector("iframe")?.getAttribute("srcdoc")).toBe(
+      "<h1>第一章</h1><p>本文。</p>",
+    );
+
+    await act(async () => button("HTMLとしてエクスポート").click());
+    expect(onExportHtml).toHaveBeenCalledWith({ bodyOnly: true });
+    expect(exportSettingsMocks.saveExportSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ htmlBodyOnly: true }),
+    );
+  });
+
+  it("ignores a stale preview result after the option changes", async () => {
+    const oldPreview = deferred<{ success: true; html: string }>();
+    const newPreview = deferred<{ success: true; html: string }>();
+    generateHtmlPreview
+      .mockReset()
+      .mockReturnValueOnce(oldPreview.promise)
+      .mockReturnValueOnce(newPreview.promise);
+
+    await act(async () => button("本文のみbody要素の中身だけを書き出します").click());
+    await act(async () => button("完全なHTML文書DOCTYPE、メタデータ、MDI用CSSを含めます").click());
+
+    await act(async () => newPreview.resolve({ success: true, html: "<p>新しい結果</p>" }));
+    expect(container.querySelector("iframe")?.getAttribute("srcdoc")).toBe("<p>新しい結果</p>");
+
+    await act(async () => oldPreview.resolve({ success: true, html: "<p>古い結果</p>" }));
+    expect(container.querySelector("iframe")?.getAttribute("srcdoc")).toBe("<p>新しい結果</p>");
+  });
+
+  it("shows a renderer error instead of a stale iframe", async () => {
+    await act(async () => button("本文のみbody要素の中身だけを書き出します").click());
+    await flushPreview();
+    generateHtmlPreview.mockResolvedValueOnce({
+      success: false,
+      error: "HTMLプレビュー生成エラー",
+    });
+
+    await act(async () => button("完全なHTML文書DOCTYPE、メタデータ、MDI用CSSを含めます").click());
+    await flushPreview();
+
+    expect(container.textContent).toContain("HTMLプレビュー生成エラー");
+    expect(container.querySelector("iframe")).toBeNull();
+  });
+});

--- a/src/lib/export/__tests__/export-settings.test.ts
+++ b/src/lib/export/__tests__/export-settings.test.ts
@@ -73,6 +73,14 @@ describe("toPdfExportSettings", () => {
 });
 
 describe("loadExportSettings", () => {
+  it("HTMLの本文のみ設定を保存値から復元する", async () => {
+    kvStore.set(STORAGE_KEY, JSON.stringify({ ...DEFAULT_EXPORT_SETTINGS, htmlBodyOnly: true }));
+
+    const loaded = await loadExportSettings();
+
+    expect(loaded.htmlBodyOnly).toBe(true);
+  });
+
   it("StorageService に保存済みの設定を読み込む", async () => {
     const settings = { ...DEFAULT_EXPORT_SETTINGS, linesPerPage: 22, landscape: false };
     kvStore.set(STORAGE_KEY, JSON.stringify(settings));

--- a/src/lib/export/__tests__/mdi-export-format-matrix.test.ts
+++ b/src/lib/export/__tests__/mdi-export-format-matrix.test.ts
@@ -52,6 +52,17 @@ describe("MDI official export format acceptance matrix", () => {
     expectNoFrontmatterLeak(html);
   });
 
+  it("passes the upstream bodyOnly option through without inventing a second renderer", async () => {
+    const fragment = await generateHtml(source, ".mdi", { bodyOnly: true });
+
+    expect(fragment).toMatch(/^<h1>第一章<\/h1>/);
+    expect(fragment).not.toContain("<!DOCTYPE html>");
+    expect(fragment).not.toContain("<html");
+    expect(fragment).toContain('<ruby class="mdi-ruby">東京');
+    expect(fragment).toContain('<p class="mdi-blank"></p>');
+    expectNoFrontmatterLeak(fragment);
+  });
+
   it.each<[TxtExportFormat, string]>([
     ["txt", "東京へ行った。"],
     ["txt-ruby", "{東京|とうきょう}へ行った。"],

--- a/src/lib/export/__tests__/use-export-text.test.tsx
+++ b/src/lib/export/__tests__/use-export-text.test.tsx
@@ -26,15 +26,17 @@ let api: ExportApi | undefined;
 const exportMdiText = vi.fn();
 const exportHTML = vi.fn();
 const copyMdiText = vi.fn();
+const requestExportDialog = vi.fn();
 const indent: TxtIndentOptions = { fullwidthSpaceIndent: true, indentCount: 2 };
 const requestTxtExportOptions = vi.fn(async () => indent as TxtIndentOptions | null);
 
-function Harness(): null {
+function Harness({ withDialog = false }: { withDialog?: boolean }): null {
   const value = useExport({
     getContent: () => "本文。",
     getTitle: () => "作品.mdi",
     getFileType: () => ".mdi",
     getIsEditorTabActive: () => true,
+    onExportDialogRequest: withDialog ? requestExportDialog : undefined,
     onRequestTxtExportOptions: requestTxtExportOptions,
   });
   useEffect(() => {
@@ -95,6 +97,18 @@ describe("useExport native text export", () => {
 });
 
 describe("useExport native HTML export", () => {
+  it("opens the shared settings dialog when the application provides it", async () => {
+    await act(async () => root.render(<Harness withDialog />));
+
+    await act(async () => api?.exportAs("html"));
+
+    expect(requestExportDialog).toHaveBeenCalledWith("html", "本文。", {
+      title: "作品.mdi",
+      language: "ja",
+    });
+    expect(exportHTML).not.toHaveBeenCalled();
+  });
+
   it("forwards live source, file type, and title to the main process", async () => {
     exportHTML.mockResolvedValue("/tmp/作品.html");
 

--- a/src/lib/export/export-settings.ts
+++ b/src/lib/export/export-settings.ts
@@ -1,5 +1,5 @@
 /**
- * Unified export settings for PDF, DOCX, and EPUB.
+ * Unified export settings for HTML, PDF, DOCX, EPUB, and TXT.
  *
  * Uses charsPerLine / linesPerPage as the canonical typesetting model
  * (more expressive than raw fontSize + lineSpacing). The same canonical
@@ -31,6 +31,8 @@ export type PageNumberPosition =
   "bottom-left" | "bottom-center" | "bottom-right" | "top-left" | "top-center" | "top-right";
 
 export interface UnifiedExportSettings {
+  /** HTML export: emit only the semantic contents of `<body>`. Default false. */
+  htmlBodyOnly: boolean;
   pageSize: ExportPageSize;
   landscape: boolean;
   verticalWriting: boolean;
@@ -64,6 +66,7 @@ const UPSTREAM_DEFAULTS = resolvePrintProfile(
 );
 
 export const DEFAULT_EXPORT_SETTINGS: UnifiedExportSettings = {
+  htmlBodyOnly: false,
   pageSize: UPSTREAM_DEFAULTS.pagination.pageSize,
   landscape: UPSTREAM_DEFAULTS.pagination.landscape,
   verticalWriting: UPSTREAM_DEFAULTS.typesetting.writingMode === "vertical",
@@ -260,6 +263,7 @@ function sanitize(raw: Partial<UnifiedExportSettings>): UnifiedExportSettings {
     typeof raw.fontFamily === "string" && raw.fontFamily.length > 0 ? raw.fontFamily : d.fontFamily;
 
   return {
+    htmlBodyOnly: typeof raw.htmlBodyOnly === "boolean" ? raw.htmlBodyOnly : d.htmlBodyOnly,
     pageSize,
     landscape: typeof raw.landscape === "boolean" ? raw.landscape : d.landscape,
     verticalWriting:

--- a/src/lib/export/html-exporter.ts
+++ b/src/lib/export/html-exporter.ts
@@ -1,10 +1,16 @@
 import { normalizeExportSource } from "./mdi-export";
+import type { HtmlExportOptions } from "./html-shared";
 
 /**
- * Render a complete standalone HTML document through the Rust-authoritative
- * MDI renderer. This module is loaded only by the Electron main process.
+ * Render HTML through the Rust-authoritative MDI renderer. Depending on
+ * `bodyOnly`, the output is either a standalone document or a body fragment.
+ * This module is loaded only by the Electron main process.
  */
-export async function generateHtml(content: string, fileType = ".mdi"): Promise<string> {
+export async function generateHtml(
+  content: string,
+  fileType = ".mdi",
+  options: HtmlExportOptions = {},
+): Promise<string> {
   const { renderHtmlWithDiagnostics } = await import("@illusions-lab/mdi");
-  return renderHtmlWithDiagnostics(normalizeExportSource(content, fileType)).output;
+  return renderHtmlWithDiagnostics(normalizeExportSource(content, fileType), options).output;
 }

--- a/src/lib/export/html-shared.ts
+++ b/src/lib/export/html-shared.ts
@@ -1,0 +1,9 @@
+import type { MdiHtmlRenderOptions } from "@illusions-lab/mdi";
+
+/**
+ * HTML options are owned by @illusions-lab/mdi.
+ *
+ * Keep this alias at the renderer/main-process boundary so Illusions does not
+ * invent a second HTML configuration schema.
+ */
+export type HtmlExportOptions = MdiHtmlRenderOptions;

--- a/src/lib/export/use-export.ts
+++ b/src/lib/export/use-export.ts
@@ -28,7 +28,7 @@ interface UseExportParams {
    * and later call the IPC with user-configured options.
    */
   onExportDialogRequest?: (
-    format: "pdf" | "docx" | "epub",
+    format: "html" | "pdf" | "docx" | "epub",
     content: string,
     metadata: ExportMetadata,
   ) => void;
@@ -153,8 +153,11 @@ export function useExport({
         return;
       }
 
-      // PDF/DOCX/EPUB export: delegate to settings dialog when callback is provided
-      if ((format === "pdf" || format === "docx" || format === "epub") && onExportDialogRequest) {
+      // Configured exports delegate to the shared settings/preview dialog.
+      if (
+        (format === "html" || format === "pdf" || format === "docx" || format === "epub") &&
+        onExportDialogRequest
+      ) {
         onExportDialogRequest(format, content, metadata);
         return;
       }

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -114,10 +114,18 @@ declare global {
       | { success: false; error: string; cancelled?: boolean; code?: string }
     >;
     cancelPdfPreview?: () => Promise<boolean>;
+    generateHtmlPreview?: (
+      content: string,
+      fileType?: import("@/lib/project/project-types").SupportedFileExtension,
+      options?: import("@/lib/export/html-shared").HtmlExportOptions,
+    ) => Promise<
+      { success: true; html: string } | { success: false; error: string; code?: string }
+    >;
     exportHTML?: (
       content: string,
       fileType?: import("@/lib/project/project-types").SupportedFileExtension,
       title?: string,
+      options?: import("@/lib/export/html-shared").HtmlExportOptions,
     ) => Promise<string | { success: false; error: string; code?: string } | null>;
     exportMdiText?: (
       content: string,


### PR DESCRIPTION
## 概要

HTMLエクスポートをPDF／DOCX／EPUBと共通のエクスポート設定ダイアログへ統合しました。

## 変更内容

- エクスポート設定にHTMLタブを追加
- @illusions-lab/mdi が提供する bodyOnly を設定として公開（完全なHTML文書／本文のみ）
- ElectronメインプロセスでRustベースのMDIレンダラーを呼び出し、生成結果をsandbox付きiframeへ直接表示
- HTMLプレビュー用IPCを追加し、入力サイズとオプションを検証
- HTML設定の保存・復元と実際のHTML書き出しへの反映を追加
- 古い直接HTML書き出し経路を共通ダイアログ経由へ統一
- UI、IPC、設定、レンダラー、旧エクスポート経路の回帰テストを追加

## 目的

HTMLだけ別経路だった操作を共通化し、Illusions側で独自のHTML設定を持たず、@illusions-lab/mdi が提供する機能をそのまま利用できるようにするためです。レンダラー側へNode/WASM依存を持ち込まず、以前の起動時ブラックスクリーンも回避します。

## 確認

- HTML関連テスト: 105件成功
- 全テスト: 2861件成功、1件スキップ
- Coverage実行成功
- Prettier、変更ファイルのESLint、TypeScript、import boundary成功
- Next.js本番ビルド成功
- Electron bundle成功
- パッケージ内のmdi_core_bg.wasm runtime smoke test成功
- Electron実機で起動、HTMLタブ、両オプション、iframeプレビューを確認

ローカルの未署名パッケージはアプリ封装とWASM検証まで成功し、Apple公証資格情報が未設定のためnotarizationのみ未実行です。