### PR TITLE
ci: tag releases at the triggering commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -900,6 +900,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.compute-version.outputs.full }}
+          target_commitish: ${{ github.sha }}
           name: Illusions v${{ needs.compute-version.outputs.full }}
           files: release-assets/*
           draft: true

--- a/.github/workflows/store-publish.yml
+++ b/.github/workflows/store-publish.yml
@@ -90,6 +90,7 @@ jobs:
       mode: flight-submission
       release_tag: ${{ needs.resolve-msstore-flight-tag.outputs.tag }}
       dry_run: ${{ inputs.dry_run || false }}
+      trusted_store_publish: true
     secrets: inherit
 
   # ---------------------------------------------------------------------------
@@ -134,6 +135,7 @@ jobs:
       mode: full-submission
       release_tag: ${{ needs.resolve-msstore-stable-tag.outputs.tag }}
       dry_run: ${{ inputs.dry_run || false }}
+      trusted_store_publish: true
     secrets: inherit
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/sync-ms-store-listing.yml
+++ b/.github/workflows/sync-ms-store-listing.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: boolean
         default: false
+      trusted_store_publish:
+        description: "Whether this call was routed through store-publish.yml"
+        required: false
+        type: boolean
+        default: false
 
   workflow_call:
     inputs:
@@ -73,14 +78,11 @@ jobs:
 
     steps:
       - name: Verify running from main branch or version tag
-        # Skipped when called via workflow_call (store-publish.yml) — github.ref
-        # there reflects the caller's context, not this job's actual checkout
-        # ref (which the Checkout step below pins explicitly based on `mode`
-        # regardless). store-publish.yml's own job-level `if:` conditions
-        # already ensure the right mode fires at the right time. This check
-        # only guards against a human directly workflow_dispatch-ing this
-        # file from the wrong branch.
-        if: github.event_name != 'workflow_call'
+        # Reusable workflows inherit the caller's event name, so event_name
+        # cannot distinguish workflow_call from workflow_dispatch here.
+        # store-publish.yml sets an explicit trusted flag after applying its
+        # own event/branch routing; direct dispatches still enforce this guard.
+        if: inputs.trusted_store_publish != true
         shell: bash
         run: |
           case "${{ inputs.mode }}" in


### PR DESCRIPTION
## Summary
- set the GitHub Release target to the workflow-triggering commit
- prevent beta tags from being created on the default branch

## Validation
- Prettier check passed for build.yml
- git diff --check passed
- current beta tag mismatch was reproduced: the release tag points to main instead of the beta merge commit