### PR TITLE
fix: use native Windows export and print windows

### DIFF
--- a/electron/ipc/__tests__/export-dialog-ipc.test.ts
+++ b/electron/ipc/__tests__/export-dialog-ipc.test.ts
@@ -17,7 +17,7 @@ describe("native export dialog window smoke contract", () => {
     expect(source).toContain('preload: path.join(__dirname, "preload.js")');
     expect(source).not.toContain('path.join(__dirname, "../preload.js")');
     expect(source).toContain("backgroundColor:");
-    expect(source).toContain("nativeTheme.shouldUseDarkColors");
+    expect(source).toContain('backgroundColor: "#00000000"');
     expect(source).toContain('"?export-dialog"');
   });
 

--- a/electron/ipc/__tests__/export-dialog-ipc.test.ts
+++ b/electron/ipc/__tests__/export-dialog-ipc.test.ts
@@ -17,8 +17,15 @@ describe("native export dialog window smoke contract", () => {
     expect(source).toContain('preload: path.join(__dirname, "preload.js")');
     expect(source).not.toContain('path.join(__dirname, "../preload.js")');
     expect(source).toContain("backgroundColor:");
-    expect(source).toContain('backgroundColor: "#00000000"');
+    expect(source).toContain('useNativeFrame ? "#1e1e1e" : "#00000000"');
     expect(source).toContain('"?export-dialog"');
+  });
+
+  it("uses the native Windows frame so export and print windows have a system close button", () => {
+    expect(source).toContain('process.platform === "win32"');
+    expect(source).toContain("frame: useNativeFrame");
+    expect(source).toContain("transparent: !useNativeFrame");
+    expect(source).toContain('request.kind === "print" ? "印刷設定"');
   });
 
   it("uses a compact native window for EPUB, which has no preview pane", () => {

--- a/electron/ipc/__tests__/project-dialog-ipc.test.ts
+++ b/electron/ipc/__tests__/project-dialog-ipc.test.ts
@@ -17,7 +17,7 @@ describe("native create-project dialog smoke contract", () => {
     expect(source).toContain("parent.setFocusable(false)");
     expect(source).toContain(": { parent, modal: true }");
     expect(source).toContain('preload: path.join(__dirname, "preload.js")');
-    expect(source).toContain("nativeTheme.shouldUseDarkColors");
+    expect(source).toContain('backgroundColor: "#00000000"');
     expect(source).toContain("?create-project");
   });
 

--- a/electron/ipc/export-dialog-ipc.js
+++ b/electron/ipc/export-dialog-ipc.js
@@ -1,4 +1,4 @@
-const { BrowserWindow, ipcMain, app, dialog, nativeTheme, screen } = require("electron");
+const { BrowserWindow, ipcMain, app, dialog, screen } = require("electron");
 const path = require("path");
 const { EXPORT_CHANNELS } = require("../lib/ipc-channels");
 const { isDev } = require("../app-constants");
@@ -36,6 +36,7 @@ function registerExportDialogHandlers() {
     return new Promise((resolve) => {
       const isTxt = request.kind === "txt";
       const isEpub = request.kind === "document" && request.format === "epub";
+      const useNativeFrame = process.platform === "win32";
       const width = isTxt ? 520 : isEpub ? 760 : 1280;
       const height = isTxt ? 480 : 820;
       const macWindowOptions =
@@ -54,13 +55,16 @@ function registerExportDialogHandlers() {
         minWidth: isTxt ? 420 : isEpub ? 640 : 960,
         minHeight: isTxt ? 380 : isEpub ? 640 : 620,
         show: false,
-        frame: false,
-        transparent: true,
+        // Windows users expect these task windows to expose the standard
+        // system title bar, including the native Close button. Keep the
+        // custom frameless treatment on macOS/Linux.
+        frame: useNativeFrame,
+        transparent: !useNativeFrame,
         hasShadow: true,
         // Prevent the native compositor from flashing its default white
         // surface while the renderer catches up during live resize.
-        backgroundColor: "#00000000",
-        title: "エクスポート設定",
+        backgroundColor: useNativeFrame ? "#1e1e1e" : "#00000000",
+        title: request.kind === "print" ? "印刷設定" : "エクスポート設定",
         webPreferences: {
           // The Electron main process is bundled into dist-main/main.js, so
           // bundled modules share dist-main as __dirname at runtime. The

--- a/electron/ipc/export-dialog-ipc.js
+++ b/electron/ipc/export-dialog-ipc.js
@@ -54,9 +54,12 @@ function registerExportDialogHandlers() {
         minWidth: isTxt ? 420 : isEpub ? 640 : 960,
         minHeight: isTxt ? 380 : isEpub ? 640 : 620,
         show: false,
+        frame: false,
+        transparent: true,
+        hasShadow: true,
         // Prevent the native compositor from flashing its default white
         // surface while the renderer catches up during live resize.
-        backgroundColor: nativeTheme.shouldUseDarkColors ? "#080808" : "#fcfcfc",
+        backgroundColor: "#00000000",
         title: "エクスポート設定",
         webPreferences: {
           // The Electron main process is bundled into dist-main/main.js, so

--- a/electron/ipc/project-dialog-ipc.js
+++ b/electron/ipc/project-dialog-ipc.js
@@ -1,4 +1,4 @@
-const { BrowserWindow, ipcMain, app, nativeTheme, screen } = require("electron");
+const { BrowserWindow, ipcMain, app, screen } = require("electron");
 const path = require("path");
 const { pathToFileURL } = require("url");
 const { PROJECT_DIALOG_CHANNELS } = require("../lib/ipc-channels");
@@ -54,7 +54,10 @@ function registerProjectDialogHandlers() {
         minWidth: 560,
         minHeight: 480,
         show: false,
-        backgroundColor: nativeTheme.shouldUseDarkColors ? "#080808" : "#fcfcfc",
+        frame: false,
+        transparent: true,
+        hasShadow: true,
+        backgroundColor: "#00000000",
         title: "新規プロジェクト",
         webPreferences: {
           preload: path.join(__dirname, "preload.js"),

--- a/electron/window-manager.js
+++ b/electron/window-manager.js
@@ -83,8 +83,11 @@ async function createSettingsWindow() {
     minWidth: 680,
     minHeight: 520,
     show: false,
+    frame: false,
+    transparent: true,
+    hasShadow: true,
     title: "設定",
-    backgroundColor: "#0f172a",
+    backgroundColor: "#00000000",
     webPreferences: {
       preload: preloadPath,
       contextIsolation: true,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -837,9 +837,55 @@ function EditorPageContent() {
   }
   const [printDialogState, setPrintDialogState] = useState<PrintDialogState | null>(null);
 
-  const handlePrintDialogRequest = useCallback((content: string, metadata: ExportMetadata) => {
-    setPrintDialogState({ content, metadata, fileType: activeFileTypeRef.current });
-  }, []);
+  const executeSystemPrint = useCallback(
+    async (state: PrintDialogState, settings: PdfExportSettings): Promise<boolean> => {
+      if (!window.electronAPI?.printDocument) {
+        notificationManager.error("印刷機能を利用できません。アプリを再起動してください");
+        return false;
+      }
+      try {
+        const result = await window.electronAPI.printDocument(
+          state.content,
+          toPdfGenerationOptions(settings, state.metadata, state.fileType),
+        );
+        if (result && !result.success) {
+          notificationManager.error(`印刷に失敗しました: ${result.error}`);
+          return false;
+        }
+        return true;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "不明なエラー";
+        notificationManager.error(`印刷に失敗しました: ${message}`);
+        return false;
+      }
+    },
+    [],
+  );
+
+  const handlePrintDialogRequest = useCallback(
+    (content: string, metadata: ExportMetadata) => {
+      const state: PrintDialogState = {
+        content,
+        metadata,
+        fileType: activeFileTypeRef.current,
+      };
+      if (window.electronAPI?.openExportDialog) {
+        void window.electronAPI
+          .openExportDialog({ kind: "print", ...state })
+          .then((result) => {
+            const options = result?.options as PdfExportSettings | undefined;
+            if (options) void executeSystemPrint(state, options);
+          })
+          .catch((error: unknown) => {
+            const message = error instanceof Error ? error.message : "不明なエラー";
+            notificationManager.error(`印刷設定を開けませんでした: ${message}`);
+          });
+        return;
+      }
+      setPrintDialogState(state);
+    },
+    [executeSystemPrint],
+  );
 
   // TXT export/copy 字下げ dialog. The export hook awaits the user's choice via
   // a promise resolved when the dialog is confirmed (options) or cancelled (null).
@@ -1000,35 +1046,9 @@ function EditorPageContent() {
   const handlePrintConfirm = useCallback(
     async (settings: PdfExportSettings) => {
       if (!printDialogState) return;
-
-      // Electron path: use IPC
-      if (window.electronAPI?.printDocument) {
-        try {
-          const result = await window.electronAPI.printDocument(
-            printDialogState.content,
-            toPdfGenerationOptions(settings, printDialogState.metadata, printDialogState.fileType),
-          );
-          if (
-            result !== null &&
-            result !== undefined &&
-            typeof result === "object" &&
-            "success" in result &&
-            !result.success
-          ) {
-            notificationManager.error(`印刷に失敗しました: ${(result as { error: string }).error}`);
-            return;
-          }
-          setPrintDialogState(null);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : "不明なエラー";
-          notificationManager.error(`印刷に失敗しました: ${message}`);
-        }
-        return;
-      }
-
-      notificationManager.error("印刷機能を利用できません。アプリを再起動してください");
+      if (await executeSystemPrint(printDialogState, settings)) setPrintDialogState(null);
     },
-    [printDialogState],
+    [executeSystemPrint, printDialogState],
   );
 
   const handleDocxExportConfirm = useCallback(async (settings: UnifiedExportSettings) => {

--- a/src/components/ExportDialog.tsx
+++ b/src/components/ExportDialog.tsx
@@ -536,7 +536,7 @@ function ExportDialogInner({
       panelClassName={clsx(
         "w-full p-0 overflow-hidden",
         presentation === "window"
-          ? "h-screen bg-background"
+          ? "h-screen rounded-xl border border-border bg-background-elevated/95 shadow-2xl"
           : clsx("mx-4", isEpub ? "max-w-2xl" : isHtml ? "max-w-5xl" : "max-w-7xl"),
       )}
     >

--- a/src/components/ExportDialogWindow.tsx
+++ b/src/components/ExportDialogWindow.tsx
@@ -9,6 +9,12 @@ import type { TxtExportFormat, TxtIndentOptions } from "@/lib/export/txt-export-
 type Request =
   | { kind: "txt"; format: TxtExportFormat; operation: "export" | "copy" }
   | {
+      kind: "print";
+      content: string;
+      metadata: ExportMetadata;
+      fileType: ".mdi" | ".md" | ".txt";
+    }
+  | {
       kind: "document";
       format: ExportDialogFormat;
       content: string;
@@ -56,6 +62,22 @@ export default function ExportDialogWindow(): React.JSX.Element | null {
         operation={request.operation}
         onCancel={() => complete(null)}
         onConfirm={(options: TxtIndentOptions) => complete({ kind: "txt", options })}
+      />
+    );
+  if (request.kind === "print")
+    return (
+      <ExportDialog
+        isOpen
+        presentation="window"
+        confirmDiscard={confirmDiscard}
+        mode="print"
+        initialFormat="pdf"
+        content={request.content}
+        metadata={request.metadata}
+        fileType={request.fileType}
+        onClose={() => complete(null)}
+        onExportPdf={(options) => complete({ kind: "print", options })}
+        onExportDocx={() => {}}
       />
     );
   return (

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -197,7 +197,7 @@ export default function SettingsModal({
       className={clsx(
         presentation === "modal"
           ? "fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-sm"
-          : "h-screen w-screen bg-background",
+          : "h-screen w-screen rounded-xl bg-background-elevated/95 p-0 shadow-2xl",
       )}
       onClick={handleOverlayClick}
     >
@@ -211,17 +211,21 @@ export default function SettingsModal({
           "relative w-full bg-background-elevated flex flex-col transition-[max-width] duration-200",
           presentation === "modal"
             ? "h-[80vh] mx-4 rounded-xl shadow-xl border border-border"
-            : "h-full",
+            : "h-full rounded-xl border border-border",
           isWide ? "max-w-6xl" : "max-w-4xl",
         )}
       >
-        <div className="flex-shrink-0 flex items-center justify-between px-6 py-4 border-b border-border">
+        <div
+          className="flex-shrink-0 flex items-center justify-between px-6 py-4 border-b border-border"
+          style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
+        >
           <h2 id={headingId} className="text-lg font-medium text-foreground">
             設定
           </h2>
           <button
             onClick={onClose}
             className="p-1 rounded hover:bg-hover text-foreground-secondary hover:text-foreground transition-colors"
+            style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
             aria-label="閉じる"
           >
             <X className="w-5 h-5" />

--- a/src/components/TxtExportDialog.tsx
+++ b/src/components/TxtExportDialog.tsx
@@ -107,7 +107,7 @@ export default function TxtExportDialog({
       ariaLabel="テキスト出力設定"
       panelClassName={
         presentation === "window"
-          ? "h-screen w-screen overflow-y-auto bg-background p-8"
+          ? "h-screen w-screen overflow-y-auto rounded-xl border border-border bg-background-elevated/95 p-8 shadow-2xl"
           : "mx-4 w-full max-w-md p-6"
       }
     >

--- a/src/components/__tests__/ExportDialogWindow.test.tsx
+++ b/src/components/__tests__/ExportDialogWindow.test.tsx
@@ -7,11 +7,13 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const source = readFileSync(path.resolve(here, "../ExportDialogWindow.tsx"), "utf8");
 
 describe("ExportDialogWindow", () => {
-  it("hosts both document and TXT export settings and returns their selection", () => {
+  it("hosts document, print, and TXT settings and returns their selection", () => {
     expect(source).toContain("<ExportDialog");
     expect(source).toContain("<TxtExportDialog");
-    expect(source.match(/presentation="window"/g)).toHaveLength(2);
-    expect(source.match(/confirmDiscard=\{confirmDiscard\}/g)).toHaveLength(2);
+    expect(source).toContain('request.kind === "print"');
+    expect(source).toContain('mode="print"');
+    expect(source.match(/presentation="window"/g)).toHaveLength(3);
+    expect(source.match(/confirmDiscard=\{confirmDiscard\}/g)).toHaveLength(3);
     expect(source).toContain("confirmExportDialogDiscard");
     expect(source).toContain("completeExportDialog");
   });

--- a/src/shared/ui/GlassDialog.tsx
+++ b/src/shared/ui/GlassDialog.tsx
@@ -168,7 +168,10 @@ export default function GlassDialog({
         aria-modal="true"
         aria-label={ariaLabel}
         tabIndex={-1}
-        className={panelClassName ?? "h-screen w-screen overflow-auto bg-background p-6"}
+        className={
+          panelClassName ??
+          "h-screen w-screen overflow-auto rounded-xl bg-background-elevated/95 p-6 shadow-2xl"
+        }
       >
         {children}
       </div>


### PR DESCRIPTION
## What changed

- use the native Windows window frame for export settings, including the system Close button
- open print settings in a dedicated Electron child window instead of an in-editor HTML overlay
- continue into the operating-system print dialog after confirming print settings
- keep the existing browser fallback

## Root cause

The shared export BrowserWindow forced `frame: false` on every platform, and print settings were rendered as a second ExportDialog inside the main editor window.

## Validation

- `npm run type-check`
- 39 focused export/print/IPC tests
- modified-file ESLint (no errors)
