### PR TITLE
印刷プロファイルと縦書きスクロールを完成

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,7 +33,7 @@ import type { BugReportCategory } from "@/lib/bug-report/bug-report-types";
 import type { TxtExportFormat, TxtIndentOptions } from "@/lib/export/txt-export-types";
 import type { ExportMetadata } from "@/lib/export/types";
 import type { PdfExportSettings } from "@/lib/export/pdf-export-settings";
-import type { UnifiedExportSettings } from "@/lib/export/export-settings";
+import { toPdfGenerationOptions, type UnifiedExportSettings } from "@/lib/export/export-settings";
 import type { EpubExportOptions } from "@/lib/export/epub-shared";
 import type { HtmlExportOptions } from "@/lib/export/html-shared";
 import { notificationManager } from "@/lib/services/notification-manager";
@@ -927,26 +927,10 @@ function EditorPageContent() {
       });
 
       try {
-        const result = await window.electronAPI.exportPDF(dialogState.content, {
-          metadata: dialogState.metadata,
-          verticalWriting: settings.verticalWriting,
-          pageSize: settings.pageSize,
-          landscape: settings.landscape,
-          margins: settings.margins,
-          charsPerLine: settings.charsPerLine,
-          linesPerPage: settings.linesPerPage,
-          fontFamily: settings.fontFamily,
-          showPageNumbers: settings.showPageNumbers,
-          pageNumberFormat: settings.pageNumberFormat,
-          pageNumberPosition: settings.pageNumberPosition,
-          textIndent: settings.textIndent,
-          fullwidthSpaceIndent: settings.fullwidthSpaceIndent,
-          googleFontFamily: settings.googleFontFamily,
-          // Thread the active tab's snapshotted file type so the HTML pipeline
-          // un-escapes MDI macros only for ".mdi" and preserves \[\[blank]]
-          // literals authored in ".md"/".txt".
-          fileType: dialogState.fileType,
-        });
+        const result = await window.electronAPI.exportPDF(
+          dialogState.content,
+          toPdfGenerationOptions(settings, dialogState.metadata, dialogState.fileType),
+        );
 
         notificationManager.dismiss(progressId);
 
@@ -978,25 +962,10 @@ function EditorPageContent() {
       // Electron path: use IPC
       if (window.electronAPI?.printDocument) {
         try {
-          const result = await window.electronAPI.printDocument(printDialogState.content, {
-            metadata: printDialogState.metadata,
-            verticalWriting: settings.verticalWriting,
-            pageSize: settings.pageSize,
-            landscape: settings.landscape,
-            margins: settings.margins,
-            charsPerLine: settings.charsPerLine,
-            linesPerPage: settings.linesPerPage,
-            fontFamily: settings.fontFamily,
-            showPageNumbers: settings.showPageNumbers,
-            pageNumberFormat: settings.pageNumberFormat,
-            pageNumberPosition: settings.pageNumberPosition,
-            textIndent: settings.textIndent,
-            fullwidthSpaceIndent: settings.fullwidthSpaceIndent,
-            googleFontFamily: settings.googleFontFamily,
-            // Pass the snapshotted file type so the HTML pipeline correctly
-            // handles .md/.txt literals vs .mdi MDI macros (#1882).
-            fileType: printDialogState.fileType,
-          });
+          const result = await window.electronAPI.printDocument(
+            printDialogState.content,
+            toPdfGenerationOptions(settings, printDialogState.metadata, printDialogState.fileType),
+          );
           if (
             result !== null &&
             result !== undefined &&

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -8,6 +8,7 @@ import {
   loadExportSettings,
   saveExportSettings,
   toPdfExportSettings,
+  toPdfGenerationOptions,
   toEpubExportOptions,
 } from "@/lib/export/export-settings";
 import { FontSelector } from "@/components/explorer/FontSelector";
@@ -360,23 +361,7 @@ function ExportDialogInner({
       try {
         const result = await window.electronAPI!.generatePdfPreview!(
           content,
-          {
-            metadata,
-            verticalWriting: settings.verticalWriting,
-            pageSize: previewSettings.pageSize,
-            landscape: previewSettings.landscape,
-            margins: previewSettings.margins,
-            charsPerLine: previewSettings.charsPerLine,
-            linesPerPage: previewSettings.linesPerPage,
-            fontFamily: previewSettings.fontFamily,
-            showPageNumbers: previewSettings.showPageNumbers,
-            pageNumberFormat: previewSettings.pageNumberFormat,
-            pageNumberPosition: previewSettings.pageNumberPosition,
-            textIndent: previewSettings.textIndent,
-            fullwidthSpaceIndent: previewSettings.fullwidthSpaceIndent,
-            googleFontFamily: previewSettings.googleFontFamily,
-            fileType,
-          },
+          toPdfGenerationOptions(previewSettings, metadata, fileType),
           previewMaxPagesPreference === "auto" ? undefined : Number(previewMaxPagesPreference),
         );
 

--- a/src/components/editor/MilkdownEditor.tsx
+++ b/src/components/editor/MilkdownEditor.tsx
@@ -48,6 +48,7 @@ import {
   setScrollProgress,
 } from "@/packages/milkdown-plugin-japanese-novel/scroll-progress";
 import { getLayoutCharsPerLine } from "@/lib/editor-page/chars-per-line-layout";
+import { resolveVerticalWheelScrollDelta } from "@/lib/editor-page/vertical-wheel-scroll";
 import type { LintIssue } from "@/lib/linting";
 import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import {
@@ -502,49 +503,17 @@ export default function MilkdownEditor({
     if (!container || !isVertical) return;
 
     const handleWheel = (event: WheelEvent) => {
-      const sensitivity = scrollSensitivity;
-      const absX = Math.abs(event.deltaX);
-      const absY = Math.abs(event.deltaY);
-      const mouseHorizontalDelta = -event.deltaY * sensitivity;
-      const hasBothAxes = absX > 0 && absY > 0;
-      const hasFineGrainedValues = (absY > 0 && absY < 50) || (absX > 0 && absX < 50);
-      const isTrackpadInput =
-        verticalScrollBehavior === "trackpad" ||
-        (verticalScrollBehavior === "auto" &&
-          (hasBothAxes || (hasFineGrainedValues && !event.ctrlKey)));
+      const scrollDelta = resolveVerticalWheelScrollDelta({
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        ctrlKey: event.ctrlKey,
+        behavior: verticalScrollBehavior,
+        sensitivity: scrollSensitivity,
+      });
+      if (scrollDelta === null) return;
 
-      if (verticalScrollBehavior === "mouse") {
-        if (absY >= absX && absY > 0) {
-          container.scrollLeft += mouseHorizontalDelta;
-          event.preventDefault();
-        } else if (absX > 0) {
-          container.scrollLeft -= event.deltaX * sensitivity;
-          event.preventDefault();
-        }
-        return;
-      }
-
-      if (isTrackpadInput) {
-        // 縦書きは横スクロールのみ（overflowY hidden）。2本指パンは支配的な軸だけを
-        // 横スクロールへ写像し、対角・慣性入力で deltaX/deltaY が競合して引っかかるのを防ぐ。
-        // 横スワイプは指の向きに追従（-deltaX）、縦スワイプは読み進み方向（+deltaY）。
-        if (absX > 0 || absY > 0) {
-          const primaryDelta = absX >= absY ? -event.deltaX : event.deltaY;
-          container.scrollLeft += primaryDelta * sensitivity;
-        }
-        event.preventDefault();
-        return;
-      }
-
-      // Mouse semantics: treat dominant deltaY as vertical wheel input and map it
-      // to horizontal movement for vertical writing.
-      if (absY >= absX && absY > 0) {
-        container.scrollLeft += mouseHorizontalDelta;
-        event.preventDefault();
-      } else if (absX > 0) {
-        container.scrollLeft -= event.deltaX * sensitivity;
-        event.preventDefault();
-      }
+      container.scrollLeft += scrollDelta;
+      event.preventDefault();
     };
 
     container.addEventListener("wheel", handleWheel, { passive: false });

--- a/src/lib/editor-page/__tests__/vertical-wheel-scroll.test.ts
+++ b/src/lib/editor-page/__tests__/vertical-wheel-scroll.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveVerticalWheelScrollDelta } from "../vertical-wheel-scroll";
+
+const trackpad = {
+  deltaY: 0,
+  ctrlKey: false,
+  behavior: "trackpad" as const,
+  sensitivity: 1,
+};
+
+describe("resolveVerticalWheelScrollDelta", () => {
+  it.each([
+    [24, 24],
+    [-24, -24],
+  ])("preserves the OS-adjusted horizontal trackpad sign (%s → %s)", (deltaX, expected) => {
+    expect(resolveVerticalWheelScrollDelta({ ...trackpad, deltaX })).toBe(expected);
+  });
+
+  it.each([
+    [24, -24],
+    [-24, 24],
+  ])(
+    "maps both vertical trackpad directions onto the vertical-rl reading axis (%s → %s)",
+    (deltaY, expected) => {
+      expect(
+        resolveVerticalWheelScrollDelta({
+          ...trackpad,
+          deltaX: 0,
+          deltaY,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it("uses only the dominant axis for diagonal and inertial trackpad input", () => {
+    expect(
+      resolveVerticalWheelScrollDelta({
+        ...trackpad,
+        deltaX: -3,
+        deltaY: 11,
+        sensitivity: 1.5,
+      }),
+    ).toBe(-16.5);
+    expect(
+      resolveVerticalWheelScrollDelta({
+        ...trackpad,
+        deltaX: -12,
+        deltaY: 4,
+        sensitivity: 1.5,
+      }),
+    ).toBe(-18);
+  });
+
+  it("keeps mouse-wheel vertical mapping and Shift-generated horizontal signs consistent", () => {
+    expect(
+      resolveVerticalWheelScrollDelta({
+        deltaX: 0,
+        deltaY: 100,
+        ctrlKey: false,
+        behavior: "mouse",
+        sensitivity: 0.5,
+      }),
+    ).toBe(-50);
+    expect(
+      resolveVerticalWheelScrollDelta({
+        deltaX: 100,
+        deltaY: 0,
+        ctrlKey: false,
+        behavior: "mouse",
+        sensitivity: 0.5,
+      }),
+    ).toBe(50);
+  });
+
+  it("auto-detects fine and dual-axis trackpad input without changing its direction", () => {
+    expect(
+      resolveVerticalWheelScrollDelta({
+        deltaX: -8,
+        deltaY: 2,
+        ctrlKey: false,
+        behavior: "auto",
+        sensitivity: 2,
+      }),
+    ).toBe(-16);
+    expect(
+      resolveVerticalWheelScrollDelta({
+        deltaX: 0,
+        deltaY: -6,
+        ctrlKey: false,
+        behavior: "auto",
+        sensitivity: 2,
+      }),
+    ).toBe(12);
+  });
+
+  it("ignores an empty wheel event", () => {
+    expect(
+      resolveVerticalWheelScrollDelta({
+        ...trackpad,
+        deltaX: 0,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/editor-page/vertical-wheel-scroll.ts
+++ b/src/lib/editor-page/vertical-wheel-scroll.ts
@@ -1,0 +1,46 @@
+export type VerticalScrollBehavior = "auto" | "mouse" | "trackpad";
+
+export interface VerticalWheelScrollInput {
+  deltaX: number;
+  deltaY: number;
+  ctrlKey: boolean;
+  behavior: VerticalScrollBehavior;
+  sensitivity: number;
+}
+
+/**
+ * Convert a wheel gesture to the scrollLeft delta used by vertical-rl.
+ *
+ * Browser wheel deltas already reflect the operating system's natural-scroll
+ * preference. Horizontal input therefore keeps deltaX's sign. Vertical input
+ * is mapped onto the reversed vertical-rl reading axis, where decreasing
+ * scrollLeft advances from the rightmost column toward the left.
+ */
+export function resolveVerticalWheelScrollDelta({
+  deltaX,
+  deltaY,
+  ctrlKey,
+  behavior,
+  sensitivity,
+}: VerticalWheelScrollInput): number | null {
+  const absX = Math.abs(deltaX);
+  const absY = Math.abs(deltaY);
+  if (absX === 0 && absY === 0) return null;
+
+  const hasBothAxes = absX > 0 && absY > 0;
+  const hasFineGrainedValues = (absY > 0 && absY < 50) || (absX > 0 && absX < 50);
+  const isTrackpadInput =
+    behavior === "trackpad" ||
+    (behavior === "auto" && (hasBothAxes || (hasFineGrainedValues && !ctrlKey)));
+
+  if (isTrackpadInput) {
+    const primaryDelta = absX >= absY ? deltaX : -deltaY;
+    return primaryDelta * sensitivity;
+  }
+
+  if (absY >= absX && absY > 0) {
+    return -deltaY * sensitivity;
+  }
+
+  return deltaX * sensitivity;
+}

--- a/src/lib/export/__tests__/export-settings.test.ts
+++ b/src/lib/export/__tests__/export-settings.test.ts
@@ -13,6 +13,7 @@ import {
   loadExportSettings,
   saveExportSettings,
   toPdfExportSettings,
+  toPdfGenerationOptions,
 } from "@/lib/export/export-settings";
 
 // インメモリ KV で StorageService をモックする
@@ -69,6 +70,46 @@ describe("toPdfExportSettings", () => {
 
     expect(converted.fontFamily).toBe('"Shippori Mincho", serif');
     expect(converted.googleFontFamily).toBe("Shippori Mincho");
+  });
+});
+
+describe("toPdfGenerationOptions", () => {
+  it("forwards the complete UI profile unchanged to preview, PDF, and system print IPCs", () => {
+    const settings = toPdfExportSettings({
+      ...DEFAULT_EXPORT_SETTINGS,
+      pageSize: "Bunko",
+      landscape: false,
+      verticalWriting: false,
+      charsPerLine: 33,
+      linesPerPage: 22,
+      margins: { top: 11, right: 12, bottom: 13, left: 14 },
+      fontFamily: "Shippori Mincho",
+      showPageNumbers: true,
+      pageNumberFormat: "fraction",
+      pageNumberPosition: "top-right",
+      textIndent: 2,
+      fullwidthSpaceIndent: true,
+    });
+
+    expect(
+      toPdfGenerationOptions(settings, { title: "組版テスト", author: "著者" }, ".mdi"),
+    ).toEqual({
+      metadata: { title: "組版テスト", author: "著者" },
+      fileType: ".mdi",
+      pageSize: "Bunko",
+      landscape: false,
+      verticalWriting: false,
+      charsPerLine: 33,
+      linesPerPage: 22,
+      margins: { top: 11, right: 12, bottom: 13, left: 14 },
+      fontFamily: '"Shippori Mincho", serif',
+      googleFontFamily: "Shippori Mincho",
+      showPageNumbers: true,
+      pageNumberFormat: "fraction",
+      pageNumberPosition: "top-right",
+      textIndent: 2,
+      fullwidthSpaceIndent: true,
+    });
   });
 });
 

--- a/src/lib/export/__tests__/pdf-export-profile.test.ts
+++ b/src/lib/export/__tests__/pdf-export-profile.test.ts
@@ -94,6 +94,14 @@ describe("PDF Chromium profile adapter", () => {
     });
   });
 
+  it("keeps preview and final export profile semantics identical", () => {
+    const content = "# 見出し\n\n本文。";
+
+    expect(preparePdfPreviewDocument(content, options, 32).prepared).toEqual(
+      preparePdfPrintDocument(content, options),
+    );
+  });
+
   it.each(["cancelled", "canceled", "Print job canceled", "Print job cancelled"])(
     "recognizes the system-print cancellation reason %s",
     (reason) => {

--- a/src/lib/export/export-settings.ts
+++ b/src/lib/export/export-settings.ts
@@ -17,7 +17,7 @@ import { resolvePrintProfile } from "@illusions-lab/mdi-export-profile";
 
 import type { PdfExportSettings } from "./pdf-export-settings";
 import type { ChapterSplitLevel, EpubExportOptions } from "./epub-shared";
-import type { ExportMetadata } from "./types";
+import type { ExportMetadata, PdfGenerationOptions } from "./types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -201,6 +201,22 @@ export function toPdfExportSettings(s: UnifiedExportSettings): PdfExportSettings
     textIndent: s.textIndent,
     fullwidthSpaceIndent: s.fullwidthSpaceIndent,
     googleFontFamily,
+  };
+}
+
+/**
+ * Build the single IPC payload shared by PDF preview, final export, and system
+ * print so every UI profile field reaches the same Chromium adapter.
+ */
+export function toPdfGenerationOptions(
+  settings: PdfExportSettings,
+  metadata: ExportMetadata,
+  fileType?: string,
+): PdfGenerationOptions {
+  return {
+    ...settings,
+    metadata,
+    fileType,
   };
 }
 


### PR DESCRIPTION
## 概要

- PDF プレビュー、正式 PDF、システム印刷の IPC オプションを共通化し、UI の印刷プロファイルを同じ Chromium adapter へ渡す
- 縦書きでトラックパッドの `deltaX` を余分に反転していた処理を修正
- 縦方向入力を vertical-rl の読書軸へ一貫して変換する
- マウス、Shift 横スクロール、対角・慣性入力、自然スクロール両方向の回帰テストを追加

## 原因

トラックパッドの WheelEvent は macOS の自然スクロール設定を反映済みですが、アプリ側で横方向の符号を再反転していました。また、縦方向入力の横軸変換は vertical-rl の `scrollLeft`（右端が先頭）と逆向きでした。

印刷側では upstream の browser-safe adapter 自体は導入済みでしたが、プレビュー、PDF、システム印刷の UI → IPC payload が各所で重複しており、profile parity を直接保証する回帰テストが不足していました。

## ユーザーへの影響

- macOS の自然スクロール ON/OFF に従って縦書きのトラックパッドが動作する
- 横書きモードは変更しない
- PDF プレビュー、正式出力、システム印刷で用紙、向き、余白、縦横書き、行列数、フォント、字下げ、ページ番号設定を同じ経路で扱う

## 検証

- `npm test` — 2871 passed / 1 skipped
- `npm run type-check`
- `npm run lint` — 0 errors（既存 warnings のみ）
- `npm run format:check`
- `npm run check:boundaries`
- `npm run build`
- `npm run bundle:electron`

Closes #2212
Closes #2240
