### PR TITLE
fix: harden beta store publication

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,14 +5,10 @@ on:
     branches: [dev, beta, alpha, main]
     paths-ignore:
       - "assets/store/**"
-      - ".github/workflows/sync-ms-store-listing.yml"
-      - ".github/workflows/store-publish.yml"
   push:
     branches: [dev, beta, alpha, main]
     paths-ignore:
       - "assets/store/**"
-      - ".github/workflows/sync-ms-store-listing.yml"
-      - ".github/workflows/store-publish.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-ms-store-listing.yml
+++ b/.github/workflows/sync-ms-store-listing.yml
@@ -26,11 +26,6 @@ on:
         required: false
         type: boolean
         default: false
-      trusted_store_publish:
-        description: "Whether this call was routed through store-publish.yml"
-        required: false
-        type: boolean
-        default: false
 
   workflow_call:
     inputs:
@@ -48,6 +43,11 @@ on:
         type: string
       dry_run:
         description: "Dry run — log actions without mutating"
+        required: false
+        type: boolean
+        default: false
+      trusted_store_publish:
+        description: "Whether this call was routed through store-publish.yml"
         required: false
         type: boolean
         default: false

--- a/scripts/submit-store.mjs
+++ b/scripts/submit-store.mjs
@@ -553,16 +553,15 @@ async function main() {
     const flight = await getPackageFlight(token);
     if (flight?.pendingFlightSubmission?.id) {
       submissionId = flight.pendingFlightSubmission.id;
-      console.log(`  Reusing existing pending package flight submission: ${submissionId}`);
-      const pendingSubmission = await apiGet(token, getSubmissionPath(submissionId));
-      const pendingStatus = pendingSubmission.status ?? pendingSubmission.commitStatus;
-      if (pendingStatus === "PreProcessing" || pendingStatus === "InProgress") {
-        console.log(
-          `  Pending package flight submission is ${pendingStatus}; deleting it before creating a fresh submission.`,
-        );
-        await apiDelete(token, getSubmissionPath(submissionId));
-        submissionId = undefined;
-      }
+      // A pending flight submission can retain the fileUploadUrl issued when
+      // it was created. Reusing an old draft then fails with a 403 after that
+      // SAS URL expires, so package automation must always start from a fresh
+      // submission.
+      console.log(
+        `  Deleting existing pending package flight submission before upload: ${submissionId}`,
+      );
+      await apiDelete(token, getSubmissionPath(submissionId));
+      submissionId = undefined;
     }
   } else if (app.pendingApplicationSubmission?.id) {
     const pendingId = app.pendingApplicationSubmission.id;


### PR DESCRIPTION
## Summary
- expose the trusted store-publish flag on the reusable workflow interface
- run required Quality checks for store workflow-only changes
- replace stale pending Store flight submissions so expired SAS upload URLs are never reused

## Verification
- Prettier check passed
- `node --check scripts/submit-store.mjs` passed
- PR checks validate the final commit