### PR TITLE
システム印刷の頁番号と縦書きスクロール検証を完成

### DIFF
--- a/electron/ipc/__tests__/file-ipc-print-window-leak.test.ts
+++ b/electron/ipc/__tests__/file-ipc-print-window-leak.test.ts
@@ -74,8 +74,9 @@ describe("file-ipc.js printDocument handler — BrowserWindow leak fix (#1919)",
 
   it("uses the shared MDI Chromium profile adapter for system print", () => {
     expect(printHandler).toContain("preparePdfPrintDocument(content, opts)");
+    expect(printHandler).toContain("electronSystemPrintHtml(prepared)");
     expect(printHandler).toContain("electronSystemPrintOptions(prepared)");
-    expect(printHandler).toContain("loadPrintDocumentHtml(printWin, prepared.html)");
+    expect(printHandler).toContain("loadPrintDocumentHtml(printWin, printHtml)");
     expect(printHandler).toContain("waitForPrintFonts(printWin.webContents)");
     expect(printHandler).not.toContain("data:text/html");
   });

--- a/electron/ipc/file-ipc.js
+++ b/electron/ipc/file-ipc.js
@@ -729,6 +729,7 @@ function registerFileHandlers() {
     try {
       const { BrowserWindow } = require("electron");
       const {
+        electronSystemPrintHtml,
         electronSystemPrintOptions,
         isPrintCancellationReason,
         loadPrintDocumentHtml,
@@ -738,6 +739,7 @@ function registerFileHandlers() {
 
       const opts = options || {};
       const prepared = preparePdfPrintDocument(content, opts);
+      const printHtml = electronSystemPrintHtml(prepared);
 
       const partition = `print-${Date.now()}`;
       printWin = new BrowserWindow({
@@ -774,7 +776,7 @@ function registerFileHandlers() {
         printWin.webContents.once("did-finish-load", () => resolve());
       });
 
-      disposePrintDocument = await loadPrintDocumentHtml(printWin, prepared.html);
+      disposePrintDocument = await loadPrintDocumentHtml(printWin, printHtml);
       await loadPromise;
       await waitForPrintFonts(printWin.webContents);
 

--- a/src/components/editor/MilkdownEditor.tsx
+++ b/src/components/editor/MilkdownEditor.tsx
@@ -48,7 +48,7 @@ import {
   setScrollProgress,
 } from "@/packages/milkdown-plugin-japanese-novel/scroll-progress";
 import { getLayoutCharsPerLine } from "@/lib/editor-page/chars-per-line-layout";
-import { resolveVerticalWheelScrollDelta } from "@/lib/editor-page/vertical-wheel-scroll";
+import { applyVerticalWheelScroll } from "@/lib/editor-page/vertical-wheel-scroll";
 import type { LintIssue } from "@/lib/linting";
 import type { RuleRunnerLike } from "@/packages/milkdown-plugin-japanese-novel/linting-plugin";
 import {
@@ -503,17 +503,10 @@ export default function MilkdownEditor({
     if (!container || !isVertical) return;
 
     const handleWheel = (event: WheelEvent) => {
-      const scrollDelta = resolveVerticalWheelScrollDelta({
-        deltaX: event.deltaX,
-        deltaY: event.deltaY,
-        ctrlKey: event.ctrlKey,
+      applyVerticalWheelScroll(container, event, {
         behavior: verticalScrollBehavior,
         sensitivity: scrollSensitivity,
       });
-      if (scrollDelta === null) return;
-
-      container.scrollLeft += scrollDelta;
-      event.preventDefault();
     };
 
     container.addEventListener("wheel", handleWheel, { passive: false });

--- a/src/lib/editor-page/__tests__/vertical-wheel-scroll.test.ts
+++ b/src/lib/editor-page/__tests__/vertical-wheel-scroll.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveVerticalWheelScrollDelta } from "../vertical-wheel-scroll";
+import {
+  applyVerticalWheelScroll,
+  resolveVerticalWheelScrollDelta,
+} from "../vertical-wheel-scroll";
 
 const trackpad = {
   deltaY: 0,
@@ -101,5 +104,44 @@ describe("resolveVerticalWheelScrollDelta", () => {
         deltaX: 0,
       }),
     ).toBeNull();
+  });
+
+  it.each([
+    [-24, 176],
+    [24, 224],
+  ])(
+    "applies the OS-adjusted horizontal gesture to the real scrollLeft value (%s)",
+    (deltaX, expectedScrollLeft) => {
+      const container = document.createElement("div");
+      container.scrollLeft = 200;
+      const event = new WheelEvent("wheel", {
+        deltaX,
+        cancelable: true,
+      });
+
+      expect(
+        applyVerticalWheelScroll(container, event, {
+          behavior: "trackpad",
+          sensitivity: 1,
+        }),
+      ).toBe(true);
+      expect(container.scrollLeft).toBe(expectedScrollLeft);
+      expect(event.defaultPrevented).toBe(true);
+    },
+  );
+
+  it("leaves the DOM and browser default untouched for an empty wheel event", () => {
+    const container = document.createElement("div");
+    container.scrollLeft = 200;
+    const event = new WheelEvent("wheel", { cancelable: true });
+
+    expect(
+      applyVerticalWheelScroll(container, event, {
+        behavior: "auto",
+        sensitivity: 1,
+      }),
+    ).toBe(false);
+    expect(container.scrollLeft).toBe(200);
+    expect(event.defaultPrevented).toBe(false);
   });
 });

--- a/src/lib/editor-page/vertical-wheel-scroll.ts
+++ b/src/lib/editor-page/vertical-wheel-scroll.ts
@@ -8,6 +8,11 @@ export interface VerticalWheelScrollInput {
   sensitivity: number;
 }
 
+export type VerticalWheelEvent = Pick<
+  WheelEvent,
+  "ctrlKey" | "deltaX" | "deltaY" | "preventDefault"
+>;
+
 /**
  * Convert a wheel gesture to the scrollLeft delta used by vertical-rl.
  *
@@ -43,4 +48,23 @@ export function resolveVerticalWheelScrollDelta({
   }
 
   return deltaX * sensitivity;
+}
+
+/** Apply the resolved delta to the real vertical-writing scroll container. */
+export function applyVerticalWheelScroll(
+  container: Pick<HTMLElement, "scrollLeft">,
+  event: VerticalWheelEvent,
+  settings: Pick<VerticalWheelScrollInput, "behavior" | "sensitivity">,
+): boolean {
+  const scrollDelta = resolveVerticalWheelScrollDelta({
+    deltaX: event.deltaX,
+    deltaY: event.deltaY,
+    ctrlKey: event.ctrlKey,
+    ...settings,
+  });
+  if (scrollDelta === null) return false;
+
+  container.scrollLeft += scrollDelta;
+  event.preventDefault();
+  return true;
 }

--- a/src/lib/export/__tests__/pdf-export-profile.test.ts
+++ b/src/lib/export/__tests__/pdf-export-profile.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   electronPdfOptions,
+  electronSystemPrintHtml,
   electronSystemPrintOptions,
   isPrintCancellationReason,
   loadPrintDocumentHtml,
@@ -92,6 +93,63 @@ describe("PDF Chromium profile adapter", () => {
       pageSize: { width: 210_000, height: 297_000 },
       margins: { marginType: "none" },
     });
+  });
+
+  it.each(
+    (
+      [
+        ["simple", "content:counter(page)"],
+        ["dash", String.raw`content:"\2014 " counter(page) " \2014"`],
+        ["fraction", 'content:counter(page) " / " counter(pages)'],
+      ] as const
+    ).flatMap(([format, expectedContent]) =>
+      (
+        [
+          "bottom-left",
+          "bottom-center",
+          "bottom-right",
+          "top-left",
+          "top-center",
+          "top-right",
+        ] as const
+      ).map((position) => [format, position, expectedContent] as const),
+    ),
+  )(
+    "adds %s page counters at %s for Chromium system print",
+    (format, position, expectedContent) => {
+      const prepared = preparePdfPrintDocument("本文。", {
+        ...options,
+        pageNumberFormat: format,
+        pageNumberPosition: position,
+      });
+      const html = electronSystemPrintHtml(prepared);
+
+      expect(html).toContain('<style id="mdi-system-print-page-numbers">');
+      expect(html).toContain(`@page{@${position}{${expectedContent};`);
+      expect(html).toContain("writing-mode:horizontal-tb");
+      expect(html).toContain("text-orientation:mixed");
+    },
+  );
+
+  it("does not inject page counters when page numbering is disabled", () => {
+    const prepared = preparePdfPrintDocument("本文。", {
+      ...options,
+      showPageNumbers: false,
+    });
+
+    expect(electronSystemPrintHtml(prepared)).toBe(prepared.html);
+  });
+
+  it.each([
+    [
+      "<html><body><p>本文。</p></body></html>",
+      /<html><head><style id="mdi-system-print-page-numbers">/,
+    ],
+    ["<p>本文。</p>", /^<style id="mdi-system-print-page-numbers">[\s\S]*<\/style><p>本文。<\/p>$/],
+  ])("injects page counters into alternate Chromium HTML shells", (html, expected) => {
+    const prepared = preparePdfPrintDocument("本文。", options);
+
+    expect(electronSystemPrintHtml({ ...prepared, html })).toMatch(expected);
   });
 
   it("keeps preview and final export profile semantics identical", () => {

--- a/src/lib/export/pdf-exporter.ts
+++ b/src/lib/export/pdf-exporter.ts
@@ -50,6 +50,7 @@ export interface PdfExportOptions {
 const EMPTY_PRINT_TEMPLATE = "<span></span>";
 const MICRONS_PER_MM = 1000;
 const PRINT_DOCUMENT_SCHEME_PREFIX = "illusions-print";
+const SYSTEM_PRINT_PAGE_NUMBER_STYLE_ID = "mdi-system-print-page-numbers";
 const PDF_FILE_WRITE_CHUNK_BYTES = 1024 * 1024;
 const DEFAULT_CHARACTERS_PER_LINE = 40;
 const DEFAULT_LINES_PER_PAGE = 30;
@@ -209,6 +210,47 @@ export function electronPdfOptions(
     footerTemplate: prepared.pageNumbers.footerTemplate ?? EMPTY_PRINT_TEMPLATE,
     ...(pageRanges ? { pageRanges } : {}),
   };
+}
+
+function systemPrintPageNumberContent(
+  format: ChromiumPrintProfile["pageNumbers"]["format"],
+): string {
+  switch (format) {
+    case "dash":
+      return String.raw`"\2014 " counter(page) " \2014"`;
+    case "fraction":
+      return 'counter(page) " / " counter(pages)';
+    default:
+      return "counter(page)";
+  }
+}
+
+/**
+ * Add Chromium page-margin counters for native/system print.
+ *
+ * printToPDF accepts the upstream header/footer HTML templates directly, but
+ * webContents.print() does not. Modern Chromium prints CSS @page margin boxes,
+ * so system print can preserve the same resolved page-number semantics without
+ * reimplementing pagination or typesetting.
+ */
+export function electronSystemPrintHtml(prepared: ChromiumPrintProfile): string {
+  if (!prepared.pageNumbers.enabled) return prepared.html;
+
+  const marginBox = `@${prepared.pageNumbers.position}`;
+  const content = systemPrintPageNumberContent(prepared.pageNumbers.format);
+  const style =
+    `<style id="${SYSTEM_PRINT_PAGE_NUMBER_STYLE_ID}">` +
+    `@page{${marginBox}{content:${content};font-family:sans-serif;font-size:8pt;` +
+    "font-weight:normal;color:#000;writing-mode:horizontal-tb;text-orientation:mixed}}" +
+    "</style>";
+
+  if (/<\/head\s*>/i.test(prepared.html)) {
+    return prepared.html.replace(/<\/head\s*>/i, `${style}</head>`);
+  }
+  if (/<html(?:\s[^>]*)?>/i.test(prepared.html)) {
+    return prepared.html.replace(/<html(?:\s[^>]*)?>/i, `$&<head>${style}</head>`);
+  }
+  return `${style}${prepared.html}`;
 }
 
 /** Convert physical profile metadata to webContents.print() host options. */


### PR DESCRIPTION
## 概要

PR #2250 の完了監査で見つかった残存差分を解消します。

- Electron system print 用 HTML に Chromium `@page` margin box の頁カウンターを追加
- simple / dash / fraction と上下左右 6 位置を upstream の resolved profile から反映
- 頁番号無効時は印刷 HTML を変更しない
- 縦書きスクロールの純粋な delta 計算だけでなく、実 `WheelEvent` → DOM `scrollLeft` → `preventDefault` の経路を回帰テスト

## 原因

`@illusions-lab/mdi-to-pdf/profile` は PDF 用の `headerTemplate` / `footerTemplate` を返しますが、Electron の `webContents.print()` は `printToPDF()` と異なり HTML テンプレートと `pageNumber` / `totalPages` placeholder を受け取りません。そのため、用紙・余白・組方向等は system print に反映されても、頁番号だけが欠けていました。

## 実装

- 版式、用紙、余白、組方向は引き続き upstream browser-safe adapter の `prepared.html` / resolved profile を唯一の情報源にする
- system print の host-specific 部分だけ Chromium CSS page-margin counter へ変換する
- PDF preview/export は既存 upstream header/footer template を継続使用し、二重頁番号を避ける

## 実機相当検証

Electron 43 / Chromium m150 で、実際のアプリ profile から A5 縦書き 16 頁 PDF を生成して Poppler で確認しました。

- 1 頁目: `1 / 16`
- 16 頁目: `16 / 16`
- 頁番号は横組み、右下、用紙内に収まり、本文・余白との重なりや裁切なし

## 自動検証

- `npm test` — 2893 passed / 1 skipped
- targeted tests — 85 passed
- `npm run type-check`
- `npx eslint . --ignore-pattern '.claude/worktrees/**'` — 0 errors（既存 warnings のみ）
- `npm run format:check`
- `npm run check:boundaries`
- `npm run build`
- `ELECTRON_BUILD=1 npx next build`
- `npm run bundle:electron`

Follow-up to #2250.
Refs #2212
Refs #2240
