### PR TITLE
feat(analytics): track document output formats

### DIFF
--- a/electron/ipc/__tests__/analytics-ipc.test.ts
+++ b/electron/ipc/__tests__/analytics-ipc.test.ts
@@ -72,6 +72,58 @@ describe("registerAnalyticsHandlers", () => {
     expect(trackEventMock).toHaveBeenCalledWith("app_closed", { duration_bucket: "15_60m" });
   });
 
+  it.each([
+    ["export", "html"],
+    ["export", "pdf"],
+    ["export", "epub"],
+    ["export", "docx"],
+    ["export", "txt"],
+    ["export", "txt-ruby"],
+    ["export", "narou"],
+    ["export", "kakuyomu"],
+    ["export", "aozora"],
+    ["copy", "txt"],
+    ["copy", "txt-ruby"],
+    ["copy", "narou"],
+    ["copy", "kakuyomu"],
+    ["copy", "aozora"],
+  ] as const)("tracks approved %s output usage for %s", async (operation, format) => {
+    const handler = await createHandler();
+
+    await handler({}, "document_output_completed", { operation, format });
+
+    expect(loadAppStateMock).toHaveBeenCalledOnce();
+    expect(trackEventMock).toHaveBeenCalledWith("document_output_completed", {
+      operation,
+      format,
+    });
+  });
+
+  it("rejects document output data outside the fixed enums", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "document_output_completed", {
+      operation: "export",
+      format: "/Users/alice/private/novel.epub",
+    });
+
+    expect(loadAppStateMock).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a document output event carrying a file path", async () => {
+    const handler = await createHandler();
+
+    await handler({}, "document_output_completed", {
+      operation: "export",
+      format: "epub",
+      path: "/Users/alice/private/novel.epub",
+    });
+
+    expect(loadAppStateMock).not.toHaveBeenCalled();
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
   it("rejects app_closed with a non-contract duration bucket before reading consent", async () => {
     const handler = await createHandler();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,7 @@ import { useDockviewPersistence } from "@/lib/dockview/use-dockview-persistence"
 import "@/lib/dockview/dockview-theme.css";
 import { useElectronMenuHandlers } from "@/lib/menu/use-electron-menu-handlers";
 import { useExport } from "@/lib/export/use-export";
+import { trackDocumentOutputResult } from "@/lib/analytics/document-output-events";
 import TxtExportDialog from "@/components/TxtExportDialog";
 import BugReportDialog from "@/components/BugReportDialog";
 import type { BugReportCategory } from "@/lib/bug-report/bug-report-types";
@@ -896,6 +897,7 @@ function EditorPageContent() {
           options,
         );
 
+        trackDocumentOutputResult("export", "html", result);
         notificationManager.dismiss(progressId);
         if (result === null || result === undefined) return;
         if (typeof result === "object" && "success" in result && !result.success) {
@@ -932,6 +934,7 @@ function EditorPageContent() {
           toPdfGenerationOptions(settings, dialogState.metadata, dialogState.fileType),
         );
 
+        trackDocumentOutputResult("export", "pdf", result);
         notificationManager.dismiss(progressId);
 
         if (result === null || result === undefined) return;
@@ -1012,6 +1015,7 @@ function EditorPageContent() {
           fileType: dialogState.fileType,
         });
 
+        trackDocumentOutputResult("export", "docx", result);
         notificationManager.dismiss(progressId);
 
         if (result === null || result === undefined) return;
@@ -1056,6 +1060,7 @@ function EditorPageContent() {
         // Electron IPC serializes Uint8Array automatically
         const result = await window.electronAPI.exportEPUB(dialogState.content, epubOptions);
 
+        trackDocumentOutputResult("export", "epub", result);
         notificationManager.dismiss(progressId);
 
         if (result === null || result === undefined) return;

--- a/src/components/settings/PrivacySettingsTab.tsx
+++ b/src/components/settings/PrivacySettingsTab.tsx
@@ -31,7 +31,9 @@ export default function PrivacySettingsTab(): React.ReactElement {
         </SettingsField>
 
         <div className="text-xs text-foreground-secondary space-y-1">
-          <p>・送信されるのは起動回数や機能利用状況などの匿名データのみです</p>
+          <p>
+            ・送信されるのは起動回数や、エクスポート・クリップボード出力の形式を含む機能利用状況などの匿名データのみです
+          </p>
           <p>・いつでもオフに切り替えられます</p>
         </div>
       </SettingsSection>

--- a/src/components/settings/__tests__/PrivacySettingsTab.test.tsx
+++ b/src/components/settings/__tests__/PrivacySettingsTab.test.tsx
@@ -44,6 +44,7 @@ describe("PrivacySettingsTab", () => {
     expect(container.textContent).toContain("匿名の使用統計を送信する");
     expect(container.textContent).toContain("エラーレポートを送信する");
     expect(container.textContent).toContain("原稿本文・ファイル名・ファイルパス");
+    expect(container.textContent).toContain("エクスポート・クリップボード出力の形式");
 
     const switches = container.querySelectorAll('[role="switch"]');
     expect(switches).toHaveLength(2);

--- a/src/lib/analytics/__tests__/document-output-events.test.ts
+++ b/src/lib/analytics/__tests__/document-output-events.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const trackUsageEvent = vi.hoisted(() => vi.fn());
+
+vi.mock("../usage-events", () => ({
+  trackUsageEvent,
+}));
+
+import { trackDocumentOutputResult } from "../document-output-events";
+
+describe("document output analytics", () => {
+  beforeEach(() => {
+    trackUsageEvent.mockReset();
+  });
+
+  it("tracks a completed file export without forwarding its path", () => {
+    trackDocumentOutputResult("export", "epub", "/Users/alice/private/novel.epub");
+
+    expect(trackUsageEvent).toHaveBeenCalledOnce();
+    expect(trackUsageEvent).toHaveBeenCalledWith("document_output_completed", {
+      operation: "export",
+      format: "epub",
+    });
+  });
+
+  it("tracks a completed formatted clipboard copy", () => {
+    trackDocumentOutputResult("copy", "kakuyomu", { success: true });
+
+    expect(trackUsageEvent).toHaveBeenCalledWith("document_output_completed", {
+      operation: "copy",
+      format: "kakuyomu",
+    });
+  });
+
+  it.each([
+    ["cancelled", null],
+    ["unavailable", undefined],
+    ["failed", { success: false, error: "/Users/alice/private/novel.mdi" }],
+  ] as const)("does not track a %s output", (_label, result) => {
+    trackDocumentOutputResult("export", "pdf", result);
+
+    expect(trackUsageEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/analytics/__tests__/usage-events.test.ts
+++ b/src/lib/analytics/__tests__/usage-events.test.ts
@@ -57,6 +57,13 @@ describe("usage analytics facade", () => {
     }).not.toThrow();
   });
 
+  it("recognizes the fixed document output event contract", async () => {
+    const { isUsageEventName } = await import("../usage-events");
+
+    expect(isUsageEventName("document_output_completed")).toBe(true);
+    expect(isUsageEventName("document_output_with_private_path")).toBe(false);
+  });
+
   it("maps raw errors to safe reason enums without exposing messages", async () => {
     const { classifyTelemetryError } = await import("../usage-events");
 

--- a/src/lib/analytics/document-output-events.ts
+++ b/src/lib/analytics/document-output-events.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import type { ExportFormat } from "@/lib/export/types";
+import { trackUsageEvent } from "./usage-events";
+
+export type DocumentOutputOperation = "export" | "copy";
+
+type DocumentOutputResult = string | { success: boolean } | null | undefined;
+
+/**
+ * Records only completed file exports and formatted clipboard copies.
+ *
+ * File paths and error objects may be present in the IPC result, so this
+ * boundary deliberately reduces the result to a success boolean before
+ * forwarding the fixed operation/format enums to analytics.
+ */
+export function trackDocumentOutputResult(
+  operation: DocumentOutputOperation,
+  format: ExportFormat,
+  result: DocumentOutputResult,
+): void {
+  const completed =
+    typeof result === "string" ||
+    (typeof result === "object" && result !== null && result.success === true);
+
+  if (!completed) return;
+
+  trackUsageEvent("document_output_completed", { operation, format });
+}

--- a/src/lib/analytics/usage-event-contract.json
+++ b/src/lib/analytics/usage-event-contract.json
@@ -473,6 +473,10 @@
       ],
       "file_type": ["mdi", "md", "txt", "unknown"],
       "collision": ["none", "confirmed", "blocked"]
+    },
+    "document_output_completed": {
+      "operation": ["export", "copy"],
+      "format": ["html", "pdf", "epub", "docx", "txt", "txt-ruby", "narou", "kakuyomu", "aozora"]
     }
   }
 }

--- a/src/lib/analytics/usage-events.ts
+++ b/src/lib/analytics/usage-events.ts
@@ -43,7 +43,8 @@ export type UsageEventName =
   | "project_folder_created"
   | "project_file_renamed"
   | "project_file_deleted"
-  | "project_file_duplicated";
+  | "project_file_duplicated"
+  | "document_output_completed";
 
 export type TelemetryReason =
   | "cancelled"

--- a/src/lib/export/__tests__/use-export-text.test.tsx
+++ b/src/lib/export/__tests__/use-export-text.test.tsx
@@ -26,6 +26,7 @@ let api: ExportApi | undefined;
 const exportMdiText = vi.fn();
 const exportHTML = vi.fn();
 const copyMdiText = vi.fn();
+const trackEvent = vi.fn(async () => undefined);
 const requestExportDialog = vi.fn();
 const indent: TxtIndentOptions = { fullwidthSpaceIndent: true, indentCount: 2 };
 const requestTxtExportOptions = vi.fn(async () => indent as TxtIndentOptions | null);
@@ -50,7 +51,7 @@ beforeEach(async () => {
   api = undefined;
   Object.defineProperty(window, "electronAPI", {
     configurable: true,
-    value: { exportHTML, exportMdiText, copyMdiText },
+    value: { exportHTML, exportMdiText, copyMdiText, analytics: { trackEvent } },
   });
   container = document.createElement("div");
   document.body.appendChild(container);
@@ -70,6 +71,10 @@ describe("useExport native text export", () => {
     await act(async () => api?.exportAs("narou"));
 
     expect(exportMdiText).toHaveBeenCalledWith("本文。", "narou", ".mdi", indent, "作品.mdi");
+    expect(trackEvent).toHaveBeenCalledWith("document_output_completed", {
+      operation: "export",
+      format: "narou",
+    });
     expect(notifications.dismiss).toHaveBeenCalledWith("progress-id");
     expect(notifications.success).toHaveBeenCalledWith("小説家になろう形式をエクスポートしました");
   });
@@ -82,6 +87,7 @@ describe("useExport native text export", () => {
     expect(notifications.dismiss).toHaveBeenCalledWith("progress-id");
     expect(notifications.success).not.toHaveBeenCalled();
     expect(notifications.error).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
   });
 
   it("reports a structured main-process export failure", async () => {
@@ -93,6 +99,17 @@ describe("useExport native text export", () => {
       "青空文庫形式のエクスポートに失敗しました: 書き込みに失敗しました",
     );
     expect(notifications.success).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+
+  it("keeps a successful export successful when analytics delivery fails", async () => {
+    exportMdiText.mockResolvedValue("/tmp/作品.txt");
+    trackEvent.mockRejectedValueOnce(new Error("analytics offline"));
+
+    await act(async () => api?.exportAs("txt"));
+
+    expect(notifications.success).toHaveBeenCalledWith("テキストをエクスポートしました");
+    expect(notifications.error).not.toHaveBeenCalled();
   });
 });
 
@@ -107,6 +124,7 @@ describe("useExport native HTML export", () => {
       language: "ja",
     });
     expect(exportHTML).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
   });
 
   it("forwards live source, file type, and title to the main process", async () => {
@@ -115,6 +133,10 @@ describe("useExport native HTML export", () => {
     await act(async () => api?.exportAs("html"));
 
     expect(exportHTML).toHaveBeenCalledWith("本文。", ".mdi", "作品.mdi");
+    expect(trackEvent).toHaveBeenCalledWith("document_output_completed", {
+      operation: "export",
+      format: "html",
+    });
     expect(requestTxtExportOptions).not.toHaveBeenCalled();
     expect(notifications.dismiss).toHaveBeenCalledWith("progress-id");
     expect(notifications.success).toHaveBeenCalledWith("HTMLをエクスポートしました");
@@ -129,6 +151,7 @@ describe("useExport native HTML export", () => {
       "HTMLのエクスポートに失敗しました: HTML生成に失敗しました",
     );
     expect(notifications.success).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
   });
 });
 
@@ -146,6 +169,10 @@ describe("useExport native text clipboard copy", () => {
 
     expect(requestTxtExportOptions).toHaveBeenCalledWith(format, "copy");
     expect(copyMdiText).toHaveBeenCalledWith("本文。", format, ".mdi", indent);
+    expect(trackEvent).toHaveBeenCalledWith("document_output_completed", {
+      operation: "copy",
+      format,
+    });
     expect(notifications.dismiss).toHaveBeenCalledWith("progress-id");
     expect(notifications.success).toHaveBeenCalledWith(`${label}をクリップボードにコピーしました`);
   });
@@ -158,6 +185,7 @@ describe("useExport native text clipboard copy", () => {
     expect(copyMdiText).not.toHaveBeenCalled();
     expect(notifications.showProgress).not.toHaveBeenCalled();
     expect(notifications.success).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
   });
 
   it("reports a structured clipboard failure", async () => {
@@ -169,5 +197,6 @@ describe("useExport native text clipboard copy", () => {
       "青空文庫形式のクリップボードへのコピーに失敗しました: クリップボードを利用できません",
     );
     expect(notifications.success).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/export/use-export.ts
+++ b/src/lib/export/use-export.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect } from "react";
+import { trackDocumentOutputResult } from "@/lib/analytics/document-output-events";
 import { notificationManager } from "@/lib/services/notification-manager";
 import type { TxtExportFormat, TxtIndentOptions } from "./txt-export-types";
 import type { SupportedFileExtension } from "@/lib/project/project-types";
@@ -137,6 +138,7 @@ export function useExport({
             indentOptions,
             title,
           );
+          trackDocumentOutputResult("export", format, result);
           notificationManager.dismiss(progressId);
 
           if (result === null || result === undefined) return;
@@ -200,6 +202,7 @@ export function useExport({
             break;
         }
 
+        trackDocumentOutputResult("export", format, result);
         notificationManager.dismiss(progressId);
 
         if (result === null || result === undefined) {
@@ -261,6 +264,7 @@ export function useExport({
           getFileType(),
           indentOptions,
         );
+        trackDocumentOutputResult("copy", format, result);
         notificationManager.dismiss(progressId);
 
         if (!result.success) {


### PR DESCRIPTION
## Summary

- add a single `document_output_completed` Aptabase event
- record only successful file exports and formatted clipboard copies
- cover HTML, PDF, EPUB, DOCX, TXT, TXT Ruby, Narou, Kakuyomu, and Aozora formats
- disclose output-format usage in the anonymous analytics privacy copy

## Privacy boundary

Only the fixed `operation` and `format` enums are sent. Manuscript content, titles, authors, filenames, paths, clipboard contents, and error messages are never forwarded. Cancelled and failed operations are not tracked. Existing analytics consent and main-process contract validation remain authoritative.

## Validation

- `npm run format:check`
- `npm run lint` (0 errors; existing warnings only)
- `npm run check:boundaries`
- `npm run type-check`
- `npm run test:coverage` — 282 files passed, 2,920 tests passed, 1 skipped
- `npm run build`
- `git diff --check`
